### PR TITLE
azure - Add `filter` property for Metric filet

### DIFF
--- a/docs/source/azure/policy/genericarmfilter.rst
+++ b/docs/source/azure/policy/genericarmfilter.rst
@@ -66,7 +66,7 @@ Find KeyVaults with more than 1000 API hits in the last hour
             threshold: 1000
             timeframe: 1
 
-Find SQL servers with less than 10% average DTU consumption over last 24 hours
+Find SQL servers with less than 10% average DTU consumption across all databases over last 24 hours
 
 .. code-block:: yaml
 
@@ -80,6 +80,7 @@ Find SQL servers with less than 10% average DTU consumption over last 24 hours
             op: lt
             threshold: 10
             timeframe: 24
+            filter:  "DatabaseResourceId eq '*'"
 
 
 Tag Filter

--- a/docs/source/azure/policy/resources/sqlserver.rst
+++ b/docs/source/azure/policy/resources/sqlserver.rst
@@ -59,6 +59,8 @@ This policy will find all SQL servers with average DTU consumption under 10 perc
             aggregation: average
             threshold: 10
             timeframe: 72
+            filter: "ElasticPoolResourceId eq '*'"
+            no_data_action: include
          actions:
           - type: notify
             template: default

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -86,7 +86,9 @@ class MetricFilter(Filter):
             'timeframe': {'type': 'number'},
             'interval': {'enum': [
                 'PT1M', 'PT5M', 'PT15M', 'PT30M', 'PT1H', 'PT6H', 'PT12H', 'P1D']},
-            'aggregation': {'enum': ['total', 'average']}
+            'aggregation': {'enum': ['total', 'average']},
+            'no_data_action': {'enum': ['include', 'exclude']},
+            'filter': {'type': 'string'}
         }
     }
 
@@ -106,6 +108,10 @@ class MetricFilter(Filter):
         self.aggregation = self.data.get('aggregation', self.DEFAULT_AGGREGATION)
         # Aggregation function to be used locally
         self.func = self.aggregation_funcs[self.aggregation]
+        # Used to reduce the set of metric data returned
+        self.filter = self.data.get('filter', None)
+        # Include or exclude resources if there is no metric data available
+        self.no_data_action = self.data.get('no_data_action', 'exclude')
 
     def process(self, resources, event=None):
         # Import utcnow function as it may have been overridden for testing purposes
@@ -130,13 +136,19 @@ class MetricFilter(Filter):
             timespan=self.timespan,
             interval=self.interval,
             metricnames=self.metric,
-            aggregation=self.aggregation
+            aggregation=self.aggregation,
+            filter=self.filter
         )
-        m = [getattr(item, self.aggregation) for item in metrics_data.value[0].timeseries[0].data]
+        if len(metrics_data.value) > 0 and len(metrics_data.value[0].timeseries) > 0:
+            m = [getattr(item, self.aggregation) for item in metrics_data.value[0].timeseries[0].data]
+        else:
+            m = None
         return m
 
     def passes_op_filter(self, resource):
         m_data = self.get_metric_data(resource)
+        if m_data is None:
+            return self.no_data_action == 'include'
         aggregate_value = self.func(m_data)
         return self.op(aggregate_value, self.threshold)
 

