### PR TITLE
s3 - various keyerror gotchas when augmenting resource

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1424,7 +1424,13 @@ class EncryptionRequiredPolicy(BucketActionBase):
             return results
 
     def process_bucket(self, b):
-        p = b.get('Policy')
+        try:
+            p = b['Policy']
+        except KeyError:
+            self.log.warning('Unable to retrieve iam policy for bucket: %s, \
+                skipping put encryption policy' % b)
+            return
+
         if p is None:
             log.info("No policy found, creating new")
             p = {'Version': "2012-10-17", "Statement": []}

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -683,7 +683,7 @@ class GlobalGrantsFilter(Filter):
                 continue
             if grant['Grantee']['URI'] not in [self.AUTH_ALL, self.GLOBAL_ALL]:
                 continue
-            if allow_website and grant['Permission'] == 'READ' and b['Website']:
+            if allow_website and grant['Permission'] == 'READ' and b.get('Website'):
                 continue
             if not perms or (perms and grant['Permission'] in perms):
                 results.append(grant['Permission'])
@@ -973,7 +973,7 @@ class DeleteBucketNotification(BucketActionBase):
     permissions = ('s3:PutBucketNotification',)
 
     def process_bucket(self, bucket):
-        n = bucket['Notification']
+        n = bucket.get('Notification')
         if not n:
             return
 
@@ -1258,7 +1258,7 @@ class ToggleLogging(BucketActionBase):
 
         for r in resources:
             client = bucket_client(session, r)
-            is_logging = bool(r['Logging'])
+            is_logging = bool(r.get('Logging'))
 
             if enabled and not is_logging:
                 variables = {
@@ -1424,7 +1424,7 @@ class EncryptionRequiredPolicy(BucketActionBase):
             return results
 
     def process_bucket(self, b):
-        p = b['Policy']
+        p = b.get('Policy')
         if p is None:
             log.info("No policy found, creating new")
             p = {'Version': "2012-10-17", "Statement": []}
@@ -2116,7 +2116,7 @@ class DeleteGlobalGrants(BucketActionBase):
                 grantee['Type'] = 'CanonicalUser'
             if ('URI' in grantee and
                 grantee['URI'] in grantees and not
-                    (grant['Permission'] == 'READ' and b['Website'])):
+                    (grant['Permission'] == 'READ' and b.get('Website'))):
                 # Remove this grantee.
                 pass
             else:

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1997,7 +1997,7 @@ class LogTarget(Filter):
     def get_s3_bucket_locations(buckets, self_log=False):
         """return (bucket_name, prefix) for all s3 logging targets"""
         for b in buckets:
-            if b['Logging']:
+            if b.get('Logging'):
                 if self_log:
                     if b['Name'] != b['Logging']['TargetBucket']:
                         continue

--- a/docs/source/policy/resources/s3.rst
+++ b/docs/source/policy/resources/s3.rst
@@ -20,6 +20,36 @@ Filters
   .. c7n-schema:: MissingPolicyStatementFilter
       :module: c7n.resources.s3
 
+``c7n:DeniedMethods``
+  A list of AWS methods that resulted in ``AccessDenied`` when called on the
+  specified bucket.
+
+  S3 buckets are augmented during resource aggregation, i.e. ``get_bucket_location``,
+  ``get_bucket_tagging``, etc. However, as buckets have resource level IAM
+  policies (bucket policy), not all buckets will return all augmentations. A full
+  list of augmentations can be found in ``c7n.resources.s3.S3_AUGMENT_TABLE``.
+
+  Use this annotation on the resource to ensure actions and filters are only
+  enforced on buckets that were augmented.
+
+  .. code-block:: yaml
+
+    policies:
+      - name: delete-non-owner-bucket
+        resource: s3
+        comment: |
+          Checks that custodian was able to retrieve tags before performing
+          delete action
+        filters:
+          - type: value
+            value_type: swap
+            key: "'c7n:DeniedMethods'"
+            value: get_bucket_tagging
+            op: ni
+          - "tag:Owner": absent
+        actions:
+          - delete
+
 Actions
 -------
 


### PR DESCRIPTION
Noticed keyerrors occurring for resources that resulted in access denied during resource augmentation + action/filter, this should resolve most of those types of issues.
```
Traceback (most recent call last):
File "/src/c7n/commands.py", line 227, in run
policy()
File "/src/c7n/policy.py", line 777, in __call__
resources = mode.run()
File "/src/c7n/policy.py", line 229, in run
resources = self.policy.resource_manager.resources()
File "/src/c7n/query.py", line 421, in resources
return self.filter_resources(resources)
File "/src/c7n/manager.py", line 90, in filter_resources
resources = f.process(resources, event)
File "/src/c7n/resources/s3.py", line 1980, in process
for bucket, _ in self.get_s3_bucket_locations(buckets, self_log):
File "/src/c7n/resources/s3.py", line 2000, in get_s3_bucket_locations
if b['Logging']:
KeyError: u'Logging'
```