### PR TITLE
[wip] historical revision source

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -35,6 +35,7 @@ from jsonschema import Draft4Validator as Validator
 from jsonschema.exceptions import best_match
 
 from c7n.manager import resources
+from c7n.query import sources
 from c7n.resources import load_resources
 from c7n.filters import ValueFilter, EventFilter, AgeFilter
 
@@ -161,7 +162,7 @@ def generate(resource_types=()):
                 'description': {'type': 'string'},
                 'tags': {'type': 'array', 'items': {'type': 'string'}},
                 'mode': {'$ref': '#/definitions/policy-mode'},
-                'source': {'enum': ['describe', 'config']},
+                'source': {'enum': list(sources.keys())},
                 'actions': {
                     'type': 'array',
                 },


### PR DESCRIPTION
Provides for evaluation of policies against a historical revisions of a set of resources. Works as is, needs some tests and examples. Also one gotcha with the boolean operators (explicit `or` and `and` in policy filters) is that they do joins on identity which ends up dropping revisions since they contain the same identity. also considering a filter  group by with select, ie select the first revision / last revision of matching resource. also need to consider use cases for deleted events/revisions bubbling through. Also date filters, currently this evaluates all config known history.