--- a/tools/c7n_azure/tests/cassettes/SqlServerTest.test_find_by_name.yaml
+++ b/tools/c7n_azure/tests/cassettes/SqlServerTest.test_find_by_name.yaml
@@ -1,0 +1,39 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.3 (Linux-4.9.125-linuxkit-x86_64-with-centos-7.5.1804-Core)
+          msrest/0.6.2 msrest_azure/0.6.0 azure-mgmt-sql/0.11.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/servers?api-version=2015-05-01-preview
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR22I5++jRR5e7e+Odj0YfrepqlddtkTcfPfrFH2WzRbEsmrbO2qp+Xl0US2o6XTdt
+        NSuyJTW/zOumqPCpvt+0WUuAP3qVZ7Nr+vt8XZbXP7HOyuK8yGdPq0VWLF9kCzSZTtu8aZtfVDZ5
+        TXB29/Y+3dvZPRjPsjabZE0+viLUqqtmvMzbj37J6KOymmatdJZnTbtu9gh+AeTvNutJM62LFb5u
+        7mbZw4OHD/Yn2/dne9n2/uzhwXb24CDbvnewd37vwe792c6D/G6dN9W6nuaf19V61dwFKr+/xeUu
+        keGymNHg7n5RTOuqqc7b8etfVN6Vr5u7A7gTQsuNg6MG7fUKDaJwP/ol3/8l/w+XDs29nQEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 26 Dec 2018 22:12:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [ca6b2c26-908a-4cde-b763-ae6c0378842c]
+      x-ms-ratelimit-remaining-subscription-reads: ['11997']
+      x-ms-request-id: [bba5c1f0-3df2-4a1b-b5db-b73ea1c0ca49]
+      x-ms-routing-request-id: ['WESTUS2:20181226T221247Z:ca6b2c26-908a-4cde-b763-ae6c0378842c']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/SqlServerTest.test_metric_database.yaml
+++ b/tools/c7n_azure/tests/cassettes/SqlServerTest.test_metric_database.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.3 (Linux-4.9.125-linuxkit-x86_64-with-centos-7.5.1804-Core)
+          msrest/0.6.2 msrest_azure/0.6.0 azure-mgmt-sql/0.11.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/servers?api-version=2015-05-01-preview
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR22I5++jRR5e7e+Odj0YfrepqlddtkTcfPfrFH2WzRbEsmrbO2qp+Xl0US2o6XTdt
+        NSuyJTW/zOumqPCpvt+0WUuAP3qVZ7Nr+vt8XZbXP7HOyuK8yGdPq0VWLF9kCzSZTtu8aZtfVDZ5
+        TXB29/Y+3dvZPRjPsjabZE0+viLUqqtmvMzbj37J6KOymmatdJZnTbtu9gh+AeTvNutJM62LFb5u
+        7mbZw4OHD/Yn2/dne9n2/uzhwXb24CDbvnewd37vwe792c6D/G6dN9W6nuaf19V61dwFKr+/xeUu
+        keGymNHg7n5RTOuqqc7b8etfVN6Vr5u7A7gTQsuNg6MG7fUKDaJwP/ol3/8l/w+XDs29nQEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 26 Dec 2018 22:12:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [349309ab-87f1-492a-89de-563601f8f5a2]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [886ad55b-d92a-48d0-8739-db3af2fc4616]
+      x-ms-routing-request-id: ['WESTUS2:20181226T221247Z:349309ab-87f1-492a-89de-563601f8f5a2']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.3 (Linux-4.9.125-linuxkit-x86_64-with-centos-7.5.1804-Core)
+          msrest/0.6.2 msrest_azure/0.6.0 azure-mgmt-monitor/0.5.2 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserver12262018/providers/microsoft.insights/metrics?timespan=2018-12-23%2014%3A10%3A00%2F2018-12-26%2014%3A10%3A00&interval=P1D&metricnames=dtu_consumption_percent&aggregation=average&$filter=DatabaseResourceId%20eq%20%27%2A%27&api-version=2018-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR9Oq
+        aT96tDP6qC0WebPKlh89+mhvZ/dge3dve+/em939R7s7j3Z2fuqu/fBT9+FHo4+KZZvXl1lJr73c
+        fUof0O/r/KNH3/vFHxUz+vBus54007pYtUW1bO5m2cODhw/2J9v3Z3vZ9v7s4cF29uAg2753sHd+
+        78Hu/dnOg/xunTfVup7mn9fVetXcbfOm/f2bX1Q21FFe313V1WUxy+vm7hfFtK6a6rwdv/5F5V35
+        urk7neIF2353b+9T4B5972zZFBfztrm7yNu6mDZ3Z+36958SousFI/z7r3LCY9nSuNrrFQ3ro+F3
+        qc0yW1CbX2xo8NEwtLKaZmXxg3z2k9r06ZuvUv06u8g/+iWjj9bLgmbmo5fyIb3DM5TXRd4weanb
+        bJa1GXcmH3X7f0pfT7Imf6UEPZsRmH7X/VbUvYFx9/VXT16fvDp7+ebsyxev7x4f8wQ+2b7/dO94
+        e/8pTeDxg4NjTOAzTODTnQend1+dvv7yq1cnp5+/+vKrl6/vvjl9/eb3f/0Tz1+fvvrJ01d3X776
+        8ifPnp6+en33i7OTV1++/vLZmzF9e1e+fn335AQv0CfygZ3Ap8dvjp8cvz6l945fvzl99dEv+f7o
+        I1CAxw7qvG6zxYpwRnPmVY+BaeQZsQOI+2hnvPNLRgOv7L//K/eHX/k+/hPGIOGa0qceB3lcS+8Z
+        rq/zC+IVaphnTbtu9j76Jf8PhjJFoqYDAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Wed, 26 Dec 2018 22:12:48 GMT']
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: ['Accept-Encoding,Accept-Encoding']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      __HandlingServerId__: [shoeboxproxyusone_shoeboxproxyusone-red_MetricsMP_IN_7]
+      x-ms-correlation-request-id: [58853cf1-6ac3-4dc3-bcf1-7c6ef8e882db]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: ['{58853cf1-6ac3-4dc3-bcf1-7c6ef8e882db}']
+      x-ms-routing-request-id: ['WESTUS2:20181226T221249Z:58853cf1-6ac3-4dc3-bcf1-7c6ef8e882db']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/SqlServerTest.test_metric_elastic_exclude.yaml
+++ b/tools/c7n_azure/tests/cassettes/SqlServerTest.test_metric_elastic_exclude.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.3 (Linux-4.9.125-linuxkit-x86_64-with-centos-7.5.1804-Core)
+          msrest/0.6.2 msrest_azure/0.6.0 azure-mgmt-sql/0.11.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/servers?api-version=2015-05-01-preview
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR22I5++jRR5e7e+Odj0YfrepqlddtkTcfPfrFH2WzRbEsmrbO2qp+Xl0US2o6XTdt
+        NSuyJTW/zOumqPCpvt+0WUuAP3qVZ7Nr+vt8XZbXP7HOyuK8yGdPq0VWLF9kCzSZTtu8aZtfVDZ5
+        TXB29/Y+3dvZPRjPsjabZE0+viLUqqtmvMzbj37J6KOymmatdJZnTbtu9gh+AeTvNutJM62LFb5u
+        7mbZw4OHD/Yn2/dne9n2/uzhwXb24CDbvnewd37vwe792c6D/G6dN9W6nuaf19V61dwFKr+/xeUu
+        keGymNHg7n5RTOuqqc7b8etfVN6Vr5u7A7gTQsuNg6MG7fUKDaJwP/ol3/8l/w+XDs29nQEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 26 Dec 2018 22:12:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [65ef2f15-a760-44a2-864f-d26120780434]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [217320cb-5b87-4ea3-89a7-7d25df35efb5]
+      x-ms-routing-request-id: ['WESTUS2:20181226T221249Z:65ef2f15-a760-44a2-864f-d26120780434']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.3 (Linux-4.9.125-linuxkit-x86_64-with-centos-7.5.1804-Core)
+          msrest/0.6.2 msrest_azure/0.6.0 azure-mgmt-monitor/0.5.2 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserver12262018/providers/microsoft.insights/metrics?timespan=2018-12-23%2014%3A10%3A00%2F2018-12-26%2014%3A10%3A00&interval=P1D&metricnames=dtu_consumption_percent&aggregation=average&$filter=ElasticPoolResourceId%20eq%20%27%2A%27&api-version=2018-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR9Oq
+        aT96tDP6qC0WebPKlh89+mhvZ/dge3dve+/em939R7s7j3Z2fuqu/fBT9+FHo4+KZZvXl1lJr73c
+        fUof0O/r/KNH3/vFHxUz+vBus54007pYtUW1bO5m2cODhw/2J9v3Z3vZ9v7s4cF29uAg2753sHd+
+        78Hu/dnOg/xunTfVup7mn9fVetXcbfOm/f2bX1Q21FFe313V1WUxy+vm7hfFtK6a6rwdv/5F5V35
+        urk7neIF2353b+9T4B5972zZFBfztrm7yNu6mDZ3Z+36958SousFI/z7r3LCY9nSuNrrFQ3ro+F3
+        qc0yW1CbX2xo8NEwtLKaZmXxg3z2k9r06ZuvUv06u8g/+iWjj9bLgmbmo5fyIb3DM5TXRd4Qeb//
+        S74v/dGcTQHAIeYRg94yxKzzC0KBGuZZ066bvY9+yf8Di1wiBP0BAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Wed, 26 Dec 2018 22:12:49 GMT']
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: ['Accept-Encoding,Accept-Encoding']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      __HandlingServerId__: [shoeboxproxyusone_shoeboxproxyusone-black_MetricsMP_IN_3]
+      x-ms-correlation-request-id: [d67acba5-3459-4051-8a06-6de017f8ad05]
+      x-ms-ratelimit-remaining-subscription-reads: ['11996']
+      x-ms-request-id: ['{d67acba5-3459-4051-8a06-6de017f8ad05}']
+      x-ms-routing-request-id: ['WESTUS2:20181226T221250Z:d67acba5-3459-4051-8a06-6de017f8ad05']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/SqlServerTest.test_metric_elastic_include.yaml
+++ b/tools/c7n_azure/tests/cassettes/SqlServerTest.test_metric_elastic_include.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.3 (Linux-4.9.125-linuxkit-x86_64-with-centos-7.5.1804-Core)
+          msrest/0.6.2 msrest_azure/0.6.0 azure-mgmt-sql/0.11.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/servers?api-version=2015-05-01-preview
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR22I5++jRR5e7e+Odj0YfrepqlddtkTcfPfrFH2WzRbEsmrbO2qp+Xl0US2o6XTdt
+        NSuyJTW/zOumqPCpvt+0WUuAP3qVZ7Nr+vt8XZbXP7HOyuK8yGdPq0VWLF9kCzSZTtu8aZtfVDZ5
+        TXB29/Y+3dvZPRjPsjabZE0+viLUqqtmvMzbj37J6KOymmatdJZnTbtu9gh+AeTvNutJM62LFb5u
+        7mbZw4OHD/Yn2/dne9n2/uzhwXb24CDbvnewd37vwe792c6D/G6dN9W6nuaf19V61dwFKr+/xeUu
+        keGymNHg7n5RTOuqqc7b8etfVN6Vr5u7A7gTQsuNg6MG7fUKDaJwP/ol3/8l/w+XDs29nQEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 26 Dec 2018 22:12:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [53ae5d30-f2be-470b-9dbb-dc61965a8366]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [ea711d71-b564-41fa-ad5a-e80bb03061e7]
+      x-ms-routing-request-id: ['WESTUS2:20181226T221250Z:53ae5d30-f2be-470b-9dbb-dc61965a8366']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.3 (Linux-4.9.125-linuxkit-x86_64-with-centos-7.5.1804-Core)
+          msrest/0.6.2 msrest_azure/0.6.0 azure-mgmt-monitor/0.5.2 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserver12262018/providers/microsoft.insights/metrics?timespan=2018-12-23%2014%3A10%3A00%2F2018-12-26%2014%3A10%3A00&interval=P1D&metricnames=dtu_consumption_percent&aggregation=average&$filter=ElasticPoolResourceId%20eq%20%27%2A%27&api-version=2018-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR9Oq
+        aT96tDP6qC0WebPKlh89+mhvZ/dge3dve+/em939R7s7j3Z2fuqu/fBT9+FHo4+KZZvXl1lJr73c
+        fUof0O/r/KNH3/vFHxUz+vBus54007pYtUW1bO5m2cODhw/2J9v3Z3vZ9v7s4cF29uAg2753sHd+
+        78Hu/dnOg/xunTfVup7mn9fVetXcbfOm/f2bX1Q21FFe313V1WUxy+vm7hfFtK6a6rwdv/5F5V35
+        urk7neIF2353b+9T4B5972zZFBfztrm7yNu6mDZ3Z+36958SousFI/z7r3LCY9nSuNrrFQ3ro+F3
+        qc0yW1CbX2xo8NEwtLKaZmXxg3z2k9r06ZuvUv06u8g/+iWjj9bLgmbmo5fyIb3DM5TXRd4Qeb//
+        S74v/dGcTQHAIeYRg94yxKzzC0KBGuZZ066bvY9+yf8Di1wiBP0BAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Wed, 26 Dec 2018 22:12:51 GMT']
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: ['Accept-Encoding,Accept-Encoding']
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      __HandlingServerId__: [shoeboxproxyusone_shoeboxproxyusone-red_MetricsMP_IN_0]
+      x-ms-correlation-request-id: [fb3df9a3-3fa7-43a7-b115-0ce8779bb790]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: ['{fb3df9a3-3fa7-43a7-b115-0ce8779bb790}']
+      x-ms-routing-request-id: ['WESTUS2:20181226T221251Z:fb3df9a3-3fa7-43a7-b115-0ce8779bb790']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/templates/sqlserver.json
+++ b/tools/c7n_azure/tests/templates/sqlserver.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+  },
+  "variables": {
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Sql/servers",
+      "location": "EastUS2",
+      "name": "cctestsqlserver12262018",
+      "properties": {
+        "administratorLogin": "custodian",
+        "administratorLoginPassword": "Cust0dianPassw0rd" ,
+        "version": "12.0"
+      },
+    },
+  ],
+  "outputs": {}
+}

