### PR TITLE
gcp - coverage backfill on serverless

### DIFF
--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -88,7 +88,7 @@ class UserCredentialReportTest(BaseTest):
                  "report_max_age": 1543724277,
                  "key": "access_keys.last_used_date",
                  "value": 30,
-                 'op': 'less-than',
+                 'op': 'greater-than',
                  "value_type": "age"},
                 {"type": "credential",
                  "report_max_age": 1543724277,

--- a/tools/c7n_gcp/tests/data/flights/mu-api-subscriber-run/get-bigquery-v2-projects-custodian-1291-datasets-devxyz_1.json
+++ b/tools/c7n_gcp/tests/data/flights/mu-api-subscriber-run/get-bigquery-v2-projects-custodian-1291-datasets-devxyz_1.json
@@ -1,0 +1,54 @@
+{
+  "headers": {
+    "etag": "8bEApZUgaFnEC8oHWsexkA==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Wed, 02 Jan 2019 12:23:19 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "1; mode=block",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39,35\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "783",
+    "-content-encoding": "gzip",
+    "content-location": "https://www.googleapis.com/bigquery/v2/projects/custodian-1291/datasets/devxyz?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#dataset",
+    "etag": "8bEApZUgaFnEC8oHWsexkA==",
+    "id": "custodian-1291:devxyz",
+    "selfLink": "https://www.googleapis.com/bigquery/v2/projects/custodian-1291/datasets/devxyz",
+    "datasetReference": {
+      "datasetId": "devxyz",
+      "projectId": "custodian-1291"
+    },
+    "defaultTableExpirationMs": "432000000",
+    "labels": {
+      "env": "dev"
+    },
+    "access": [
+      {
+        "role": "WRITER",
+        "specialGroup": "projectWriters"
+      },
+      {
+        "role": "OWNER",
+        "specialGroup": "projectOwners"
+      },
+      {
+        "role": "OWNER",
+        "userByEmail": "kapilt@gmail.com"
+      },
+      {
+        "role": "READER",
+        "specialGroup": "projectReaders"
+      }
+    ],
+    "creationTime": "1545638193635",
+    "lastModifiedTime": "1545639501954",
+    "location": "US"
+  }
+}

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -18,6 +18,8 @@ import os
 import shutil
 import sys
 
+import mock
+
 from c7n.exceptions import PolicyValidationError
 from c7n.policy import PolicyCollection
 from c7n.testing import functional
@@ -61,7 +63,8 @@ class FunctionTest(BaseTest):
             func_info['name'],
             'projects/custodian-1291/locations/us-central1/functions/custodian-dev')
 
-    def test_handler_run(self):
+    @mock.patch('c7n.policy.PolicyCollection.from_data')
+    def test_handler_run(self, from_data):
         func_cwd = self.get_temp_dir()
         output_temp = self.get_temp_dir()
         pdata = {
@@ -79,7 +82,7 @@ class FunctionTest(BaseTest):
 
         self.patch(p, 'push', lambda evt, ctx: None)
         self.patch(handler, 'get_tmp_output_dir', lambda: output_temp)
-        self.patch(PolicyCollection, 'from_data', lambda data, config: [p])
+        from_data.return_value = [p]
         self.change_cwd(func_cwd)
         self.assertEqual(handler.run(event), True)
 

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -21,7 +21,6 @@ import sys
 import mock
 
 from c7n.exceptions import PolicyValidationError
-from c7n.policy import PolicyCollection
 from c7n.testing import functional
 
 from c7n_gcp import handler, mu, policy

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -75,8 +75,7 @@ class FunctionTest(BaseTest):
             fh.write(json.dumps({'policies': [pdata]}))
 
         event = event_data('bq-dataset-create.json')
-        factory = self.replay_flight_data('mu-handler-run')
-        p = self.load_policy(pdata, session_factory=factory)
+        p = self.load_policy(pdata)
 
         self.patch(p, 'push', lambda evt, ctx: None)
         self.patch(handler, 'get_tmp_output_dir', lambda: output_temp)

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import time
+import os
+import shutil
+import sys
 
 from c7n.exceptions import PolicyValidationError
+from c7n.policy import PolicyCollection
 from c7n.testing import functional
-from c7n_gcp import mu
-from gcp_common import BaseTest
+
+from c7n_gcp import handler, mu, policy
+
+from gcp_common import BaseTest, event_data
 
 
 HELLO_WORLD = """\
@@ -53,6 +60,44 @@ class FunctionTest(BaseTest):
         self.assertEqual(
             func_info['name'],
             'projects/custodian-1291/locations/us-central1/functions/custodian-dev')
+
+    def test_handler_run(self):
+        func_cwd = self.get_temp_dir()
+        output_temp = self.get_temp_dir()
+        pdata = {
+            'name': 'dataset-created',
+            'resource': 'gcp.bq-dataset',
+            'mode': {
+                'type': 'gcp-audit',
+                'methods': ['datasetservice.insert']}}
+
+        with open(os.path.join(func_cwd, 'config.json'), 'w') as fh:
+            fh.write(json.dumps({'policies': [pdata]}))
+
+        event = event_data('bq-dataset-create.json')
+        factory = self.replay_flight_data('mu-handler-run')
+        p = self.load_policy(pdata, session_factory=factory)
+
+        self.patch(p, 'push', lambda evt, ctx: None)
+        self.patch(handler, 'get_tmp_output_dir', lambda: output_temp)
+        self.patch(PolicyCollection, 'from_data', lambda data, config: [p])
+        self.change_cwd(func_cwd)
+        self.assertEqual(handler.run(event), True)
+
+    def test_handler_tmp_dir(self):
+        # platform specific test ..
+        if sys.platform not in ('linux2', 'darwin'):
+            return
+        tmp_dir = handler.get_tmp_output_dir()
+        self.assertTrue(tmp_dir.startswith('/tmp'))
+        self.addCleanup(shutil.rmtree, tmp_dir)
+
+    def test_abstract_gcp_mode(self):
+        p = self.load_policy({'name': 'instance', 'resource': 'gcp.instance'})
+        exec_mode = policy.FunctionMode(p)
+        self.assertRaises(NotImplementedError, exec_mode.run)
+        self.assertRaises(NotImplementedError, exec_mode.provision)
+        self.assertEqual(None, exec_mode.validate())
 
     def test_periodic_validate_tz(self):
         self.assertRaises(
@@ -128,6 +173,22 @@ class FunctionTest(BaseTest):
         if self.recording:
             time.sleep(52)
         p.get_execution_mode().deprovision()
+
+    def test_api_subscriber_run(self):
+        factory = self.replay_flight_data('mu-api-subscriber-run')
+        p = self.load_policy({
+            'name': 'dataset-created',
+            'resource': 'gcp.bq-dataset',
+            'mode': {
+                'type': 'gcp-audit',
+                'methods': ['datasetservice.insert']}},
+            session_factory=factory)
+        exec_mode = p.get_execution_mode()
+        self.assertTrue(isinstance(exec_mode, policy.ApiAuditMode))
+        event = event_data('bq-dataset-create.json')
+        resources = exec_mode.run(event, None)
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['labels'], {'env': 'dev'})
 
     @functional
     def test_api_subscriber(self):


### PR DESCRIPTION
Add some additional unit tests on a few modules where coverage report were low, primarily c7n_gcp/policy.py and c7n_gcp/handler.py

