### PR TITLE
aws - vpc additional related filters (subnet, nat, igw)

### DIFF
--- a/c7n/filters/related.py
+++ b/c7n/filters/related.py
@@ -17,7 +17,7 @@ import importlib
 
 import jmespath
 
-from .core import ValueFilter, glob_match, regex_match, operator_in, operator_ni, difference, intersect, OPERATORS
+from .core import ValueFilter, OPERATORS
 
 class RelatedResourceFilter(ValueFilter):
 
@@ -70,13 +70,18 @@ class RelatedResourceFilter(ValueFilter):
         op = self.data.get('operator', 'or')
         found = []
         self.log.debug("Processings resources " + str(related_ids))
+
         if self.data.get('match-resource') is True:
             self.data['value'] = self.get_resource_value(
                 self.data['key'], resource)
+
         if self.data.get('value_type') == 'resource_count':
             self.log.debug("Op for resource_count: " + op)
-            self.log.debug("Which op for count? " + str(self.data))
-            return OPERATORS[self.data.get('op')](len(related_ids), self.data.get('value'))
+            count_matches = OPERATORS[self.data.get('op')](len(related_ids), self.data.get('value'))
+            if count_matches:
+                self.add_annotations(related_ids, resource)
+            return count_matches
+
         for rid in related_ids:
             robj = related.get(rid, None)
             if robj is None:
@@ -90,15 +95,19 @@ class RelatedResourceFilter(ValueFilter):
             if self.match(robj):
                 found.append(rid)
 
-        if self.AnnotationKey is not None and found:
-            akey = 'c7n:%s' % self.AnnotationKey
-            resource[akey] = list(set(found).union(resource.get(akey, [])))
+        if found:
+            self.add_annotations(found, resource)
 
         if op == 'or' and found:
             return True
         elif op == 'and' and len(found) == len(related_ids):
             return True
         return False
+
+    def add_annotations(self, related_ids, resource):
+        if self.AnnotationKey is not None:
+            akey = 'c7n:%s' % self.AnnotationKey
+            resource[akey] = list(set(related_ids).union(resource.get(akey, [])))
 
     def process(self, resources, event=None):
         related = self.get_related(resources)

--- a/c7n/filters/related.py
+++ b/c7n/filters/related.py
@@ -19,6 +19,7 @@ import jmespath
 
 from .core import ValueFilter, OPERATORS
 
+
 class RelatedResourceFilter(ValueFilter):
 
     RelatedResource = None

--- a/c7n/filters/related.py
+++ b/c7n/filters/related.py
@@ -69,14 +69,12 @@ class RelatedResourceFilter(ValueFilter):
         model = self.manager.get_model()
         op = self.data.get('operator', 'or')
         found = []
-        self.log.debug("Processings resources " + str(related_ids))
 
         if self.data.get('match-resource') is True:
             self.data['value'] = self.get_resource_value(
                 self.data['key'], resource)
 
         if self.data.get('value_type') == 'resource_count':
-            self.log.debug("Op for resource_count: " + op)
             count_matches = OPERATORS[self.data.get('op')](len(related_ids), self.data.get('value'))
             if count_matches:
                 self.add_annotations(related_ids, resource)

--- a/c7n/filters/related.py
+++ b/c7n/filters/related.py
@@ -17,8 +17,7 @@ import importlib
 
 import jmespath
 
-from .core import ValueFilter
-
+from .core import ValueFilter, glob_match, regex_match, operator_in, operator_ni, difference, intersect, OPERATORS
 
 class RelatedResourceFilter(ValueFilter):
 
@@ -70,9 +69,14 @@ class RelatedResourceFilter(ValueFilter):
         model = self.manager.get_model()
         op = self.data.get('operator', 'or')
         found = []
+        self.log.debug("Processings resources " + str(related_ids))
         if self.data.get('match-resource') is True:
             self.data['value'] = self.get_resource_value(
                 self.data['key'], resource)
+        if self.data.get('value_type') == 'resource_count':
+            self.log.debug("Op for resource_count: " + op)
+            self.log.debug("Which op for count? " + str(self.data))
+            return OPERATORS[self.data.get('op')](len(related_ids), self.data.get('value'))
         for rid in related_ids:
             robj = related.get(rid, None)
             if robj is None:

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -203,7 +203,88 @@ class VpcSecurityGroupFilter(RelatedResourceFilter):
             self.manager.get_resource_manager('security-group').resources()
             if g.get('VpcId', '') in vpc_ids
         }
