### PR TITLE
[WIP] Policy element deprecation "framework"

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -234,6 +234,12 @@ def _dryrun_option(p):
         help="Don't execute actions but filter resources")
 
 
+def _deprecation_option(p):
+    p.add_argument(
+        '--deprecation', default='warn', choices=['warn', 'error', 'ignore'],
+        help="Action when any policy element is deprecated")
+
+
 def _key_val_pair(value):
     """
     Type checker to ensure that --field values are of the format key=val
@@ -331,6 +337,7 @@ def setup_parser():
     run.set_defaults(command="c7n.commands.run")
     _default_options(run)
     _dryrun_option(run)
+    _deprecation_option(run)
     run.add_argument(
         "-m", "--metrics-enabled",
         default=False, action="store_true",

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -29,7 +29,7 @@ import yaml
 
 from c7n.policy import Policy, PolicyCollection, load as policy_load
 from c7n.reports import report as do_report
-from c7n.utils import Bag, dumps, load_file
+from c7n.utils import Bag, dumps, load_file, init_deprecation_warnings
 from c7n.manager import resources
 from c7n.resources import load_resources
 from c7n import schema
@@ -42,6 +42,8 @@ def policy_command(f):
 
     @wraps(f)
     def _load_policies(options):
+        init_deprecation_warnings(options)
+
         load_resources()
         vars = _load_vars(options)
 


### PR DESCRIPTION
Addresses https://github.com/capitalone/cloud-custodian/issues/775.

* Decorate resource, action and/or filter classes with `@deprecated`
* New command-line option `--deprecated` with allowed values `ignore`, `warn` or `error`
* Log warning or throw exception during policy validation
* Use Python [`warnings`](https://docs.python.org/2/library/warnings.html) package