### PR TITLE
Added CC support to mail processing.

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -190,7 +190,8 @@ class EmailDelivery(object):
         # these were manually set by the policy writer in notify to section
         # or it's an email from an aws event username from an ldap_lookup
         email_to_addrs_to_resources_map = {}
-        targets = sqs_message['action']['to']
+        targets = sqs_message['action']['to'] + \
+            (sqs_message['action']['cc'] if 'cc' in sqs_message['action'] else [])
         no_owner_targets = self.get_valid_emails_from_list(
             sqs_message['action'].get('owner_absent_contact', [])
         )


### PR DESCRIPTION
1. Added CC support for general email delivery.
2. 'resource-owner' allowed in TO field only.
3. 'account-emails' allowed in TO field only.