### PR TITLE
azure - default to consumption plan for event based Functions infrastructure

### DIFF
--- a/docs/source/azure/advanced/azurefunctions.rst
+++ b/docs/source/azure/advanced/azurefunctions.rst
@@ -43,7 +43,7 @@ keys:
   - name (default: cloud-custodian)
   - location (default: West US 2)
   - resourceGroupName (default: cloud-custodian)
-  - skuTier (default: dynamic) # consumption
+  - skuTier (default: Dynamic) # consumption
   - skuName (default: None)
 - storageAccount
   - name (default: custodian + sha256(resourceGroupName+subscription_id)[:8])

--- a/docs/source/azure/advanced/azurefunctions.rst
+++ b/docs/source/azure/advanced/azurefunctions.rst
@@ -42,7 +42,7 @@ keys:
 
 - servicePlan
   - name (default: cloud-custodian)
-  - location (default: West US 2)
+  - location (default: East US)
   - resourceGroupName (default: cloud-custodian)
   - skuTier (default: Dynamic) # consumption
   - skuName (default: Y1)

--- a/docs/source/azure/advanced/azurefunctions.rst
+++ b/docs/source/azure/advanced/azurefunctions.rst
@@ -30,6 +30,7 @@ When deploying an Azure function the following ARM resources are required and cr
 Functions can be ran in either a dedicated Application Service Plan (Basic, Standard or Premium) or in a Consumption plan.
 More details on the different hosting models offered by Azure Functions can be found `here <https://docs.microsoft.com/en-us/azure/azure-functions/functions-scale>`_.
 By default, we will run all Custodian policies using the Consumption hosting model. (i.e. skuTier=dynamic)
+Linux Consumption is currently only available in the following regions: East Asia, East US, West Europe, and West US
 
 A dedicated plan can service multiple Function Applications.  If you provide the same servicePlanName with all policies or
 use the default name then only new Function Applications will be created during deployment, all using the same
@@ -44,7 +45,7 @@ keys:
   - location (default: West US 2)
   - resourceGroupName (default: cloud-custodian)
   - skuTier (default: Dynamic) # consumption
-  - skuName (default: None)
+  - skuName (default: Y1)
 - storageAccount
   - name (default: custodian + sha256(resourceGroupName+subscription_id)[:8])
   - location (default: servicePlan location)

--- a/docs/source/azure/advanced/azurefunctions.rst
+++ b/docs/source/azure/advanced/azurefunctions.rst
@@ -27,9 +27,12 @@ When deploying an Azure function the following ARM resources are required and cr
 - Application Service Plan (shared across functions)
 - Application Service (per function)
 
-A single Application Service Plan (Basic, Standard or Premium) can service a large number
-of Application Service Instances.  If you provide the same servicePlanName with all policies or
-use the default name then only new Applications will be created during deployment, all using the same
+Functions can be ran in either a dedicated Application Service Plan (Basic, Standard or Premium) or in a Consumption plan.
+More details on the different hosting models offered by Azure Functions can be found `here <https://docs.microsoft.com/en-us/azure/azure-functions/functions-scale>`_.
+By default, we will run all Custodian policies using the Consumption hosting model. (i.e. skuTier=dynamic)
+
+A dedicated plan can service multiple Function Applications.  If you provide the same servicePlanName with all policies or
+use the default name then only new Function Applications will be created during deployment, all using the same
 shared plan resources.
 
 Execution in Azure functions comes with a default set of configurations for the provisioned
@@ -40,8 +43,8 @@ keys:
   - name (default: cloud-custodian)
   - location (default: West US 2)
   - resourceGroupName (default: cloud-custodian)
-  - skuTier (default: Basic)
-  - skuName (default: B1)
+  - skuTier (default: dynamic) # consumption
+  - skuName (default: None)
 - storageAccount
   - name (default: custodian + sha256(resourceGroupName+subscription_id)[:8])
   - location (default: servicePlan location)

--- a/docs/source/azure/advanced/azurefunctions.rst
+++ b/docs/source/azure/advanced/azurefunctions.rst
@@ -27,8 +27,8 @@ When deploying an Azure function the following ARM resources are required and cr
 - Application Service Plan (shared across functions)
 - Application Service (per function)
 
-Functions can be ran in either a dedicated Application Service Plan (Basic, Standard or Premium) or in a Consumption plan.
-More details on the different hosting models offered by Azure Functions can be found `here <https://docs.microsoft.com/en-us/azure/azure-functions/functions-scale>`_.
+Functions can be deployed in either a dedicated Application Service Plan (Basic, Standard or Premium) or in a Consumption plan.
+More details on the different hosting models offered by Azure Functions can be found in the `Azure Functions documentation <https://docs.microsoft.com/en-us/azure/azure-functions/functions-scale>`_.
 By default, we will run all Custodian policies using the Consumption hosting model. (i.e. skuTier=dynamic)
 Linux Consumption is currently only available in the following regions: East Asia, East US, West Europe, and West US
 
@@ -63,7 +63,7 @@ West Europe. The sku, skuCode, and workerSize correlate to scaling up the App Se
 If specified resources already exist in the subscription (discoverable by resource group name and resource name), Cloud Custodian won't make any changes (location, sku)
 and will use existing resources as-is. If resource doesn't exist, it will be provisioned using provided configuration.
 
-If you have existing infrastructure, you can specify resource ids for the following itesm (instead of applying previous schema):
+If you have existing infrastructure, you can specify resource ids for the following items (instead of applying previous schema):
 
 - storageAccount
 - servicePlan

--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -3,7 +3,7 @@ Azure Functions
 """
 # Docker version from https://hub.docker.com/r/microsoft/azure-functions/
 FUNCTION_DOCKER_VERSION = 'DOCKER|mcr.microsoft.com/azure-functions/python:latest'
-FUNCTION_EXT_VERSION = 'beta'
+FUNCTION_EXT_VERSION = '~2'
 FUNCTION_EVENT_TRIGGER_MODE = 'azure-event-grid'
 FUNCTION_TIME_TRIGGER_MODE = 'azure-periodic'
 FUNCTION_KEY_URL = 'hostruntime/admin/host/systemkeys/_master?api-version=2018-02-01'

--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -8,7 +8,7 @@ FUNCTION_EVENT_TRIGGER_MODE = 'azure-event-grid'
 FUNCTION_TIME_TRIGGER_MODE = 'azure-periodic'
 FUNCTION_KEY_URL = 'hostruntime/admin/host/systemkeys/_master?api-version=2018-02-01'
 FUNCTION_CONSUMPTION_BLOB_CONTAINER = 'cloud-custodian-packages'
-FUNCTION_PACKAGE_SAS_EXPIRY_DAYS = 365 * 10 # 10 years
+FUNCTION_PACKAGE_SAS_EXPIRY_DAYS = 365 * 10  # 10 years
 
 """
 Event Grid Mode

--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -7,6 +7,8 @@ FUNCTION_EXT_VERSION = 'beta'
 FUNCTION_EVENT_TRIGGER_MODE = 'azure-event-grid'
 FUNCTION_TIME_TRIGGER_MODE = 'azure-periodic'
 FUNCTION_KEY_URL = 'hostruntime/admin/host/systemkeys/_master?api-version=2018-02-01'
