### PR TITLE
Adding slack notification via tag value

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/azure/azure_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/azure_queue_processor.py
@@ -81,7 +81,7 @@ class MailerAzureQueueProcessor(object):
             queue_message['policy']['name'],
             ', '.join(queue_message['action'].get('to'))))
 
-        if any(e.startswith('slack') or e.startswith('https://hooks.slack.com/')
+        if any(e.startswith('slack') or e.startswith('https://hooks.slack.com/') or e.startswith("slackchannel")
                 for e in queue_message.get('action', ()).get('to')):
             from c7n_mailer.slack_delivery import SlackDelivery
             slack_delivery = SlackDelivery(self.config,

--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -91,12 +91,7 @@ class SlackDelivery(object):
                     resource_list,
                     self.logger, 'slack_template', 'slack_default',
                     self.config['templates_folders'])
-#begin new
             elif target.startswith('slackchannel') and 'tags' in resource:
-                #for e in sqs_message.get('action', ()).get('to'):
-##add in check to see if it's an email
-                     # = resource.get()
-                    # if e.startswith('tags'):
                 tag_name = target.split(':', 1)[1]
                 result = resource.get('tags', {}).get(tag_name, None)
                 resolved_addrs = result

--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -97,16 +97,15 @@ class SlackDelivery(object):
 ##add in check to see if it's an email
                      # = resource.get()
                     # if e.startswith('tags'):
-                        tag_name = target.split(':', 1)[1]
-                        result = resource.get('tags', {}).get(tag_name, None)
-                        resolved_addrs = result
-                        slack_messages[resolved_addrs] = get_rendered_jinja(
-                            resolved_addrs, sqs_message,
-                            resource_list,
-                            self.logger, 'slack_template', 'slack_default',
-                            self.config['templates_folders'])
-                    else:
-                        return
+                tag_name = target.split(':', 1)[1]
+                result = resource.get('tags', {}).get(tag_name, None)
+                resolved_addrs = result
+                slack_messages[resolved_addrs] = get_rendered_jinja(
+                    resolved_addrs, sqs_message,
+                    resource_list,
+                    self.logger, 'slack_template', 'slack_default',
+                    self.config['templates_folders'])
+
                 self.logger.debug("Generating message for specified Slack channel.")
         return slack_messages
 


### PR DESCRIPTION
This addition gives a user the ability to specify "slackchannel:" in the to field of actions, and then specify a tag value from which to pull a slack delivery method from. Tested with Azure.