### PR TITLE
azure - add support for groups and unknown principals in auto-tag-user action

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -175,9 +175,9 @@ class AutoTagUser(EventAction):
     max_query_days = 90
 
     # compiled JMES paths
-    sp_jmes_path = jmespath.compile(constants.EVENT_GRID_SP_NAME_JMES_PATH)
-    user_jmes_path = jmespath.compile(constants.EVENT_GRID_USER_NAME_JMES_PATH)
     service_admin_jmes_path = jmespath.compile(constants.EVENT_GRID_SERVICE_ADMIN_JMES_PATH)
+    sp_jmes_path = jmespath.compile(constants.EVENT_GRID_SP_NAME_JMES_PATH)
+    default_jmes_path = jmespath.compile(constants.EVENT_GRID_DEFAULT_NAME_JMES_PATH)
     principal_role_jmes_path = jmespath.compile(constants.EVENT_GRID_PRINCIPAL_ROLE_JMES_PATH)
     principal_type_jmes_path = jmespath.compile(constants.EVENT_GRID_PRINCIPAL_TYPE_JMES_PATH)
 
@@ -234,14 +234,14 @@ class AutoTagUser(EventAction):
             # The Subscription Admins role does not have a principal type
             if StringUtils.equal(principal_role, 'Subscription Admin'):
                 user = self.service_admin_jmes_path.search(event_item) or user
-            # Non Subscription Admins have either a User or ServicePrincipal type
-            elif StringUtils.equal(principal_type, 'User'):
-                user = self.user_jmes_path.search(event_item) or user
+            # ServicePrincipal type
             elif StringUtils.equal(principal_type, 'ServicePrincipal'):
                 user = self.sp_jmes_path.search(event_item) or user
+            # Other types (e.g. User, Office 365 Groups, and Security Groups)
+            elif self.default_jmes_path.search(event_item):
+                user = self.default_jmes_path.search(event_item)
             else:
-                self.log.error('Principal type of event cannot be determined.')
-                return
+                self.log.error('Principal could not be determined.')
         else:
             # Calculate start time
             delta_days = self.data.get('days', self.max_query_days)

--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -177,7 +177,7 @@ class AutoTagUser(EventAction):
     # compiled JMES paths
     service_admin_jmes_path = jmespath.compile(constants.EVENT_GRID_SERVICE_ADMIN_JMES_PATH)
     sp_jmes_path = jmespath.compile(constants.EVENT_GRID_SP_NAME_JMES_PATH)
-    default_jmes_path = jmespath.compile(constants.EVENT_GRID_DEFAULT_NAME_JMES_PATH)
+    upn_jmes_path = jmespath.compile(constants.EVENT_GRID_UPN_CLAIM_JMES_PATH)
     principal_role_jmes_path = jmespath.compile(constants.EVENT_GRID_PRINCIPAL_ROLE_JMES_PATH)
     principal_type_jmes_path = jmespath.compile(constants.EVENT_GRID_PRINCIPAL_TYPE_JMES_PATH)
 
@@ -238,8 +238,8 @@ class AutoTagUser(EventAction):
             elif StringUtils.equal(principal_type, 'ServicePrincipal'):
                 user = self.sp_jmes_path.search(event_item) or user
             # Other types (e.g. User, Office 365 Groups, and Security Groups)
-            elif self.default_jmes_path.search(event_item):
-                user = self.default_jmes_path.search(event_item)
+            elif self.upn_jmes_path.search(event_item):
+                user = self.upn_jmes_path.search(event_item)
             else:
                 self.log.error('Principal could not be determined.')
         else:

--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -11,7 +11,7 @@ FUNCTION_KEY_URL = 'hostruntime/admin/host/systemkeys/_master?api-version=2018-0
 """
 Event Grid Mode
 """
-EVENT_GRID_DEFAULT_NAME_JMES_PATH = \
+EVENT_GRID_UPN_CLAIM_JMES_PATH = \
     'data.claims."http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"'
 EVENT_GRID_SP_NAME_JMES_PATH = 'data.claims.appid'
 EVENT_GRID_SERVICE_ADMIN_JMES_PATH = \

--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -11,8 +11,8 @@ FUNCTION_KEY_URL = 'hostruntime/admin/host/systemkeys/_master?api-version=2018-0
 """
 Event Grid Mode
 """
-EVENT_GRID_USER_NAME_JMES_PATH = \
-    'data.claims."http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"'
+EVENT_GRID_DEFAULT_NAME_JMES_PATH = \
+    'data.claims."http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"'
 EVENT_GRID_SP_NAME_JMES_PATH = 'data.claims.appid'
 EVENT_GRID_SERVICE_ADMIN_JMES_PATH = \
     'data.claims."http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"'