+FUNCTION_CONSUMPTION_BLOB_CONTAINER = 'cloud-custodian-packages'
+FUNCTION_PACKAGE_SAS_EXPIRY_DAYS = 365 * 10 # 10 years
 
 """
 Event Grid Mode

--- a/tools/c7n_azure/c7n_azure/function.py
+++ b/tools/c7n_azure/c7n_azure/function.py
@@ -15,8 +15,6 @@
 import logging
 import sys
 
-# do not generate pycache
-sys.dont_write_bytecode = True
 from os.path import dirname, join
 
 # The working path for the Azure Function doesn't include this file's folder

--- a/tools/c7n_azure/c7n_azure/function.py
+++ b/tools/c7n_azure/c7n_azure/function.py
@@ -15,6 +15,10 @@
 import json
 import logging
 import sys
+import os
+
+# do not generate pycache
+sys.dont_write_bytecode = True
 from os.path import dirname, join
 
 # The working path for the Azure Function doesn't include this file's folder

--- a/tools/c7n_azure/c7n_azure/function.py
+++ b/tools/c7n_azure/c7n_azure/function.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import sys
-import os
 
 # do not generate pycache
 sys.dont_write_bytecode = True

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -55,30 +55,30 @@ class FunctionAppUtilities(object):
         return connection_string
 
     @staticmethod
-    def deploy_function_app(parameters):
+    def deploy_function_app(function_params):
         function_app_unit = FunctionAppDeploymentUnit()
         function_app_params = defaultdict(lambda: None)
         function_app_params.update({
-            'name': parameters.function_app_name,
-            'resource_group_name': parameters.function_app_resource_group_name,
-            'location': parameters.service_plan['location']})
+            'name': function_params.function_app_name,
+            'resource_group_name': function_params.function_app_resource_group_name,
+            'location': function_params.service_plan['location']})
 
         function_app = function_app_unit.get(function_app_params)
         if function_app:
             return function_app
 
         # provision app plan for non-consumption Function apps
-        if not StringUtils.equal(parameters.service_plan['tier'], 'dynamic'):
+        if not StringUtils.equal(function_params.service_plan['tier'], 'dynamic'):
             sp_unit = AppServicePlanUnit()
-            app_service_plan = sp_unit.provision_if_not_exists(parameters.service_plan)
+            app_service_plan = sp_unit.provision_if_not_exists(function_params.service_plan)
             function_app_params.update({'location': app_service_plan.location,
                                         'app_service_plan_id': app_service_plan.id})
 
         ai_unit = AppInsightsUnit()
-        app_insights = ai_unit.provision_if_not_exists(parameters.app_insights)
+        app_insights = ai_unit.provision_if_not_exists(function_params.app_insights)
 
         sa_unit = StorageAccountUnit()
-        storage_account_id = sa_unit.provision_if_not_exists(parameters.storage_account).id
+        storage_account_id = sa_unit.provision_if_not_exists(function_params.storage_account).id
         con_string = FunctionAppUtilities.get_storage_account_connection_string(storage_account_id)
 
         function_app_params.update({'app_insights_key': app_insights.instrumentation_key,

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -56,7 +56,7 @@ class FunctionAppUtilities(object):
 
     @staticmethod
     def is_consumption_plan(function_params):
-        return StringUtils.equal(function_params.service_plan['tier'], 'dynamic')
+        return StringUtils.equal(function_params.service_plan['sku_tier'], 'dynamic')
 
     @staticmethod
     def deploy_function_app(function_params):
@@ -71,7 +71,7 @@ class FunctionAppUtilities(object):
         if function_app:
             return function_app
 
-        # provision app plan for non-consumption Function apps
+        # dedicated app plan
         if not FunctionAppUtilities.is_consumption_plan(function_params):
             sp_unit = AppServicePlanUnit()
             app_service_plan = sp_unit.provision_if_not_exists(function_params.service_plan)
@@ -148,4 +148,4 @@ class FunctionAppUtilities(object):
                 properties=app_settings.properties
             )
 
-            cls.log.info('Finished publishing Function application')
+        cls.log.info('Finished publishing Function application')

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from collections import defaultdict
 
 from c7n.utils import local_session
 
@@ -52,17 +53,24 @@ class FunctionAppUtilities(object):
         return connection_string
 
     @staticmethod
-    def deploy_dedicated_function_app(parameters):
+    def deploy_function_app(parameters):
         function_app_unit = FunctionAppDeploymentUnit()
-        function_app_params = \
-            {'name': parameters.function_app_name,
-             'resource_group_name': parameters.function_app_resource_group_name}
+        function_app_params = defaultdict(lambda: None)
+        function_app_params.update({
+            'name': parameters.function_app_name,
+            'resource_group_name': parameters.function_app_resource_group_name,
+            'location': parameters.service_plan['location']})
+
         function_app = function_app_unit.get(function_app_params)
         if function_app:
             return function_app
 
-        sp_unit = AppServicePlanUnit()
-        app_service_plan = sp_unit.provision_if_not_exists(parameters.service_plan)
+        # provision a dedicated app service plan
+        if parameters.service_plan['sku_name'] and parameters.service_plan['sku_tier']:
+            sp_unit = AppServicePlanUnit()
+            app_service_plan = sp_unit.provision_if_not_exists(parameters.service_plan)
+            function_app_params.update({'location': app_service_plan.location,
+                                        'app_service_plan_id': app_service_plan.id})
 
         ai_unit = AppInsightsUnit()
         app_insights = ai_unit.provision_if_not_exists(parameters.app_insights)
@@ -71,9 +79,7 @@ class FunctionAppUtilities(object):
         storage_account_id = sa_unit.provision_if_not_exists(parameters.storage_account).id
         con_string = FunctionAppUtilities.get_storage_account_connection_string(storage_account_id)
 
-        function_app_params.update({'location': app_service_plan.location,
-                                    'app_service_plan_id': app_service_plan.id,
-                                    'app_insights_key': app_insights.instrumentation_key,
+        function_app_params.update({'app_insights_key': app_insights.instrumentation_key,
                                     'storage_account_connection_string': con_string})
 
         return function_app_unit.provision(function_app_params)

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -76,6 +76,8 @@ class FunctionAppUtilities(object):
             app_name = ResourceIdParser.get_resource_name(app_id)
             app_resource_group_name = ResourceIdParser.get_resource_group(app_id)
             app_service_plan = web_client.app_service_plans.get(app_resource_group_name, app_name)
+
+            # update the sku tier to properly reflect what is provisioned in Azure
             parameters.service_plan['sku_tier'] = app_service_plan.sku.tier
 
             return function_app

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -22,7 +22,7 @@ from c7n_azure.provisioning.app_service_plan import AppServicePlanUnit
 from c7n_azure.provisioning.storage_account import StorageAccountUnit
 from c7n_azure.provisioning.function_app import FunctionAppDeploymentUnit
 from c7n_azure.session import Session
-from c7n_azure.utils import ResourceIdParser
+from c7n_azure.utils import ResourceIdParser, StringUtils
 
 
 class FunctionAppUtilities(object):
@@ -65,8 +65,8 @@ class FunctionAppUtilities(object):
         if function_app:
             return function_app
 
-        # provision a dedicated app service plan
-        if parameters.service_plan.get('sku_name') and parameters.service_plan.get('sku_tier'):
+        # provision app plan for non-consumption Function apps
+        if not StringUtils.equal(parameters.service_plan['tier'], 'dynamic'):
             sp_unit = AppServicePlanUnit()
             app_service_plan = sp_unit.provision_if_not_exists(parameters.service_plan)
             function_app_params.update({'location': app_service_plan.location,

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -66,7 +66,7 @@ class FunctionAppUtilities(object):
             return function_app
 
         # provision a dedicated app service plan
-        if parameters.service_plan['sku_name'] and parameters.service_plan['sku_tier']:
+        if parameters.service_plan.get('sku_name') and parameters.service_plan.get('sku_tier'):
             sp_unit = AppServicePlanUnit()
             app_service_plan = sp_unit.provision_if_not_exists(parameters.service_plan)
             function_app_params.update({'location': app_service_plan.location,

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -55,6 +55,10 @@ class FunctionAppUtilities(object):
         return connection_string
 
     @staticmethod
+    def is_consumption_plan(function_params):
+        return StringUtils.equal(function_params.service_plan['tier'], 'dynamic')
+
+    @staticmethod
     def deploy_function_app(function_params):
         function_app_unit = FunctionAppDeploymentUnit()
         function_app_params = defaultdict(lambda: None)
@@ -68,7 +72,7 @@ class FunctionAppUtilities(object):
             return function_app
 
         # provision app plan for non-consumption Function apps
-        if not StringUtils.equal(function_params.service_plan['tier'], 'dynamic'):
+        if not FunctionAppUtilities.is_consumption_plan(function_params):
             sp_unit = AppServicePlanUnit()
             app_service_plan = sp_unit.provision_if_not_exists(function_params.service_plan)
             function_app_params.update({'location': app_service_plan.location,
@@ -94,7 +98,7 @@ class FunctionAppUtilities(object):
         cls.log.info('Publishing Function application')
 
         # provision using Kudu Zip-Deploy
-        if not StringUtils.equal(function_params.service_plan['tier'], 'dynamic'):
+        if not FunctionAppUtilities.is_consumption_plan(function_params):
             publish_creds = web_client.web_apps.list_publishing_credentials(
                 function_params.function_app_resource_group_name,
                 function_params.function_app_name).result()
@@ -137,7 +141,6 @@ class FunctionAppUtilities(object):
                 function_params.function_app_resource_group_name,
                 function_params.function_app_name)
             app_settings.properties['WEBSITE_RUN_FROM_PACKAGE'] = blob_url
-
             web_client.web_apps.update_application_settings(
                 function_params.function_app_resource_group_name,
                 function_params.function_app_name,
@@ -145,4 +148,4 @@ class FunctionAppUtilities(object):
                 properties=app_settings.properties
             )
 
-            cls.log.debug('Finished publishing Function application')
+            cls.log.info('Finished publishing Function application')

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -84,6 +84,8 @@ class FunctionAppUtilities(object):
 
         sp_unit = AppServicePlanUnit()
         app_service_plan = sp_unit.provision_if_not_exists(parameters.service_plan)
+
+        # if only resource_id is provided, retrieve existing app plan sku tier
         parameters.service_plan['sku_tier'] = app_service_plan.sku.tier
 
         ai_unit = AppInsightsUnit()

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -161,14 +161,14 @@ class FunctionAppUtilities(object):
                 )
             except CloudError as e:
                 # This appears to be a bug in the API
-                # Success returns a 200, which is unexpected and gets rethrown as a CloudError
-                if e.response.status_code == 200:
+                # Success can be either 200 or 204, which is unexpected and gets rethrown as a CloudError
+                if e.response.status_code in [200, 204]:
                     break
 
                 cls.log.error("Failed to sync triggers...")
                 cls.log.error(e)
 
-            if res and res.status_code == 200:
+            if res and res.status_code in [200, 204]:
                 break
             else:
                 cls.log.info("Retrying in 5 seconds...")

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -11,20 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import datetime
 import logging
 from collections import defaultdict
 
-from c7n_azure.function_package import FunctionPackage
-
-from c7n.utils import local_session
-
+from azure.storage.blob import BlobPermissions
+from c7n_azure.constants import FUNCTION_CONSUMPTION_BLOB_CONTAINER, FUNCTION_PACKAGE_SAS_EXPIRY_DAYS
 from c7n_azure.provisioning.app_insights import AppInsightsUnit
 from c7n_azure.provisioning.app_service_plan import AppServicePlanUnit
-from c7n_azure.provisioning.storage_account import StorageAccountUnit
 from c7n_azure.provisioning.function_app import FunctionAppDeploymentUnit
+from c7n_azure.provisioning.storage_account import StorageAccountUnit
 from c7n_azure.session import Session
+from c7n_azure.storage_utils import StorageUtilities
 from c7n_azure.utils import ResourceIdParser, StringUtils
+
+from c7n.utils import local_session
 
 
 class FunctionAppUtilities(object):
@@ -87,11 +88,14 @@ class FunctionAppUtilities(object):
 
     @classmethod
     def publish_functions_package(cls, function_params, package):
-        client = local_session(Session).client('azure.mgmt.web.WebSiteManagementClient')
+        session = local_session(Session)
+        web_client = session.client('azure.mgmt.web.WebSiteManagementClient')
 
-        # provision using Kudu
+        cls.log.info('Publishing Function application')
+
+        # provision using Kudu Zip-Deploy
         if not StringUtils.equal(function_params.service_plan['tier'], 'dynamic'):
-            publish_creds = client.web_apps.list_publishing_credentials(
+            publish_creds = web_client.web_apps.list_publishing_credentials(
                 function_params.function_app_resource_group_name,
                 function_params.function_app_name).result()
 
@@ -99,5 +103,46 @@ class FunctionAppUtilities(object):
                 package.publish(publish_creds)
             else:
                 cls.log.error("Aborted deployment, ensure Application Service is healthy.")
+        # provision using WEBSITE_RUN_FROM_PACKAGE
         else:
-            cls.log.info("Consumption Plan")
+            # fetch blob client
+            blob_client = StorageUtilities.get_blob_client_from_storage_account(
+                function_params.storage_account['resource_group_name'],
+                function_params.storage_account['name'],
+                session,
+                sas_generation=True
+            )
+
+            # create container for package
+            blob_client.create_container(FUNCTION_CONSUMPTION_BLOB_CONTAINER)
+
+            # upload package
+            blob_name = '%s.zip' % function_params.function_app_name
+            blob_client.create_blob_from_path(FUNCTION_CONSUMPTION_BLOB_CONTAINER, blob_name, package.pkg.path)
+
+            # create blob url for package
+            sas = blob_client.generate_blob_shared_access_signature(
+                FUNCTION_CONSUMPTION_BLOB_CONTAINER,
+                blob_name,
+                BlobPermissions.READ,
+                datetime.datetime.utcnow() + datetime.timedelta(days=FUNCTION_PACKAGE_SAS_EXPIRY_DAYS)  # expire in 10 years
+            )
+            blob_url = blob_client.make_blob_url(
+                FUNCTION_CONSUMPTION_BLOB_CONTAINER,
+                blob_name,
+                sas_token=sas)
+
+            # update application settings function package
+            app_settings = web_client.web_apps.list_application_settings(
+                function_params.function_app_resource_group_name,
+                function_params.function_app_name)
+            app_settings.properties['WEBSITE_RUN_FROM_PACKAGE'] = blob_url
+
+            web_client.web_apps.update_application_settings(
+                function_params.function_app_resource_group_name,
+                function_params.function_app_name,
+                kind=str,
+                properties=app_settings.properties
+            )
+
+            cls.log.debug('Finished publishing Function application')

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -16,7 +16,8 @@ import logging
 import time
 
 from azure.storage.blob import BlobPermissions
-from c7n_azure.constants import FUNCTION_CONSUMPTION_BLOB_CONTAINER, FUNCTION_PACKAGE_SAS_EXPIRY_DAYS
+from c7n_azure.constants import \
+    FUNCTION_CONSUMPTION_BLOB_CONTAINER, FUNCTION_PACKAGE_SAS_EXPIRY_DAYS
 from c7n_azure.provisioning.app_insights import AppInsightsUnit
 from c7n_azure.provisioning.app_service_plan import AppServicePlanUnit
 from c7n_azure.provisioning.function_app import FunctionAppDeploymentUnit
@@ -90,11 +91,12 @@ class FunctionAppUtilities(object):
         storage_account_id = sa_unit.provision_if_not_exists(function_params.storage_account).id
         con_string = FunctionAppUtilities.get_storage_account_connection_string(storage_account_id)
 
-        function_app_params.update({'location': app_service_plan.location,
-                                    'app_service_plan_id': app_service_plan.id,
-                                    'app_insights_key': app_insights.instrumentation_key,
-                                    'is_consumption_plan': FunctionAppUtilities.is_consumption_plan(function_params),
-                                    'storage_account_connection_string': con_string})
+        function_app_params.update(
+            {'location': app_service_plan.location,
+             'app_service_plan_id': app_service_plan.id,
+             'app_insights_key': app_insights.instrumentation_key,
+             'is_consumption_plan': FunctionAppUtilities.is_consumption_plan(function_params),
+             'storage_account_connection_string': con_string})
 
         return function_app_unit.provision(function_app_params)
 
@@ -130,14 +132,16 @@ class FunctionAppUtilities(object):
 
             # upload package
             blob_name = '%s.zip' % function_params.function_app_name
-            blob_client.create_blob_from_path(FUNCTION_CONSUMPTION_BLOB_CONTAINER, blob_name, package.pkg.path)
+            blob_client.create_blob_from_path(
+                FUNCTION_CONSUMPTION_BLOB_CONTAINER, blob_name, package.pkg.path)
 
             # create blob url for package
             sas = blob_client.generate_blob_shared_access_signature(
                 FUNCTION_CONSUMPTION_BLOB_CONTAINER,
                 blob_name,
                 BlobPermissions.READ,
-                datetime.datetime.utcnow() + datetime.timedelta(days=FUNCTION_PACKAGE_SAS_EXPIRY_DAYS)
+                datetime.datetime.utcnow() +
+                datetime.timedelta(days=FUNCTION_PACKAGE_SAS_EXPIRY_DAYS)
                 # expire in 10 years
             )
             blob_url = blob_client.make_blob_url(
@@ -167,7 +171,8 @@ class FunctionAppUtilities(object):
                 )
             except CloudError as e:
                 # This appears to be a bug in the API
-                # Success can be either 200 or 204, which is unexpected and gets rethrown as a CloudError
+                # Success can be either 200 or 204, which is
+                # unexpected and gets rethrown as a CloudError
                 if e.response.status_code in [200, 204]:
                     break
 

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -28,8 +28,7 @@ from c7n_azure.utils import ResourceIdParser, StringUtils
 
 
 class FunctionAppUtilities(object):
-    def __init__(self):
-        self.log = logging.getLogger('custodian.azure.function_app_utils')
+    log = logging.getLogger('custodian.azure.function_app_utils')
 
     class FunctionAppInfrastructureParameters:
         def __init__(self, app_insights, service_plan, storage_account,
@@ -86,18 +85,19 @@ class FunctionAppUtilities(object):
 
         return function_app_unit.provision(function_app_params)
 
-    def publish_functions_package(self, function_params, package):
+    @classmethod
+    def publish_functions_package(cls, function_params, package):
         client = local_session(Session).client('azure.mgmt.web.WebSiteManagementClient')
 
         # provision using Kudu
         if not StringUtils.equal(function_params.service_plan['tier'], 'dynamic'):
             publish_creds = client.web_apps.list_publishing_credentials(
-                self.function_params.function_app_resource_group_name,
-                self.function_params.function_app_name).result()
+                function_params.function_app_resource_group_name,
+                function_params.function_app_name).result()
 
             if package.wait_for_status(publish_creds):
                 package.publish(publish_creds)
             else:
-                self.log.error("Aborted deployment, ensure Application Service is healthy.")
+                cls.log.error("Aborted deployment, ensure Application Service is healthy.")
         else:
-            self.log.info("Consumption Plan")
+            cls.log.info("Consumption Plan")

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -111,7 +111,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
                 'location': 'eastus',
                 'resource_group_name': 'cloud-custodian',
                 'sku_tier': 'Dynamic', # consumption plan
-                'sku_name': None
+                'sku_name': 'Y1'
             })
 
         # Metadata used for automatic naming

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -188,14 +188,14 @@ class AzureFunctionMode(ServerlessExecutionMode):
         self.log.info("Building function package for %s" % self.function_params.function_app_name)
 
         package = FunctionPackage(self.policy_name)
-        self.log.info("Function package , size is %dMB" % (package.pkg.size / (1024 * 1024)))
-
         package.build(self.policy.data,
                       modules=['c7n', 'c7n-azure'],
                       non_binary_packages=['pyyaml', 'pycparser', 'tabulate'],
                       excluded_packages=['azure-cli-core', 'distlib', 'futures'],
                       queue_name=queue_name)
         package.close()
+
+        self.log.info("Function package built, size is %dMB" % (package.pkg.size / (1024 * 1024)))
         return package
 
 

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -110,7 +110,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
                 'name': 'cloud-custodian',
                 'location': 'eastus',
                 'resource_group_name': 'cloud-custodian',
-                'sku_tier': 'Dynamic', # consumption plan
+                'sku_tier': 'Dynamic',  # consumption plan
                 'sku_name': 'Y1'
             })
 

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -190,7 +190,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
 
         package = FunctionPackage(self.policy_name)
         package.build(self.policy.data,
-                      modules=['c7n', 'c7n-azure'],
+                      modules=['c7n', 'c7n-azure', 'applicationinsights'],
                       non_binary_packages=['pyyaml', 'pycparser', 'tabulate'],
                       excluded_packages=['azure-cli-core', 'distlib', 'futures'],
                       queue_name=queue_name)

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -107,14 +107,12 @@ class AzureFunctionMode(ServerlessExecutionMode):
             'servicePlan',
             {
                 'name': 'cloud-custodian',
-                'location': 'westus2',
+                'location': 'westus',
                 'resource_group_name': 'cloud-custodian',
-                'sku_name': 'B1',
-                'sku_tier': 'Basic'
             })
 
         # Metadata used for automatic naming
-        location = service_plan.get('location', 'westus2')
+        location = service_plan.get('location', 'westus')
         rg_name = service_plan['resource_group_name']
         sub_id = session.get_subscription_id()
         target_sub_id = session.get_function_target_subscription_id()
@@ -175,7 +173,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
             sys.exit(1)
 
         self.function_params = self.get_function_app_params()
-        FunctionAppUtilities().deploy_dedicated_function_app(self.function_params)
+        FunctionAppUtilities().deploy_function_app(self.function_params)
 
     def get_logs(self, start, end):
         """Retrieve logs for the policy"""

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -175,7 +175,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
             sys.exit(1)
 
         self.function_params = self.get_function_app_params()
-        self.function_app = FunctionAppUtilities().deploy_function_app(self.function_params)
+        self.function_app = FunctionAppUtilities.deploy_function_app(self.function_params)
 
     def get_logs(self, start, end):
         """Retrieve logs for the policy"""
@@ -210,7 +210,7 @@ class AzurePeriodicMode(AzureFunctionMode, PullMode):
     def provision(self):
         super(AzurePeriodicMode, self).provision()
         package = self.build_functions_package()
-        FunctionAppUtilities().publish_functions_package(self.function_params, package)
+        FunctionAppUtilities.publish_functions_package(self.function_params, package)
 
     def run(self, event=None, lambda_context=None):
         """Run the actual policy."""
@@ -248,7 +248,7 @@ class AzureEventGridMode(AzureFunctionMode):
         storage_account = self._create_storage_queue(queue_name, session)
         self._create_event_subscription(storage_account, queue_name, session)
         package = self.build_functions_package(queue_name)
-        FunctionAppUtilities().publish_functions_package(self.function_params, package)
+        FunctionAppUtilities.publish_functions_package(self.function_params, package)
 
     def run(self, event=None, lambda_context=None):
         """Run the actual policy."""

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -110,7 +110,8 @@ class AzureFunctionMode(ServerlessExecutionMode):
                 'name': 'cloud-custodian',
                 'location': 'eastus',
                 'resource_group_name': 'cloud-custodian',
-                'sku_tier': 'dynamic' # consumption plan
+                'sku_tier': 'Dynamic', # consumption plan
+                'sku_name': None
             })
 
         # Metadata used for automatic naming

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -203,6 +203,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
         client = local_session(self.policy.session_factory) \
             .client('azure.mgmt.web.WebSiteManagementClient')
 
+        # dedicated
         if self.function_app['server_farm_id']:
             publish_creds = client.web_apps.list_publishing_credentials(
                 self.function_params.function_app_resource_group_name,

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -110,6 +110,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
                 'name': 'cloud-custodian',
                 'location': 'eastus',
                 'resource_group_name': 'cloud-custodian',
+                'tier': 'dynamic' #consumption
             })
 
         # Metadata used for automatic naming

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -190,7 +190,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
 
         package = FunctionPackage(self.policy_name)
         package.build(self.policy.data,
-                      modules=['c7n', 'c7n-azure', 'applicationinsights'],
+                      modules=['c7n', 'c7n-azure'],
                       non_binary_packages=['pyyaml', 'pycparser', 'tabulate'],
                       excluded_packages=['azure-cli-core', 'distlib', 'futures'],
                       queue_name=queue_name)

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -110,11 +110,11 @@ class AzureFunctionMode(ServerlessExecutionMode):
                 'name': 'cloud-custodian',
                 'location': 'eastus',
                 'resource_group_name': 'cloud-custodian',
-                'tier': 'dynamic' #consumption
+                'tier': 'dynamic' # consumption plan
             })
 
         # Metadata used for automatic naming
-        location = service_plan.get('location', 'westus')
+        location = service_plan.get('location', 'eastus')
         rg_name = service_plan['resource_group_name']
         sub_id = session.get_subscription_id()
         target_sub_id = session.get_function_target_subscription_id()

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -108,7 +108,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
             'servicePlan',
             {
                 'name': 'cloud-custodian',
-                'location': 'westus',
+                'location': 'eastus',
                 'resource_group_name': 'cloud-custodian',
             })
 

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -110,7 +110,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
                 'name': 'cloud-custodian',
                 'location': 'eastus',
                 'resource_group_name': 'cloud-custodian',
-                'tier': 'dynamic' # consumption plan
+                'sku_tier': 'dynamic' # consumption plan
             })
 
         # Metadata used for automatic naming

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -23,11 +23,11 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
         site_config = SiteConfig(app_settings=[])
         functionapp_def = Site(location=params['location'], site_config=site_config)
 
-        # linux app
+        # linux app settings
         functionapp_def.kind = 'functionapp,linux'
         functionapp_def.reserved = True
 
-        # dedicated app plan
+        # dedicated app plan settings
         if params['app_service_plan_id']:
             functionapp_def.server_farm_id = params['app_service_plan_id']
             site_config.linux_fx_version = FUNCTION_DOCKER_VERSION
@@ -36,11 +36,13 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
                                       FunctionAppDeploymentUnit.generate_machine_decryption_key()))
             site_config.always_on = True
 
+        # application insights settings
         app_insights_key = params['app_insights_key']
         if app_insights_key:
             site_config.app_settings.append(
                 azure_name_value_pair('APPINSIGHTS_INSTRUMENTATIONKEY', app_insights_key))
 
+        # general app settings
         con_string = params['storage_account_connection_string']
         site_config.app_settings.append(azure_name_value_pair('AzureWebJobsStorage', con_string))
         site_config.app_settings.append(azure_name_value_pair('AzureWebJobsDashboard', con_string))

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -4,7 +4,7 @@ from binascii import hexlify
 from azure.mgmt.web.models import (Site, SiteConfig)
 from c7n_azure.constants import (FUNCTION_DOCKER_VERSION, FUNCTION_EXT_VERSION)
 from c7n_azure.provisioning.deployment_unit import DeploymentUnit
-from c7n_azure.utils import azure_name_value_pair, StringUtils
+from c7n_azure.utils import azure_name_value_pair
 
 
 class FunctionAppDeploymentUnit(DeploymentUnit):

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -2,11 +2,9 @@ import os
 from binascii import hexlify
 
 from azure.mgmt.web.models import (Site, SiteConfig)
-
-from c7n_azure.utils import azure_name_value_pair
-
-from c7n_azure.provisioning.deployment_unit import DeploymentUnit
 from c7n_azure.constants import (FUNCTION_DOCKER_VERSION, FUNCTION_EXT_VERSION)
+from c7n_azure.provisioning.deployment_unit import DeploymentUnit
+from c7n_azure.utils import azure_name_value_pair, StringUtils
 
 
 class FunctionAppDeploymentUnit(DeploymentUnit):
@@ -23,13 +21,13 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
         site_config = SiteConfig(app_settings=[])
         functionapp_def = Site(location=params['location'], site_config=site_config)
 
-        # linux app settings
+        # common function app settings
         functionapp_def.kind = 'functionapp,linux'
         functionapp_def.reserved = True
+        functionapp_def.server_farm_id = params['app_service_plan_id']
 
         # dedicated app plan settings
-        if params['app_service_plan_id']:
-            functionapp_def.server_farm_id = params['app_service_plan_id']
+        if not params['is_consumption_plan']:
             site_config.linux_fx_version = FUNCTION_DOCKER_VERSION
             site_config.app_settings.append(
                 azure_name_value_pair('MACHINEKEY_DecryptionKey',

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -23,7 +23,6 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
 
         # common function app settings
         functionapp_def.kind = 'functionapp,linux'
-        functionapp_def.reserved = True
         functionapp_def.server_farm_id = params['app_service_plan_id']
 
         # dedicated app plan settings

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -23,17 +23,18 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
         site_config = SiteConfig(app_settings=[])
         functionapp_def = Site(location=params['location'], site_config=site_config)
 
+        # linux app
         functionapp_def.kind = 'functionapp,linux'
+        functionapp_def.reserved = True
 
-        # dedicated linux app plan
+        # dedicated app plan
         if params['app_service_plan_id']:
             functionapp_def.server_farm_id = params['app_service_plan_id']
             site_config.linux_fx_version = FUNCTION_DOCKER_VERSION
             site_config.app_settings.append(
                 azure_name_value_pair('MACHINEKEY_DecryptionKey',
                                       FunctionAppDeploymentUnit.generate_machine_decryption_key()))
-
-        site_config.always_on = True
+            site_config.always_on = True
 
         app_insights_key = params['app_insights_key']
         if app_insights_key:

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -24,7 +24,10 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
         functionapp_def = Site(location=params['location'], site_config=site_config)
 
         functionapp_def.kind = 'functionapp,linux'
-        functionapp_def.server_farm_id = params['app_service_plan_id']
+
+        # dedicated linux app plan
+        if params['app_service_plan_id']:
+            functionapp_def.server_farm_id = params['app_service_plan_id']
 
         site_config.linux_fx_version = FUNCTION_DOCKER_VERSION
         site_config.always_on = True

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -28,8 +28,11 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
         # dedicated linux app plan
         if params['app_service_plan_id']:
             functionapp_def.server_farm_id = params['app_service_plan_id']
+            site_config.linux_fx_version = FUNCTION_DOCKER_VERSION
+            site_config.app_settings.append(
+                azure_name_value_pair('MACHINEKEY_DecryptionKey',
+                                      FunctionAppDeploymentUnit.generate_machine_decryption_key()))
 
-        site_config.linux_fx_version = FUNCTION_DOCKER_VERSION
         site_config.always_on = True
 
         app_insights_key = params['app_insights_key']
@@ -43,9 +46,6 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
         site_config.app_settings.append(azure_name_value_pair('FUNCTIONS_EXTENSION_VERSION',
                                                               FUNCTION_EXT_VERSION))
         site_config.app_settings.append(azure_name_value_pair('FUNCTIONS_WORKER_RUNTIME', 'python'))
-        site_config.app_settings.append(
-            azure_name_value_pair('MACHINEKEY_DecryptionKey',
-                          FunctionAppDeploymentUnit.generate_machine_decryption_key()))
 
         return self.client.web_apps.create_or_update(params['resource_group_name'],
                                                      params['name'],

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -22,11 +22,15 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
         functionapp_def = Site(location=params['location'], site_config=site_config)
 
         # common function app settings
-        functionapp_def.kind = 'functionapp,linux'
         functionapp_def.server_farm_id = params['app_service_plan_id']
+        functionapp_def.reserved = True  # This implies Linux for auto-created app plans
 
-        # dedicated app plan settings
-        if not params['is_consumption_plan']:
+        # consumption app plan
+        if params['is_consumption_plan']:
+            functionapp_def.kind = 'functionapp,linux'
+        # dedicated app plan
+        else:
+            functionapp_def.kind = 'functionapp,linux,container'
             site_config.linux_fx_version = FUNCTION_DOCKER_VERSION
             site_config.app_settings.append(
                 azure_name_value_pair('MACHINEKEY_DecryptionKey',

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -44,8 +44,7 @@ setup(
         "custodian.resources": [
             'azure = c7n_azure.entry:initialize_azure']
     },
-    install_requires=["applicationinsights",
-                      "azure-mgmt-authorization",
+    install_requires=["azure-mgmt-authorization",
                       "azure-mgmt-applicationinsights",
                       "azure-mgmt-batch",
                       "azure-mgmt-cognitiveservices",

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -44,7 +44,8 @@ setup(
         "custodian.resources": [
             'azure = c7n_azure.entry:initialize_azure']
     },
-    install_requires=["azure-mgmt-authorization",
+    install_requires=["applicationinsights",
+                      "azure-mgmt-authorization",
                       "azure-mgmt-applicationinsights",
                       "azure-mgmt-batch",
                       "azure-mgmt-cognitiveservices",

--- a/tools/c7n_azure/tests/cassettes/DeploymentUnitsTest.test_function_app_consumption.yaml
+++ b/tools/c7n_azure/tests/cassettes/DeploymentUnitsTest.test_function_app_consumption.yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Storage/storageAccounts/custodianaccount47182748?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9ez3f/7q9Uejj9oir71PP/olo4/eFssZf1TV2UVObQr8ebdZT5pp
+        Xazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3YPf+bOdBfrfOm2pdT/PP62q9au5O
+        101bzYpsud3mTbs9y1dldb3Il+32elm0zd1VXV0Ws7xu7n5RTOuqqc7bsWJxl97Ez+PptFovqa2F
+        lckn+w92D/Ye7B8QujrQDS3a6xVa3NgLNS2raYYRU/MrQnrd7NGHbXbREEmJVoTyKq+JiPj7o2Xe
+        XlX12+NpyX9OrldZQ799dPyDdZ2/zuvLYkoNRx9dFnW7zsoX0vzVuqRPH33v+0TplffHLD/P1mV7
+        PNX+j8uyusIENevVqqrb5tttu2re1Nn5eTH9cllef/ToPCubfPRRvpzW1zxRQKMxHdPv50VJI//F
+        1CKblDnNa1uv6YUya9pT+ehNwdTb29l9uL2zu71z8GZn59H+/Uf7O+OHDw/u3//0/k8Bh0lZTb4B
+        QATpbX79mrmEGvdmBF0RjS+LhgZTLC+IT1s0fL2eTvN8Rh2PPprWOU/Rpg7vfbq7u08dAlqxyOrr
+        0+VsVRWYYxqEDOajOej56O4gb43Rbjyt6nx8RTJSXTVjmvG7BPQXrfM1+r4RAjeMgmhBtNuA4IZR
+        EDK5N0NAuwgAJjUT53mM6Rsi/br58vyltKHvssusKIHNR7/kl/w/XxcCUGcEAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:02:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [72562364-d3bf-4aa3-8dc2-34f9f7a2c972]
+      x-ms-ratelimit-remaining-subscription-reads: ['11997']
+      x-ms-request-id: [60e32aa1-1357-44d2-a9e1-59399d67d0cb]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010213Z:72562364-d3bf-4aa3-8dc2-34f9f7a2c972']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Storage/storageAccounts/custodianaccount47182748/listKeys?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
+        6+ajR9/jX15ki/yjR/ht96PRR5dZucafP3my/8W94tnpJ8X+T188bD+//vwnv/2dn9j7iR/s7T24
+        Wv3eb14ffD47aN/9op98UH/5/Cd+r5fvnp1PXz//tGruHd+/95O/10/83g9f/eSDu58/eVd+5/xJ
+        /d3f58vfK/+pycVnn1EXq7xeFE1TVEvC4aNnXz1//tEvGXVQ2aN2BpW3e7/oMr8+OT/Ndk+/s3/9
+        4PO7V1/MZ99+9+l+ef/Fu9/n27Nnn7brl7/357Mf/NS74tN3s2dNdvDq9/lyup49bK5+0fLu7z3b
+        f7U4Ob5/8NNPl1+8e7mbt/s7xfEgKt//Jf8P0lzYKiABAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:02:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [8b9f6088-3a66-4c9b-8db0-78cd00d54d46]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [50e405d4-6430-4da8-8f29-91b23cd2aeb1]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010213Z:8b9f6088-3a66-4c9b-8db0-78cd00d54d46']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-consumption-47182748?api-version=2018-02-01
+  response:
+    body: {string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Web/sites/cc-consumption-47182748''
+        under resource group ''custodian-test-deployment-units'' was not found."}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['178']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 01:02:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [d402652a-b8fd-4a3e-925f-e0fe53875133]
+      x-ms-failure-cause: [gateway]
+      x-ms-request-id: [d402652a-b8fd-4a3e-925f-e0fe53875133]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010213Z:d402652a-b8fd-4a3e-925f-e0fe53875133']
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-consumption-47182748?api-version=2018-02-01
+  response:
+    body: {string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Web/sites/cc-consumption-47182748''
+        under resource group ''custodian-test-deployment-units'' was not found."}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['178']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 01:02:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [c0449e82-2998-4397-874d-23a7534659bf]
+      x-ms-failure-cause: [gateway]
+      x-ms-request-id: [c0449e82-2998-4397-874d-23a7534659bf]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010213Z:c0449e82-2998-4397-874d-23a7534659bf']
+    status: {code: 404, message: Not Found}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['807']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-consumption-47182748?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrvTddNWsyJbbrd5027P8lVZXS/yZbu9XhZtc3dVV5fFLK+bu18U07pqqvN2/N18crcp
+        qP3d6XR7Sj2vF4zB9v6D3YO9B/sHH40+WmaLnDAcbtBer9AgApW+fFssMb7z9XKK97LValQWy/U7
+        +qqsphk+o6+vCOM1mhOSq7xuC3r30S++ueumzVq0eLVeLovlBX0yr5r2Bb1G739v6MVx9oN1nV/l
+        E0ZyvMzbj74/Ihwmr1fZFOBuIOX2d+nTr17TCw2/QHjk5fnzYvmW3p237ap5dPfuVXbVbNNwZtuT
+        7Hp752B3nK2KTs9XRJzqijF4tH9//+7XYALAAhI0g++FtEzQhmmv81VFbar6+jW1BElpcMPNq6tl
+        Xn/0aLkuy9FH6ya7yF/r3Lyo6kVWUpN8mU3KnLihrdf56KNstiiWp+Fn2uTbX3sS8cfLgIcWeZvN
+        sjYzuNGU2G+/Z1mMJm/97tm7nyTxoE4I2cusXOOLj37JyDb6rkxXpBlA/xLqntj7dd62xIoEnT+k
+        zy6zoswmRVm01z2aNE15AmzOC5IFoISXRh9Nm5p+/x5BnFJX5lMM7otqRgDkb8Prr5uSAVNDN6Lb
+        k40AKwB67WnR8BTQp8XqSdbkM4L+Km/WZWu6vSzqdp2VZy/NB+18vZis6mJpm7TVVysiOgEM/z6z
+        IM03rhODwYuqPamW58UF4Qk0MMo3omKoyXKW1bOPQOtptVitQ4I0eX2Z18+yetH/5IyY7OdUzTIm
+        54RJc1dEkXnu6TXNVzF9WWZgJ+oLzQhVkYei+b3zJTHao/OsbOjvOdGh/kn7Z5k1LY2fuCefvSkW
+        +VftlAa5t7P7cHtnl3TOm53dRzt7j/b2xnv3+KEuCPuapPNVPq0In+un+XlGc0uUZeI7RUrM09Ko
+        jjdxb71ettTtxjbgM5lPMyeOZDwnA4xKr7Z1dk6C8UW2JIRrTykInObtml5XAlLzZrqAqjoum+p1
+        W61WIKMSqs3qi7x9fZWtXpeV5VJwFg32dEkcXS2B0PA3pFTOi5JGJg2mZUEfHhN6NOnXHS0mX0Ku
+        7ReKB+DyGKyYmW9m1SIrlqRYaDJJFRAlzmYEhP4iVjK9bjCm1bqdVOvl7Gx1PJsRGzWg00e798af
+        7o8f3Bvv7u6M9nfox8F499698YH949OH4939XfPn3n1q+uneSN7b3X9A/98h6GQKmoLw/fJnr5fR
+        /T36cGd8cH+8t/sA3z28R2x7MP70ISFAHNISffL6dfEDmoQdIhjx3PUX+YIMFFj/J9YVdDx90ayb
+        Vb6cQSJKq2bAhYbmr/KsgUxRW0PJ03f5dI1fvqLpbE6y6Zw6kTcX2bsXpN7y+svz71b1W2825hWp
+        3jZbrIgEPWsPnMsKsnS2PK/cK12+ggjId21mjAYJlq9zCPwNSoc6m4kcGyHBO3G5ihsAkgqWDpJe
+        8sMUC3ZlvlyW18qlv+SX/D8+rXP8rgoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:02:37 GMT']
+      ETag: ['"1D4A6EDD030B520"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [7651f240-b921-421e-b668-f4acec3c0057]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-ms-request-id: [066713dd-fdd7-4e15-b18b-c6306c432f63]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010238Z:7651f240-b921-421e-b668-f4acec3c0057']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/DeploymentUnitsTest.test_function_app_dedicated.yaml
+++ b/tools/c7n_azure/tests/cassettes/DeploymentUnitsTest.test_function_app_dedicated.yaml
@@ -1,0 +1,465 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Storage/storageAccounts/custodianaccount47182748?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9ez3f/7q9Uejj9oir71PP/olo4/eFssZf1TV2UVObQr8ebdZT5pp
+        Xazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3YPf+bOdBfrfOm2pdT/PP62q9au5O
+        101bzYpsud3mTbs9y1dldb3Il+32elm0zd1VXV0Ws7xu7n5RTOuqqc7bsWJxl97Ez+PptFovqa2F
+        lckn+w92D/Ye7B8QujrQDS3a6xVa3NgLNS2raYYRU/MrQnrd7NGHbXbREEmJVoTyKq+JiPj7o2Xe
+        XlX12+NpyX9OrldZQ799dPyDdZ2/zuvLYkoNRx9dFnW7zsoX0vzVuqRPH33v+0TplffHLD/P1mV7
+        PNX+j8uyusIENevVqqrb5tttu2re1Nn5eTH9cllef/ToPCubfPRRvpzW1zxRQKMxHdPv50VJI//F
+        1CKblDnNa1uv6YUya9pT+ehNwdTb29l9uL2zu71z8GZn59H+/Uf7O+OHDw/u3//0/k8Bh0lZTb4B
+        QATpbX79mrmEGvdmBF0RjS+LhgZTLC+IT1s0fL2eTvN8Rh2PPprWOU/Rpg7vfbq7u08dAlqxyOrr
+        0+VsVRWYYxqEDOajOej56O4gb43Rbjyt6nx8RTJSXTVjmvG7BPQXrfM1+r4RAjeMgmhBtNuA4IZR
+        EDK5N0NAuwgAJjUT53mM6Rsi/br58vyltKHvssusKIHNR7/kl/w/XxcCUGcEAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:02:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [89599098-42af-4ee2-be7f-097e0b07c251]
+      x-ms-ratelimit-remaining-subscription-reads: ['11995']
+      x-ms-request-id: [93170044-c85d-4bfd-b2e1-5cdf05bfc17f]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010238Z:89599098-42af-4ee2-be7f-097e0b07c251']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Storage/storageAccounts/custodianaccount47182748/listKeys?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
+        6+ajR9/jX15ki/yjR/ht96PRR5dZucafP3my/8W94tnpJ8X+T188bD+//vwnv/2dn9j7iR/s7T24
+        Wv3eb14ffD47aN/9op98UH/5/Cd+r5fvnp1PXz//tGruHd+/95O/10/83g9f/eSDu58/eVd+5/xJ
+        /d3f58vfK/+pycVnn1EXq7xeFE1TVEvC4aNnXz1//tEvGXVQ2aN2BpW3e7/oMr8+OT/Ndk+/s3/9
+        4PO7V1/MZ99+9+l+ef/Fu9/n27Nnn7brl7/357Mf/NS74tN3s2dNdvDq9/lyup49bK5+0fLu7z3b
+        f7U4Ob5/8NNPl1+8e7mbt/s7xfEgKt//Jf8P0lzYKiABAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:02:38 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [cdad7f33-c8a6-400b-9021-56f4585db96a]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [7c5f9291-c9eb-486f-acd1-dddf15f282ea]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010238Z:cdad7f33-c8a6-400b-9021-56f4585db96a']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/serverfarms/cloud-custodian-test?api-version=2018-02-01
+  response:
+    body: {string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Web/serverFarms/cloud-custodian-test''
+        under resource group ''custodian-test-deployment-units'' was not found."}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['181']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 01:02:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [66deac11-827d-4213-a05f-20d18a9760d1]
+      x-ms-failure-cause: [gateway]
+      x-ms-request-id: [66deac11-827d-4213-a05f-20d18a9760d1]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010238Z:66deac11-827d-4213-a05f-20d18a9760d1']
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          resourcemanagementclient/2.1.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/custodian-test-deployment-units?api-version=2018-05-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrvTddNWsyJbbrd5027P8lVZXS/yZbu9XhZt89Hoo2W2yKmvmxuW1TQDItT4ipqsmz36
+        sM0umo8e/eKP3tAnx6vVyzLD9+d5/mBy78He9mR/tr+9f+/Th9vZwfl0e28ne7CXTffz/HxKL5/Q
+        qNYLHt32Lr323ap+29BvwTfm849+yeijVV2t8rotcu6T/rosGmpSLC9et1mLYbxeT6d5PstnH/2S
+        X/L/AM8NdXpGAQAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['354']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 01:02:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [89e3eefd-b210-438a-bdce-ff280b118e35]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: [89e3eefd-b210-438a-bdce-ff280b118e35]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010238Z:89e3eefd-b210-438a-bdce-ff280b118e35']
+    status: {code: 200, message: OK}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['214']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/serverfarms/cloud-custodian-test?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrvTddNWsyJbbrd5027P8lVZXS/yZbu9XhZtc3dVV5fFLK+bu18U07pqqvN2/N18crfJ
+        68u8Ps/qBcEoq/VsO4T00eijZbbICcmBb9vrFb4dhEpN3hZLjLIslut39GdZTTMMlD76LsFIv3qd
+        7tHHhOEqr9sibz569Is/EgjPCMIZvbv/4N7BTYhcVfXbvH5d/ABtnubn2boMPwagHfPBmyKvXzC8
+        5bosCfZ6McnrL8+/y98SCrujj6bruiYKykeAEADufavw9fMXEYBNm7Vr+vWjV3k2uyYYV/nk9Sqb
+        AnA4nt4EboNUX73eozcafoOgeUxDAG7DNfRWNlsUy9dFm/ujn1dNWywvTpeXRV0t0evwNy/r6rwo
+        7auL7F2xWC96w71HM1pmS+nlo58s6nadlU/zWUGTn89e0lcGmVfrZVss8i5O02qxWrf5F9WMPiK6
+        65v0VkMt5WNpeZFXr/ILoQLIZDkK89Lmr6cZsd7FR4/Os7LJLcanZUZDmwrCJxUhwXNkGAFv0jBo
+        QvskwExL10XzelXRiwq6oT9O362Kmhn8DY3KNDyv8/zL8/O87n790d7O7sPtnb3tnQdvdnYf7ew9
+        2t8Z37tP6LfZBSEgr3dEKBB++vwG5pE3IFEEpK3XhGnR/N75EhRTzOckxvVP2j8XM5a7j66yq2ab
+        JHO2vbiab+/sPPj9IYoEr83qi1yZX4lHpPI/9USCAFwWDQ2ZyPiaZADDfr2eTvN8RhiJGBC50RrD
+        /SVEyLdraAGV+Ce71Ig0Q43fs6aY0p8Ngcef+Oo8WxTlNf6iP6YZyUfR0p+7v+SX/D8A8Nw6YQUA
+        AA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:03:01 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [379d093f-28bb-4c29-b017-238a9738f510]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [fd8afc6d-be51-4bef-8aa0-545fa2b24bfa]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010301Z:379d093f-28bb-4c29-b017-238a9738f510']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-dedicated-47182748?api-version=2018-02-01
+  response:
+    body: {string: '{"Code":"NotFound","Message":"Cannot find WebSite with name cc-dedicated-47182748.","Target":null,"Details":[{"Message":"Cannot
+        find WebSite with name cc-dedicated-47182748."},{"Code":"NotFound"},{"ErrorEntity":{"ExtendedCode":"51004","MessageTemplate":"Cannot
+        find {0} with name {1}.","Parameters":["WebSite","cc-dedicated-47182748"],"Code":"NotFound","Message":"Cannot
+        find WebSite with name cc-dedicated-47182748."}}],"Innererror":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['439']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 01:03:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [5b75dfa7-9537-4889-85a2-ba952a416fc9]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: [5b75dfa7-9537-4889-85a2-ba952a416fc9]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010302Z:5b75dfa7-9537-4889-85a2-ba952a416fc9']
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-dedicated-47182748?api-version=2018-02-01
+  response:
+    body: {string: '{"Code":"NotFound","Message":"Cannot find WebSite with name cc-dedicated-47182748.","Target":null,"Details":[{"Message":"Cannot
+        find WebSite with name cc-dedicated-47182748."},{"Code":"NotFound"},{"ErrorEntity":{"ExtendedCode":"51004","MessageTemplate":"Cannot
+        find {0} with name {1}.","Parameters":["WebSite","cc-dedicated-47182748"],"Code":"NotFound","Message":"Cannot
+        find WebSite with name cc-dedicated-47182748."}}],"Innererror":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['439']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 01:03:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [9258a914-7330-4243-bf4f-a12e99671cca]
+      x-ms-ratelimit-remaining-subscription-reads: ['11996']
+      x-ms-request-id: [9258a914-7330-4243-bf4f-a12e99671cca]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010302Z:9258a914-7330-4243-bf4f-a12e99671cca']
+    status: {code: 404, message: Not Found}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1201']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-dedicated-47182748?api-version=2018-02-01
+  response:
+    body: {string: '{"Code":"InternalServerError","Message":"Internal server error
+        occurred. ","Target":null,"Details":[{"Message":"Internal server error occurred.
+        "},{"Code":"InternalServerError"},{"ErrorEntity":{"ExtendedCode":"01021","MessageTemplate":"Internal
+        server error occurred. {0}","Parameters":[""],"Code":"InternalServerError","Message":"Internal
+        server error occurred. "}}],"Innererror":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Connection: [close]
+      Content-Length: ['386']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 01:03:06 GMT']
+      ETag: ['"1D4A6EDE9103340"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [cde94351-ad3c-4420-b9e3-b535f90468e5]
+      x-ms-failure-cause: [service]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-ms-request-id: [cde94351-ad3c-4420-b9e3-b535f90468e5]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010307Z:cde94351-ad3c-4420-b9e3-b535f90468e5']
+    status: {code: 500, message: Internal Server Error}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['1201']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-dedicated-47182748?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrvTddNWsyJbbrd5027P8lVZXS/yZbu9XhZtc3dVV5fFLK+bu18U07pqqvN2/N18crcp
+        qP3d6ZTemBXTrM1n2/sPdg/2HuwffDT6aJktcsJv6Ov2eoWvIxDpy7fFEmM7Xy+nGFa2Wo3KYrl+
+        N5pWyzYrlnlNjcqKgNK31PCK8F7jRUJ1lddtQVAe/eKbUGha+oS+f7VeLovlBX0yr5r2Bb1Eb38v
+        /to4+8G6zq/yCaM6XubtR98fUf+T16tsCmA3EHP7u/TpV6/36I2G3yA08vL8ebF8Sy/P23bVPLp7
+        9yq7arZpLLPtxdV8e2fnwThbFZ2ur4hG1RWj8Gj//v7dr8EHgAUkaBLfD2uZqMGpr/NVRS2q+vo1
+        tQNBaWxDjasrTOej5bosRx+tm+wif63z8qKqF1lJTfJlNilz4oi2Xuejj7LZoliehp9pk29/nQkc
+        DbRspotIa5pu/PEy4LRF3mazrM3MOGju7Lffs4xIs7x+9+zdT5Io0SRRv5dZucYXT788+b1OX/3M
+        YlqPF1YgptXiLne/beSARPG6nVfLRyUh2rQf/ZKRBf1d4YYIcCD0SwhpEqLXedsSoxNO/CF9dpkV
+        ZTYpyqK97lG9acoTjOGc6aIvEa2amn7/HkGcUlfmU5Dki2pGAORvI0mvm5IBU0NHhzi5eawBqQms
+        vk4vPS0anmL6tFg9yZp8RrBf5c26bE2nl0XdrrPy7KX5oJ2vF5NVXSxtk7b6akUTRQDDv88sSPON
+        68Rg8KJqT6rleXFBeAINjPGNqDFqspxl9cyfkvgo40z1/52RvrKy/RG4iph0tQ6nvsnry7x+ltWL
+        /idnJLA/pyaLMTknTAhGWa1n2yEkGiv1hEaEqGiWovm98yUJ1KPzrGzo7znRof5J+2eZNS2NnqQk
+        n70pFvlX7ZSGuLez+3B7Z3d75+DNzu6jnXuPdg7GBw8/pecBdUE91qTnXuXTirC5fpqfZzS3hvjO
+        HMHa0ZiON0lpvV621O3GNjRfucynmRFHMJ6RKKvSi22dnZP4f5EtCd3aU64CpXm7ppeJeYopNSbO
+        hro/LpvqdVutViChEqnN6ou8fX2VrV6XleVQcBUN9HRJ3FwtgczwN6Ruz4uSRiUNpmVBHx4TcjTd
+        1x1bIF9Cd9kvFA/A5RFYETPfzKoF+RWkPGkiiQzEmGczAkJ/EROZXm/lllTrdlKtl7Oz1fFsRszU
+        gF4f3d8b7z64P967vz/e3Rnhr4N74wP6YHfP/vXpePf+p+av3Z2d8b777j79wIyQ8DUFYf7lz14v
+        /Nf93fHew/HBPfPHvXvjPWYJO9TXxQ9oOnaIdMR511/kC1IJEICfWFewg/RFs25W+ZIY601RWmUD
+        XjTUf5VnDSSL2hqanr7Lp2v88hVNbHOSTefUiby5yN69ICWX11+ef7eq33rzMq/I0LTZYkUk6LlO
+        wLmsIFFny/PKvdLlMAiCfNdmxkSSePl6h8CH6oKkxsiRKB7qbCbSbIQF78SkK24ESDpYSkiCyZ9V
+        HNgr/HJZXiu3/pJf8v8AeY/8iPwLAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:03:24 GMT']
+      ETag: ['"1D4A6EDEBB2A380"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [1570707b-30d0-4616-aa76-94b36716d508]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['499']
+      x-ms-request-id: [7474dae7-dece-4783-9cfd-f57ceee7736b]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010325Z:1570707b-30d0-4616-aa76-94b36716d508']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-dedicated-47182748/config/web?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrvTddNWsyJbbrd5027P8lVZXS/yZbu9XhZtc3dVV5fFLK+bu18U07pqqvN2/N18crcp
+        qP3d6ZTemBXTrM1n2/sPdg/2Huwf3J1Wy/Pi4u5VPvlo9NEyW+SEarQlfd1er/B1FDiDoTZlRa/R
+        CKnddwnJ9KvX6R59TKit8rot8uajR7/4o+V6McnrL8+/W9VvCd2PHu2OPprl59m6bJ9W0zWGRB9+
+        76On8tl43i4IhvdX6f2ZNSv6q1jO8nf4yv8dzYqiadqs5tfoT+0Gb72jP6Xpar766Ps0/Lx9VhMJ
+        rgitnyS8ZBiX++Mdaklt3Gf4+7qdV8vgo2U1y4MPymK5fvfsnfvs6Zcnv9fpq59ZTOvxwlJxWi3u
+        Zj9Y1/n2+Xo5BfFoKhn6o5KmoGkJ0hUhWl01HqzluixHH9X5L1pTizd1Ni2WF6fLbFLmxG3nWdnk
+        +HZRtfnTfLK+uLj56w7oeduunlf8TffFsrponhZ1Pm2r+vp18YP8ebEo2o8e3bsPArdZQY1P67qq
+        B95frSdl0czpm6+avFau+92G2M61fpk1DU0OARIUs9Xqdd629A2xi34EQr4mvLKL/Hg6rdbMSr/4
+        l4w+WhBis6zNTEti2SWNgEb8uq19EItsSp3lv1d+bT6ZZ8tZmddfUH9+w5ny6quqosHLZ8108UbE
+        5EW1zAn7dZPf23tStMLrL+tqmjcEoa3XRAgSu9fV9G3eNl0SZeVVdt18SbMhLX86u8w6E4SPTqol
+        kXuZ19EPOy8Q+ifVYkGDeU7fEoqEHv1FlJq9LFY5cWv+BbEwfXG2bPOLGhNBTS6Lul1n5fFqVWJy
+        CCDh/71fbD5/mbVzeuUutVzNrxtqYj6Cavh9f9+rq6saBKKv67ysspkdqoxMwRh+YhUBfH8JSSSx
+        /fG6nR/PFgXNEuHz0aMd++mbfJktW/cxq8cFofmyqsqzGU1M0V77ryppo+0CYNqwJuYpFvnxU3Cp
+        INX5sMuQGN6TrMyWkEaiwPM8a9pXIqMNUYD0OLj11brEKL9HI8zfkV4keMKmH9XZYvXVyn5PbFtC
+        tOgP6SBbt9W386y0NFRUzef6pjRuRSt8KSbHfHpJau6FiBxhhDkCMbsAzedOvn7xR0QiaSOA1kvq
+        dU6Y05QTp5yUBf1+zBJlmrTV25yoX9W5hS9fZGVZXZGSeNdC/stXJPeY/q/qknqSJqqpSWLYqJmP
+        p9zNmYUkf7/Op3VuhdD/7ARm55xRfDMnu7MiWbcNyTasHWhF6ng9o9dJTO3ns1mBUWUl6bNi+TKj
+        WbJfFs1xRq+0FSMKccMolYoXVXVR5kIZh7L/qSAZfvMlgZu/npLFtL2cZ9N8UlVviWsdHO/DEIz5
+        IgKovSpaojmpiIZ0V+0puc43IURrrVSnCvIOlfj3m2H0sCNun1ZwB36xmYov64IITp98j81R8+ju
+        XWsjx6zqYT2JjXvfbpPRp1cvbmi1zN+RL2CbkEA269WqqtuTOmfNQPOos0nYrdYN6TWgSkyxKsgD
+        KcjxIkD2Q+KD11fZ6nVZqYzJ5/CKyi+uX/+inuCq/n2d15fFNDfayBH23Rc3NCgw9+uaPntFSqYu
+        ZGDmW4x4b8d2KhqXNOKbsrHG4aPdMVy0c6KN6r+PjsuS/ocZoC/IC6XO89nZkmhKcnGCySON+0t+
+        yf8Dj8+QXdsKAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:03:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [6d518676-0f5a-428e-852f-37afcfdf57c1]
+      x-ms-ratelimit-remaining-subscription-reads: ['11992']
+      x-ms-request-id: [8babd339-00db-4e14-ac0a-9282846553ae]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010326Z:6d518676-0f5a-428e-852f-37afcfdf57c1']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/custodian-test-deployment-units/providers/Microsoft.Web/sites/cc-dedicated-47182748/config/appsettings/list?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrvTddNWsyJbbrd5027P8lVZXS/yZbu9XhZtc3dVV5fFLK+bu18U07pqqvN2/N18crcp
+        qP3d6ZTemBXTrM1n2/sPdg/2Huwf3J1Wy/Pi4m62WjV52xbLi+aj0UfLbJETyuGH7fUKH0ZBMxBq
+        U1YEnsZH7b5LKKZfvU736GNCbJXXbZE3Hz36xR99cXzy7bMXp7/X6e/z+z/Np/U1U+T3yq/ppf39
+        0wcHu5/uP92j/z09ODk4eHB8unP69ODBydP7+w8P9u8/2Hn47OT09MGTB/fuHzzcf3a8v/NkZ/fB
+        /u6DZ08e7lNfxz9Y1zmh9p1q0rxuqzq7ANZP8/NsXbany9mqKpZt87Ku2mpalZ/N23bVHB5Pp9V6
+        2b6gcX9mqZzJh4ZUphFh+tlPnux/ca94dvpJsf/TFw/bz68//8lvf+cn9n7iB3t7D65Wv/eb1wef
+        zw7ad7/oJx/UXz7/id/r5btn59PXzz+tmnvH9+/95O/1E7/3w1c/+eDu50/eld85f1J/9/f58vfK
+        f2py8dlnHfyfZs18UmU1+Of/OyN49tWLkzdnX754/fuf/t5vTl+8pl9//588fYWfNI5J3mZBo+9+
+        +er3On31+7/66sWbsy9OqcXqup0TC/2SX/L/AF4JtHk6AwAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 01:03:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [539c578b-18ec-4d2a-8ba0-32ac9544fef8]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-request-id: [5acfc999-5b3d-4efc-8cbe-8b68e90cdc26]
+      x-ms-routing-request-id: ['WESTUS2:20190108T010326Z:539c578b-18ec-4d2a-8ba0-32ac9544fef8']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/FunctionAppUtilsTest.test_deploy_function_app_pre_existing_app_fetch_actual_sku_tier.yaml
+++ b/tools/c7n_azure/tests/cassettes/FunctionAppUtilsTest.test_deploy_function_app_pre_existing_app_fetch_actual_sku_tier.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Web/sites/cloud-custodian-test?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrtt3rS///l6OQWIbLXarvNf1Nxd1dVlMcvr5u4XxbSumuq8HX83n9xtCmp/d1pW69n2
+        dN201azIltv0WfvR6KNltsgJqYFv2+sVvo3Aoy/fFkuMx8NjVBbL9Tv6qqymGT6jr79LkNKvXqd7
+        9DFhuMrrtqDXH/3iG7pu2qzF16/Wy2WxvKBP5lXTvqB36OXvRd8aZz9Y1/lVPmEMx8u8/ej7o4/o
+        79erbApY9GmfbtvA8KvXe9Su4XbUd16ePy+Wb+mVeduumkd3715lV8024T/bXlzNt3d2HoyzVdHp
+        8IoIUl1xx4/27+/f/RoTDVhAYmCOu7jKXAzNbZ2vKmpQ1devqRlIRwMaaFtdLfP6o0fLdVmOPlo3
+        2UX+WifgRVUvspKa5MtsUuY05W29zkcfZbNFsTwNP9Mm3/4aMzWKN2ymi0hjmlb88TLgp0XeZrOs
+        zcwoaLbst9+z7Ebzun737N1PkpwQYanby6xc44uPfsnINvquzGSkGUD/EuqeZuR13rbEmQSdP6TP
+        LrOizCZFWbTXPeo1TXkCbM4LEg2ghJdo0E1Nv3+PIE6pK/MpBvdFNSMA8rdh/ddNyYCpoRtRlG59
+        mhFUfZveeVo0PFP0abF6kjX5jEC/ypt12Zo+L4u6XWfl2UvzQTtfLyaruljaJm311YooTgDDv88s
+        SPON68Rg8KJqT6rleXFBeAINDPGNqBtqspxl9cyfkegg48zx/52BvrIC+hF4alotVutw4pu8vszr
+        Z1m96H9yRmL3c2BNuP9z6n+D3uFGhJ5ohaL5vfMlCdGj86xs6O85jb7+SftnmTUtjZkkI5+9KRb5
+        V+2UBra3s/twe2d3e+fgzc7Bo70Hj/YfjvdgRKizmtTTq3xaESLXT/PzjCbTUNuZi2m1bPNle7xJ
+        KOv1sqUeN7ahCcplAs0UzPJVWV0vCDhPwQAV2jo7J2H/IlsStrWnEgVI83ZN7xKzFFNqTJwMHX1c
+        NtXrtlqtQDwlT5vVF3n7+ipbvS4ry5HgIhrn6ZK4t1oCl+FvSE2eFyUNShpMy4I+PCbkljTejgaX
+        L6Gp7BeKB+DyCKxImW9m1SIrlqQqaQpJuREXnc0ICP1F7GN63eAtVOt2Uq2Xs7PV8WxGzNOASh/d
+        3xvvPrg/3ru/P97dGeGvg3vjA/pgd8/+9el49/6n5q/dnZ3xvvvuPv04IOgkYk1B+H75s9cL/3V/
+        d7z3cHxwz/xx7954bx8IgBGJPnn9uvgBTcLu/XufEs2I466/yBck++D5n1hXMFw7xAnrZpUvZxCF
+        0moV8KAh+6s8ayBM1NYQ8/RdPl3jl69oRpuTbDqnfuTNRfbuBWmzvP7y/LtV/dabkHlF9qTNFiui
+        Qs+7AdplBUk6W55X7pUua0EA5Ls2M5aQxMpXMAQeEtHTMNTFTGTXyAa1pE57shRX8SQLLBMkrmvb
+        MXtrXy7La+XNX/JL/h9ee1hfdQsAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 08:43:52 GMT']
+      ETag: ['"1D4A72C0A348240"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [f5b785b2-915d-44d8-9e2c-3dc2f66bfeb2]
+      x-ms-ratelimit-remaining-subscription-reads: ['11995']
+      x-ms-request-id: [54830471-8bd1-425f-a7d7-715ca8b83435]
+      x-ms-routing-request-id: ['WESTUS2:20190108T084352Z:f5b785b2-915d-44d8-9e2c-3dc2f66bfeb2']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Web/serverfarms/cloud-custodian-test?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrtt3rS///l6OQWIbLXarvNf1Nxd1dVlMcvr5u4XxbSumuq8HX83n9xt8voyr8+zetHc
+        nZbVerY9XTdtNSuy5TYgfTT6aJktckJt4Nv2eoVvB6FSk7fFEmMri+X6Hf1ZVtMMuNFH3yUY6Vev
+        0z36mDBc5XVb5M1Hj37xRwLhGUE4o3f3H+x/ehMiV1X9Nq9fFz9Am6f5ebYuw48BaMd88KbI6xcM
+        b7kuS4K9Xkzy+svz7/K3hMLu6KPpuq7zZSsfAUIAuPetwtfPX0QANm3WrunXj17l2eyaYFzlk9er
+        bArAGEVv2rZBoK9e71G7htsRDI9B6LXbcAi9lc0WxfJ10eb+mOdV0xbLi9PlZVFXywUhPfzNy7o6
+        L0r76iJ7VyzWi94g79E8ltlSevnoJ4u6XWfl03xW0JTns5f0lUHm1XrZFou8i9O0WqzWbf5FNaOP
+        iNr6Jr3VUEv5WFpe5NWr/EKoADJZPsJstPnraUYMd/HRo/OsbHKL8WmZ0dCmgvBJRUjwzJjpx5s0
+        DPqkTwLMr3RdNK9XFb2ooBv64/TdqqiZrd/QqEzD8zrPvzw/z+vu1x/t7ew+3N7Z29558Gbn4NHe
+        p4/298YP9+7hoTG02QVhITA60hNIO31O+Pb5RtpBhOjVtl4TkkXze+dLEEuRnpPc1j9p/1zMWNA+
+        usqumm0Sxdn24mq+vbPz4PeH7BG8NqsvcuV2pRsxu/+pJwME4LJoCCGi4Gtieoz49Xo6zfMZYSR8
+        T5RGawzylxAN364h9iriT3apEamCGr9nTTGlPxsCjz/x1Xm2KMpr/EV/TDMSjaKlP3d/yS/5fwC1
+        LCoJSAUAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 08:43:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [8f659590-cef4-479e-a593-9db79310a131]
+      x-ms-ratelimit-remaining-subscription-reads: ['11995']
+      x-ms-request-id: [99edb78f-9093-45cb-af30-350ce5364240]
+      x-ms-routing-request-id: ['WESTUS2:20190108T084352Z:8f659590-cef4-479e-a593-9db79310a131']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/FunctionAppUtilsTest.test_publish_functions_package_consumption.yaml
+++ b/tools/c7n_azure/tests/cassettes/FunctionAppUtilsTest.test_publish_functions_package_consumption.yaml
@@ -1,0 +1,312 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Storage/storageAccounts/cloudcustodiantest?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9ez3f/7q9Uejj9oir71PP/olo4/eFssZf1TV2UVObQr8ebdZT5pp
+        Xazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3YPf+bOdBfrfOm2pdT/PP62q9au62
+        edP+/ufr5RQgstVqu85/UXN3VVeXxSyvm7tfFNO6aqrzdqx9323k5/F0Wq2XbXN3Wlbr2XRNH8+K
+        bAl4hJ4OLPpde73CdzdCpqZlNc2AGDW/opfXzR592GYXDRGPqEJorvKayIW/P1rm7VVVvz2elvzn
+        5HqVNfTbR8c/WNf567y+LKbUcPTRZVG366x8Ic1frUv69NH3vk80XXl/zPLzbF22x0wYQCnL6gpT
+        0axXq6pum2+37ap5U2fn58X0y2V5/dGj86xs8tFH+XJaX/OUAI3GdEy/nxcljfwXU4tsUuY0g229
+        phfKrGlP5aM3BdNtb2f34fbO7vbOwZudg0d7nz7a3xvv7jzcffDw3k8Bh0lZTb4BQATpbX79mvmB
+        GvdmBF0RjS+LhgZTLC+II1s0fL2eTvN8Rh2PPprWOU/Rhg539j/99P6nOz9FrVd1scjq69PlbFUV
+        mGMahAzmozno+ehuhJ/GaDGeVnU+viI5qK6aMc31XQL3i9b5Gr1ueJebRF9uQajNL3OT6MsylZve
+        RYvIq0xSJsLzGHM3ROJ18+X5S2lD32WXWVECj49+yS/5fwDZGzDNOQQAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 09:24:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [efb41027-c2ba-41f2-bd98-c69570d19f1d]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [590bd4d8-3ddb-4141-a789-77d5ef6836df]
+      x-ms-routing-request-id: ['WESTUS2:20190108T092413Z:efb41027-c2ba-41f2-bd98-c69570d19f1d']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Storage/storageAccounts/cloudcustodiantest/listKeys?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
+        6+ajR9/jX15ki/yjR/ht96PRR5dZucafi3vF9d4nu6/Pf/LV6f4iP3h2Pn3wi56+/u53F1fl7/Xd
+        4/WzvesHxfny9Pda7n3yEzvZSTZ9t793cHl98OVPXzUv8gcPP985/b2v6/b3zn6v+7ufHDeL7z7J
+        L68++4y6WOX1omiaoloSDh89++r5849+yaiDyh61M6is73++vvzB7vLp/qv6+uHV67cvd6u3J6sv
+        f58nu3unP7Wf3ft9Hv7kqydPpmcXb3+v47Pv3n3zrm1Ovnz96qeOf/oHP/F7vbv37VU5O7l3evJJ
+        M/9iZ/rlOlv81C96cDyIyvd/yf8DNh01QiABAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 09:24:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [81c8df5f-37ae-4cbb-aa80-10e0e241a52e]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [093e9945-5a83-430c-8049-9ae8b95a9130]
+      x-ms-routing-request-id: ['WESTUS2:20190108T092413Z:81c8df5f-37ae-4cbb-aa80-10e0e241a52e']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/1.4.0-1.4.0 (Python CPython 3.6.5; Darwin 18.2.0)]
+      x-ms-date: ['Tue, 08 Jan 2019 09:24:13 GMT']
+      x-ms-version: ['2018-03-28']
+    method: PUT
+    uri: https://cloudcustodiantest.blob.core.windows.net/cloud-custodian-packages?restype=container
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:b47859bf-d01e-0098-1633-a787b7000000\nTime:2019-01-08T09:24:13.9630295Z</Message></Error>"}
+    headers:
+      Content-Length: ['230']
+      Content-Type: [application/xml]
+      Date: ['Tue, 08 Jan 2019 09:24:13 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-error-code: [ContainerAlreadyExists]
+      x-ms-request-id: [b47859bf-d01e-0098-1633-a787b7000000]
+      x-ms-version: ['2018-03-28']
+    status: {code: 409, message: The specified container already exists.}
+- request:
+    body: null
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/1.4.0-1.4.0 (Python CPython 3.6.5; Darwin 18.2.0)]
+      x-ms-blob-type: [BlockBlob]
+      x-ms-date: ['Tue, 08 Jan 2019 09:24:13 GMT']
+      x-ms-version: ['2018-03-28']
+    method: PUT
+    uri: https://cloudcustodiantest.blob.core.windows.net/cloud-custodian-packages/cloud-custodian-test.zip
+  response:
+    body: {string: ''}
+    headers:
+      Content-MD5: [1B2M2Y8AsgTpgAmY7PhCfg==]
+      Date: ['Tue, 08 Jan 2019 09:24:13 GMT']
+      ETag: ['"0x8D6754B0E25DEF2"']
+      Last-Modified: ['Tue, 08 Jan 2019 09:24:13 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [b47859c7-d01e-0098-1a33-a787b7000000]
+      x-ms-request-server-encrypted: ['true']
+      x-ms-version: ['2018-03-28']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Web/sites/cloud-custodian-test/config/appsettings/list?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrtt3rS///l6OQWIbLXarvNf1Nxd1dVlMcvr5u4XxbSumuq8HX83n9xtCmp/d1pW69n2
+        dN201azIltv0WXt3Wi3Pi4u7BKLJ27ZYXjQfjT5aZouc8Aw/bK9X+DAKmYFQm7KaZsCI2n2XoKdf
+        vU736GPCa5XXbZE3Hz36xR8d/2Bd5/Tyd6pJ8zRr5pMqq0GWp/l5ti7b0+VsVRXLtnlZV201rcrP
+        5m27ag6Pp9NqvWxfEG6f8VDsSAiF1nz9e+XXny3uFdd7n+y+Pv/JV6f7i/zg2fn0wS96+vq7311c
+        lb/Xd4/Xz/auHxTny9Pfa7n3yU/sZCfZ9N3+3sHl9cGXP33VvMgfPPx85/T3vq7b3zv7ve7vfnLc
+        LL77JL+8+uwzGomP++u2qrML0OT/C5g/++rFyZuzL1+8/v1Pf+83py9e06+//0+evsJPGsEvxTS5
+        Jt/98tXvdfrq93/11Ys3Z1+c0ver63ZO0zr66Ivjk2+fvTj9vU5/n9//aT6tr5mHCXVqs793/9nJ
+        w/vHJ6c7z3YOdvefPXn6cOf0+ODJ/fv3Tu8/efL0wdMnDw4enOw8OTnYuf/gwf3d4wf3P33w9ODk
+        4d7us2c7BP27p09en705Rce//7NXX37x+788Pvm9jj8HBkzKR3eFiwMCjidlNRlPqzofXxXLWXXV
+        jJc5cTYaeuy+yqZvabqIWztfMIwfFKvfo8k/29vZe7i9s7u9c//NzsPf/d7x3i79c3//p35hs/qs
+        /oXNJTXYPdjeube9d/ALm/qzyS9siovP1vP5wy/u11dXv/e3997c/73zbx/8Pm8uf68nn16f/eB3
+        33vybvGyuaafOy+efzGbLN79xO9+7+lHv+SX/D8oXm9eDAQAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 09:24:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [964053ed-9832-4bf5-bb0e-e37cc3afb250]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-request-id: [d7ba643e-c00c-40f5-b6e1-649a0983d6d0]
+      x-ms-routing-request-id: ['WESTUS2:20190108T092414Z:964053ed-9832-4bf5-bb0e-e37cc3afb250']
+    status: {code: 200, message: OK}
+- request:
+    body: mock_body
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['825']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Web/sites/cloud-custodian-test/config/appsettings?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrtt3rS///l6OQWIbLXarvNf1Nxd1dVlMcvr5u4XxbSumuq8HX83n9xtCmp/d1pW69n2
+        dN201azIltv0WXt3Wi3Pi4u7BKLJ27ZYXjQfjT5aZouc8Aw/bK9X+DAKmYFQm7KaZsCI2n2XoKdf
+        vU736GPCa5XXbZE3Hz36xR8d/2Bd5/Tyd6pJ8zRr5pMqq0GWp/l5ti7b0+VsVRXLtnlZV201rcrP
+        5m27ag6Pp9NqvWxfEG6f8VDsSAiF1nz9e+XXny3uFdd7n+y+Pv/JV6f7i/zg2fn0wS96+vq7311c
+        lb/Xd4/Xz/auHxTny9Pfa7n3yU/sZCfZ9N3+3sHl9cGXP33VvMgfPPx85/T3vq7b3zv7ve7vfnLc
+        LL77JL+8+uwzGomP++u2qrML0OT/C5g/++rFyZuzL1+8/v1Pf+83py9e06+//0+evsJPGsEvxTS5
+        Jt/98tXvdfrq93/11Ys3Z1+c0ver63ZO0zr66Ivjk2+fvTj9vU5/n9//aT6tr5mHCXVqs793/9nJ
+        w/vHJ6c7z3YOdvefPXn6cOf0+ODJ/fv3Tu8/efL0wdMnDw4enOw8OTnYuf/gwf3d4wf3P33w9ODk
+        4d7us2c7BP27p09en705Rce//7NXX37x+788Pvm9jj8HBkzKR3eFiwMCjidlNRlPqzofXxXLWXXV
+        jJc5cTYaeuy+yqZvabqIWztfMIwfFKvfo8k/29vZe7i9s7u9c//NzsPf/d7x3j79s7v/U7+wWX1W
+        /8LmkhrsHmzv3NveO/iFTf3Z5Bc2xcVnv9fFu7cPf2K2evtg/yeXr9++/snz09flu/sPrxe7+7NX
+        2fmXJ8fPfuLkd9978otWZwe/+72nH/2SX/L/AJyfJ+0KBAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 09:24:15 GMT']
+      ETag: ['"1D4A733ECC82F60"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [5a018953-8933-440a-b7d5-fe3883d8e3e6]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [ef2fb206-37e8-4a4f-9c2a-2cf3bf4119f3]
+      x-ms-routing-request-id: ['WESTUS2:20190108T092416Z:5a018953-8933-440a-b7d5-fe3883d8e3e6']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Web/sites/cloud-custodian-test/syncfunctiontriggers?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfNevpNG+aj37J/wOYQdJ9FAAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 09:24:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0, Apache/2.4.10, (Debian)]
+      Set-Cookie: [ARRAffinity=390bed2f5631f2e0d837a46b3191896e948d3a72bf9d98064486eacc376139bf;Path=/;HttpOnly;Domain=cloud-custodian-test.scm.azurewebsites.net]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [ec4133fd-6598-4f60-bf54-39a7ee0e7b36]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [fccf9dde-cc97-4799-9592-da40f97f90db]
+      x-ms-routing-request-id: ['WESTUS2:20190108T092419Z:ec4133fd-6598-4f60-bf54-39a7ee0e7b36']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Web/sites/cloud-custodian-test/config/appsettings/list?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrtt3rS///l6OQWIbLXarvNf1Nxd1dVlMcvr5u4XxbSumuq8HX83n9xtCmp/d1pW69n2
+        dN201azIltv0WXt3Wi3Pi4u7BKLJ27ZYXjQfjT5aZouc8Aw/bK9X+DAKmYFQm7KaZsCI2n2XoKdf
+        vU736GPCa5XXbZE3Hz36xR8d/2Bd5/Tyd6pJ8zRr5pMqq0GWp/l5ti7b0+VsVRXLtnlZV201rcrP
+        5m27ag6Pp9NqvWxfEG6f8VDsSAiF1nz9e+XXny3uFdd7n+y+Pv/JV6f7i/zg2fn0wS96+vq7311c
+        lb/Xd4/Xz/auHxTny9Pfa7n3yU/sZCfZ9N3+3sHl9cGXP33VvMgfPPx85/T3vq7b3zv7ve7vfnLc
+        LL77JL+8+uwzGomP++u2qrML0OT/C5g/++rFyZuzL1+8/v1Pf+83py9e06+//0+evsJPGsEvxTS5
+        Jt/98tXvdfrq93/11Ys3Z1+c0ver63ZO0zr66Ivjk2+fvTj9vU5/n9//aT6tr5mHCXVqs793/9nJ
+        w/vHJ6c7z3YOdvefPXn6cOf0+ODJ/fv3Tu8/efL0wdMnDw4enOw8OTnYuf/gwf3d4wf3P33w9ODk
+        4d7us2c7BP27p09en705Rce//7NXX37x+788Pvm9jj8HBkzKR3eFiwMCjidlNRlPqzofXxXLWXXV
+        jJc5cTYaeuy+yqZvabqIWztfMIwfFKvfo8k/29vZe7i9s7u9c//NzsPf/d7x3j79s7v/U7+wWX1W
+        /8LmkhrsHmzv3NveO/iFTf3Z5Bc2xcVnv9fFu7cPf2K2evtg/yeXr9++/snz09flu/sPrxe7+7NX
+        2fmXJ8fPfuLkd9978otWZwe/+72nH/2SX/L/AJyfJ+0KBAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 09:24:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [64dd05f9-1eb0-471c-bc31-4d05c6c80b19]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-request-id: [fbeb59bc-33cc-4a72-98c1-bcb0e63b8aab]
+      x-ms-routing-request-id: ['WESTUS2:20190108T092420Z:64dd05f9-1eb0-471c-bc31-4d05c6c80b19']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/FunctionAppUtilsTest.test_publish_functions_package_dedicated.yaml
+++ b/tools/c7n_azure/tests/cassettes/FunctionAppUtilsTest.test_publish_functions_package_dedicated.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Web/sites/cloud-custodian-test/config/publishingcredentials/list?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Sx7ePDwwf5k+/5sL9venz082M4eHGTb9w72zu892L0/23mQ363zplrX
+        0/zzulqvmrtt3rS///l6OQWIbLXarvNf1Nxd1dVlMcvr5u4XxbSumuq8HX83n9xtCmp/d1pW69n2
+        dN201azIltv0WXt3tZ6URTMvlhfTOp/ly7bIyubu7xZr+9Hoo2W2yGkAA9+21yt8G+s72g29UlbT
+        DEOg175LQNKvXqd79DENZJXXbZE3Hz36xdrrcl2W9I0F9FWT1y/4m4+G0HWNX2ZNc1XVoP79X3RV
+        FW9+n9/7809Pi+P7P53df/bd/eMXJ+ufvno7ze59+1X13f17k+fNw8u95ovydFmef7rOrl7sPTx+
+        UP8gCvPbWTPvo+d/+zorW9NikbfZLGsz83fRPM3LvM0JtXOiST76qJkuvqoLwnTetqvm0d34bDz6
+        kHH8njGIY+p4nP1gXedX+YSnbbzM249+yS/5fwAb2eZbtwIAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Tue, 08 Jan 2019 09:32:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [bdc0e593-4a6b-4f8d-90f8-000e66145da9]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-request-id: [30008b41-f752-4914-8902-528fc1d88a06]
+      x-ms-routing-request-id: ['WESTUS2:20190108T093226Z:bdc0e593-4a6b-4f8d-90f8-000e66145da9']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.21.0]
+    method: GET
+    uri: https://cloud-custodian-test.scm.azurewebsites.net/api/deployments
+  response:
+    body: {string: '[]'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['2']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 09:32:26 GMT']
+      ETag: ['"6ac6b952"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Apache/2.4.10 (Debian)]
+      Set-Cookie: [ARRAffinity=390bed2f5631f2e0d837a46b3191896e948d3a72bf9d98064486eacc376139bf;Path=/;HttpOnly;Domain=cloud-custodian-test.scm.azurewebsites.net]
+      X-AspNet-Version: [4.0.30319]
+      x-ms-request-id: [8d872a9a-82ff-4c64-a72c-aff9c013c940]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-web/0.40.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Web/sites/cloud-custodian-test/syncfunctiontriggers?api-version=2018-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfNevpNG+aj37J/wOYQdJ9FAAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Jan 2019 09:32:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/10.0, Apache/2.4.10, (Debian)]
+      Set-Cookie: [ARRAffinity=390bed2f5631f2e0d837a46b3191896e948d3a72bf9d98064486eacc376139bf;Path=/;HttpOnly;Domain=cloud-custodian-test.scm.azurewebsites.net]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-correlation-request-id: [c639c6c4-cc5e-41d1-90f7-9080a57ba6e9]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [a6116156-9ad2-4fd8-9da5-1f3c4a4a68fd]
+      x-ms-routing-request-id: ['WESTUS2:20190108T093228Z:c639c6c4-cc5e-41d1-90f7-9080a57ba6e9']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_blob_client_from_storage_account_with_sas.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_blob_client_from_storage_account_with_sas.yaml
@@ -1,0 +1,187 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
+        alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
+        epp/XlfrVXN3+mCZrVarMlveXdXVZTHL6+buF8W0rprqvB1rh3cb+Xk8nVbrZUuvremTWZEts53Z
+        3r3Jwz1CSQcT+6q9XuGrG+FS07KaZhgONc+zpl3jsza7aIhcRAfCcZXXRCD8/dEyb6+q+u3xtOQ/
+        J9errKHfPjr+wbrOX+f1ZTGlhqOPLou6XWflC2n+al3Sp4++932i4sr7Y5afZ+uyPZ5q98dlWV2B
+        +M16tarqtvl2266aN3V2fl5Mv1yW1x89Os/KJh99lC+n9TVPAtBoTMf0+3lR0sB/MbXIJmVOc9bW
+        a3qhpJGdykdvCqba3s7uw+2d3e2d/Td7u4/u7z3a2RnvPbx3f3dv56eAw6SsJt8AIIL0Nr9+zRxA
+        jXsTgq6IxpdFQ4MplhfEgy0avl5Pp3k+o45HH03rnGdoQ4e79x7sPfz005+i1qu6WGT19elytqoK
+        TDENQgbz0Rz0fHS3z0xjNBhPqzofXxHjV1fNmKb6LkH7RescErThVW4RfbcFmTa+yy2i78o8bngV
+        DSJvMjmZAM8jfN0QddfNl+cvpQl9lV1mRQksMFXESv8vUhNTene9YBhfT1XMdvLd+7s7O4SWDij2
+        1Y9UhYjzLST8/pud+492P320czDe2d3ffXD/Pkn411EVUUAE6WdNVdgOH4wf3vt052Dv3vuqCsMx
+        X0NV2Fe5RfTdFmTa+C63iL4r87jhVTSIvMnkZAL8f1xVlNV6tt3M87LcpqED+rYM4/3URrNnekfn
+        79D5O+qcMNUxbmjxzSiRjxbNthnc9rqh96hRBoWx7Q0SxKSB/b9J14jAfzOq5mB7d2979+GbvXuP
+        9vYf3b833iH1sHd/lzTE+6maDYAI0s+Cqul0uDd+SKxy/x7pNkBjMdqoagbY6z00zhAEbhgF0YJo
+        twHBDaMgZHJvhoB2EQBMaibO/7fV0OL6lf/Be+me1XU7r5bn6+VUv9ndu7d/n5DTYQ1+/83oHSIL
+        Yfv/JoXys+C87MEFoP/t743vkR6493CfFMH7aZQNgAjSz4JG6XS4O354sLO3u0sqDNBYIjZplDjb
+        3F6fDLzPzaIAWhDsZgDcLApApvWm99Eq8jqTmIny/21Nsrq+ypv2PRUIiMTUwbsH558CIR1K/Muv
+        pzoAgMn580t17D58tPfpo91dhCsHe/sPSeK/nuqIACJIP4uqQzvcGT/cub+//ynlZACNRWCz6ujx
+        zPvojf7L3Cb6dgtS3fA2t4m+LbO58WU0ibzLZGVCeOoCLzF//39HXbSE8u+vQvteSmM6bfWj60+z
+        t9e/aJVdzNp7FaGmgxpu8PWUB6Hdzqf5sq2zkon880mJPHize/DoPsUFn47vP/x0f3+HrDjhAKH6
+        BgARpJ81JeJ3uLP36cMd0lqAxoKxSYkM8M/tFckQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMGE+p
+        9Pj+/2PK5XLxXnpl//7iF00vsgert81V0WRlsVy/u1wQUjqcwe9/pFWIqfDzNsrAZhv2Hu0/eLS7
+        N37w6f2Dh/t7pAzeT6tsAESQfha0Sq/DTw8ePPh0/7arN3H2ub1SGXifm0UBtCDYzQC4WRSATOtN
+        76NV5HUmMRPl62uU7/+S/wewA+uTDB4AAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1450']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 07 Jan 2019 22:04:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [a22931f9-9b5f-42e8-b313-f1d35ff1bcf5]
+      x-ms-original-request-ids: [a75c3e69-aa12-4ba6-a017-128612c96eec, eda08c53-3e75-4ac2-b0c0-3eb338c313d3,
+        57e3b9c1-5076-4973-906b-0ab6e45678be]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [a22931f9-9b5f-42e8-b313-f1d35ff1bcf5]
+      x-ms-routing-request-id: ['WESTUS2:20190107T220444Z:a22931f9-9b5f-42e8-b313-f1d35ff1bcf5']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9ez3f/7q9Uejj9oir71PP/olo4/eFssZf1TV2UVObQr8ebdZT5pp
+        Xazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3YPf+bOdBfrfOm2pdT/PP62q9au62
+        edP+/o2Avbuqq8tiltfN3S+KaV011Xk71i7vapvj6bRaL9vm7nTa6kfXn2Zvr3/RKruYtfcqQk0H
+        NdygvV6hwY19UNOymmYYHDUntNv5NF+2dVau8V2bXTRERKIO4b3KayIb/v5ombdXVf32eFryn5Pr
+        VdbQbx8d/2Bd56/z+rKYUsPRR5dF3a6z8oU0f7Uu6dNH3/s+0Xbl/THLz7N12R5PFY3jsqyuMCXN
+        erWq6rb5dtuumjd1dn5eTL9cltcfPTrPyiYffZQvp/U1Tw3QaEzH9Pt5URIBfjG1yCZlTjPZ1mt6
+        ocya9lQ+elMwDfd2dh9u7+xu7zx4s3vw6P7+o/ufju8//HR/f2f3p4DDpKwm3wAggvQ2v37NfEGN
+        exODrojGl0VDgymWF8SZLRq+Xk+neT6jjkcfTeucZ2pThzt7nz7cefhT1HpVF4usvj5dzlZVgamm
+        QchgPpqDno/uDjHYGM3G06rOx1ckFNVVM6YJv0swf9E6X6PrmwBwuyiEFiS7BQRuF4UgM3sjADSL
+        vM9kZsI838D3DVF/3Xx5/lKaUpPsMitK4PTRL/kl/w8OZP5zXAQAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 Jan 2019 22:04:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [e9706541-b22f-47cd-a9c7-f6f0c05829e5]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [498b104b-49ac-402c-b264-0679e037610f]
+      x-ms-routing-request-id: ['WESTUS2:20190107T220444Z:e9706541-b22f-47cd-a9c7-f6f0c05829e5']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: POST
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o/listKeys?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
+        6+ajR9/jX15ki/yjR/ht96PRR5dZucafy4PZydPf+/Ins59evL34/Pjuq5/8fV4+P6jKZ9cnT36f
+        p0/yr2ZP3z27+OSnH7x89vKnmt/7J96c/KLj+fnTp7/3xfV3TyevTn56lR+vJ/XvtbffnK2+utpd
+        fbku84vPPqMuVnm9KJqmqJaEw0fPvnr+/KNfMuqgskftDCrl6umr09cXr3+f46xuLs9e7LTzt6c/
+        de/l/sX577W/PN19Wp69uTpYTL76vd8cv977RfeW9e9zd/aLjo/fPK0nT1//1KufOmme/PRq9YM6
+        //z+dz959lO/1+wX3f3qahCV7/+S/wfeZPydIAEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 Jan 2019 22:04:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [048ad332-2f8e-4813-b5f5-93a0aeb71527]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-request-id: [9c27e532-f29d-446d-87e1-cc6876d11058]
+      x-ms-routing-request-id: ['WESTUS2:20190107T220444Z:048ad332-2f8e-4813-b5f5-93a0aeb71527']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/1.4.0-1.4.0 (Python CPython 3.6.5; Darwin 18.2.0)]
+      x-ms-date: ['Mon, 07 Jan 2019 22:04:44 GMT']
+      x-ms-version: ['2018-03-28']
+    method: PUT
+    uri: https://cctstoragey6akyqpagdt3o.blob.core.windows.net/test?restype=container
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:bf3b1658-101e-0147-6dd4-a6da0d000000\nTime:2019-01-07T22:04:44.9557718Z</Message></Error>"}
+    headers:
+      Content-Length: ['230']
+      Content-Type: [application/xml]
+      Date: ['Mon, 07 Jan 2019 22:04:44 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-error-code: [ContainerAlreadyExists]
+      x-ms-request-id: [bf3b1658-101e-0147-6dd4-a6da0d000000]
+      x-ms-version: ['2018-03-28']
+    status: {code: 409, message: The specified container already exists.}
+- request:
+    body: mock_body
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['17']
+      User-Agent: [Azure-Storage/1.4.0-1.4.0 (Python CPython 3.6.5; Darwin 18.2.0)]
+      x-ms-blob-type: [BlockBlob]
+      x-ms-date: ['Mon, 07 Jan 2019 22:04:44 GMT']
+      x-ms-version: ['2018-03-28']
+    method: PUT
+    uri: https://cctstoragey6akyqpagdt3o.blob.core.windows.net/test/test.txt
+  response:
+    body: {string: ''}
+    headers:
+      Content-MD5: [C54pDjExkICJDvhIlcZ1DQ==]
+      Date: ['Mon, 07 Jan 2019 22:04:44 GMT']
+      ETag: ['"0x8D674EC21F381A5"']
+      Last-Modified: ['Mon, 07 Jan 2019 22:04:45 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [bf3b1689-101e-0147-15d4-a6da0d000000]
+      x-ms-request-server-encrypted: ['true']
+      x-ms-version: ['2018-03-28']
+    status: {code: 201, message: Created}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_blob_client_from_storage_account_without_sas.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_blob_client_from_storage_account_without_sas.yaml
@@ -1,0 +1,103 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
+        alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
+        epp/XlfrVXN3+mCZrVarMlveXdXVZTHL6+buF8W0rprqvB1rh3cb+Xk8nVbrZUuvremTWZEts53Z
+        3r3Jwz1CSQcT+6q9XuGrG+FS07KaZhgONc+zpl3jsza7aIhcRAfCcZXXRCD8/dEyb6+q+u3xtOQ/
+        J9errKHfPjr+wbrOX+f1ZTGlhqOPLou6XWflC2n+al3Sp4++932i4sr7Y5afZ+uyPZ5q98dlWV2B
+        +M16tarqtvl2266aN3V2fl5Mv1yW1x89Os/KJh99lC+n9TVPAtBoTMf0+3lR0sB/MbXIJmVOc9bW
+        a3qhpJGdykdvCqba3s7uw+2d3e2d/Td7u4/u7z3a2RnvPbx3f3dv56eAw6SsJt8AIIL0Nr9+zRxA
+        jXsTgq6IxpdFQ4MplhfEgy0avl5Pp3k+o45HH03rnGdoQ4e79x7sPfz005+i1qu6WGT19elytqoK
+        TDENQgbz0Rz0fHS3z0xjNBhPqzofXxHjV1fNmKb6LkH7RescErThVW4RfbcFmTa+yy2i78o8bngV
+        DSJvMjmZAM8jfN0QddfNl+cvpQl9lV1mRQksMFXESv8vUhNTene9YBhfT1XMdvLd+7s7O4SWDij2
+        1Y9UhYjzLST8/pud+492P320czDe2d3ffXD/Pkn411EVUUAE6WdNVdgOH4wf3vt052Dv3vuqCsMx
+        X0NV2Fe5RfTdFmTa+C63iL4r87jhVTSIvMnkZAL8f1xVlNV6tt3M87LcpqED+rYM4/3URrNnekfn
+        79D5O+qcMNUxbmjxzSiRjxbNthnc9rqh96hRBoWx7Q0SxKSB/b9J14jAfzOq5mB7d2979+GbvXuP
+        9vYf3b833iH1sHd/lzTE+6maDYAI0s+Cqul0uDd+SKxy/x7pNkBjMdqoagbY6z00zhAEbhgF0YJo
+        twHBDaMgZHJvhoB2EQBMaibO/7fV0OL6lf/Be+me1XU7r5bn6+VUv9ndu7d/n5DTYQ1+/83oHSIL
+        Yfv/JoXys+C87MEFoP/t743vkR6493CfFMH7aZQNgAjSz4JG6XS4O354sLO3u0sqDNBYIjZplDjb
+        3F6fDLzPzaIAWhDsZgDcLApApvWm99Eq8jqTmIny/21Nsrq+ypv2PRUIiMTUwbsH558CIR1K/Muv
+        pzoAgMn580t17D58tPfpo91dhCsHe/sPSeK/nuqIACJIP4uqQzvcGT/cub+//ynlZACNRWCz6ujx
+        zPvojf7L3Cb6dgtS3fA2t4m+LbO58WU0ibzLZGVCeOoCLzF//39HXbSE8u+vQvteSmM6bfWj60+z
+        t9e/aJVdzNp7FaGmgxpu8PWUB6Hdzqf5sq2zkon880mJPHize/DoPsUFn47vP/x0f3+HrDjhAKH6
+        BgARpJ81JeJ3uLP36cMd0lqAxoKxSYkM8M/tFckQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMGE+p
+        9Pj+/2PK5XLxXnpl//7iF00vsgert81V0WRlsVy/u1wQUjqcwe9/pFWIqfDzNsrAZhv2Hu0/eLS7
+        N37w6f2Dh/t7pAzeT6tsAESQfha0Sq/DTw8ePPh0/7arN3H2ub1SGXifm0UBtCDYzQC4WRSATOtN
+        76NV5HUmMRPl62uU7/+S/wewA+uTDB4AAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1450']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 07 Jan 2019 22:04:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [8aa93141-e04f-4b6b-b5f2-27e2fd775cb9]
+      x-ms-original-request-ids: [10a7979c-55c4-45e3-9958-d38f6b6bd76a, abd9b3bd-8726-4440-9164-6fffa7d796ad,
+        eac0f42c-eb87-43c3-9c12-fc526ec14eb7]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: [8aa93141-e04f-4b6b-b5f2-27e2fd775cb9]
+      x-ms-routing-request-id: ['WESTUS2:20190107T220450Z:8aa93141-e04f-4b6b-b5f2-27e2fd775cb9']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9ez3f/7q9Uejj9oir71PP/olo4/eFssZf1TV2UVObQr8ebdZT5pp
+        Xazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3YPf+bOdBfrfOm2pdT/PP62q9au62
+        edP+/o2Avbuqq8tiltfN3S+KaV011Xk71i7vapvj6bRaL9vm7nTa6kfXn2Zvr3/RKruYtfcqQk0H
+        NdygvV6hwY19UNOymmYYHDUntNv5NF+2dVau8V2bXTRERKIO4b3KayIb/v5ombdXVf32eFryn5Pr
+        VdbQbx8d/2Bd56/z+rKYUsPRR5dF3a6z8oU0f7Uu6dNH3/s+0Xbl/THLz7N12R5PFY3jsqyuMCXN
+        erWq6rb5dtuumjd1dn5eTL9cltcfPTrPyiYffZQvp/U1Tw3QaEzH9Pt5URIBfjG1yCZlTjPZ1mt6
+        ocya9lQ+elMwDfd2dh9u7+xu7zx4s3vw6P7+o/ufju8//HR/f2f3p4DDpKwm3wAggvQ2v37NfEGN
+        exODrojGl0VDgymWF8SZLRq+Xk+neT6jjkcfTeucZ2pThzt7nz7cefhT1HpVF4usvj5dzlZVgamm
+        QchgPpqDno/uDjHYGM3G06rOx1ckFNVVM6YJv0swf9E6X6PrmwBwuyiEFiS7BQRuF4UgM3sjADSL
+        vM9kZsI838D3DVF/3Xx5/lKaUpPsMitK4PTRL/kl/w8OZP5zXAQAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 Jan 2019 22:04:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [285f3cae-03e5-4ae7-99dc-031101a4a3b8]
+      x-ms-ratelimit-remaining-subscription-reads: ['11997']
+      x-ms-request-id: [3202c633-a1e4-4cb3-a050-13d16e1fd67d]
+      x-ms-routing-request-id: ['WESTUS2:20190107T220450Z:285f3cae-03e5-4ae7-99dc-031101a4a3b8']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_blob_client_from_storage_account_without_sas_fails_sas_generation.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_blob_client_from_storage_account_without_sas_fails_sas_generation.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
+        alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
+        epp/XlfrVXN3+mCZrVarMlveXdXVZTHL6+buF8W0rprqvB1rh3cb+Xk8nVbrZUuvremTWZEts53Z
+        3r3Jwz1CSQcT+6q9XuGrG+FS07KaZhgONc+zpl3jsza7aIhcRAfCcZXXRCD8/dEyb6+q+u3xtOQ/
+        J9errKHfPjr+wbrOX+f1ZTGlhqOPLou6XWflC2n+al3Sp4++932i4sr7Y5afZ+uyPZ5q98dlWV2B
+        +M16tarqtvl2266aN3V2fl5Mv1yW1x89Os/KJh99lC+n9TVPAtBoTMf0+3lR0sB/MbXIJmVOc9bW
+        a3qhpJGdykdvCqba3s7uw+2d3e2d/Td7u4/u7z3a2RnvPbx3f3dv56eAw6SsJt8AIIL0Nr9+zRxA
+        jXsTgq6IxpdFQ4MplhfEgy0avl5Pp3k+o45HH03rnGdoQ4e79x7sPfz005+i1qu6WGT19elytqoK
+        TDENQgbz0Rz0fHS3z0xjNBhPqzofXxHjV1fNmKb6LkH7RescErThVW4RfbcFmTa+yy2i78o8bngV
+        DSJvMjmZAM8jfN0QddfNl+cvpQl9lV1mRQksMFXESv8vUhNTene9YBhfT1XMdvLd+7s7O4SWDij2
+        1Y9UhYjzLST8/pud+492P320czDe2d3ffXD/Pkn411EVUUAE6WdNVdgOH4wf3vt052Dv3vuqCsMx
+        X0NV2Fe5RfTdFmTa+C63iL4r87jhVTSIvMnkZAL8f1xVlNV6tt3M87LcpqED+rYM4/3URrNnekfn
+        79D5O+qcMNUxbmjxzSiRjxbNthnc9rqh96hRBoWx7Q0SxKSB/b9J14jAfzOq5mB7d2979+GbvXuP
+        9vYf3b833iH1sHd/lzTE+6maDYAI0s+Cqul0uDd+SKxy/x7pNkBjMdqoagbY6z00zhAEbhgF0YJo
+        twHBDaMgZHJvhoB2EQBMaibO/7fV0OL6lf/Be+me1XU7r5bn6+VUv9ndu7d/n5DTYQ1+/83oHSIL
+        Yfv/JoXys+C87MEFoP/t743vkR6493CfFMH7aZQNgAjSz4JG6XS4O354sLO3u0sqDNBYIjZplDjb
+        3F6fDLzPzaIAWhDsZgDcLApApvWm99Eq8jqTmIny/21Nsrq+ypv2PRUIiMTUwbsH558CIR1K/Muv
+        pzoAgMn580t17D58tPfpo91dhCsHe/sPSeK/nuqIACJIP4uqQzvcGT/cub+//ynlZACNRWCz6ujx
+        zPvojf7L3Cb6dgtS3fA2t4m+LbO58WU0ibzLZGVCeOoCLzF//39HXbSE8u+vQvteSmM6bfWj60+z
+        t9e/aJVdzNp7FaGmgxpu8PWUB6Hdzqf5sq2zkon880mJPHize/DoPsUFn47vP/x0f3+HrDjhAKH6
+        BgARpJ81JeJ3uLP36cMd0lqAxoKxSYkM8M/tFckQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMGE+p
+        9Pj+/2PK5XLxXnpl//7iF00vsgert81V0WRlsVy/u1wQUjqcwe9/pFWIqfDzNsrAZhv2Hu0/eLS7
+        N37w6f2Dh/t7pAzeT6tsAESQfha0Sq/DTw8ePPh0/7arN3H2ub1SGXifm0UBtCDYzQC4WRSATOtN
+        76NV5HUmMRPl62uU7/+S/wewA+uTDB4AAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1450']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 07 Jan 2019 22:04:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [9eee3664-f86b-43db-86f4-07217db77f11]
+      x-ms-original-request-ids: [37ec4234-9ab0-4980-8a87-1ac37f405aa4, da5b0021-5cb0-405c-b86b-7e96c839c228,
+        e3a9121a-fe07-45dc-a564-761bec68bbd2]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [9eee3664-f86b-43db-86f4-07217db77f11]
+      x-ms-routing-request-id: ['WESTUS2:20190107T220451Z:9eee3664-f86b-43db-86f4-07217db77f11']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.5 (Darwin-18.2.0-x86_64-i386-64bit) msrest/0.6.2 msrest_azure/0.6.0
+          azure-mgmt-storage/3.1.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR83b
+        9UePfvFHy2yRf/Too9dttpxl9ez3f/7q9Uejj9oir71PP/olo4/eFssZf1TV2UVObQr8ebdZT5pp
+        Xazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3YPf+bOdBfrfOm2pdT/PP62q9au62
+        edP+/o2Avbuqq8tiltfN3S+KaV011Xk71i7vapvj6bRaL9vm7nTa6kfXn2Zvr3/RKruYtfcqQk0H
+        NdygvV6hwY19UNOymmYYHDUntNv5NF+2dVau8V2bXTRERKIO4b3KayIb/v5ombdXVf32eFryn5Pr
+        VdbQbx8d/2Bd56/z+rKYUsPRR5dF3a6z8oU0f7Uu6dNH3/s+0Xbl/THLz7N12R5PFY3jsqyuMCXN
+        erWq6rb5dtuumjd1dn5eTL9cltcfPTrPyiYffZQvp/U1Tw3QaEzH9Pt5URIBfjG1yCZlTjPZ1mt6
+        ocya9lQ+elMwDfd2dh9u7+xu7zx4s3vw6P7+o/ufju8//HR/f2f3p4DDpKwm3wAggvQ2v37NfEGN
+        exODrojGl0VDgymWF8SZLRq+Xk+neT6jjkcfTeucZ2pThzt7nz7cefhT1HpVF4usvj5dzlZVgamm
+        QchgPpqDno/uDjHYGM3G06rOx1ckFNVVM6YJv0swf9E6X6PrmwBwuyiEFiS7BQRuF4UgM3sjADSL
+        vM9kZsI838D3DVF/3Xx5/lKaUpPsMitK4PTRL/kl/w8OZP5zXAQAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Mon, 07 Jan 2019 22:04:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
+          Microsoft-HTTPAPI/2.0']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [2bb26f12-659c-4bdc-ab61-72900bfdf019]
+      x-ms-ratelimit-remaining-subscription-reads: ['11997']
+      x-ms-request-id: [8e4568a3-b08e-41a1-ab82-04b067339228]
+      x-ms-routing-request-id: ['WESTUS2:20190107T220451Z:2bb26f12-659c-4bdc-ab61-72900bfdf019']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/1.4.0-1.4.0 (Python CPython 3.6.5; Darwin 18.2.0)]
+      x-ms-date: ['Mon, 07 Jan 2019 22:04:51 GMT']
+      x-ms-version: ['2018-03-28']
+    method: PUT
+    uri: https://cctstoragey6akyqpagdt3o.blob.core.windows.net/test?restype=container
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:5aca6f57-b01e-00cd-31d5-a6267b000000\nTime:2019-01-07T22:04:52.5217826Z</Message></Error>"}
+    headers:
+      Content-Length: ['230']
+      Content-Type: [application/xml]
+      Date: ['Mon, 07 Jan 2019 22:04:51 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-error-code: [ContainerAlreadyExists]
+      x-ms-request-id: [5aca6f57-b01e-00cd-31d5-a6267b000000]
+      x-ms-version: ['2018-03-28']
+    status: {code: 409, message: The specified container already exists.}
+- request:
+    body: mock_body
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['17']
+      User-Agent: [Azure-Storage/1.4.0-1.4.0 (Python CPython 3.6.5; Darwin 18.2.0)]
+      x-ms-blob-type: [BlockBlob]
+      x-ms-date: ['Mon, 07 Jan 2019 22:04:52 GMT']
+      x-ms-version: ['2018-03-28']
+    method: PUT
+    uri: https://cctstoragey6akyqpagdt3o.blob.core.windows.net/test/test.txt
+  response:
+    body: {string: ''}
+    headers:
+      Content-MD5: [C54pDjExkICJDvhIlcZ1DQ==]
+      Date: ['Mon, 07 Jan 2019 22:04:51 GMT']
+      ETag: ['"0x8D674EC26771B1C"']
+      Last-Modified: ['Mon, 07 Jan 2019 22:04:52 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [5aca71e4-b01e-00cd-76d5-a6267b000000]
+      x-ms-request-server-encrypted: ['true']
+      x-ms-version: ['2018-03-28']
+    status: {code: 201, message: Created}
+version: 1

--- a/tools/c7n_azure/tests/templates/functionapp-reqs.json
+++ b/tools/c7n_azure/tests/templates/functionapp-reqs.json
@@ -1,46 +1,86 @@
 {
-    "resources": [
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "cloudcustodiantest",
-            "location": "westus2",
-            "properties": {
-                "accountType": "Standard_LRS"
+  "variables": {
+    "functionAppName": "cloud-custodian-test",
+    "appHostingPlanName": "cloud-custodian-test",
+    "storageAccountName": "cloudcustodiantest",
+    "storageAccountid": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "westus2",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "name": "[variables('appHostingPlanName')]",
+      "type": "Microsoft.Web/serverfarms",
+      "location": "westus2",
+      "properties": {
+        "name": "[variables('appHostingPlanName')]",
+        "workerSizeId": "0",
+        "reserved": true,
+        "numberOfWorkers": "1",
+        "hostingEnvironment": ""
+      },
+      "sku": {
+        "Tier": "Basic",
+        "Name": "B1"
+      },
+      "kind": "linux"
+    },
+    {
+      "apiVersion": "2015-05-01",
+      "name": "cloud-custodian-test",
+      "type": "microsoft.insights/components",
+      "location": "westus2",
+      "tags": {
+        "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', 'cloud-custodian-test')]": "Resource"
+      },
+      "properties": {
+        "ApplicationId": "cloud-custodian-test",
+        "Request_Source": "IbizaWebAppExtensionCreate"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "kind": "functionapp,linux,container",
+      "name": "[variables('functionAppName')]",
+      "apiVersion": "2016-08-01",
+      "location": "westus2",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('appHostingPlanName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appHostingPlanName'))]",
+        "siteConfig": {
+          "appSettings": [
+            {
+              "name": "AzureWebJobsDashboard",
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2018-07-01').keys[0].value)]"
+            },
+            {
+              "name": "AzureWebJobsStorage",
+              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2018-07-01').keys[0].value)]"
+            },
+            {
+              "name": "FUNCTIONS_EXTENSION_VERSION",
+              "value": "~2"
+            },
+            {
+              "name": "FUNCTIONS_WORKER_RUNTIME",
+              "value": "python"
             }
-        },
-        {
-            "apiVersion": "2016-09-01",
-            "name": "cloud-custodian-test",
-            "type": "Microsoft.Web/serverfarms",
-            "location": "westus2",
-            "properties": {
-                "name": "cloud-custodian-test",
-                "workerSizeId": "0",
-                "reserved": true,
-                "numberOfWorkers": "1",
-                "hostingEnvironment": ""
-            },
-            "sku": {
-                "Tier": "Basic",
-                "Name": "B1"
-            },
-            "kind": "linux"
-        },
-        {
-            "apiVersion": "2015-05-01",
-            "name": "cloud-custodian-test",
-            "type": "microsoft.insights/components",
-            "location": "westus2",
-            "tags": {
-                "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', 'cloud-custodian-test')]": "Resource"
-            },
-            "properties": {
-                "ApplicationId": "cloud-custodian-test",
-                "Request_Source": "IbizaWebAppExtensionCreate"
-            }
+          ]
         }
-    ],
-    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0"
+      }
+    }
+  ],
+  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0"
 }

--- a/tools/c7n_azure/tests/test_deployment_units.py
+++ b/tools/c7n_azure/tests/test_deployment_units.py
@@ -14,15 +14,16 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from azure_common import BaseTest
-
+from c7n_azure.constants import FUNCTION_DOCKER_VERSION
+from c7n_azure.functionapp_utils import FunctionAppUtilities
+from c7n_azure.provisioning.app_insights import AppInsightsUnit
+from c7n_azure.provisioning.app_service_plan import AppServicePlanUnit
+from c7n_azure.provisioning.function_app import FunctionAppDeploymentUnit
+from c7n_azure.provisioning.storage_account import StorageAccountUnit
+from c7n_azure.session import Session
 from msrestazure.azure_exceptions import CloudError
 
 from c7n.utils import local_session
-from c7n_azure.session import Session
-
-from c7n_azure.provisioning.app_insights import AppInsightsUnit
-from c7n_azure.provisioning.storage_account import StorageAccountUnit
-from c7n_azure.provisioning.app_service_plan import AppServicePlanUnit
 
 
 class DeploymentUnitsTest(BaseTest):
@@ -30,9 +31,13 @@ class DeploymentUnitsTest(BaseTest):
     rg_name = 'custodian-test-deployment-units'
 
     @classmethod
+    def setUpClass(cls):
+        cls.session = local_session(Session)
+
+    @classmethod
     def tearDownClass(cls):
         try:
-            client = local_session(Session).client('azure.mgmt.resource.ResourceManagementClient')
+            client = cls.session.client('azure.mgmt.resource.ResourceManagementClient')
             client.resource_groups.delete(cls.rg_name)
         except CloudError:
             pass
@@ -41,6 +46,7 @@ class DeploymentUnitsTest(BaseTest):
         self.assertEqual(unit.get(params), None)
         result = unit.provision_if_not_exists(params)
         self.assertNotEqual(result, None)
+        return result
 
     def test_app_insights(self):
         params = {'name': 'cloud-custodian-test',
@@ -67,3 +73,77 @@ class DeploymentUnitsTest(BaseTest):
         unit = AppServicePlanUnit()
 
         self._validate(unit, params)
+
+    def test_function_app_consumption(self):
+        # provision storage account
+        sa_params = {
+            'name': 'custodianaccount47182748',
+            'location': 'westus2',
+            'resource_group_name': self.rg_name}
+        storage_unit = StorageAccountUnit()
+        storage_account_id = storage_unit.provision_if_not_exists(sa_params).id
+        conn_string = FunctionAppUtilities.get_storage_account_connection_string(storage_account_id)
+
+        # provision function app
+        func_params = {
+            'name': 'cc-consumption-47182748',
+            'location': 'westus',
+            'resource_group_name': self.rg_name,
+            'app_service_plan_id': None,  # auto-provision a dynamic app plan
+            'app_insights_key': None,
+            'is_consumption_plan': True,
+            'storage_account_connection_string': conn_string
+        }
+        func_unit = FunctionAppDeploymentUnit()
+        func_app = self._validate(func_unit, func_params)
+
+        # verify settings are properly configured
+        self.assertEquals(func_app.kind, 'functionapp,linux')
+        self.assertTrue(func_app.reserved)
+
+    def test_function_app_dedicated(self):
+        # provision storage account
+        sa_params = {
+            'name': 'custodianaccount47182748',
+            'location': 'westus2',
+            'resource_group_name': self.rg_name}
+        storage_unit = StorageAccountUnit()
+        storage_account_id = storage_unit.provision_if_not_exists(sa_params).id
+        conn_string = FunctionAppUtilities.get_storage_account_connection_string(storage_account_id)
+
+        # provision app plan
+        app_plan_params = {
+            'name': 'cloud-custodian-test',
+            'location': 'westus2',
+            'resource_group_name': self.rg_name,
+            'sku_tier': 'Basic',
+            'sku_name': 'B1'}
+        app_plan_unit = AppServicePlanUnit()
+        app_plan = app_plan_unit.provision_if_not_exists(app_plan_params)
+
+        # provision function app
+        func_app_name = 'cc-dedicated-47182748'
+        func_params = {
+            'name': func_app_name,
+            'location': 'westus',
+            'resource_group_name': self.rg_name,
+            'app_service_plan_id': app_plan.id,
+            'app_insights_key': None,
+            'is_consumption_plan': False,
+            'storage_account_connection_string': conn_string
+        }
+        func_unit = FunctionAppDeploymentUnit()
+        func_app = self._validate(func_unit, func_params)
+
+        # verify settings are properly configured
+        self.assertEquals(func_app.kind, 'functionapp,linux,container')
+        self.assertTrue(func_app.reserved)
+
+        wc = self.session.client('azure.mgmt.web.WebSiteManagementClient')
+
+        site_config = wc.web_apps.get_configuration(self.rg_name, func_app_name)
+        self.assertTrue(site_config.always_on)
+        self.assertEquals(site_config.linux_fx_version, FUNCTION_DOCKER_VERSION)
+
+        app_settings = wc.web_apps.list_application_settings(self.rg_name, func_app_name)
+        self.assertIsNotNone(app_settings.properties['MACHINEKEY_DecryptionKey'])

--- a/tools/c7n_azure/tests/test_functionapp_utils.py
+++ b/tools/c7n_azure/tests/test_functionapp_utils.py
@@ -27,7 +27,7 @@ CONST_GROUP_NAME = 'test_functionapp-reqs'
 class FunctionAppUtilsTest(BaseTest):
     def setUp(self):
         super(FunctionAppUtilsTest, self).setUp()
-        self.functionapp_util = FunctionAppUtilities()
+        self.functionapp_util = FunctionAppUtilities
 
     @arm_template('functionapp-reqs.json')
     def test_get_storage_connection_string(self):

--- a/tools/c7n_azure/tests/test_functionapp_utils.py
+++ b/tools/c7n_azure/tests/test_functionapp_utils.py
@@ -67,5 +67,5 @@ class FunctionAppUtilsTest(BaseTest):
             function_app_resource_group_name=CONST_GROUP_NAME,
             function_app_name='custodian-test-app')
 
-        app = self.functionapp_util.deploy_dedicated_function_app(parameters)
+        app = self.functionapp_util.deploy_function_app(parameters)
         self.assertIsNotNone(app)

--- a/tools/c7n_azure/tests/test_functionapp_utils.py
+++ b/tools/c7n_azure/tests/test_functionapp_utils.py
@@ -14,20 +14,23 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from azure_common import BaseTest, arm_template
+from c7n_azure.function_package import FunctionPackage
 from c7n_azure.functionapp_utils import FunctionAppUtilities
 
 from c7n_azure.provisioning.app_insights import AppInsightsUnit
+from mock import patch
 
 from c7n.utils import local_session
 from c7n_azure.session import Session
 
 CONST_GROUP_NAME = 'test_functionapp-reqs'
+prefix = 'hxxuvke6yrmoe'
 
 
 class FunctionAppUtilsTest(BaseTest):
     def setUp(self):
         super(FunctionAppUtilsTest, self).setUp()
-        self.functionapp_util = FunctionAppUtilities
+        self.session = local_session(Session)
 
     @arm_template('functionapp-reqs.json')
     def test_get_storage_connection_string(self):
@@ -67,5 +70,103 @@ class FunctionAppUtilsTest(BaseTest):
             function_app_resource_group_name=CONST_GROUP_NAME,
             function_app_name='custodian-test-app')
 
-        app = self.functionapp_util.deploy_function_app(parameters)
+        app = FunctionAppUtilities.deploy_function_app(parameters)
         self.assertIsNotNone(app)
+
+    @arm_template('functionapp-reqs.json')
+    def test_deploy_function_app_pre_existing_app_fetch_actual_sku_tier(self):
+
+        parameters = FunctionAppUtilities.FunctionAppInfrastructureParameters(
+            app_insights={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloud-custodian-test'
+            },
+            storage_account={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloudcustodiantest'
+            },
+            service_plan={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloud-custodian-test',
+                'sku_tier': 'something wrong'
+            },
+            function_app_resource_group_name=CONST_GROUP_NAME,
+            function_app_name='cloud-custodian-test')
+
+        FunctionAppUtilities.deploy_function_app(parameters)
+        self.assertEquals(parameters.service_plan['sku_tier'], 'Basic')
+
+    def test_is_consumption_plan(self):
+        params = FunctionAppUtilities.FunctionAppInfrastructureParameters(
+            app_insights=None,
+            storage_account=None,
+            service_plan={
+                'sku_tier': 'dynamic'
+            },
+            function_app_resource_group_name=CONST_GROUP_NAME,
+            function_app_name='cloud-custodian-test')
+
+        self.assertTrue(FunctionAppUtilities.is_consumption_plan(params))
+
+        params.service_plan['sku_tier'] = 'other'
+        self.assertFalse(FunctionAppUtilities.is_consumption_plan(params))
+
+    @arm_template('functionapp-reqs.json')
+    def test_publish_functions_package_consumption(self):
+        parameters = FunctionAppUtilities.FunctionAppInfrastructureParameters(
+            app_insights={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloud-custodian-test'
+            },
+            storage_account={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloudcustodiantest'
+            },
+            service_plan={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloud-custodian-test',
+                'sku_tier': 'dynamic'
+            },
+            function_app_resource_group_name=CONST_GROUP_NAME,
+            function_app_name='cloud-custodian-test')
+
+        FunctionAppUtilities.publish_functions_package(
+            parameters, FunctionPackage("TestPolicy"))
+
+        # verify app setting updated
+        wc = self.session.client('azure.mgmt.web.WebSiteManagementClient')
+        app_settings = wc.web_apps.list_application_settings(
+            CONST_GROUP_NAME, 'cloud-custodian-test')
+        self.assertIsNotNone(app_settings.properties['WEBSITE_RUN_FROM_PACKAGE'])
+
+    @arm_template('functionapp-reqs.json')
+    @patch('c7n_azure.function_package.FunctionPackage.publish')
+    def test_publish_functions_package_dedicated(self, mock_function_package_publish):
+        parameters = FunctionAppUtilities.FunctionAppInfrastructureParameters(
+            app_insights={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloud-custodian-test'
+            },
+            storage_account={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloudcustodiantest'
+            },
+            service_plan={
+                'id': '',
+                'resource_group_name': CONST_GROUP_NAME,
+                'name': 'cloud-custodian-test',
+                'sku_tier': 'Basic'
+            },
+            function_app_resource_group_name=CONST_GROUP_NAME,
+            function_app_name='cloud-custodian-test')
+
+        FunctionAppUtilities.publish_functions_package(parameters, FunctionPackage("TestPolicy"))
+        mock_function_package_publish.assert_called_once()

--- a/tools/c7n_azure/tests/test_policy.py
+++ b/tools/c7n_azure/tests/test_policy.py
@@ -120,15 +120,15 @@ class AzurePolicyModeTest(BaseTest):
         self.assertEqual(function_mode.policy_name, p.data['name'])
 
         self.assertEqual(params.service_plan['name'], "cloud-custodian")
-        self.assertEqual(params.service_plan['location'], "westus2")
+        self.assertEqual(params.service_plan['location'], "eastus")
         self.assertEqual(params.service_plan['resource_group_name'], "cloud-custodian")
 
         self.assertEqual(params.app_insights['name'], 'cloud-custodian')
-        self.assertEqual(params.app_insights['location'], "westus2")
+        self.assertEqual(params.app_insights['location'], "eastus")
         self.assertEqual(params.app_insights['resource_group_name'], 'cloud-custodian')
 
         self.assertTrue(params.storage_account['name'].startswith('custodian'))
-        self.assertEqual(params.storage_account['location'], "westus2")
+        self.assertEqual(params.storage_account['location'], "eastus")
         self.assertEqual(params.storage_account['resource_group_name'], 'cloud-custodian')
 
         self.assertTrue(params.function_app_name.startswith('test-azure-serverless-mode-'))

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -113,7 +113,7 @@ def provision(config):
         function_app_resource_group_name=service_plan['resource_group_name'],
         function_app_name=function_app_name)
 
-    FunctionAppUtilities().deploy_function_app(params)
+    FunctionAppUtilities.deploy_function_app(params)
 
     log.info("Building function package for %s" % function_app_name)
     package = build_function_package(config, function_name)

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -78,13 +78,14 @@ def provision(config):
     # service plan is parse first, because its location might be shared with storage & insights
     service_plan = AzureFunctionMode.extract_properties(function_properties,
                                                 'servicePlan',
-                                                {'name': 'cloud-custodian',
-                                                 'location': 'westus2',
-                                                 'resource_group_name': 'cloud-custodian',
-                                                 'sku_name': 'B1',
-                                                 'sku_tier': 'Basic'})
+                                                {
+                                                    'name': 'cloud-custodian',
+                                                    'location': 'eastus',
+                                                    'resource_group_name': 'cloud-custodian',
+                                                    'tier': 'dynamic'  # consumption plan
+                                                })
 
-    location = service_plan.get('location', 'westus2')
+    location = service_plan.get('location', 'eastus')
     rg_name = service_plan['resource_group_name']
 
     sub_id = local_session(Session).get_subscription_id()
@@ -120,12 +121,4 @@ def provision(config):
 
     log.info("Function package built, size is %dMB" % (package.pkg.size / (1024 * 1024)))
 
-    client = local_session(Session).client('azure.mgmt.web.WebSiteManagementClient')
-    publish_creds = client.web_apps.list_publishing_credentials(
-        service_plan['resource_group_name'],
-        function_app_name).result()
-
-    if package.wait_for_status(publish_creds):
-        package.publish(publish_creds)
-    else:
-        log.error("Aborted deployment, ensure Application Service is healthy.")
+    FunctionAppUtilities.publish_functions_package(params, package)

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -40,7 +40,7 @@ def build_function_package(config, function_name):
         os.path.join(os.path.dirname(__file__), 'function.py'))
 
     package.build(None,
-                  modules=['c7n', 'c7n-azure', 'c7n-mailer', 'applicationinsights'],
+                  modules=['c7n', 'c7n-azure', 'c7n-mailer'],
                   non_binary_packages=['pyyaml', 'pycparser', 'tabulate',
                                        'datadog', 'MarkupSafe', 'simplejson'],
                   excluded_packages=['azure-cli-core', 'distlib', 'futures'])

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -113,7 +113,7 @@ def provision(config):
         function_app_resource_group_name=service_plan['resource_group_name'],
         function_app_name=function_app_name)
 
-    FunctionAppUtilities().deploy_dedicated_function_app(params)
+    FunctionAppUtilities().deploy_function_app(params)
 
     log.info("Building function package for %s" % function_app_name)
     package = build_function_package(config, function_name)

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -40,7 +40,7 @@ def build_function_package(config, function_name):
         os.path.join(os.path.dirname(__file__), 'function.py'))
 
     package.build(None,
-                  modules=['c7n', 'c7n-azure', 'c7n-mailer'],
+                  modules=['c7n', 'c7n-azure', 'c7n-mailer', 'applicationinsights'],
                   non_binary_packages=['pyyaml', 'pycparser', 'tabulate',
                                        'datadog', 'MarkupSafe', 'simplejson'],
                   excluded_packages=['azure-cli-core', 'distlib', 'futures'])

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -82,7 +82,8 @@ def provision(config):
                                                     'name': 'cloud-custodian',
                                                     'location': 'eastus',
                                                     'resource_group_name': 'cloud-custodian',
-                                                    'sku_tier': 'dynamic'  # consumption plan
+                                                    'sku_tier': 'Dynamic',  # consumption plan
+                                                    'sku_name': None
                                                 })
 
     location = service_plan.get('location', 'eastus')

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -83,7 +83,7 @@ def provision(config):
                                                     'location': 'eastus',
                                                     'resource_group_name': 'cloud-custodian',
                                                     'sku_tier': 'Dynamic',  # consumption plan
-                                                    'sku_name': None
+                                                    'sku_name': 'Y1'
                                                 })
 
     location = service_plan.get('location', 'eastus')

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -82,7 +82,7 @@ def provision(config):
                                                     'name': 'cloud-custodian',
                                                     'location': 'eastus',
                                                     'resource_group_name': 'cloud-custodian',
-                                                    'tier': 'dynamic'  # consumption plan
+                                                    'sku_tier': 'dynamic'  # consumption plan
                                                 })
 
     location = service_plan.get('location', 'eastus')


### PR DESCRIPTION
- Fix #2632 
- Defaulting to use Linux Consumption plan when deploying functions
- Consumption is an App Plan with `tier == Dynamics` and `name == Y1`
- Consumption Deployment is done through `WEBSITE_RUN_FROM_PACKAGE`
   1. We first package Custodian like normal
   2. Then we upload the zip to blob storage account of the Function App
   3. Finally, we get a SAS token for the blob and set the `WEBSITE_RUN_FROM_PACKAGE` Application Settings of the function to this.
- Added calls to Sync Triggers, because it's needed for the scaling controller