+        self.log.debug("Returning vpc_group_ids: " + str(vpc_group_ids))
         return vpc_group_ids
+
+@Vpc.filter_registry.register('subnet')
+class VpcSubnetFilter(RelatedResourceFilter):
+    """Filter VPCs based on Subnet attributes
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: gray-vpcs
+                resource: vpc
+                filters:
+                  - type: security-group
+                    key: tag:Color
+                    value: Gray
+    """
+    schema = type_schema(
+        'subnet', rinherit=ValueFilter.schema,
+        **{'match-resource': {'type': 'boolean'},
+           'operator': {'enum': ['and', 'or']}})
+    RelatedResource = "c7n.resources.vpc.Subnet"
+    RelatedIdsExpression = '[Subnets][].SubnetId'
+    #AnnotationKey = "matched-vpcs-subnets"
+    AnnotationKey = "MatchedVpcsSubnets"
+
+    def get_related_ids(self, resources):
+        vpc_ids = [vpc['VpcId'] for vpc in resources]
+        vpc_subnet_ids = {
+            g['SubnetId'] for g in
+            self.manager.get_resource_manager('subnet').resources()
+            if g.get('VpcId', '') in vpc_ids
+        }
+        self.log.debug("Returning vpc_subnet_ids: " + str(vpc_subnet_ids))
+        return vpc_subnet_ids
+
+@Vpc.filter_registry.register('internet-gateway')
+class VpcInternetGatewayFilter(RelatedResourceFilter):
+    """Filter VPCs based on Internet Gateway attributes
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: gray-vpcs
+                resource: vpc
+                filters:
+                  - type: security-group
+                    key: tag:Color
+                    value: Gray
+    """
+    schema = type_schema(
+        'internet-gateway', rinherit=ValueFilter.schema,
+        **{'match-resource': {'type': 'boolean'},
+           'operator': {'enum': ['and', 'or']}})
+    RelatedResource = "c7n.resources.vpc.InternetGateway"
+    RelatedIdsExpression = '[InternetGateways][].InternetGatewayId'
+    #AnnotationKey = "matched-vpcs-igws"
+    AnnotationKey = "MatchedVpcsIgws"
+
+    def get_related_ids(self, resources):
+        vpc_ids = [vpc['VpcId'] for vpc in resources]
+        self.log.debug("Filtering vpc_ids: " + str(vpc_ids))
+        #vpc_igw_ids = {
+            #g['InternetGatewayId'] for g in
+            #self.manager.get_resource_manager('internet-gateway').resources()
+            #if g.get('VpcId', '') in vpc_ids
+        #}
+        vpc_igw_ids = set()
+        for igw in self.manager.get_resource_manager('internet-gateway').resources():
+            self.log.debug("Found IGW: " + igw['InternetGatewayId'])
+            for attachment in igw['Attachments']:
+                self.log.debug("Found VpcId: " + attachment.get('VpcId'))
+                if attachment.get('VpcId', '') in vpc_ids:
+                    self.log.debug("Matching VpcId: " + attachment.get('VpcId'))
+		    vpc_igw_ids.add(igw['InternetGatewayId'])
+
+        self.log.debug("Returning vpc_igw_ids: " + str(vpc_igw_ids))
+        return vpc_igw_ids
 
 
 @Vpc.filter_registry.register('vpc-attributes')

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -203,7 +203,6 @@ class VpcSecurityGroupFilter(RelatedResourceFilter):
             self.manager.get_resource_manager('security-group').resources()
             if g.get('VpcId', '') in vpc_ids
         }
-        self.log.debug("Returning vpc_group_ids: " + str(vpc_group_ids))
         return vpc_group_ids
 
 @Vpc.filter_registry.register('subnet')
@@ -237,7 +236,6 @@ class VpcSubnetFilter(RelatedResourceFilter):
             self.manager.get_resource_manager('subnet').resources()
             if g.get('VpcId', '') in vpc_ids
         }
-        self.log.debug("Returning vpc_subnet_ids: " + str(vpc_subnet_ids))
         return vpc_subnet_ids
 
 @Vpc.filter_registry.register('nat-gateway')
@@ -271,7 +269,6 @@ class VpcNatGatewayFilter(RelatedResourceFilter):
             self.manager.get_resource_manager('nat-gateway').resources()
             if g.get('VpcId', '') in vpc_ids
         }
-        self.log.debug("Returning vpc_natgw_ids: " + str(vpc_natgw_ids))
         return vpc_natgw_ids
 
 @Vpc.filter_registry.register('internet-gateway')