--- a/tools/c7n_azure/tests/cassettes/TagsTest.test_auto_tag_user_event_grid_group_event.yaml
+++ b/tools/c7n_azure/tests/cassettes/TagsTest.test_auto_tag_user_event_grid_group_event.yaml
@@ -1,0 +1,650 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LOVGEbFGPzxQ1MJHSJY5SBD6OldwvOX/D8XkTxBAAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [b5fc6c3b-2fda-4b44-a645-e61c005e4eb8]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3999,Microsoft.Compute/LowCostGet30Min;31998']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [a3a5c365-2051-4f17-b60e-ca5fe9c64464]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010142Z:b5fc6c3b-2fda-4b44-a645-e61c005e4eb8']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LOVGEbFGPzxQ1MJHSJY5SBD6OldwvOX/D8XkTxBAAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [f798cc0a-7daf-4e7b-bc84-6fd68dfb73d6]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3998,Microsoft.Compute/LowCostGet30Min;31997']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [1bc4990d-f195-420a-b6e9-0ab407aab1be]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010142Z:f798cc0a-7daf-4e7b-bc84-6fd68dfb73d6']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute?api-version=2018-05-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ313V1WUx
+        y+vm7hfFtK6a6rwdn1SL1brNPxp9tMwWebPKpjlBj32frdt5VRc/yLjHjx597xd/lK1WZTHlD86A
+        1Kc7+afT2acPth9OD6bb+w/v724/nNybbu/dm+7dz/Z2P32YnROkuirzp/l5sSzsm/n+gwc72XSy
+        vfdgLyf8pwfbBw/O723v7p3v72ef7u7t7e1/9EtG/S6zezv3Dh7u59vnu7OD7f3s3oPtyfnuzvan
+        D7Ls0/v72c79h5/Gu3y4cy+bPiAUD7LZ/e39/H5Gb073tu/n+w/P9+/vZHv7u/EuDyafTs4PDrZ3
+        Z7tE60/3Pt2e7OzvbD/MHuw9zLOH96af3o93uX9/erD36YPp9sHOhN6cPPyUXtqnUe7enxycU7fT
+        6Sza5e7B/sOdh9Ns+9OH57vb+/c+pen9NHuwPb1//yDPP80nO5PZN9zl/ZwIcW+2v31/f0Yv7u0S
+        oT7N9renn+Y0McRSBzu78S7Pz4kH8vsTmsEHe9v79x/MtieT3QfbxKA796Y79/b3Ds6jXU7zT8/P
+        d/ez7QfnM2KfTw/u04v5zvb5p9n57Hx6nh3kO/EupwR/OqOXZpOM3szopSx/8HD7YDa5t5/P6OVs
+        J9rlvQd7u/s71Hxyb/KARklzeZCfP9ye3X/w8ODTBw8/3Rsa5e26/D69mzfVup7mb65XuYiN/wlB
+        yi6zoswmRVm016/ztqH+ykpwRPuPTrOmTb96TR/rb+ke/f7dnH+n307yZVtnpfzxoqrbeRp89Loi
+        yQ0/klan67oiDBSW/Yt7OW6KjH7nd3Pvg+9kq2yZoon9A2/TH8frBh0UmfnWfWCh0KdP6uwHRSkf
+        0Z/8Mz1bzhi6QdL8DdD2j5Nsmc0yMxD3gXbHbX3iaEP6jD756veyXdKv+J5++72qOvcByt+m3bM6
+        W05z+zVNZbYqfpLUp5kY4g1SAjvbzCL8x86n/h/79o8H27t73h8797bvgZPpD3rhwP9jn/7YXtX5
+        ZZFf2Q9d8/voYhfqRf6g/+3a5oThLD/P1mV7bBEl/qKWDgYN4WVdnRel8iLZBPwRtGYEdx4SXP5O
+        3gpaGHgQKW0VfE+DJwi72/PrSU3mqg+Au9gMgPrA0Pi7KAQhKURsSnzI8lNgVB+dkO1qXqmQfV5X
+        65X544vqMh+l/P1rz376XzNKHQm9LOp2nZVfZNN5saQufiSg5m+Atn+oPGob94F2x2194mhD+ow+
+        IankruRXfE+/iUBqO/u3afcjAZXv5K2ghYEHZtZWwfc0eILwQxPQH1TL/AuyvcXyQkZl5IeagjuI
+        BZgt0A4NPuKZoP/f++j7wMBrrrNNb9DXt2gPTnKic4sXOlx1q3eYIyE/Rgpv8Q4jdvtxdzRC9A2i
+        9DepCkfp6+umzRfHTVNcLPOZ+e5sRrQhZ4WZY7OqvJu/a/MlmOJHWvNHWlPVoPnQNSct+SOtyS0M
+        Sb9pWWaUNsrq62lW5j+KP/CK/Rug7R8ql9rGfaDdcVufONqQPqNPSDq5K/kV39NvIpjazv5t2v3s
+        CSq90xVHw7n8B0H5IUgvNdPXaFz//5NeWOgf+TzhO4zY7cfdURPRN4jS36Se/HCfx+rRH/k+gG6Q
+        NH8DtP1DNai2cR9od9zWJ442pM/oE9Kj3JX8iu/pN1Gh2s7+bdp1+Jx4x0kwTwzJ8I9UqmthcALT
+        a6vge6IIQfghqVTAuKXkhZ//SPx+JH7frPgR2j+PpWuZt1dV/fZs2eb1OS0Y/ki+/j8lX8wT1Fr+
+        GBQpYS3+g154aL+hP+g19we1dH/Q/9wfPxIyaWEI+15CFn7uhO5HQueGYv4GaPuHypi2cR9od9zW
+        J442pM/oE5I07kp+xff0mwiZtrN/m3Y/Ejp+K2hhugS/a6vgexoLQfh/n9Ct1pOymJ69PJ7N6I2G
+        aPAjITN/A7T9Q2VK27gPtDtu6xNHG9Jn9AlJFnclv+J7+k2EStvZv027nwUhExg3MjsB+jllVcd+
+        ISsK+goHHwDS13OeBX/+g1745vzkTaO5S/xdy6/0tv0Y4wAPCaPob46N+FNlAvlDpCf4iHkm/Eha
+        WaliWPYv7kVFit+FdJgPRKzQxP6Bt+kPJ1L6rfvAQqFP//8mY1+HweidLhv97HEdo32jWHP//5+2
+        YVZm7l4uXhc/oLH+SI7M3wBt/1Cx0TbuA+2O2/rE0Yb0GX1CwsNdya/4nn4TudF29m/T7mdPjoSf
+        +A964UciE4UgFLtBZOr18qRaLLLl7Edi8/NEbATgjVxOgP5fwqPrJrsgRH/EnuZvgLZ/KDdqG/eB
+        dsdtfeJoQ/qMPiGe5K7kV3xPvwk7ajv7t2n3s82e/Ae98COtHoUgFLtBYsKw/kei8/NRdAj6wOKo
+        acHd3ygX1O3/S7iak1LNnN4kGPZjQlwYjGdFf3Nzxp8qxeUPYdXgI56g8CNpZVmYYdm/uBflX34X
+        rGg+EB5GE/sH3qY/HP/qt+4DC4U+/RFDG5biP+gFZVf540e2QFoYikWlhvj0R1klg6T5G6DtHyoa
+        2sZ9oN1xW5842pA+o09IQLgr+RXf028iG9rO/m3a/ZzIivuGxGCDWEQ4iP5saQAvq2LZnlRlmU+F
+        hTrsxMPDZJgpBf2ISEw4HSz9SX+ASh224M+Fe4KmDDT8iN/m36R9CEj77nCDvsOo8O8BRDdx9Jt5
+        RXgQMO0f2kjZQ0G4D7Stfm7ZiwHavxzzanP3ATcEAelT4RgFZf/mFvQXELEQf7bZiQBOafiToiza
+        AqqS6L7MWV0RZ9yCUe76n/+IbQSE+0Db6ud2Whmg/ctxiTZ3H3BDEJA+FTZRUPZvbkF/AREL8Wed
+        bSIM0olG7hImF8uqaYsprTW2xfKixx0YrVBbf3NzwZ8CfUJf/pCJDT7ioYcfSSs7/QzL/sW9KDPw
+        uyCs+UCmE03sH3ib/nCzod+6DywU+rTDXvzTTohB0vwN0PYP5RVt4z7Q7ritTxxtSJ/RJx570q/4
+        nn4T1tB29m/T7jbcQQxA/9u91Uwv8rYupk/z82JJWgQwfjTR5m+Atn/ovGob94F2x2194mhD+ow+
+        odnlruRXfE+/ycRqO/u3afehE93Mszqf/eQXZ4tYag4oGNiCIvcbfoSh0W88Jv4aRDRTwRDsrPFf
+        /kv0mxJIQcZHQBpqh3we5+bc2qaF47t7aeD+/26gdjh3s7otzrNp+3IwymbsFA/BjYcTfqSI/1BH
+        u3FcRIiG+huIhhgH7U0wYKTDjxS9n80xkWV1ZvY2A5wVzdveaHrIKRKMufZPf9IfjKfFWpvRb6I9
+        g6YMNPyI3+bfpH0ISPvuaEN9h1Hh3wOITnHRb+YV0cGAaf/QRh2S2g+0rX5u1SsDtH855a3N3Qfc
+        EASkT0VjKij7N7egv4CIhXgbdUoz/BAeEs8w/eGmm/5gRct/GEeK/6A2QbZDAN+YviCAP9vJB2rB
+        OP8SQukHpFu+yFYr9uSAk+FJagoK0wzzrKMdGnzEQ6X/3xPO9porBekN+voW7XkWLPfd4oXOTN3q
+        HZ5yMIXh7Fu8w4jdftwdMYq+QZQmXeYr9ZO6appXqhc+r6v1yvzxRXWZj1L+/vV60kzrYoWe/K95
+        8jtKpVmSspxXPwrXFIT7QNvq51bwGaD9y+kRbe4+4IYgIH0qikRB2b+5Bf0FRCzEDrsSCzhB5IkR
+        Ufz/qWL52WZ3y+IUkjZvidEGnASeGkye4UBML7EXs5zODf1Jf/DkhUzLnws3B00ZaPgRv82/SfsQ
+        kPb9I+5nbuGJEX75/yX3A0aHXQsORuitHzEncYP9QNvq55Z5GKD9y/GiNncfcEMQkD4VZlRQ9m9u
+        QX8BEQvxdsxJjjxNJ3MdzS1m3/7BE81/kL/fz6TxH/RCkM//fz3bjn6ISrusLo6XWXlNicSeVGCW
+        hcv0N8eD/KlOm/whDB18xFMefiStLNszLPsX96JCwO+CocwHwsZoYv/A2/SH40L91n1godCnHbHi
+        n5YRDZLmb4C2f6iMaBv3gXbHbX3iaEP6jD7xxJJ+xff0m4iEtrN/m3Y/C1LBnm+dXxSgDCb4dZu1
+        4IRX/FlOiZqPfsn/A7kS4XIOVgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['3213']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [6ed59a51-9973-434b-84ef-bf2cb8b28ca2]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [6ed59a51-9973-434b-84ef-bf2cb8b28ca2]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010142Z:6ed59a51-9973-434b-84ef-bf2cb8b28ca2']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LOVGEbFGPzxQ1MJHSJY5SBD6OldwvOX/D8XkTxBAAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [2d7aa3f2-3308-4996-97ab-e87e07f54cef]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31996']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [8cd0ab59-56ce-4df6-babd-51b1010f28b3]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010143Z:2d7aa3f2-3308-4996-97ab-e87e07f54cef']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1656']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOriqxUpGPqA35KmH7UqhI40Rhgui7pdZ+UXLO80NdK+rCwPfETU
+        budT4os6K9emQZtdeCRg5qOP6BP+9ZJaWp3xUTOd57M1k/OjavnZ1hfbX40O7hySXZXfd+mP9gef
+        rVr7xgk0VFWfLrKixFvTslrPfs/pmmhJs7QkCi380YGVfmjao0Mwq0cE+Z6KJjx/yf8DDLthhisJ
+        AAA=
+    headers:
+      Azure-AsyncNotification: [Enabled]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/aa98974b-5d2a-4d98-a78a-382f3715d07e/providers/Microsoft.Compute/locations/southcentralus/operations/8de8c0b8-c21c-4ab9-9ac8-cac7fafc67b9?api-version=2018-10-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [ec664373-5717-41f8-ae4d-b685edbe0011]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;239,Microsoft.Compute/PutVM30Min;1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [8de8c0b8-c21c-4ab9-9ac8-cac7fafc67b9]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010144Z:ec664373-5717-41f8-ae4d-b685edbe0011']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOriqxUpGPqA35KmH7UqhI40Rhgui7pdZ+UXLO80NdK+rCwPfETU
+        budT4os6K9emQZtdeCRg5qOP6BP+9ZJaWp3xUTOd57M1k/OjavnZ1hfbX40O7hySXZXfd+mP9gef
+        rVr7xgk0VFWfLrKixFvTslrPfs/pmmhJs7QkCi380YGVfmjao0Mwq0cE+Z6KJjx/yf8DDLthhisJ
+        AAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [8a1be55e-55c6-44e6-8b5d-4b28fb54aff1]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3995,Microsoft.Compute/LowCostGet30Min;31994']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [db9c94c6-3977-4e6c-b90c-54e7979d0056]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010145Z:8a1be55e-55c6-44e6-8b5d-4b28fb54aff1']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LNVa984gYqq6tNFVpR4a1pW69nvOV0TMWmalkSihT868NIPTX10CGYViSDf09GE5y/5fwAkfbSX
+        LAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [6e76bca7-ada5-4464-8262-c96021a0920d]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3994,Microsoft.Compute/LowCostGet30Min;31993']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [08c2602f-3e40-48f3-ba77-3cd516361d6d]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010145Z:6e76bca7-ada5-4464-8262-c96021a0920d']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UeXWbnOP3qUfg9/pSl/iOejVV2t8rot8oa+tR/TF5eLsxl99NHBg53d2cPsfHsy3XmwvX9w/952
+        9mk+2X7w4GBvtrd///zep3sfjbwX51k9u8rq/GVdnRclOvXA0veXi9fFD/DxR0+yppj+/sc7H7nv
+        f4kPqWmrOrsYBFQs6MtX+Xle58tp72tqsFpPyqKZ5zV999FJtqyWxTQrfWTxfFSdEwg0+WqyXrbr
+        13l9SX93WzVv12iz++l4Z3+8s/38zeteE3qtKaolmpVZmzetN7BwaNS4ap4WzVtq28W6at5crzCc
+        j54Xy/W7Xi/LbMHfTqfo4nLx+3/JkH7/3d//4Hz3wd7O7sOHD6c7+5/uZwefZpMHk9mnn+YPzvf2
+        9w96oKZ1Tnh+uWoV62d1tTgDVfsts+m8WF6g0as8m323Ltp+o0W2pHdnwIYadsZF3+t8Hk+nFRHa
+        jPJ1my1nxDO///NXPZLSSwVz4d1mPWmmdcGoNnez7OHBwwf7k+37s71se3/28GA7e3CQbd872Du/
+        92D3/mznQX63zptqXU/zz+tqvWruglq//+XiLnH8ZTGjqbr7RTGtq6Y6b8cn1WK1bvO7M0K9ufs1
+        KBuiHU41DQJwwfWfP6HB3Nvxvw3bfjTL2gydQhxVWM3TJ2i5xrTtBBDw9HkECOz9/vvZ/oPJ/fPZ
+        g8mDh/v3JrPJwac79+8/3N95cC/PzvMsQv4ui5wuVu11rJ1jkBfVsscb1OIG7qAWX4c/6LWfSw7B
+        n7egaxfrcNLxhCyyu7N3L2zxS/w/v+/+8CGR6hjSlVNBv36hjHG52L+/+EXTi+zB6m1zVYR0/Sib
+        LYrlV01eGz7CaNf0d6ddCQV1Ui3Pi4t1nYHw1DjomBrRwLJJmb/MmuaqqmfH63aeL1vSxNr+PCub
+        3H/HHxK93+TEgy3Lw9C4l3lLoN96gzcfnS1p0OfZFObte7+YWeVnm1NeSM93exjcXVz/5BcviulH
+        v+T7AfazIrtYVg2RZHD6JlXVPnXNut9Ti3wJItPw0rZe5x54PEayvqoLavDRvG1XzaO7dwMWaDKe
+        zcvFeFJWk/G0qvPxVbGcVVfNmIZyN+BhjxuDoTA9YANJFZDcko2g7l6vp9M8nxFypqV756NWpdzR
+        z0jaZVG366z8ghULzZ97p6ws83xE09LOp8RQdVau/UZtdtGhE3MxfUyf8q/iE9k3qEEzneezNdP/
+        o2r52dYX21+NDu4ckoMgv+/SH+0PPlu1wVsnUJFVfbrIihJvTstqPfs9p2siOk3tkki5iI0cvPiN
+        qK03p6/f/P4/+UWUGQeIaRWYG0jPZijOPNUkeL/k/wHYsQYWSQoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [76bd56d8-a379-4148-819e-0dc5da9db2e8]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostGet3Min;139,Microsoft.Compute/HighCostGet30Min;699']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [5d2b3588-e51e-488e-99c4-640631173a4d]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010145Z:76bd56d8-a379-4148-819e-0dc5da9db2e8']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute?api-version=2018-05-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ313V1WUx
+        y+vm7hfFtK6a6rwdn1SL1brNPxp9tMwWebPKpjlBj32frdt5VRc/yLjHjx597xd/lK1WZTHlD86A
+        1Kc7+afT2acPth9OD6bb+w/v724/nNybbu/dm+7dz/Z2P32YnROkuirzp/l5sSzsm/n+gwc72XSy
+        vfdgLyf8pwfbBw/O723v7p3v72ef7u7t7e1/9EtG/S6zezv3Dh7u59vnu7OD7f3s3oPtyfnuzvan
+        D7Ls0/v72c79h5/Gu3y4cy+bPiAUD7LZ/e39/H5Gb073tu/n+w/P9+/vZHv7u/EuDyafTs4PDrZ3
+        Z7tE60/3Pt2e7OzvbD/MHuw9zLOH96af3o93uX9/erD36YPp9sHOhN6cPPyUXtqnUe7enxycU7fT
+        6Sza5e7B/sOdh9Ns+9OH57vb+/c+pen9NHuwPb1//yDPP80nO5PZN9zl/ZwIcW+2v31/f0Yv7u0S
+        oT7N9renn+Y0McRSBzu78S7Pz4kH8vsTmsEHe9v79x/MtieT3QfbxKA796Y79/b3Ds6jXU7zT8/P
+        d/ez7QfnM2KfTw/u04v5zvb5p9n57Hx6nh3kO/EupwR/OqOXZpOM3szopSx/8HD7YDa5t5/P6OVs
+        J9rlvQd7u/s71Hxyb/KARklzeZCfP9ye3X/w8ODTBw8/3Rsa5e26/D69mzfVup7mb65XuYiN/wlB
+        yi6zoswmRVm016/ztqH+ykpwRPuPTrOmTb96TR/rb+ke/f7dnH+n307yZVtnpfzxoqrbeRp89Loi
+        yQ0/klan67oiDBSW/Yt7OW6KjH7nd3Pvg+9kq2yZoon9A2/TH8frBh0UmfnWfWCh0KdP6uwHRSkf
+        0Z/8Mz1bzhi6QdL8DdD2j5Nsmc0yMxD3gXbHbX3iaEP6jD756veyXdKv+J5++72qOvcByt+m3bM6
+        W05z+zVNZbYqfpLUp5kY4g1SAjvbzCL8x86n/h/79o8H27t73h8797bvgZPpD3rhwP9jn/7YXtX5
+        ZZFf2Q9d8/voYhfqRf6g/+3a5oThLD/P1mV7bBEl/qKWDgYN4WVdnRel8iLZBPwRtGYEdx4SXP5O
+        3gpaGHgQKW0VfE+DJwi72/PrSU3mqg+Au9gMgPrA0Pi7KAQhKURsSnzI8lNgVB+dkO1qXqmQfV5X
+        65X544vqMh+l/P1rz376XzNKHQm9LOp2nZVfZNN5saQufiSg5m+Atn+oPGob94F2x2194mhD+ow+
+        IankruRXfE+/iUBqO/u3afcjAZXv5K2ghYEHZtZWwfc0eILwQxPQH1TL/AuyvcXyQkZl5IeagjuI
+        BZgt0A4NPuKZoP/f++j7wMBrrrNNb9DXt2gPTnKic4sXOlx1q3eYIyE/Rgpv8Q4jdvtxdzRC9A2i
+        9DepCkfp6+umzRfHTVNcLPOZ+e5sRrQhZ4WZY7OqvJu/a/MlmOJHWvNHWlPVoPnQNSct+SOtyS0M
+        Sb9pWWaUNsrq62lW5j+KP/CK/Rug7R8ql9rGfaDdcVufONqQPqNPSDq5K/kV39NvIpjazv5t2v3s
+        CSq90xVHw7n8B0H5IUgvNdPXaFz//5NeWOgf+TzhO4zY7cfdURPRN4jS36Se/HCfx+rRH/k+gG6Q
+        NH8DtP1DNai2cR9od9zWJ442pM/oE9Kj3JX8iu/pN1Gh2s7+bdp1+Jx4x0kwTwzJ8I9UqmthcALT
+        a6vge6IIQfghqVTAuKXkhZ//SPx+JH7frPgR2j+PpWuZt1dV/fZs2eb1OS0Y/ki+/j8lX8wT1Fr+
+        GBQpYS3+g154aL+hP+g19we1dH/Q/9wfPxIyaWEI+15CFn7uhO5HQueGYv4GaPuHypi2cR9od9zW
+        J442pM/oE5I07kp+xff0mwiZtrN/m3Y/Ejp+K2hhugS/a6vgexoLQfh/n9Ct1pOymJ69PJ7N6I2G
+        aPAjITN/A7T9Q2VK27gPtDtu6xNHG9Jn9AlJFnclv+J7+k2EStvZv027nwUhExg3MjsB+jllVcd+
+        ISsK+goHHwDS13OeBX/+g1745vzkTaO5S/xdy6/0tv0Y4wAPCaPob46N+FNlAvlDpCf4iHkm/Eha
+        WaliWPYv7kVFit+FdJgPRKzQxP6Bt+kPJ1L6rfvAQqFP//8mY1+HweidLhv97HEdo32jWHP//5+2
+        YVZm7l4uXhc/oLH+SI7M3wBt/1Cx0TbuA+2O2/rE0Yb0GX1CwsNdya/4nn4TudF29m/T7mdPjoSf
+        +A964UciE4UgFLtBZOr18qRaLLLl7Edi8/NEbATgjVxOgP5fwqPrJrsgRH/EnuZvgLZ/KDdqG/eB
+        dsdtfeJoQ/qMPiGe5K7kV3xPvwk7ajv7t2n3s82e/Ae98COtHoUgFLtBYsKw/kei8/NRdAj6wOKo
+        acHd3ygX1O3/S7iak1LNnN4kGPZjQlwYjGdFf3Nzxp8qxeUPYdXgI56g8CNpZVmYYdm/uBflX34X
+        rGg+EB5GE/sH3qY/HP/qt+4DC4U+/RFDG5biP+gFZVf540e2QFoYikWlhvj0R1klg6T5G6DtHyoa
+        2sZ9oN1xW5842pA+o09IQLgr+RXf028iG9rO/m3a/ZzIivuGxGCDWEQ4iP5saQAvq2LZnlRlmU+F
+        hTrsxMPDZJgpBf2ISEw4HSz9SX+ASh224M+Fe4KmDDT8iN/m36R9CEj77nCDvsOo8O8BRDdx9Jt5
+        RXgQMO0f2kjZQ0G4D7Stfm7ZiwHavxzzanP3ATcEAelT4RgFZf/mFvQXELEQf7bZiQBOafiToiza
+        AqqS6L7MWV0RZ9yCUe76n/+IbQSE+0Db6ud2Whmg/ctxiTZ3H3BDEJA+FTZRUPZvbkF/AREL8Wed
+        bSIM0olG7hImF8uqaYsprTW2xfKixx0YrVBbf3NzwZ8CfUJf/pCJDT7ioYcfSSs7/QzL/sW9KDPw
+        uyCs+UCmE03sH3ib/nCzod+6DywU+rTDXvzTTohB0vwN0PYP5RVt4z7Q7ritTxxtSJ/RJx570q/4
+        nn4T1tB29m/T7jbcQQxA/9u91Uwv8rYupk/z82JJWgQwfjTR5m+Atn/ovGob94F2x2194mhD+ow+
+        odnlruRXfE+/ycRqO/u3afehE93Mszqf/eQXZ4tYag4oGNiCIvcbfoSh0W88Jv4aRDRTwRDsrPFf
+        /kv0mxJIQcZHQBpqh3we5+bc2qaF47t7aeD+/26gdjh3s7otzrNp+3IwymbsFA/BjYcTfqSI/1BH
+        u3FcRIiG+huIhhgH7U0wYKTDjxS9n80xkWV1ZvY2A5wVzdveaHrIKRKMufZPf9IfjKfFWpvRb6I9
+        g6YMNPyI3+bfpH0ISPvuaEN9h1Hh3wOITnHRb+YV0cGAaf/QRh2S2g+0rX5u1SsDtH855a3N3Qfc
+        EASkT0VjKij7N7egv4CIhXgbdUoz/BAeEs8w/eGmm/5gRct/GEeK/6A2QbZDAN+YviCAP9vJB2rB
+        OP8SQukHpFu+yFYr9uSAk+FJagoK0wzzrKMdGnzEQ6X/3xPO9porBekN+voW7XkWLPfd4oXOTN3q
+        HZ5yMIXh7Fu8w4jdftwdMYq+QZQmXeYr9ZO6appXqhc+r6v1yvzxRXWZj1L+/vV60kzrYoWe/K95
+        8jtKpVmSspxXPwrXFIT7QNvq51bwGaD9y+kRbe4+4IYgIH0qikRB2b+5Bf0FRCzEDrsSCzhB5IkR
+        Ufz/qWL52WZ3y+IUkjZvidEGnASeGkye4UBML7EXs5zODf1Jf/DkhUzLnws3B00ZaPgRv82/SfsQ
+        kPb9I+5nbuGJEX75/yX3A0aHXQsORuitHzEncYP9QNvq55Z5GKD9y/GiNncfcEMQkD4VZlRQ9m9u
+        QX8BEQvxdsxJjjxNJ3MdzS1m3/7BE81/kL/fz6TxH/RCkM//fz3bjn6ISrusLo6XWXlNicSeVGCW
+        hcv0N8eD/KlOm/whDB18xFMefiStLNszLPsX96JCwO+CocwHwsZoYv/A2/SH40L91n1godCnHbHi
+        n5YRDZLmb4C2f6iMaBv3gXbHbX3iaEP6jD7xxJJ+xff0m4iEtrN/m3Y/C1LBnm+dXxSgDCb4dZu1
+        4IRX/FlOiZqPfsn/A7kS4XIOVgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['3213']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [eb168dc6-06a3-44af-b57a-d44245e12648]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [eb168dc6-06a3-44af-b57a-d44245e12648]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010146Z:eb168dc6-06a3-44af-b57a-d44245e12648']
+    status: {code: 200, message: OK}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1617']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOriqxUpGPqA35KmH7UqhI40Rhgui7pdZ+UXLO80NdK+rCwPfETU
+        budT4os6K9emQZtdeCRg5qOP6BP+9ZJaWp3xUTOd57M1k/OjavnZ1hfbX40O7hySXZXfd+mP9gef
+        rcQuKsZgj29EI7w5ff3m9//JL6L8MUAEqxtkCD21S3j+kv8HBNZCNv8IAAA=
+    headers:
+      Azure-AsyncNotification: [Enabled]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/aa98974b-5d2a-4d98-a78a-382f3715d07e/providers/Microsoft.Compute/locations/southcentralus/operations/22872703-3c36-4f5e-b5a1-49ccd6569190?api-version=2018-10-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [7280c385-7f8b-4433-b765-3acf62612805]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;238,Microsoft.Compute/PutVM30Min;1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [22872703-3c36-4f5e-b5a1-49ccd6569190]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010147Z:7280c385-7f8b-4433-b765-3acf62612805']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LOVGEbFGPzxQ1MJHSJY5SBD6OldwvOX/D8XkTxBAAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:01:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [07dd13ef-6ebe-48c1-be26-f8bd05b3f195]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3991,Microsoft.Compute/LowCostGet30Min;31990']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [4d1715b0-9547-4706-b13c-c6e9d3a78828]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010148Z:07dd13ef-6ebe-48c1-be26-f8bd05b3f195']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/TagsTest.test_auto_tag_user_event_grid_unknown_principal_event.yaml
+++ b/tools/c7n_azure/tests/cassettes/TagsTest.test_auto_tag_user_event_grid_unknown_principal_event.yaml
@@ -1,0 +1,647 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LOVGEbFGPzxQ1MJHSJY5SBD6OldwvOX/D8XkTxBAAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [2e9db622-8f14-420b-895c-3043b0bf4588]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3999,Microsoft.Compute/LowCostGet30Min;31984']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [c60b6696-894f-4ed4-91df-d1c697b29e8d]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010525Z:2e9db622-8f14-420b-895c-3043b0bf4588']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LOVGEbFGPzxQ1MJHSJY5SBD6OldwvOX/D8XkTxBAAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [d2e79b61-7662-46d7-975e-dc7c64976255]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3998,Microsoft.Compute/LowCostGet30Min;31983']
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: [4882cc6d-6812-4fd4-a9f2-58c413caa5bc]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010525Z:d2e79b61-7662-46d7-975e-dc7c64976255']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute?api-version=2018-05-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ313V1WUx
+        y+vm7hfFtK6a6rwdn1SL1brNPxp9tMwWebPKpjlBj32frdt5VRc/yLjHjx597xd/lK1WZTHlD86A
+        1Kc7+afT2acPth9OD6bb+w/v724/nNybbu/dm+7dz/Z2P32YnROkuirzp/l5sSzsm/n+gwc72XSy
+        vfdgLyf8pwfbBw/O723v7p3v72ef7u7t7e1/9EtG/S6zezv3Dh7u59vnu7OD7f3s3oPtyfnuzvan
+        D7Ls0/v72c79h5/Gu3y4cy+bPiAUD7LZ/e39/H5Gb073tu/n+w/P9+/vZHv7u/EuDyafTs4PDrZ3
+        Z7tE60/3Pt2e7OzvbD/MHuw9zLOH96af3o93uX9/erD36YPp9sHOhN6cPPyUXtqnUe7enxycU7fT
+        6Sza5e7B/sOdh9Ns+9OH57vb+/c+pen9NHuwPb1//yDPP80nO5PZN9zl/ZwIcW+2v31/f0Yv7u0S
+        oT7N9renn+Y0McRSBzu78S7Pz4kH8vsTmsEHe9v79x/MtieT3QfbxKA796Y79/b3Ds6jXU7zT8/P
+        d/ez7QfnM2KfTw/u04v5zvb5p9n57Hx6nh3kO/EupwR/OqOXZpOM3szopSx/8HD7YDa5t5/P6OVs
+        J9rlvQd7u/s71Hxyb/KARklzeZCfP9ye3X/w8ODTBw8/3Rsa5e26/D69mzfVup7mb65XuYiN/wlB
+        yi6zoswmRVm016/ztqH+ykpwRPuPTrOmTb96TR/rb+ke/f7dnH+n307yZVtnpfzxoqrbeRp89Loi
+        yQ0/klan67oiDBSW/Yt7OW6KjH7nd3Pvg+9kq2yZoon9A2/TH8frBh0UmfnWfWCh0KdP6uwHRSkf
+        0Z/8Mz1bzhi6QdL8DdD2j5Nsmc0yMxD3gXbHbX3iaEP6jD756veyXdKv+J5++72qOvcByt+m3bM6
+        W05z+zVNZbYqfpLUp5kY4g1SAjvbzCL8x86n/h/79o8H27t73h8797bvgZPpD3rhwP9jn/7YXtX5
+        ZZFf2Q9d8/voYhfqRf6g/+3a5oThLD/P1mV7bBEl/qKWDgYN4WVdnRel8iLZBPwRtGYEdx4SXP5O
+        3gpaGHgQKW0VfE+DJwi72/PrSU3mqg+Au9gMgPrA0Pi7KAQhKURsSnzI8lNgVB+dkO1qXqmQfV5X
+        65X544vqMh+l/P1rz376XzNKHQm9LOp2nZVfZNN5saQufiSg5m+Atn+oPGob94F2x2194mhD+ow+
+        IankruRXfE+/iUBqO/u3afcjAZXv5K2ghYEHZtZWwfc0eILwQxPQH1TL/AuyvcXyQkZl5IeagjuI
+        BZgt0A4NPuKZoP/f++j7wMBrrrNNb9DXt2gPTnKic4sXOlx1q3eYIyE/Rgpv8Q4jdvtxdzRC9A2i
+        9DepCkfp6+umzRfHTVNcLPOZ+e5sRrQhZ4WZY7OqvJu/a/MlmOJHWvNHWlPVoPnQNSct+SOtyS0M
+        Sb9pWWaUNsrq62lW5j+KP/CK/Rug7R8ql9rGfaDdcVufONqQPqNPSDq5K/kV39NvIpjazv5t2v3s
+        CSq90xVHw7n8B0H5IUgvNdPXaFz//5NeWOgf+TzhO4zY7cfdURPRN4jS36Se/HCfx+rRH/k+gG6Q
+        NH8DtP1DNai2cR9od9zWJ442pM/oE9Kj3JX8iu/pN1Gh2s7+bdp1+Jx4x0kwTwzJ8I9UqmthcALT
+        a6vge6IIQfghqVTAuKXkhZ//SPx+JH7frPgR2j+PpWuZt1dV/fZs2eb1OS0Y/ki+/j8lX8wT1Fr+
+        GBQpYS3+g154aL+hP+g19we1dH/Q/9wfPxIyaWEI+15CFn7uhO5HQueGYv4GaPuHypi2cR9od9zW
+        J442pM/oE5I07kp+xff0mwiZtrN/m3Y/Ejp+K2hhugS/a6vgexoLQfh/n9Ct1pOymJ69PJ7N6I2G
+        aPAjITN/A7T9Q2VK27gPtDtu6xNHG9Jn9AlJFnclv+J7+k2EStvZv027nwUhExg3MjsB+jllVcd+
+        ISsK+goHHwDS13OeBX/+g1745vzkTaO5S/xdy6/0tv0Y4wAPCaPob46N+FNlAvlDpCf4iHkm/Eha
+        WaliWPYv7kVFit+FdJgPRKzQxP6Bt+kPJ1L6rfvAQqFP//8mY1+HweidLhv97HEdo32jWHP//5+2
+        YVZm7l4uXhc/oLH+SI7M3wBt/1Cx0TbuA+2O2/rE0Yb0GX1CwsNdya/4nn4TudF29m/T7mdPjoSf
+        +A964UciE4UgFLtBZOr18qRaLLLl7Edi8/NEbATgjVxOgP5fwqPrJrsgRH/EnuZvgLZ/KDdqG/eB
+        dsdtfeJoQ/qMPiGe5K7kV3xPvwk7ajv7t2n3s82e/Ae98COtHoUgFLtBYsKw/kei8/NRdAj6wOKo
+        acHd3ygX1O3/S7iak1LNnN4kGPZjQlwYjGdFf3Nzxp8qxeUPYdXgI56g8CNpZVmYYdm/uBflX34X
+        rGg+EB5GE/sH3qY/HP/qt+4DC4U+/RFDG5biP+gFZVf540e2QFoYikWlhvj0R1klg6T5G6DtHyoa
+        2sZ9oN1xW5842pA+o09IQLgr+RXf028iG9rO/m3a/ZzIivuGxGCDWEQ4iP5saQAvq2LZnlRlmU+F
+        hTrsxMPDZJgpBf2ISEw4HSz9SX+ASh224M+Fe4KmDDT8iN/m36R9CEj77nCDvsOo8O8BRDdx9Jt5
+        RXgQMO0f2kjZQ0G4D7Stfm7ZiwHavxzzanP3ATcEAelT4RgFZf/mFvQXELEQf7bZiQBOafiToiza
+        AqqS6L7MWV0RZ9yCUe76n/+IbQSE+0Db6ud2Whmg/ctxiTZ3H3BDEJA+FTZRUPZvbkF/AREL8Wed
+        bSIM0olG7hImF8uqaYsprTW2xfKixx0YrVBbf3NzwZ8CfUJf/pCJDT7ioYcfSSs7/QzL/sW9KDPw
+        uyCs+UCmE03sH3ib/nCzod+6DywU+rTDXvzTTohB0vwN0PYP5RVt4z7Q7ritTxxtSJ/RJx570q/4
+        nn4T1tB29m/T7jbcQQxA/9u91Uwv8rYupk/z82JJWgQwfjTR5m+Atn/ovGob94F2x2194mhD+ow+
+        odnlruRXfE+/ycRqO/u3afehE93Mszqf/eQXZ4tYag4oGNiCIvcbfoSh0W88Jv4aRDRTwRDsrPFf
+        /kv0mxJIQcZHQBpqh3we5+bc2qaF47t7aeD+/26gdjh3s7otzrNp+3IwymbsFA/BjYcTfqSI/1BH
+        u3FcRIiG+huIhhgH7U0wYKTDjxS9n80xkWV1ZvY2A5wVzdveaHrIKRKMufZPf9IfjKfFWpvRb6I9
+        g6YMNPyI3+bfpH0ISPvuaEN9h1Hh3wOITnHRb+YV0cGAaf/QRh2S2g+0rX5u1SsDtH855a3N3Qfc
+        EASkT0VjKij7N7egv4CIhXgbdUoz/BAeEs8w/eGmm/5gRct/GEeK/6A2QbZDAN+YviCAP9vJB2rB
+        OP8SQukHpFu+yFYr9uSAk+FJagoK0wzzrKMdGnzEQ6X/3xPO9porBekN+voW7XkWLPfd4oXOTN3q
+        HZ5yMIXh7Fu8w4jdftwdMYq+QZQmXeYr9ZO6appXqhc+r6v1yvzxRXWZj1L+/vV60kzrYoWe/K95
+        8jtKpVmSspxXPwrXFIT7QNvq51bwGaD9y+kRbe4+4IYgIH0qikRB2b+5Bf0FRCzEDrsSCzhB5IkR
+        Ufz/qWL52WZ3y+IUkjZvidEGnASeGkye4UBML7EXs5zODf1Jf/DkhUzLnws3B00ZaPgRv82/SfsQ
+        kPb9I+5nbuGJEX75/yX3A0aHXQsORuitHzEncYP9QNvq55Z5GKD9y/GiNncfcEMQkD4VZlRQ9m9u
+        QX8BEQvxdsxJjjxNJ3MdzS1m3/7BE81/kL/fz6TxH/RCkM//fz3bjn6ISrusLo6XWXlNicSeVGCW
+        hcv0N8eD/KlOm/whDB18xFMefiStLNszLPsX96JCwO+CocwHwsZoYv/A2/SH40L91n1godCnHbHi
+        n5YRDZLmb4C2f6iMaBv3gXbHbX3iaEP6jD7xxJJ+xff0m4iEtrN/m3Y/C1LBnm+dXxSgDCb4dZu1
+        4IRX/FlOiZqPfsn/A7kS4XIOVgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['3213']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [9bbe6405-2c53-43a3-af3a-6c74866d70ca]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: [9bbe6405-2c53-43a3-af3a-6c74866d70ca]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010526Z:9bbe6405-2c53-43a3-af3a-6c74866d70ca']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LOVGEbFGPzxQ1MJHSJY5SBD6OldwvOX/D8XkTxBAAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [d070f3ab-0ff2-4670-ad6d-4ede9647122f]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31982']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [7260e05f-fbf4-4305-9b85-e2cf95c667b9]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010526Z:d070f3ab-0ff2-4670-ad6d-4ede9647122f']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1644']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOriqxUpGPqA35KmH7UqhI40Rhgui7pdZ+UXLO80NdK+rCwPfETU
+        budT4os6K9emQZtdeCRg5qOP6BP+9ZJaWp3xUTOd57M1k/OjavnZ1hfbX40O7hySXZXfd+mP9gef
+        rVr7xgk0VFWfLrKixFtfLd8uq6ulPyKwzw9NY3SIZHWHINxTy4TnL/l/AFjEuNofCQAA
+    headers:
+      Azure-AsyncNotification: [Enabled]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/aa98974b-5d2a-4d98-a78a-382f3715d07e/providers/Microsoft.Compute/locations/southcentralus/operations/68d463c9-3ae8-469d-a186-5b32dad3c8ed?api-version=2018-10-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [599c07b4-9184-4555-b72b-f1f96de92366]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;239,Microsoft.Compute/PutVM30Min;1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [68d463c9-3ae8-469d-a186-5b32dad3c8ed]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010527Z:599c07b4-9184-4555-b72b-f1f96de92366']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LNVa984gYqq6tNFVpR466vl22V1tfRHBP75oamMDpGs8hCEe3qZ8Pwl/w9lRjtVIAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [9d0cdbe2-e55a-4761-8199-b9b1a85e2136]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3995,Microsoft.Compute/LowCostGet30Min;31980']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [4e5c76fa-8fd8-4c40-86fe-b2273a8770bb]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010528Z:9d0cdbe2-e55a-4761-8199-b9b1a85e2136']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LNVa984gYqq6tNFVpR466vl22V1tfRHBP75oamMDpGs8hCEe3qZ8Pwl/w9lRjtVIAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [9c126c7d-4ca2-49b8-87db-2bf103bc5756]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3993,Microsoft.Compute/LowCostGet30Min;31978']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [eff539dd-30b2-4a26-a5e1-f471249c7a60]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010528Z:9c126c7d-4ca2-49b8-87db-2bf103bc5756']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UeXWbnOP3qUfg9/pSl/iOejVV2t8rot8oa+tR/TF5eLsxl99NHBg53d2cPsfHsy3XmwvX9w/952
+        9mk+2X7w4GBvtrd///zep3sfjbwX51k9u8rq/GVdnRclOvXA0veXi9fFD/DxR0+yppj+/sc7H7nv
+        f4kPqWmrOrsYBFQs6MtX+Xle58tp72tqsFpPyqKZ5zV999FJtqyWxTQrfWTxfFSdEwg0+WqyXrbr
+        13l9SX93WzVv12iz++l4Z3+8s/38zeteE3qtKaolmpVZmzetN7BwaNS4ap4WzVtq28W6at5crzCc
+        j54Xy/W7Xi/LbMHfTqfo4nLx+3/JkH7/3d//4Hz3wd7O7sOHD6c7+5/uZwefZpMHk9mnn+YPzvf2
+        9w96oKZ1Tnh+uWoV62d1tTgDVfsts+m8WF6g0as8m323Ltp+o0W2pHdnwIYadsZF3+t8Hk+nFRHa
+        jPJ1my1nxDO///NXPZLSSwVz4d1mPWmmdcGoNnez7OHBwwf7k+37s71se3/28GA7e3CQbd872Du/
+        92D3/mznQX63zptqXU/zz+tqvWruglq//+XiLnH8ZTGjqbr7RTGtq6Y6b8cn1WK1bvO7M0K9ufs1
+        KBuiHU41DQJwwfWfP6HB3Nvxvw3bfjTL2gydQhxVWM3TJ2i5xrTtBBDw9HkECOz9/vvZ/oPJ/fPZ
+        g8mDh/v3JrPJwac79+8/3N95cC/PzvMsQv4ui5wuVu11rJ1jkBfVsscb1OIG7qAWX4c/6LWfSw7B
+        n7egaxfrcNLxhCyyu7N3L2zxS/w/v+/+8CGR6hjSlVNBv36hjHG52L+/+EXTi+zB6m1zVYR0/Sib
+        LYrlV01eGz7CaNf0d6ddCQV1Ui3Pi4t1nYHw1DjomBrRwLJJmb/MmuaqqmfH63aeL1vSxNr+PCub
+        3H/HHxK93+TEgy3Lw9C4l3lLoN96gzcfnS1p0OfZFObte7+YWeVnm1NeSM93exjcXVz/5BcviulH
+        v+T7AfazIrtYVg2RZHD6JlXVPnXNut9Ti3wJItPw0rZe5x54PEayvqoLavDRvG1XzaO7dwMWaDKe
+        zcvFeFJWk/G0qvPxVbGcVVfNmIZyN+BhjxuDoTA9YANJFZDcko2g7l6vp9M8nxFypqV756NWpdzR
+        z0jaZVG366z8ghULzZ97p6ws83xE09LOp8RQdVau/UZtdtGhE3MxfUyf8q/iE9k3qEEzneezNdP/
+        o2r52dYX21+NDu4ckoMgv+/SH+0PPlu1wVsnUJFVfbrIihJvfrV8u6yulrHRgv++EVX15vT1m9//
+        J7+IMuAAAa3Scsj37ITizNNLwvZL/h984q78PQoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [a57ff2b1-298e-4f89-8915-0c63046771da]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/HighCostGet3Min;139,Microsoft.Compute/HighCostGet30Min;698']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [6ffd2780-9137-4232-b0da-2332d672ce54]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010528Z:a57ff2b1-298e-4f89-8915-0c63046771da']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute?api-version=2018-05-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ313V1WUx
+        y+vm7hfFtK6a6rwdn1SL1brNPxp9tMwWebPKpjlBj32frdt5VRc/yLjHjx597xd/lK1WZTHlD86A
+        1Kc7+afT2acPth9OD6bb+w/v724/nNybbu/dm+7dz/Z2P32YnROkuirzp/l5sSzsm/n+gwc72XSy
+        vfdgLyf8pwfbBw/O723v7p3v72ef7u7t7e1/9EtG/S6zezv3Dh7u59vnu7OD7f3s3oPtyfnuzvan
+        D7Ls0/v72c79h5/Gu3y4cy+bPiAUD7LZ/e39/H5Gb073tu/n+w/P9+/vZHv7u/EuDyafTs4PDrZ3
+        Z7tE60/3Pt2e7OzvbD/MHuw9zLOH96af3o93uX9/erD36YPp9sHOhN6cPPyUXtqnUe7enxycU7fT
+        6Sza5e7B/sOdh9Ns+9OH57vb+/c+pen9NHuwPb1//yDPP80nO5PZN9zl/ZwIcW+2v31/f0Yv7u0S
+        oT7N9renn+Y0McRSBzu78S7Pz4kH8vsTmsEHe9v79x/MtieT3QfbxKA796Y79/b3Ds6jXU7zT8/P
+        d/ez7QfnM2KfTw/u04v5zvb5p9n57Hx6nh3kO/EupwR/OqOXZpOM3szopSx/8HD7YDa5t5/P6OVs
+        J9rlvQd7u/s71Hxyb/KARklzeZCfP9ye3X/w8ODTBw8/3Rsa5e26/D69mzfVup7mb65XuYiN/wlB
+        yi6zoswmRVm016/ztqH+ykpwRPuPTrOmTb96TR/rb+ke/f7dnH+n307yZVtnpfzxoqrbeRp89Loi
+        yQ0/klan67oiDBSW/Yt7OW6KjH7nd3Pvg+9kq2yZoon9A2/TH8frBh0UmfnWfWCh0KdP6uwHRSkf
+        0Z/8Mz1bzhi6QdL8DdD2j5Nsmc0yMxD3gXbHbX3iaEP6jD756veyXdKv+J5++72qOvcByt+m3bM6
+        W05z+zVNZbYqfpLUp5kY4g1SAjvbzCL8x86n/h/79o8H27t73h8797bvgZPpD3rhwP9jn/7YXtX5
+        ZZFf2Q9d8/voYhfqRf6g/+3a5oThLD/P1mV7bBEl/qKWDgYN4WVdnRel8iLZBPwRtGYEdx4SXP5O
+        3gpaGHgQKW0VfE+DJwi72/PrSU3mqg+Au9gMgPrA0Pi7KAQhKURsSnzI8lNgVB+dkO1qXqmQfV5X
+        65X544vqMh+l/P1rz376XzNKHQm9LOp2nZVfZNN5saQufiSg5m+Atn+oPGob94F2x2194mhD+ow+
+        IankruRXfE+/iUBqO/u3afcjAZXv5K2ghYEHZtZWwfc0eILwQxPQH1TL/AuyvcXyQkZl5IeagjuI
+        BZgt0A4NPuKZoP/f++j7wMBrrrNNb9DXt2gPTnKic4sXOlx1q3eYIyE/Rgpv8Q4jdvtxdzRC9A2i
+        9DepCkfp6+umzRfHTVNcLPOZ+e5sRrQhZ4WZY7OqvJu/a/MlmOJHWvNHWlPVoPnQNSct+SOtyS0M
+        Sb9pWWaUNsrq62lW5j+KP/CK/Rug7R8ql9rGfaDdcVufONqQPqNPSDq5K/kV39NvIpjazv5t2v3s
+        CSq90xVHw7n8B0H5IUgvNdPXaFz//5NeWOgf+TzhO4zY7cfdURPRN4jS36Se/HCfx+rRH/k+gG6Q
+        NH8DtP1DNai2cR9od9zWJ442pM/oE9Kj3JX8iu/pN1Gh2s7+bdp1+Jx4x0kwTwzJ8I9UqmthcALT
+        a6vge6IIQfghqVTAuKXkhZ//SPx+JH7frPgR2j+PpWuZt1dV/fZs2eb1OS0Y/ki+/j8lX8wT1Fr+
+        GBQpYS3+g154aL+hP+g19we1dH/Q/9wfPxIyaWEI+15CFn7uhO5HQueGYv4GaPuHypi2cR9od9zW
+        J442pM/oE5I07kp+xff0mwiZtrN/m3Y/Ejp+K2hhugS/a6vgexoLQfh/n9Ct1pOymJ69PJ7N6I2G
+        aPAjITN/A7T9Q2VK27gPtDtu6xNHG9Jn9AlJFnclv+J7+k2EStvZv027nwUhExg3MjsB+jllVcd+
+        ISsK+goHHwDS13OeBX/+g1745vzkTaO5S/xdy6/0tv0Y4wAPCaPob46N+FNlAvlDpCf4iHkm/Eha
+        WaliWPYv7kVFit+FdJgPRKzQxP6Bt+kPJ1L6rfvAQqFP//8mY1+HweidLhv97HEdo32jWHP//5+2
+        YVZm7l4uXhc/oLH+SI7M3wBt/1Cx0TbuA+2O2/rE0Yb0GX1CwsNdya/4nn4TudF29m/T7mdPjoSf
+        +A964UciE4UgFLtBZOr18qRaLLLl7Edi8/NEbATgjVxOgP5fwqPrJrsgRH/EnuZvgLZ/KDdqG/eB
+        dsdtfeJoQ/qMPiGe5K7kV3xPvwk7ajv7t2n3s82e/Ae98COtHoUgFLtBYsKw/kei8/NRdAj6wOKo
+        acHd3ygX1O3/S7iak1LNnN4kGPZjQlwYjGdFf3Nzxp8qxeUPYdXgI56g8CNpZVmYYdm/uBflX34X
+        rGg+EB5GE/sH3qY/HP/qt+4DC4U+/RFDG5biP+gFZVf540e2QFoYikWlhvj0R1klg6T5G6DtHyoa
+        2sZ9oN1xW5842pA+o09IQLgr+RXf028iG9rO/m3a/ZzIivuGxGCDWEQ4iP5saQAvq2LZnlRlmU+F
+        hTrsxMPDZJgpBf2ISEw4HSz9SX+ASh224M+Fe4KmDDT8iN/m36R9CEj77nCDvsOo8O8BRDdx9Jt5
+        RXgQMO0f2kjZQ0G4D7Stfm7ZiwHavxzzanP3ATcEAelT4RgFZf/mFvQXELEQf7bZiQBOafiToiza
+        AqqS6L7MWV0RZ9yCUe76n/+IbQSE+0Db6ud2Whmg/ctxiTZ3H3BDEJA+FTZRUPZvbkF/AREL8Wed
+        bSIM0olG7hImF8uqaYsprTW2xfKixx0YrVBbf3NzwZ8CfUJf/pCJDT7ioYcfSSs7/QzL/sW9KDPw
+        uyCs+UCmE03sH3ib/nCzod+6DywU+rTDXvzTTohB0vwN0PYP5RVt4z7Q7ritTxxtSJ/RJx570q/4
+        nn4T1tB29m/T7jbcQQxA/9u91Uwv8rYupk/z82JJWgQwfjTR5m+Atn/ovGob94F2x2194mhD+ow+
+        odnlruRXfE+/ycRqO/u3afehE93Mszqf/eQXZ4tYag4oGNiCIvcbfoSh0W88Jv4aRDRTwRDsrPFf
+        /kv0mxJIQcZHQBpqh3we5+bc2qaF47t7aeD+/26gdjh3s7otzrNp+3IwymbsFA/BjYcTfqSI/1BH
+        u3FcRIiG+huIhhgH7U0wYKTDjxS9n80xkWV1ZvY2A5wVzdveaHrIKRKMufZPf9IfjKfFWpvRb6I9
+        g6YMNPyI3+bfpH0ISPvuaEN9h1Hh3wOITnHRb+YV0cGAaf/QRh2S2g+0rX5u1SsDtH855a3N3Qfc
+        EASkT0VjKij7N7egv4CIhXgbdUoz/BAeEs8w/eGmm/5gRct/GEeK/6A2QbZDAN+YviCAP9vJB2rB
+        OP8SQukHpFu+yFYr9uSAk+FJagoK0wzzrKMdGnzEQ6X/3xPO9porBekN+voW7XkWLPfd4oXOTN3q
+        HZ5yMIXh7Fu8w4jdftwdMYq+QZQmXeYr9ZO6appXqhc+r6v1yvzxRXWZj1L+/vV60kzrYoWe/K95
+        8jtKpVmSspxXPwrXFIT7QNvq51bwGaD9y+kRbe4+4IYgIH0qikRB2b+5Bf0FRCzEDrsSCzhB5IkR
+        Ufz/qWL52WZ3y+IUkjZvidEGnASeGkye4UBML7EXs5zODf1Jf/DkhUzLnws3B00ZaPgRv82/SfsQ
+        kPb9I+5nbuGJEX75/yX3A0aHXQsORuitHzEncYP9QNvq55Z5GKD9y/GiNncfcEMQkD4VZlRQ9m9u
+        QX8BEQvxdsxJjjxNJ3MdzS1m3/7BE81/kL/fz6TxH/RCkM//fz3bjn6ISrusLo6XWXlNicSeVGCW
+        hcv0N8eD/KlOm/whDB18xFMefiStLNszLPsX96JCwO+CocwHwsZoYv/A2/SH40L91n1godCnHbHi
+        n5YRDZLmb4C2f6iMaBv3gXbHbX3iaEP6jD7xxJJ+xff0m4iEtrN/m3Y/C1LBnm+dXxSgDCb4dZu1
+        4IRX/FlOiZqPfsn/A7kS4XIOVgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['3213']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [c0c0397f-6dc2-470d-b4af-71fa7d0ed257]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [c0c0397f-6dc2-470d-b4af-71fa7d0ed257]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010529Z:c0c0397f-6dc2-470d-b4af-71fa7d0ed257']
+    status: {code: 200, message: OK}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1617']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOriqxUpGPqA35KmH7UqhI40Rhgui7pdZ+UXLO80NdK+rCwPfETU
+        budT4os6K9emQZtdeCRg5qOP6BP+9ZJaWp3xUTOd57M1k/OjavnZ1hfbX40O7hySXZXfd+mP9gef
+        rcQuKsZgj29EI7w5ff3m9//JL6L8MUAEqxtkCD21S3j+kv8HBNZCNv8IAAA=
+    headers:
+      Azure-AsyncNotification: [Enabled]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/aa98974b-5d2a-4d98-a78a-382f3715d07e/providers/Microsoft.Compute/locations/southcentralus/operations/0b42fab2-c835-4400-9702-ef1142dedf0b?api-version=2018-10-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [1f48916a-476c-4d12-83d1-99811a59878b]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/PutVM3Min;238,Microsoft.Compute/PutVM30Min;1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [0b42fab2-c835-4400-9702-ef1142dedf0b]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010530Z:1f48916a-476c-4d12-83d1-99811a59878b']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.5.1
+          computemanagementclient/4.3.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2018-10-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz48OHuzszh5m59uT6c6D7f2D+/e2s0/zyfaDBwd7s739++f3
+        Pt37aKQvzbN6dpXV+cu6Oi/KnN5XcPTd5eJ18QN89NGTrCmmv//xzkfy3S8xbzdtVWcX0ZeLBX3x
+        Kj/P63w5Db6iL1frSVk087ymzz86yZbVsphmpUEKz0fVOb2Kr7+arJft+nVeX9Lffovm7Rrf7346
+        3tkf72w/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvzNdAqQ
+        l4vf/0uG8Pvv/v4H57sP9nZ2Hz58ON3Z/3Q/O/g0mzyYzD79NH9wvre/fxCAmdY54fTlqlUMn9XV
+        4gwUC1tl03mxvECDV3k2+25dtGGDRbakd2bAgBp5Y6DvdG6Op9OKCGhG9LrNljOa89//+auAXPRC
+        wdxzt1lPmmldMGrN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX0/zz
+        ulqvmrugzO9/ubhLXHpZzGga7n5RTOuqqc7b8Um1WK3b/O6MUG7ufg0qOpTdNBLygAdu/fwJDeLe
+        jvnGtflolrUZOoHIfM98mnaIVq4xHTv2LTz9OUdne7//frb/YHL/fPZg8uDh/r3JbHLw6c79+w/3
+        dx7cy7PzPOuQtzvlp4tVe91t4yb8RbUM5pq+3TDb9O37zje98nM54/jzFjT0MXaTiSec8t2dvXvu
+        219ifv2+/GLeJNGO6aqpoFi/0Im+XOzfX/yi6UX2YPW2uSoc3T7KZoti+VWT14YnMJo1/e21KaE0
+        TqrleXGxrjMQlRrazqgBIZ5Nyvxl1jRXVT07XrfzfNmSBtS251nZ5Ka9QZ3ea3LioZb5tzuuZd4S
+        qLfe4MxHZ0sa2Hk2han43i/mKf/ZnvEX0vPdHgZ3F9c/+cWLYvrRL/m+xXxWZBfLqqHhR6dmUlXt
+        U9fE/46+zZcgJA0pbet1riDxGGn4qi7oy4/mbbtqHt29G0xrk/FMXS7Gk7KajKdVnY+viuWsumrG
+        hPpdy3vKTRZlHjNsC4kqyRfpZOri9Xo6zfMZIYNW0vajVqXQ0cZIw2VRt+us/IIFnuZG2peVZYKP
+        iNztfEqMUWfl2jRoswuPBsx99BF9wr9eUkurND5qpvN8tmZ6flQtP9v6Yvur0cGdQzKs8vsu/dH+
+        4LOVGEbFGPzxQ1MJHSJY5SBD6OldwvOX/D8XkTxBAAkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 20 Dec 2018 01:05:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [4129ccd6-7d01-4368-bebb-cc1c0213e68e]
+      x-ms-ratelimit-remaining-resource: ['Microsoft.Compute/LowCostGet3Min;3990,Microsoft.Compute/LowCostGet30Min;31975']
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [a5e7633c-140a-4ab0-9073-d5764ad299c6]
+      x-ms-routing-request-id: ['CANADACENTRAL:20181220T010531Z:4129ccd6-7d01-4368-bebb-cc1c0213e68e']
+      x-ms-served-by: [5bf72e87-b853-4001-bd50-8d9de6e6ce78_131858177052582863]
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/test_tags.py
+++ b/tools/c7n_azure/tests/test_tags.py
@@ -686,7 +686,7 @@ class TagsTest(BaseTest):
             'data': {
                 'authorization': {
                     'evidence': {
-                        'principalType': 'Group'
+                        'principalType': 'User'
                     }
                 },
                 'claims': {
@@ -701,6 +701,51 @@ class TagsTest(BaseTest):
 
         after_tags = self.get_tags()
         self.assertEqual(after_tags['CreatorEmail'], 'cloud@custodian.com')
+
+    @arm_template('vm.json')
+    def test_auto_tag_user_event_grid_unknown_principal_event(self):
+        policy = self.load_policy(
+            {
+                'name': 'test-azure-tag',
+                'resource': 'azure.vm',
+                'mode': {
+                    'type': 'azure-event-grid',
+                    'events': [
+                        {
+                            'resourceProvider': 'Microsoft.Compute/virtualMachines',
+                            'event': 'write'
+                        }
+                    ]},
+                'actions': [
+                    {'type': 'auto-tag-user',
+                     'tag': 'CreatorEmail',
+                     'update': True}
+                ],
+            },
+            session_factory=None,
+            validate=True,
+        )
+
+        vm_id = self.get_vm_resource_id()
+
+        event = [{
+            'subject': vm_id,
+            'data': {
+                'authorization': {
+                    'evidence': {
+                        'principalType': 'Group'
+                    }
+                },
+                'claims': {
+                },
+                'operationName': 'Microsoft.Compute/virtualMachines/write',
+            }
+        }]
+
+        policy.push(event, None)
+
+        after_tags = self.get_tags()
+        self.assertEqual(after_tags['CreatorEmail'], 'Unknown')
 
     @arm_template('vm.json')
     def test_auto_tag_user_event_grid_user_event_missing_info(self):

--- a/tools/c7n_azure/tests/test_tags.py
+++ b/tools/c7n_azure/tests/test_tags.py
@@ -550,7 +550,7 @@ class TagsTest(BaseTest):
                     }
                 },
                 'claims': {
-                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name':
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn':
                         'cloud@custodian.com',
                 },
                 'operationName': 'Microsoft.Compute/virtualMachines/write',
