### PR TITLE
aws - lambda policy support either with detail or sans detail on cwe event

### DIFF
--- a/c7n/cwe.py
+++ b/c7n/cwe.py
@@ -132,8 +132,11 @@ class CloudWatchEvents(object):
             id_query = e.get('ids')
             if not id_query:
                 raise ValueError("No id query configured")
-            resource_ids = jmespath.search(
-                id_query, event.get('detail', {}))
+            evt = event
+            # be forgiving for users specifying with details or without
+            if not id_query.startswith('detail.'):
+                evt = event.get('detail', {})
+            resource_ids = jmespath.search(id_query, evt)
             if resource_ids:
                 break
         return resource_ids

--- a/c7n/filters/health.py
+++ b/c7n/filters/health.py
@@ -38,9 +38,6 @@ class HealthEventFilter(Filter):
                    'health:DescribeEventDetails')
 
     def process(self, resources, event=None):
-        if not resources:
-            return resources
-
         client = local_session(self.manager.session_factory).client(
             'health', region_name='us-east-1')
         f = self.get_filter_parameters()

--- a/tests/test_cwe.py
+++ b/tests/test_cwe.py
@@ -54,7 +54,30 @@ class CloudWatchEventsFacadeTest(TestCase):
                 {"detail": event_data("event-cloud-trail-run-instances.json")},
                 {"type": "cloudtrail", "events": ["RunInstances"]},
             ),
-            ["i-784cdacd", u"i-7b4cdace"],
+            ["i-784cdacd", "i-7b4cdace"],
+        )
+
+    def test_get_ids_sans_with_details_expr(self):
+        self.assertEqual(
+            CloudWatchEvents.get_ids(
+                {'detail': event_data('event-cloud-trail-run-instances.json')},
+                {'type': 'cloudtrail', 'events': [
+                    {'ids': 'detail.responseElements.instancesSet.items[].instanceId',
+                     'source': 'ec2.amazonaws.com',
+                     'event': 'RunInstances'}]}),
+            ["i-784cdacd", "i-7b4cdace"],
+        )
+
+    def test_get_ids_sans_without_details_expr(self):
+        self.assertEqual(
+            sorted(CloudWatchEvents.get_ids(
+                {'detail': event_data('event-cloud-trail-run-instances.json')},
+                {'type': 'cloudtrail', 'events': [
+                    {'ids': 'responseElements.instancesSet.items[].instanceId',
+                     'source': 'ec2.amazonaws.com',
+                     'event': 'RunInstances'}
+                ]})),
+            ["i-784cdacd", "i-7b4cdace"],
         )
 
     def test_get_ids_multiple_events(self):


### PR DESCRIPTION
we've seen users get this wrong a few times, and its not obvious when they do, so go ahead and support setting with detail prefix and without detail prefix.