### PR TITLE
azure - pin EventGrid sdk to RC2

### DIFF
--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -65,7 +65,7 @@ setup(
                       "azure-mgmt-monitor",
                       "azure-mgmt-policyinsights",
                       "azure-mgmt-subscription",
-                      "azure-mgmt-eventgrid>=2.0.0rc1",
+                      "azure-mgmt-eventgrid==2.0.0rc2",  # RC2 supports AdvancedFilters
                       "azure-graphrbac",
                       "azure-storage-blob",
                       "azure-storage-queue",


### PR DESCRIPTION
- We need RC2 because it provides the AdvancedFilters needed for Azure Functions for event based sourcees
-  https://pypi.org/project/azure-mgmt-eventgrid/2.0.0/