--- a/tools/c7n_azure/tests/test_sqlserver.py
+++ b/tools/c7n_azure/tests/test_sqlserver.py
@@ -1,0 +1,102 @@
+# Copyright 2015-2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from azure_common import BaseTest
+
+import datetime
+from mock import patch
+
+
+class SqlServerTest(BaseTest):
+
+    TEST_DATE = datetime.datetime(2018, 12, 26, 14, 10, 00)
+
+    def test_sql_server_schema_validate(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-policy-assignment',
+                'resource': 'azure.sqlserver'
+            }, validate=True)
+            self.assertTrue(p)
+
+    # run ./templates/provision.sh sqlserver to deploy required resource.
+    def test_find_by_name(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-server',
+            'resource': 'azure.sqlserver',
+            'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'eq',
+                 'value_type': 'normalize',
+                 'value': 'cctestsqlserver12262018'}],
+        })
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    @patch('c7n_azure.actions.utcnow', return_value=TEST_DATE)
+    def test_metric_elastic_exclude(self, utcnow):
+        p = self.load_policy({
+            'name': 'test-azure-sql-server',
+            'resource': 'azure.sqlserver',
+            'filters': [
+                {'type': 'metric',
+                 'metric': 'dtu_consumption_percent',
+                 'op': 'lt',
+                 'aggregation': 'average',
+                 'threshold': 10,
+                 'timeframe': 72,
+                 'filter': "ElasticPoolResourceId eq '*'"
+                 }],
+        })
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    @patch('c7n_azure.actions.utcnow', return_value=TEST_DATE)
+    def test_metric_elastic_include(self, utcnow):
+        p = self.load_policy({
+            'name': 'test-azure-sql-server',
+            'resource': 'azure.sqlserver',
+            'filters': [
+                {'type': 'metric',
+                 'metric': 'dtu_consumption_percent',
+                 'op': 'lt',
+                 'aggregation': 'average',
+                 'threshold': 10,
+                 'timeframe': 72,
+                 'filter': "ElasticPoolResourceId eq '*'",
+                 'no_data_action': 'include'
+                 }],
+        })
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    @patch('c7n_azure.actions.utcnow', return_value=TEST_DATE)
+    def test_metric_database(self, utcnow):
+        p = self.load_policy({
+            'name': 'test-azure-sql-server',
+            'resource': 'azure.sqlserver',
+            'filters': [
+                {'type': 'metric',
+                 'metric': 'dtu_consumption_percent',
+                 'op': 'lt',
+                 'aggregation': 'average',
+                 'threshold': 10,
+                 'timeframe': 72,
+                 'filter': "DatabaseResourceId eq '*'"
+                 }],
+        })
+        resources = p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
- allow user to specify 'filter' (to reduce set of data) rules in Azure Metrics filter
- add no_data_action property: if there is no metric data, include or exclude those resources from results
- add tests for azure.sqlserver
- update examples

Filter is required for dtu_consumption_procent metric, see this thread for details: https://github.com/Azure/azure-libraries-for-net/issues/181

https://github.com/cloud-custodian/cloud-custodian/issues/3086
