### PR TITLE
aws.s3 - 'Logging' key not present on all s3 buckets

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1283,7 +1283,7 @@ class ToggleLogging(BucketActionBase):
 
         for r in resources:
             client = bucket_client(session, r)
-            is_logging = bool(r['Logging'])
+            is_logging = bool(r.get('Logging'))
 
             if enabled and not is_logging:
                 variables = {
@@ -2022,7 +2022,7 @@ class LogTarget(Filter):
     def get_s3_bucket_locations(buckets, self_log=False):
         """return (bucket_name, prefix) for all s3 logging targets"""
         for b in buckets:
-            if b['Logging']:
+            if b.get('Logging'):
                 if self_log:
                     if b['Name'] != b['Logging']['TargetBucket']:
                         continue


### PR DESCRIPTION
- is-log-target filter error
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/c7n/commands.py", line 237, in run
    policy()
  File "/usr/local/lib/python2.7/site-packages/c7n/policy.py", line 866, in __call__
    resources = PullMode(self).run()
  File "/usr/local/lib/python2.7/site-packages/c7n/policy.py", line 232, in run
    resources = self.policy.resource_manager.resources()
  File "/usr/local/lib/python2.7/site-packages/c7n/query.py", line 413, in resources
    resources = self.filter_resources(resources)
  File "/usr/local/lib/python2.7/site-packages/c7n/manager.py", line 105, in filter_resources
    resources = f.process(resources, event)
  File "/usr/local/lib/python2.7/site-packages/c7n/resources/s3.py", line 2005, in process
    for bucket, _ in self.get_s3_bucket_locations(buckets, self_log):
  File "/usr/local/lib/python2.7/site-packages/c7n/resources/s3.py", line 2025, in get_s3_bucket_locations
    if b['Logging']:
KeyError: u'Logging'
```
- toggle-logging action error
```
Traceback (most recent call last):
  File "/src/c7n/policy.py", line 264, in run
    results = a.process(resources)
  File "/src/c7n/resources/s3.py", line 1286, in process
    is_logging = bool(r['Logging'])
KeyError: u'Logging'
```