### PR TITLE
new resource aws.docdb 

### DIFF
--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -74,6 +74,17 @@ class RDSCluster(QueryResourceManager):
             self.generate_arn, self.retry))
         return dbs
 
+docdb_cluster_filters = FilterRegistry('docdb-cluster.filters')
+docdb_cluster_actions = ActionRegistry('docdb-cluster.actions')
+
+@resources.register('docdb-cluster')
+class docdbCluster(RDSCluster):
+    """
+    Resource manager for DocumentDB clusters.
+    """
+    def __init__(self, data, options):
+        super( docdbCluster, self ).__init__(data, options)
+
 
 def _rds_cluster_tags(model, dbs, session_factory, executor_factory, generator, retry):
     """Augment rds clusters with their respective tags."""
@@ -194,12 +205,14 @@ class RemoveTag(tags.RemoveTag):
                 ResourceName=arn, TagKeys=tag_keys)
 
 
+@docdb_cluster_filters.register('security-group')
 @filters.register('security-group')
 class SecurityGroupFilter(net_filters.SecurityGroupFilter):
 
     RelatedIdsExpression = "VpcSecurityGroups[].VpcSecurityGroupId"
 
 
+@docdb_cluster_filters.register('subnet')
 @filters.register('subnet')
 class SubnetFilter(net_filters.SubnetFilter):
 
@@ -227,6 +240,7 @@ class SubnetFilter(net_filters.SubnetFilter):
 filters.register('network-location', net_filters.NetworkLocation)
 
 
