### PR TITLE
azure - Ensure package list remains the same

### DIFF
--- a/tools/c7n_azure/c7n_azure/dependency_manager.py
+++ b/tools/c7n_azure/c7n_azure/dependency_manager.py
@@ -49,7 +49,7 @@ class DependencyManager(object):
             if sum(pname[0].lower() in e.lower() for e in res) > 1:
                 logger.debug("removing duplicate dependency:" + val)
                 res.pop(i)
-        return res
+        return sorted(res)
 
     @staticmethod
     def prepare_non_binary_wheels(packages, folder):


### PR DESCRIPTION
If packages list order changes, its hash is different -- forced re-download dependencies