### PR TITLE
Azure - removed days from event grid example

### DIFF
--- a/docs/source/azure/advanced/azurefunctions.rst
+++ b/docs/source/azure/advanced/azurefunctions.rst
@@ -206,7 +206,6 @@ of one of the `shortcuts <https://github.com/capitalone/cloud-custodian/blob/mas
           actions:
             - type: auto-tag-user
               tag: CreatorEmail
-              days: 10
 
 Advanced Authentication Options
 ###############################


### PR DESCRIPTION
The event grid example on this page generates the following error:

```
  File "c:\code\cloud-custodian\tools\c7n_azure\c7n_azure\actions.py", line 203, in validate
    "Auto tag user in event mode does not use days.")
```
Removed `days: 10` as it's not support in this mode. Updated example runs. 

@aluong @erwelch - small update to example as it does not work as is. 