+@docdb_cluster_actions.register('delete')
 @actions.register('delete')
 class Delete(BaseAction):
     """Action to delete a RDS cluster

--- a/tests/data/placebo/test_docdb_cluster_delete/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_docdb_cluster_delete/rds.DescribeDBClusters_1.json
@@ -1,0 +1,172 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusters": [
+            {
+                "AllocatedStorage": 1,
+                "AvailabilityZones": [
+                    "us-east-1d",
+                    "us-east-1a",
+                    "us-east-1b"
+                ],
+                "BackupRetentionPeriod": 1,
+                "DBClusterIdentifier": "docdb-2019-01-15-20-50-29",
+                "DBClusterParameterGroup": "default.docdb3.6",
+                "DBSubnetGroup": "default",
+                "Status": "available",
+                "EarliestRestorableTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 15,
+                    "hour": 20,
+                    "minute": 51,
+                    "second": 38,
+                    "microsecond": 65000
+                },
+                "Endpoint": "docdb-2019-01-15-20-50-29.cluster-cz6wy8cci3uf.us-east-1.docdb.amazonaws.com",
+                "ReaderEndpoint": "docdb-2019-01-15-20-50-29.cluster-ro-cz6wy8cci3uf.us-east-1.docdb.amazonaws.com",
+                "MultiAZ": true,
+                "Engine": "docdb",
+                "EngineVersion": "3.6.0",
+                "LatestRestorableTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 14,
+                    "minute": 34,
+                    "second": 0,
+                    "microsecond": 320000
+                },
+                "Port": 27017,
+                "MasterUsername": "admintest",
+                "PreferredBackupWindow": "00:00-00:30",
+                "PreferredMaintenanceWindow": "wed:03:16-wed:03:46",
+                "ReadReplicaIdentifiers": [],
+                "DBClusterMembers": [
+                    {
+                        "DBInstanceIdentifier": "docdb-2019-01-15-20-50-293",
+                        "IsClusterWriter": true,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1
+                    },
+                    {
+                        "DBInstanceIdentifier": "docdb-2019-01-15-20-50-292",
+                        "IsClusterWriter": false,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1
+                    }
+                ],
+                "VpcSecurityGroups": [
+                    {
+                        "VpcSecurityGroupId": "sg-6c7fa917",
+                        "Status": "active"
+                    }
+                ],
+                "HostedZoneId": "ZNKXH85TT8WVW",
+                "StorageEncrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/b10f842a-feb7-4318-92d5-0640a75b7688",
+                "DbClusterResourceId": "cluster-VXNMH6B35IHXX3UZ2JV5D43MIM",
+                "DBClusterArn": "arn:aws:rds:us-east-1:644160558196:cluster:docdb-2019-01-15-20-50-29",
+                "AssociatedRoles": [],
+                "IAMDatabaseAuthenticationEnabled": false,
+                "ClusterCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 15,
+                    "hour": 20,
+                    "minute": 50,
+                    "second": 59,
+                    "microsecond": 382000
+                },
+                "EngineMode": "provisioned",
+                "DeletionProtection": false,
+                "HttpEndpointEnabled": false
+            },
+            {
+                "AllocatedStorage": 1,
+                "AvailabilityZones": [
+                    "us-east-1d",
+                    "us-east-1b",
+                    "us-east-1e"
+                ],
+                "BackupRetentionPeriod": 1,
+                "DBClusterIdentifier": "test-cluster",
+                "DBClusterParameterGroup": "default.docdb3.6",
+                "DBSubnetGroup": "default",
+                "Status": "available",
+                "EarliestRestorableTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 15,
+                    "hour": 19,
+                    "minute": 19,
+                    "second": 13,
+                    "microsecond": 939000
+                },
+                "Endpoint": "test-cluster.cluster-cz6wy8cci3uf.us-east-1.docdb.amazonaws.com",
+                "ReaderEndpoint": "test-cluster.cluster-ro-cz6wy8cci3uf.us-east-1.docdb.amazonaws.com",
+                "MultiAZ": false,
+                "Engine": "docdb",
+                "EngineVersion": "3.6.0",
+                "LatestRestorableTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 15,
+                    "hour": 20,
+                    "minute": 50,
+                    "second": 17,
+                    "microsecond": 120000
+                },
+                "Port": 27017,
+                "MasterUsername": "admintest",
+                "PreferredBackupWindow": "00:00-00:30",
+                "PreferredMaintenanceWindow": "fri:08:10-fri:08:40",
+                "ReadReplicaIdentifiers": [],
+                "DBClusterMembers": [],
+                "VpcSecurityGroups": [
+                    {
+                        "VpcSecurityGroupId": "sg-6c7fa917",
+                        "Status": "active"
+                    }
+                ],
+                "HostedZoneId": "ZNKXH85TT8WVW",
+                "StorageEncrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/b10f842a-feb7-4318-92d5-0640a75b7688",
+                "DbClusterResourceId": "cluster-U6HU2WAHDKBRZ45UMMAQO5RJIE",
+                "DBClusterArn": "arn:aws:rds:us-east-1:644160558196:cluster:test-cluster",
+                "AssociatedRoles": [],
+                "IAMDatabaseAuthenticationEnabled": false,
+                "ClusterCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 15,
+                    "hour": 19,
+                    "minute": 18,
+                    "second": 24,
+                    "microsecond": 830000
+                },
+                "EngineMode": "provisioned",
+                "DeletionProtection": false,
+                "HttpEndpointEnabled": false
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "53824cd8-aec8-4e49-a60e-a7605ba5bb7f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "53824cd8-aec8-4e49-a60e-a7605ba5bb7f",
+                "content-type": "text/xml",
+                "content-length": "5664",
+                "vary": "Accept-Encoding",
+                "date": "Wed, 16 Jan 2019 14:37:42 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_docdb_cluster_delete/rds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_docdb_cluster_delete/rds.ListTagsForResource_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Type": "Sender",
+            "Code": "InvalidParameterValue",
+            "Message": "Invalid resource name:  arn:aws:rds:us-east-1::cluster:docdb-2019-01-15-20-50-29"
+        },
+        "ResponseMetadata": {
+            "RequestId": "69de725e-07c5-4d9e-8a0d-39906021a36a",
+            "HTTPStatusCode": 400,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "69de725e-07c5-4d9e-8a0d-39906021a36a",
+                "content-type": "text/xml",
+                "content-length": "332",
+                "date": "Wed, 16 Jan 2019 14:37:42 GMT",
+                "connection": "close"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_docdb_cluster_delete/rds.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_docdb_cluster_delete/rds.ListTagsForResource_2.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Type": "Sender",
+            "Code": "InvalidParameterValue",
+            "Message": "Invalid resource name:  arn:aws:rds:us-east-1::cluster:test-cluster"
+        },
+        "ResponseMetadata": {
+            "RequestId": "74469c4d-ea85-47e8-a7f1-b4b6027b5107",
+            "HTTPStatusCode": 400,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "74469c4d-ea85-47e8-a7f1-b4b6027b5107",
+                "content-type": "text/xml",
+                "content-length": "319",
+                "date": "Wed, 16 Jan 2019 14:37:43 GMT",
+                "connection": "close"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_docdb_delete/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_docdb_delete/rds.DescribeDBInstances_1.json
@@ -1,0 +1,227 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "docdb-2019-01-15-20-50-292",
+                "DBInstanceClass": "db.r4.large",
+                "Engine": "docdb",
+                "DBInstanceStatus": "available",
+                "MasterUsername": "admintest",
+                "Endpoint": {
+                    "Address": "docdb-2019-01-15-20-50-292.cz6wy8cci3uf.us-east-1.docdb.amazonaws.com",
+                    "Port": 27017,
+                    "HostedZoneId": "ZNKXH85TT8WVW"
+                },
+                "AllocatedStorage": 1,
+                "InstanceCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 15,
+                    "hour": 21,
+                    "minute": 1,
+                    "second": 15,
+                    "microsecond": 461000
+                },
+                "PreferredBackupWindow": "00:00-00:30",
+                "BackupRetentionPeriod": 1,
+                "DBSecurityGroups": [],
+                "VpcSecurityGroups": [
+                    {
+                        "VpcSecurityGroupId": "sg-6c7fa917",
+                        "Status": "active"
+                    }
+                ],
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "default.docdb3.6",
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ],
+                "AvailabilityZone": "us-east-1a",
+                "DBSubnetGroup": {
+                    "DBSubnetGroupName": "default",
+                    "DBSubnetGroupDescription": "default",
+                    "VpcId": "vpc-d2d616b5",
+                    "SubnetGroupStatus": "Complete",
+                    "Subnets": [
+                        {
+                            "SubnetIdentifier": "subnet-3a334610",
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-east-1d"
+                            },
+                            "SubnetStatus": "Active"
+                        },
+                        {
+                            "SubnetIdentifier": "subnet-efbcccb7",
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-east-1b"
+                            },
+                            "SubnetStatus": "Active"
+                        },
+                        {
+                            "SubnetIdentifier": "subnet-e3b194de",
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-east-1e"
+                            },
+                            "SubnetStatus": "Active"
+                        },
+                        {
+                            "SubnetIdentifier": "subnet-914763e7",
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-east-1a"
+                            },
+                            "SubnetStatus": "Active"
+                        }
+                    ]
+                },
+                "PreferredMaintenanceWindow": "sat:04:32-sat:05:02",
+                "PendingModifiedValues": {},
+                "MultiAZ": false,
+                "EngineVersion": "3.6.0",
+                "AutoMinorVersionUpgrade": true,
+                "ReadReplicaDBInstanceIdentifiers": [],
+                "LicenseModel": "na",
+                "OptionGroupMemberships": [
+                    {
+                        "OptionGroupName": "default:docdb-3-6",
+                        "Status": "in-sync"
+                    }
+                ],
+                "PubliclyAccessible": false,
+                "StorageType": "aurora",
+                "DbInstancePort": 0,
+                "DBClusterIdentifier": "docdb-2019-01-15-20-50-29",
+                "StorageEncrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/b10f842a-feb7-4318-92d5-0640a75b7688",
+                "DbiResourceId": "db-DPFJXNOBAQW6VKNPGWO4BYOXPA",
+                "CACertificateIdentifier": "rds-ca-2015",
+                "DomainMemberships": [],
+                "CopyTagsToSnapshot": false,
+                "MonitoringInterval": 0,
+                "PromotionTier": 1,
+                "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:docdb-2019-01-15-20-50-292",
+                "IAMDatabaseAuthenticationEnabled": false,
+                "PerformanceInsightsEnabled": false,
+                "DeletionProtection": false
+            },
+            {
+                "DBInstanceIdentifier": "docdb-2019-01-15-20-50-293",
+                "DBInstanceClass": "db.r4.large",
+                "Engine": "docdb",
+                "DBInstanceStatus": "available",
+                "MasterUsername": "admintest",
+                "Endpoint": {
+                    "Address": "docdb-2019-01-15-20-50-293.cz6wy8cci3uf.us-east-1.docdb.amazonaws.com",
+                    "Port": 27017,
+                    "HostedZoneId": "ZNKXH85TT8WVW"
+                },
+                "AllocatedStorage": 1,
+                "InstanceCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 15,
+                    "hour": 20,
+                    "minute": 56,
+                    "second": 28,
+                    "microsecond": 736000
+                },
+                "PreferredBackupWindow": "00:00-00:30",
+                "BackupRetentionPeriod": 1,
+                "DBSecurityGroups": [],
+                "VpcSecurityGroups": [
+                    {
+                        "VpcSecurityGroupId": "sg-6c7fa917",
+                        "Status": "active"
+                    }
+                ],
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "default.docdb3.6",
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ],
+                "AvailabilityZone": "us-east-1d",
+                "DBSubnetGroup": {
+                    "DBSubnetGroupName": "default",
+                    "DBSubnetGroupDescription": "default",
+                    "VpcId": "vpc-d2d616b5",
+                    "SubnetGroupStatus": "Complete",
+                    "Subnets": [
+                        {
+                            "SubnetIdentifier": "subnet-3a334610",
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-east-1d"
+                            },
+                            "SubnetStatus": "Active"
+                        },
+                        {
+                            "SubnetIdentifier": "subnet-efbcccb7",
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-east-1b"
+                            },
+                            "SubnetStatus": "Active"
+                        },
+                        {
+                            "SubnetIdentifier": "subnet-e3b194de",
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-east-1e"
+                            },
+                            "SubnetStatus": "Active"
+                        },
+                        {
+                            "SubnetIdentifier": "subnet-914763e7",
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-east-1a"
+                            },
+                            "SubnetStatus": "Active"
+                        }
+                    ]
+                },
+                "PreferredMaintenanceWindow": "fri:10:02-fri:10:32",
+                "PendingModifiedValues": {},
+                "MultiAZ": false,
+                "EngineVersion": "3.6.0",
+                "AutoMinorVersionUpgrade": true,
+                "ReadReplicaDBInstanceIdentifiers": [],
+                "LicenseModel": "na",
+                "OptionGroupMemberships": [
+                    {
+                        "OptionGroupName": "default:docdb-3-6",
+                        "Status": "in-sync"
+                    }
+                ],
+                "PubliclyAccessible": false,
+                "StorageType": "aurora",
+                "DbInstancePort": 0,
+                "DBClusterIdentifier": "docdb-2019-01-15-20-50-29",
+                "StorageEncrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/b10f842a-feb7-4318-92d5-0640a75b7688",
+                "DbiResourceId": "db-BTPPGF55CWZLLMZQXHTSDDNKYA",
+                "CACertificateIdentifier": "rds-ca-2015",
+                "DomainMemberships": [],
+                "CopyTagsToSnapshot": false,
+                "MonitoringInterval": 0,
+                "PromotionTier": 1,
+                "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:docdb-2019-01-15-20-50-293",
+                "IAMDatabaseAuthenticationEnabled": false,
+                "PerformanceInsightsEnabled": false,
+                "DeletionProtection": false
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "35e871a4-3704-4218-8903-61df2a5fb776",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "35e871a4-3704-4218-8903-61df2a5fb776",
+                "content-type": "text/xml",
+                "content-length": "9213",
+                "vary": "Accept-Encoding",
+                "date": "Wed, 16 Jan 2019 14:37:55 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_docdb_delete/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_docdb_delete/tagging.GetResources_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:db:docdb-2019-01-15-20-50-292",
+                "Tags": [
+                    {
+                        "Key": "missing",
+                        "Value": "tag"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:db:docdb-2019-01-15-20-50-293",
+                "Tags": [
+                    {
+                        "Key": "missing",
+                        "Value": "tag"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:db:test",
+                "Tags": [
+                    {
+                        "Key": "missing",
+                        "Value": "tag"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "4ff2428c-199c-11e9-a469-f1f595dd4ec4",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "4ff2428c-199c-11e9-a469-f1f595dd4ec4",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "399",
+                "date": "Wed, 16 Jan 2019 14:37:55 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_docdb.py
+++ b/tests/test_docdb.py
@@ -1,0 +1,36 @@
+# Copyright 2017 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .common import BaseTest, TestConfig as Config
+
+from nose.tools import set_trace
+
+class docdbTest(BaseTest):
+
+    def test_docdb_delete(self): 
+        session_factory = self.record_flight_data("test_docdb_delete")
+        p = self.load_policy(
+            {
+                "name": "docdb-delete",
+                "resource": "docdb",
+                "filters": [{"tag:Owner": "test"}],
+                "actions": [{"type": "delete", "skip-snapshot": True}],
+            },
+            config=Config.empty(),
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        set_trace() 
+        self.assertEqual(len(resources), 1)

--- a/tests/test_docdb_cluster.py
+++ b/tests/test_docdb_cluster.py
@@ -1,0 +1,36 @@
+# Copyright 2016-2017 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .common import BaseTest
+
+from nose.tools import set_trace
+
+class RDSClusterTest(BaseTest):
+
+    def test_docdb_cluster_delete(self): 
+        session_factory = self.record_flight_data("test_docdb_cluster_delete")
+        set_trace() 
+        p = self.load_policy(
+            {
+                "name": "docdb-delete",
+                "resource": "docdb-cluster",
+                "filters": [{"tag:Owner": "test"}],
+                "actions": [{"type": "delete", "skip-snapshot": True}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        set_trace() 
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
docdb inheriting RDS - setup for segmenting docdb actions while falling back to RDS.

Would like to use as a basis for discussion to figure out an optimal solution.

TLDR:

1. docdb has it’s own APIs/CLI/SDK namespace
2. docdb emits out of CloudTrail as a RDS event
3. RDS includes and can accept docdb resources through the RDS APIs
4. RDS currently treats docdb as an engine type under the hood.

Suggested approach here would be to look to segment `docdb` and `RDS`.

Pros:
1. Avoid policy writer confusion (Personally, I would not expect an RDS policy to impact an docdb resource, especially if it has it's own namespace).
2. Enable policies to be written to control the two services separately.

Cons:
1. Could result in duplication of effort (ie, right not docdb is covered by existing RDS policies), but also could result in unintended consequences and having to update existing policies if policy should exclude docdb.