### PR TITLE
aws - rds retry switch to generic retry add Throttling retry code

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -350,6 +350,7 @@ class QueryResourceManager(ResourceManager):
             'ThrottlingException',
             'RequestLimitExceeded',
             'Throttled',
+            'Throttling',
             'Client.RequestLimitExceeded')))
 
     def __init__(self, data, options):

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -114,7 +114,6 @@ class RDS(QueryResourceManager):
     filter_registry = filters
     action_registry = actions
     _generate_arn = None
-    retry = staticmethod(get_retry(('Throttled',)))
 
     def __init__(self, data, options):
         super(RDS, self).__init__(data, options)


### PR DESCRIPTION
closes #3340 