### PR TITLE
aws - validate max length on lambda policies

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -361,6 +361,14 @@ class LambdaMode(ServerlessExecutionMode):
         }
     }
 
+    def validate(self):
+        super(LambdaMode, self).validate()
+        prefix = self.policy.data.get('function-prefix', 'custodian-')
+        if len(prefix + self.policy.name) > 64:
+            raise PolicyValidationError(
+                "Custodian Lambda policies have a max length with prefix of 64"
+                " policy:%s prefix:%s" % (prefix, self.policy.name))
+
     def get_metrics(self, start, end, period):
         from c7n.mu import LambdaManager, PolicyLambda
         manager = LambdaManager(self.policy.session_factory)
@@ -529,6 +537,7 @@ class CloudTrailMode(LambdaMode):
         rinherit=LambdaMode.schema)
 
     def validate(self):
+        super(CloudTrailMode, self).validate()
         from c7n import query
         events = self.policy.data['mode'].get('events')
         assert events, "cloud trail mode requires specifiying events to subscribe"
@@ -598,6 +607,7 @@ class GuardDutyMode(LambdaMode):
         return resources
 
     def validate(self):
+        super(GuardDutyMode, self).validate()
         if self.policy.data['resource'] not in self.supported_resources:
             raise ValueError(
                 "Policy:%s resource:%s Guard duty mode only supported for %s" % (

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -21,7 +21,7 @@ import shutil
 import tempfile
 
 from c7n import policy, manager
-from c7n.exceptions import ResourceLimitExceeded
+from c7n.exceptions import ResourceLimitExceeded, PolicyValidationError
 from c7n.resources.aws import AWS
 from c7n.resources.ec2 import EC2
 from c7n.utils import dumps
@@ -872,6 +872,16 @@ class GuardModeTest(BaseTest):
             {"name": "vpc", "resource": "vpc", "mode": {"type": "guard-duty"}},
             validate=True,
         )
+
+    def test_lambda_policy_validate_name(self):
+        name = "ec2-instance-guard-D8488F01-0E3E-4772-A3CB-E66EEBB9BDF4"
+        with self.assertRaises(PolicyValidationError) as e_cm:
+            self.load_policy(
+                {"name": name,
+                 "resource": "ec2",
+                 "mode": {"type": "guard-duty"}},
+                validate=True)
+        self.assertTrue("max length with prefix" in str(e_cm.exception))
 
     @mock.patch("c7n.mu.LambdaManager.publish")
     def test_ec2_guard_event_pattern(self, publish):


### PR DESCRIPTION
closes #3352