@@ -304,9 +301,7 @@ class VpcInternetGatewayFilter(RelatedResourceFilter):
         for igw in self.manager.get_resource_manager('internet-gateway').resources():
             for attachment in igw['Attachments']:
                 if attachment.get('VpcId', '') in vpc_ids:
-		    vpc_igw_ids.add(igw['InternetGatewayId'])
-
-        self.log.debug("Returning vpc_igw_ids: " + str(vpc_igw_ids))
+                    vpc_igw_ids.add(igw['InternetGatewayId'])
         return vpc_igw_ids
 
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -205,6 +205,7 @@ class VpcSecurityGroupFilter(RelatedResourceFilter):
         }
         return vpc_group_ids
 
+
 @Vpc.filter_registry.register('subnet')
 class VpcSubnetFilter(RelatedResourceFilter):
     """Filter VPCs based on Subnet attributes
@@ -238,6 +239,7 @@ class VpcSubnetFilter(RelatedResourceFilter):
         }
         return vpc_subnet_ids
 
+
 @Vpc.filter_registry.register('nat-gateway')
 class VpcNatGatewayFilter(RelatedResourceFilter):
     """Filter VPCs based on NAT Gateway attributes
@@ -270,6 +272,7 @@ class VpcNatGatewayFilter(RelatedResourceFilter):
             if g.get('VpcId', '') in vpc_ids
         }
         return vpc_natgw_ids
+
 
 @Vpc.filter_registry.register('internet-gateway')
 class VpcInternetGatewayFilter(RelatedResourceFilter):

