### PR TITLE
coverage only on package files in tools not tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 
 [testenv:py27-cov]
 commands =
-    py.test -n {env:C7N_TEST_WORKERS:auto} --junitxml=junit/test-results.xml --cov c7n --cov tools/c7n_azure --cov tools/c7n_gcp --cov tools/c7n_mailer --durations 20 tests tools {posargs}
+    py.test -n {env:C7N_TEST_WORKERS:auto} --junitxml=junit/test-results.xml --cov c7n --cov tools/c7n_azure/c7n_azure --cov tools/c7n_gcp/c7n_gcp --cov tools/c7n_mailer/c7n_mailer --durations 20 tests tools {posargs}
 
 [testenv:py36]
 commands =


### PR DESCRIPTION

else we get coverage on unit tests and setup files, etc.