### PR TITLE
aws.asg - network-location security-group related filter keyerror fix

### DIFF
--- a/c7n/filters/related.py
+++ b/c7n/filters/related.py
@@ -49,6 +49,8 @@ class RelatedResourceFilter(ValueFilter):
             "[].%s" % self.RelatedIdsExpression, resources))
 
     def get_related(self, resources):
+        if hasattr(self, 'initialize'):
+            self.initialize(resources)
         resource_manager = self.get_resource_manager()
         related_ids = self.get_related_ids(resources)
         model = resource_manager.get_model()

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -134,10 +134,6 @@ class SecurityGroupFilter(
             group_ids.update(cfg.get('SecurityGroups', ()))
         return group_ids
 
-    def process(self, asgs, event=None):
-        self.initialize(asgs)
-        return super(SecurityGroupFilter, self).process(asgs, event)
-
 
 @filters.register('subnet')
 class SubnetFilter(net_filters.SubnetFilter):

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -134,6 +134,10 @@ class SecurityGroupFilter(
             group_ids.update(cfg.get('SecurityGroups', ()))
         return group_ids
 
+    def process(self, asgs, event=None):
+        self.initialize(asgs)
+        return super(SecurityGroupFilter, self).process(asgs, event)
+
 
 @filters.register('subnet')
 class SubnetFilter(net_filters.SubnetFilter):


### PR DESCRIPTION
`process` is never called during the `network-location` filter when used with `security-group`, so `self.initialize` is also never called, causing `self.configs` to be empty and causing the key error in https://github.com/capitalone/cloud-custodian/issues/2664

example failing policy:
```yaml
policies:

  - name: asg-find-bad-sg
    resource: asg
    filters:
      - type: network-location
        compare: ["resource","security-group"]
        key: "tag:some-tag"
        missing-ok: false
        max-cardinality: 1
        ignore:
          - Description: some-sg
```