### PR TITLE
Codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,11 +8,19 @@ coverage:
   precision: 2
   round: up
   range: "70...100"
-
   status:
     patch:
       default:
         threshold: "10%"
     project:
-      default:
-        threshold: "0.09%"
+      azure:
+        paths: "tools/c7n_azure"
+      gcp:
+        paths: "tools/c7n_gcp"
+      # aws is weaved throughout core atm can't easily call it out separately
+      mailer:
+        paths: "tools/c7n_mailer"
+      custodian:
+        paths:
+          - "!tools"
+      default: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+comment: off
+
+coverage:
+  precision: 2
+  round: up
+  range: "70...100"
+
+  status:
+    patch:
+      default:
+        threshold: "10%"
+    project:
+      default:
+        threshold: "0.09%"

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 
 [testenv:py27-cov]
 commands =
-    py.test -n {env:C7N_TEST_WORKERS:auto} --cov c7n --durations 20 tests tools {posargs}
+    py.test -n {env:C7N_TEST_WORKERS:auto} --cov c7n --cov tools/c7n_azure --cov tools/c7n_gcp --cov tools/c7n_mailer --durations 20 tests tools {posargs}
 
 [testenv:py36]
 commands =


### PR DESCRIPTION
the defaults are a little harsh, and config is via file in repo. also try to break out some of the tools reporting separately.