--- a/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeInternetGateways_1.json
+++ b/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeInternetGateways_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "InternetGateways": [
+            {
+                "Tags": [],
+                "Attachments": [
+                    {
+                        "State": "available",
+                        "VpcId": "vpc-0c1be6284618ac4c1"
+                    }
+                ],
+                "InternetGatewayId": "igw-0978760ab0696f757"
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "688ea6ff-7a28-41fb-9729-eea68fab91d8",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Tue, 27 Jun 2017 17:50:58 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeInternetGateways_1.json
+++ b/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeInternetGateways_1.json
@@ -3,7 +3,12 @@
     "data": {
         "InternetGateways": [
             {
-                "Tags": [],
+                "Tags": [
+                    {
+                        "Value": "Fancy Internet Gateway",
+                        "Key": "Name"
+                    }
+                ],
                 "Attachments": [
                     {
                         "State": "available",

--- a/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeNatGateways_1.json
+++ b/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeNatGateways_1.json
@@ -12,7 +12,12 @@
                     }
                 ],
                 "VpcId": "vpc-0c1be6284618ac4c1",
-                "Tags": [],
+                "Tags": [
+                    {
+                        "Value": "Fancy NAT Gateway",
+                        "Key": "Name"
+                    }
+                ],
                 "State": "available",
                 "NatGatewayId": "nat-0bdb87de14bdf340a",
                 "SubnetId": "subnet-03b1c10838dfbb431",

--- a/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeNatGateways_1.json
+++ b/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeNatGateways_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "NatGateways": [
+            {
+                "NatGatewayAddresses": [
+                    {
+                        "PublicIp": "1.2.3.4",
+                        "NetworkInterfaceId": "eni-0d9ed30596168bcf1",
+                        "AllocationId": "eipalloc-0ee66407",
+                        "PrivateIp": "10.0.0.216"
+                    }
+                ],
+                "VpcId": "vpc-0c1be6284618ac4c1",
+                "Tags": [],
+                "State": "available",
+                "NatGatewayId": "nat-0bdb87de14bdf340a",
+                "SubnetId": "subnet-03b1c10838dfbb431",
+                "CreateTime": "2019-01-08T16:19:20.000Z"
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "688ea6ff-7a28-41fb-9729-eea68fab91d8",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Tue, 27 Jun 2017 17:50:58 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeSubnets_1.json
+++ b/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeSubnets_1.json
@@ -1,0 +1,56 @@
+{
+    "status_code": 200,
+    "data": {
+        "Subnets": [
+            {
+                "AvailabilityZone": "us-east-1d",
+                "Tags": [
+                    {
+                        "Value": "Public subnet",
+                        "Key": "Name"
+                    }
+                ],
+                "AvailableIpAddressCount": 250,
+                "DefaultForAz": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "VpcId": "vpc-0c1be6284618ac4c1",
+                "State": "available",
+                "MapPublicIpOnLaunch": false,
+                "SubnetId": "subnet-03b1c10838dfbb431",
+                "CidrBlock": "10.0.0.0/24",
+                "AssignIpv6AddressOnCreation": false
+            },
+            {
+                "AvailabilityZone": "us-east-1d",
+                "Tags": [
+                    {
+                        "Value": "Private subnet",
+                        "Key": "Name"
+                    }
+                ],
+                "AvailableIpAddressCount": 251,
+                "DefaultForAz": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "VpcId": "vpc-0c1be6284618ac4c1",
+                "State": "available",
+                "MapPublicIpOnLaunch": false,
+                "SubnetId": "subnet-019190c7bd977c594",
+                "CidrBlock": "10.0.1.0/24",
+                "AssignIpv6AddressOnCreation": false
+            }
+        ]
+    ,
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "688ea6ff-7a28-41fb-9729-eea68fab91d8",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Tue, 27 Jun 2017 17:50:58 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_scenario_2/ec2.DescribeVpcs_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200,
+    "data": {
+        "Vpcs": [
+            {
+                "VpcId": "vpc-0c1be6284618ac4c1",
+                "InstanceTenancy": "default",
+                "Tags": [
+                    {
+                        "Value": "scenario-2-test",
+                        "Key": "Name"
+                    }
+                ],
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-0999d4dea61f0ff21",
+                        "CidrBlock": "10.0.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "State": "available",
+                "DhcpOptionsId": "dopt-73a70517",
+                "CidrBlock": "10.0.0.0/16",
+                "IsDefault": false
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "688ea6ff-7a28-41fb-9729-eea68fab91d8",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Tue, 27 Jun 2017 17:50:58 GMT"
+            }
+        }
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -2127,6 +2127,38 @@ class SecurityGroupTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["Tags"][0]["Value"], "FancyTestVPC")
 
+    def test_vpc_scenario_2(self):
+        factory = self.replay_flight_data("test_vpc_scenario_2")
+        p = self.load_policy(
+            {
+                "name": "vpc-scenario-2",
+                "resource": "vpc",
+                "filters": [
+                    {
+                        "type": "subnet",
+                        "value_type": "resource_count",
+                        "value": 2,
+                        "op": "lt"
+                    },
+                    {
+                        "type": "internet-gateway",
+                        "value_type": "resource_count",
+                        "value": 1,
+                        "op": "gte"
+                    },
+                    {
+                        "type": "nat-gateway",
+                        "value_type": "resource_count",
+                        "value": 1,
+                        "op": "gte"
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
 
 class EndpointTest(BaseTest):
 

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -2159,6 +2159,66 @@ class SecurityGroupTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 0)
 
+    def test_vpc_by_subnet(self):
+        factory = self.replay_flight_data("test_vpc_scenario_2")
+        p = self.load_policy(
+            {
+                "name": "vpc-subnet",
+                "resource": "vpc",
+                "filters": [
+                    {
+                        "type": "subnet",
+                        "key": "tag:Name",
+                        "value": "Public subnet",
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["Tags"][0]["Value"], "scenario-2-test")
+
+    def test_vpc_by_internet_gateway(self):
+        factory = self.replay_flight_data("test_vpc_scenario_2")
+        p = self.load_policy(
+            {
+                "name": "vpc-internet-gateway",
+                "resource": "vpc",
+                "filters": [
+                    {
+                        "type": "internet-gateway",
+                        "key": "tag:Name",
+                        "value": "Fancy Internet Gateway",
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["Tags"][0]["Value"], "scenario-2-test")
+
+    def test_vpc_by_nat_gateway(self):
+        factory = self.replay_flight_data("test_vpc_scenario_2")
+        p = self.load_policy(
+            {
+                "name": "vpc-nat-gateway",
+                "resource": "vpc",
+                "filters": [
+                    {
+                        "type": "nat-gateway",
+                        "key": "tag:Name",
+                        "value": "Fancy NAT Gateway",
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["Tags"][0]["Value"], "scenario-2-test")
+
 
 class EndpointTest(BaseTest):
 


### PR DESCRIPTION
Adding filters to the `vpc` resource, similar to the existing `VpcSecurityGroupFilter` filter:
- VpcSubnetFilter
- VpcNatGatewayFilter
- VpcInternetGatewayFilter

Also, fixed `resource_count` value_type for these RelatedResourceFilters.

Example using new filters:
```
 resource: vpc
 filters:
    - type: subnet
      value_type: resource_count
      value: 2
      op: lt
    - type: internet-gateway
      value_type: resource_count
      value: 1
      op: gte
```