@@ -654,6 +654,53 @@ class TagsTest(BaseTest):
 
         after_tags = self.get_tags()
         self.assertEqual(after_tags['CreatorEmail'], '12345')
+
+    @arm_template('vm.json')
+    def test_auto_tag_user_event_grid_group_event(self):
+        policy = self.load_policy(
+            {
+                'name': 'test-azure-tag',
+                'resource': 'azure.vm',
+                'mode': {
+                    'type': 'azure-event-grid',
+                    'events': [
+                        {
+                            'resourceProvider': 'Microsoft.Compute/virtualMachines',
+                            'event': 'write'
+                        }
+                    ]},
+                'actions': [
+                    {'type': 'auto-tag-user',
+                     'tag': 'CreatorEmail',
+                     'update': True}
+                ],
+            },
+            session_factory=None,
+            validate=True,
+        )
+
+        vm_id = self.get_vm_resource_id()
+
+        event = [{
+            'subject': vm_id,
+            'data': {
+                'authorization': {
+                    'evidence': {
+                        'principalType': 'Group'
+                    }
+                },
+                'claims': {
+                    'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn':
+                        'cloud@custodian.com',
+                },
+                'operationName': 'Microsoft.Compute/virtualMachines/write',
+            }
+        }]
+
+        policy.push(event, None)
+
+        after_tags = self.get_tags()
+        self.assertEqual(after_tags['CreatorEmail'], 'cloud@custodian.com')
 
     @arm_template('vm.json')
     def test_auto_tag_user_event_grid_user_event_missing_info(self):


### PR DESCRIPTION
- User, Office 365 Groups, and Security Groups will now use the UPN claim to determine the value of the principal that created them
- When we cannot determine the principal, we will use the value `Unknown`
- Fix #3172 