### PR TITLE
wip - aws.global-accelerator with parent_spec

### DIFF
--- a/c7n/resources/__init__.py
+++ b/c7n/resources/__init__.py
@@ -91,6 +91,7 @@ def load_resources():
     import c7n.resources.support
     import c7n.resources.vpc
     import c7n.resources.waf
+    import c7n.resources.globalaccelerator
 
     # Load external plugins (private sdks etc)
     from c7n.manager import resources

--- a/c7n/resources/globalaccelerator.py
+++ b/c7n/resources/globalaccelerator.py
@@ -1,0 +1,438 @@
+# Copyright 2016-2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from c7n.actions import (
+    ActionRegistry, BaseAction)
+from c7n.manager import resources
+from c7n.query import QueryResourceManager, ChildResourceManager
+from c7n.utils import local_session, type_schema
+
+actions = ActionRegistry('globalaccelerator.actions')
+
+
+@resources.register('global-accelerator')
+class AcceleratorInstance(QueryResourceManager):
+
+    class resource_type(object):
+        service = 'globalaccelerator'
+        enum_spec = ('list_accelerators', 'Accelerators', None)
+        detail_spec = (
+            'describe_accelerator', 'AcceleratorArn',
+            'AcceleratorArn', None)
+        id = 'AcceleratorArn'
+        name = 'Name'
+        date = 'CreatedTime'
+        dimension = None
+        filter_name = None
+
+    def augment(self, resources):
+        client = local_session(self.session_factory).client('globalaccelerator',
+            region_name='us-west-2')
+
+        for r in resources:
+            extra_ = self.retry(client.describe_accelerator_attributes,
+                AcceleratorArn=r['AcceleratorArn'])['AcceleratorAttributes']
+
+            for i in extra_:
+                r[i] = extra_[i]
+
+        return resources
+
+
+@resources.register('global-accelerator-listener')
+class AcceleratorListener(ChildResourceManager):
+
+    class resource_type(object):
+        service = 'globalaccelerator'
+        enum_spec = ('list_listeners', 'Listeners', None)
+        detail_spec = (
+            'describe_listener', 'ListenerArn',
+            'ListenerArn', None)
+        id = 'ListenerArn'
+        name = None
+        date = 'CreatedTime'
+        dimension = None
+        filter_name = None
+        parent_spec = ('global-accelerator', 'AcceleratorArn', None)
+
+
+@resources.register('global-accelerator-endpoint-group')
+class AcceleratorEndpointGroup(ChildResourceManager):
+
+    class resource_type(object):
+        service = 'globalaccelerator'
+        enum_spec = ('list_endpoint_groups', 'EndpointGroups', None)
+        detail_spec = (
+            'describe_endpoint_group', 'EndpointGroupArn',
+            'EndpointGroupArn', None)
+        id = 'EndpointGroupArn'
+        name = None
+        date = 'CreatedTime'
+        dimension = None
+        filter_name = None
+        parent_spec = ('global-accelerator-listener', 'ListenerArn', None)
+
+
+@AcceleratorEndpointGroup.action_registry.register('delete')
+class DeleteEndpointGroup(BaseAction):
+    '''Deletes global-accelerator-endpoint(s)
+
+    :example:
+
+    .. code-block: yaml
+
+        policies:
+          - name: delete-global-accelerator-endpoint
+            resource: global-accelerator-endpoint
+            actions:
+              - delete
+            filters:
+              - EndpointGroupRegion: us-west-2
+    '''
+    schema = type_schema('delete')
+    permissions = ('globalaccelerator:DeleteEndpointGroup',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('globalaccelerator',
+            region_name='us-west-2')
+        for m in resources:
+            client.delete_endpoint_group(
+                EndpointGroupArn=m['EndpointGroupArn'])
+
+
+@AcceleratorListener.action_registry.register('delete')
+class DeleteListener(BaseAction):
+    '''Deletes global-accelerator-listener(s)
+
+    :example:
+
+    .. code-block: yaml
+
+        policies:
+          - name: delete-global-accelerator-listener
+            resource: global-accelerator-listener
+            actions:
+              - delete
+            filters:
+              - ClientAffinity: NONE
+    '''
+    schema = type_schema('delete')
+    permissions = ('globalaccelerator:DeleteListener',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('globalaccelerator',
+            region_name='us-west-2')
+        for m in resources:
+            try:
+                client.delete_listener(ListenerArn=m['ListenerArn'])
+            # deleting a listener with endpoints is forbidden
+            except client.exceptions.AssociatedEndpointGroupFoundException:
+                pass
+
+
+@AcceleratorInstance.action_registry.register('delete')
+class DeleteAccelerator(BaseAction):
+    '''Deletes global-accelerator(s)
+
+    :example:
+
+    .. code-block: yaml
+
+        policies:
+          - name: delete-global-accelerator
+            resource: global-accelerator
+            filters:
+              - Enabled: False
+            actions:
+              - delete
+    '''
+    schema = type_schema('delete')
+    permissions = ('globalaccelerator:DeleteAccelerator',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('globalaccelerator',
+            region_name='us-west-2')
+
+        for m in resources:
+            if m['Enabled']:
+                continue
+            try:
+                client.delete_accelerator(AcceleratorArn=m['AcceleratorArn'])
+            except client.exceptions.AcceleratorNotFoundException:
+                pass
+
+
+@AcceleratorInstance.action_registry.register('modify-global-accelerator')
+class ModifyAccelerator(BaseAction):
+    '''Modifies an accelerator instance based on specified parameter
+    using UpdateAccelerator and UpdateAcceleratorAttributes.
+
+    'update-accelerator-attributes' and 'uppate-accelerator' are arrays with
+    key value pairs that should be set to the property and value you wish to
+    modify.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: disable-accelerator-protection
+                resource: global-accelerator-listener
+                filters:
+                  - enabled: true
+                actions:
+                  - type: modify-global-accelerator
+                    update:
+                      - property: 'Enabled'
+                        value: false
+
+    .. code-block:: yaml
+
+            policies:
+              - name: disable-accelerator-flowlogs-protection
+                resource: global-accelerator-listener
+                actions:
+                  - type: update-accelerator-attributes
+                    update:
+                      - property: 'FlowLogsEnabled'
+                        value: false
+    '''
+
+    schema = type_schema(
+        'modify-global-accelerator', **{
+            'update-accelerator-attributes': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'property': {'type': 'string', 'enum': [
+                            'FlowLogsEnabled',
+                            'FlowLogsS3Bucket',
+                            'FlowLogsS3Prefix']},
+                        'value': {}
+                    },
+                },
+            },
+            'update-accelerator': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'property': {'type': 'string', 'enum': [
+                            'Enabled']},
+                        'value': {}
+                    },
+                },
+            }
+        }
+    )
+
+    permissions = ('globalaccelerator:UpdateAccelerator',
+        'globalaccelerator:UpdateAcceleratorAttributes')
+
+    def process(self, resources):
+        c = local_session(self.manager.session_factory).client(
+            'globalaccelerator', region_name='us-west-2')
+        update_iteration = (
+            ('update-accelerator-attributes', c.update_accelerator_attributes),
+            ('update-accelerator', c.update_accelerator))
+
+        for (key, update_method) in update_iteration:
+
+            for r in resources:
+                param = {}
+                schema_attributes = []
+
+                if key in self.data:
+                    schema_attributes = self.data.get(key)
+
+                for update in schema_attributes:
+                    update_prop = update['property']
+                    if r.get(update_prop) != update['value']:
+                        param[update_prop] = update['value']
+
+                if not param:
+                    continue
+                param['AcceleratorArn'] = r['AcceleratorArn']
+                update_method(**param)
+
+
+@AcceleratorEndpointGroup.action_registry.register('modify')
+class ModifyAcceleratorEndpoint(BaseAction):
+    '''Modifies an accelerator endpoint based on specified parameter
+    using UpdateEndpointGroup.
+
+
+    :example:
+
+    .. code-block:: yaml
+        policies:
+          - name: modify-global-accelerator-endpoint-threshold
+            resource: global-accelerator-endpoint-group
+            actions:
+              - type: modify
+                update:
+                  - property: 'ThresholdCount'
+                    value: 5
+    '''
+
+    update_accelerator_endpoint = {
+        'type': 'array',
+        'items': {
+            'type': 'object',
+            'properties': {
+                'property': {
+                    'type': 'string',
+                    'enum': [
+                        'TrafficDialPercentage',
+                        'HealthCheckPort',
+                        'HealthCheckProtocol',
+                        'HealthCheckPath',
+                        'HealthCheckIntervalSeconds',
+                        'ThresholdCount',
+                    ]
+                },
+                'value': {},
+                'EndpointConfigurations': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'properties': {
+                            'property': {'type': 'string', 'enum': ['EndpointId', 'Weight']},
+                            'value': {},
+                        }
+                    },
+                },
+            },
+        },
+    }
+    schema = type_schema(
+        'modify', **{
+            'update-accelerator-endpoint': update_accelerator_endpoint
+        }
+    )
+
+    permissions = ('globalaccelerator:UpdateEndpointGroup')
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('globalaccelerator',
+            region_name='us-west-2')
+
+        for endpoint_group_resource in resources:
+
+            existing_endpoint_ids = set(())
+            param = {}
+
+            for endpoint_data in endpoint_group_resource['EndpointDescriptions']:
+                existing_endpoint_ids.add(endpoint_data['EndpointId'])
+
+            for update in self.data.get('update-accelerator-endpoint'):
+                if 'property' in update and (
+                        endpoint_group_resource[update['property']] != update['value']):
+                    param[update['property']] = update['value']
+
+                elif 'EndpointConfigurations' in update:
+                    for i in update['EndpointConfigurations']:
+
+                        # the EndpointId has to be in the resource
+                        if i['EndpointId'] in existing_endpoint_ids:
+                            if 'EndpointConfigurations' not in param:
+                                param['EndpointConfigurations'] = []
+
+                            param['EndpointConfigurations'].append({
+                                'EndpointId': i['EndpointId'],
+                                'Weight': i['Weight']
+                            })
+
+            if not param:
+                continue
+
+            param['EndpointGroupArn'] = endpoint_group_resource['EndpointGroupArn']
+
+            try:
+                client.update_endpoint_group(**param)
+            except (client.exceptions.EndpointGroupNotFoundException,
+                    client.exceptions.InvalidArgumentException) as e:
+                pass
+
+
+@AcceleratorListener.action_registry.register('modify')
+class ModifyAcceleratorListener(BaseAction):
+    '''Modifies an accelerator listener based on specified parameter
+    using UpdateListener.
+
+
+    :example:
+
+    .. code-block:: yaml
+        policies:
+          - name: modify-global-accelerator-listener-protocol
+            resource: global-accelerator-listener
+            actions:
+              - type: modify
+                update:
+                  - property: Protocol
+                    value: TCP
+            filters:
+                  - Health: UDP
+    '''
+    schema = type_schema('modify',
+        **{'update-accelerator-listener': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'property': {'type': 'string', 'enum': [
+                        'PortRanges',
+                        'Protocol',
+                        'ClientAffinity',
+                    ]},
+                    'value': {},
+                    'PortRanges': {
+                        'type': 'arrary',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'FromPort': {'type': 'string'},
+                                'ToPort': {'type': 'string'},
+                            }
+                        },
+                    },
+                },
+            },
+        }})
+
+    permissions = ('globalaccelerator:UpdateListener')
+
+    def process(self, resources):
+
+        c = local_session(self.manager.session_factory).client('globalaccelerator',
+        region_name='us-west-2')
+
+        for r in resources:
+            param = {}
+            for update in self.data.get('update-accelerator-listener'):
+                port_ranges = update.get('PortRanges', [])
+                if port_ranges:
+                    param['PortRanges'] = port_ranges
+                else:
+                    if r[update['property']] != update['value']:
+                        param[update['property']] = update['value']
+            if not param:
+                continue
+            param['ListenerArn'] = r['ListenerArn']
+            try:
+                c.update_listener(**param)
+            except c.exceptions.ListenerNotFoundException:
+                raise

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DeleteEndpointGroup_1.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DeleteEndpointGroup_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "185d24c7-5646-4daa-ac55-31dc8993b047",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:38:01 GMT",
+                "x-amzn-requestid": "185d24c7-5646-4daa-ac55-31dc8993b047",
+                "content-length": "0",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": true,
+            "FlowLogsS3Bucket": "test-for-global-accelerator-bucket/test-custodian",
+            "FlowLogsS3Prefix": "us-west-2"
+        },
+        "ResponseMetadata": {
+            "RequestId": "bcc43812-0310-446f-9f93-ca7363c57244",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:37:37 GMT",
+                "x-amzn-requestid": "bcc43812-0310-446f-9f93-ca7363c57244",
+                "content-length": "152",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DescribeEndpointGroup_1.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DescribeEndpointGroup_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+            "EndpointGroupRegion": "us-east-1",
+            "EndpointDescriptions": [],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 80,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 30,
+            "ThresholdCount": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "3656d40b-51c8-4ab4-8c36-3d3c6ccda63d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:37:39 GMT",
+                "x-amzn-requestid": "3656d40b-51c8-4ab4-8c36-3d3c6ccda63d",
+                "content-length": "365",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DescribeEndpointGroup_2.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DescribeEndpointGroup_2.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/e92a14e5b300",
+            "EndpointGroupRegion": "us-east-2",
+            "EndpointDescriptions": [],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 80,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 30,
+            "ThresholdCount": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "88f81f3f-38e0-45bb-aff1-e8ee4fa1337f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:37:39 GMT",
+                "x-amzn-requestid": "88f81f3f-38e0-45bb-aff1-e8ee4fa1337f",
+                "content-length": "365",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DescribeListener_1.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.DescribeListener_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listener": {
+            "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+            "PortRanges": [
+                {
+                    "FromPort": 80,
+                    "ToPort": 80
+                }
+            ],
+            "Protocol": "TCP",
+            "ClientAffinity": "NONE"
+        },
+        "ResponseMetadata": {
+            "RequestId": "8be13e11-f954-4731-87f3-9789f77d7dbc",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:37:38 GMT",
+                "x-amzn-requestid": "8be13e11-f954-4731-87f3-9789f77d7dbc",
+                "content-length": "221",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 18,
+                    "hour": 10,
+                    "minute": 59,
+                    "second": 22,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "5a35b8c1-2aef-4066-94b9-97d9ac0f3e0a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:37:37 GMT",
+                "x-amzn-requestid": "5a35b8c1-2aef-4066-94b9-97d9ac0f3e0a",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.ListEndpointGroups_1.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.ListEndpointGroups_1.json
@@ -1,0 +1,39 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroups": [
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+                "EndpointGroupRegion": "us-east-1",
+                "EndpointDescriptions": [],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 80,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            },
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/e92a14e5b300",
+                "EndpointGroupRegion": "us-east-2",
+                "EndpointDescriptions": [],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 80,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "5cfcbfca-a107-4cd9-843c-05a868a7c501",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:37:36 GMT",
+                "x-amzn-requestid": "5cfcbfca-a107-4cd9-843c-05a868a7c501",
+                "content-length": "716",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.ListEndpointGroups_2.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.ListEndpointGroups_2.json
@@ -1,0 +1,39 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroups": [
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+                "EndpointGroupRegion": "us-east-1",
+                "EndpointDescriptions": [],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 80,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            },
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/e92a14e5b300",
+                "EndpointGroupRegion": "us-east-2",
+                "EndpointDescriptions": [],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 80,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "12a96610-d2fa-4321-af62-60b93cd3bd60",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:37:38 GMT",
+                "x-amzn-requestid": "12a96610-d2fa-4321-af62-60b93cd3bd60",
+                "content-length": "716",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_1/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+                "PortRanges": [
+                    {
+                        "FromPort": 80,
+                        "ToPort": 80
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "NONE"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "ad774f06-eacd-436f-b851-1bf8f00e0e3c",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:37:38 GMT",
+                "x-amzn-requestid": "ad774f06-eacd-436f-b851-1bf8f00e0e3c",
+                "content-length": "224",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_endpoint_groups_2/globalaccelerator.ListEndpointGroups_1.json
+++ b/tests/data/placebo/test_delete_endpoint_groups_2/globalaccelerator.ListEndpointGroups_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroups": [
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+                "EndpointGroupRegion": "us-east-1",
+                "EndpointDescriptions": [],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 80,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "9df1b94a-2b4e-47ec-9424-1ad2dffd03de",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 16:38:01 GMT",
+                "x-amzn-requestid": "9df1b94a-2b4e-47ec-9424-1ad2dffd03de",
+                "content-length": "368",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_listeners1/globalaccelerator.DeleteListener_1.json
+++ b/tests/data/placebo/test_delete_listeners1/globalaccelerator.DeleteListener_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "b05ca10c-4090-47d9-b576-28fef550c165",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 15:59:21 GMT",
+                "x-amzn-requestid": "b05ca10c-4090-47d9-b576-28fef550c165",
+                "content-length": "0",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_listeners1/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_delete_listeners1/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": true,
+            "FlowLogsS3Bucket": "test-for-global-accelerator-bucket/test-custodian",
+            "FlowLogsS3Prefix": "us-west-2"
+        },
+        "ResponseMetadata": {
+            "RequestId": "d134e7d1-66a7-4eea-9df2-c147581833d2",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 15:58:34 GMT",
+                "x-amzn-requestid": "d134e7d1-66a7-4eea-9df2-c147581833d2",
+                "content-length": "152",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_listeners1/globalaccelerator.DescribeListener_1.json
+++ b/tests/data/placebo/test_delete_listeners1/globalaccelerator.DescribeListener_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listener": {
+            "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+            "PortRanges": [
+                {
+                    "FromPort": 80,
+                    "ToPort": 80
+                }
+            ],
+            "Protocol": "TCP",
+            "ClientAffinity": "NONE"
+        },
+        "ResponseMetadata": {
+            "RequestId": "41d57ce1-c9c3-4808-a55d-510d52601ef9",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 15:58:35 GMT",
+                "x-amzn-requestid": "41d57ce1-c9c3-4808-a55d-510d52601ef9",
+                "content-length": "221",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_listeners1/globalaccelerator.DescribeListener_2.json
+++ b/tests/data/placebo/test_delete_listeners1/globalaccelerator.DescribeListener_2.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listener": {
+            "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/aa6eea2b",
+            "PortRanges": [
+                {
+                    "FromPort": 65,
+                    "ToPort": 65
+                }
+            ],
+            "Protocol": "UDP",
+            "ClientAffinity": "NONE"
+        },
+        "ResponseMetadata": {
+            "RequestId": "60d6f25e-08a9-48c1-b3bd-e3b486cab9f5",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 15:58:35 GMT",
+                "x-amzn-requestid": "60d6f25e-08a9-48c1-b3bd-e3b486cab9f5",
+                "content-length": "221",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_listeners1/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_delete_listeners1/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 18,
+                    "hour": 10,
+                    "minute": 44,
+                    "second": 24,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "097e372c-c2d0-4e05-8ac2-30254a68817d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 15:58:34 GMT",
+                "x-amzn-requestid": "097e372c-c2d0-4e05-8ac2-30254a68817d",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_listeners1/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_delete_listeners1/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+                "PortRanges": [
+                    {
+                        "FromPort": 80,
+                        "ToPort": 80
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "NONE"
+            },
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/aa6eea2b",
+                "PortRanges": [
+                    {
+                        "FromPort": 65,
+                        "ToPort": 65
+                    }
+                ],
+                "Protocol": "UDP",
+                "ClientAffinity": "NONE"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "ea5a0a14-cde2-4b6c-a1b4-802ca99a91a7",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 15:58:33 GMT",
+                "x-amzn-requestid": "ea5a0a14-cde2-4b6c-a1b4-802ca99a91a7",
+                "content-length": "433",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_listeners1/globalaccelerator.ListListeners_2.json
+++ b/tests/data/placebo/test_delete_listeners1/globalaccelerator.ListListeners_2.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+                "PortRanges": [
+                    {
+                        "FromPort": 80,
+                        "ToPort": 80
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "NONE"
+            },
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/aa6eea2b",
+                "PortRanges": [
+                    {
+                        "FromPort": 65,
+                        "ToPort": 65
+                    }
+                ],
+                "Protocol": "UDP",
+                "ClientAffinity": "NONE"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "0a637682-8b2c-4722-b45f-5db6cc84cf89",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 15:58:34 GMT",
+                "x-amzn-requestid": "0a637682-8b2c-4722-b45f-5db6cc84cf89",
+                "content-length": "433",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_delete_listeners_2/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_delete_listeners_2/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+                "PortRanges": [
+                    {
+                        "FromPort": 80,
+                        "ToPort": 80
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "NONE"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "50f013b6-786a-44e4-aaf4-cd34d418061d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 15:59:22 GMT",
+                "x-amzn-requestid": "50f013b6-786a-44e4-aaf4-cd34d418061d",
+                "content-length": "224",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DeleteAccelerator_1.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DeleteAccelerator_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "f3c10792-255f-4efd-8e00-653947a5b6c8",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:26 GMT",
+                "x-amzn-requestid": "f3c10792-255f-4efd-8e00-653947a5b6c8",
+                "content-length": "0",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DeleteAccelerator_2.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DeleteAccelerator_2.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "95b8c2ba-eef7-40dd-a706-57af7ad8f5f7",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:27 GMT",
+                "x-amzn-requestid": "95b8c2ba-eef7-40dd-a706-57af7ad8f5f7",
+                "content-length": "0",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": true,
+            "FlowLogsS3Bucket": "test-for-global-accelerator-bucket/test-custodian",
+            "FlowLogsS3Prefix": "us-west-2"
+        },
+        "ResponseMetadata": {
+            "RequestId": "f609b189-20ce-434e-9e9f-fe8b0c5855e6",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:26 GMT",
+                "x-amzn-requestid": "f609b189-20ce-434e-9e9f-fe8b0c5855e6",
+                "content-length": "152",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DescribeAcceleratorAttributes_2.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DescribeAcceleratorAttributes_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": false
+        },
+        "ResponseMetadata": {
+            "RequestId": "da3c2539-8794-48a5-a8cb-fae801113b6d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:26 GMT",
+                "x-amzn-requestid": "da3c2539-8794-48a5-a8cb-fae801113b6d",
+                "content-length": "51",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DescribeAcceleratorAttributes_3.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.DescribeAcceleratorAttributes_3.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": false
+        },
+        "ResponseMetadata": {
+            "RequestId": "76faf9c2-d27c-4a68-a0cb-4c95579aa136",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:26 GMT",
+                "x-amzn-requestid": "76faf9c2-d27c-4a68-a0cb-4c95579aa136",
+                "content-length": "51",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,127 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 23,
+                    "second": 59,
+                    "microsecond": 0
+                }
+            },
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/406016d8-f8bd-45db-b166-56f5f100b6b9",
+                "Name": "delete-me2-accelerator",
+                "IpAddressType": "IPV4",
+                "Enabled": false,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.149.156",
+                            "76.223.21.239"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 27,
+                    "second": 48,
+                    "microsecond": 0
+                }
+            },
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/d801730a-b47e-49ac-85bf-44b50dc15bfd",
+                "Name": "delete-me-accelerator",
+                "IpAddressType": "IPV4",
+                "Enabled": false,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.133.139",
+                            "76.223.8.242"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 24,
+                    "second": 54,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 27,
+                    "second": 58,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "7f879748-9d95-43f2-bb50-855c1060177f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:25 GMT",
+                "x-amzn-requestid": "7f879748-9d95-43f2-bb50-855c1060177f",
+                "content-length": "1032",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListAccelerators_2.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListAccelerators_2.json
@@ -1,0 +1,127 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 23,
+                    "second": 59,
+                    "microsecond": 0
+                }
+            },
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/406016d8-f8bd-45db-b166-56f5f100b6b9",
+                "Name": "delete-me2-accelerator",
+                "IpAddressType": "IPV4",
+                "Enabled": false,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.149.156",
+                            "76.223.21.239"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 27,
+                    "second": 48,
+                    "microsecond": 0
+                }
+            },
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/d801730a-b47e-49ac-85bf-44b50dc15bfd",
+                "Name": "delete-me-accelerator",
+                "IpAddressType": "IPV4",
+                "Enabled": false,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.133.139",
+                            "76.223.8.242"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 24,
+                    "second": 54,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 27,
+                    "second": 58,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "ca9c1260-fbb4-464d-a67f-2d45a43be552",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:25 GMT",
+                "x-amzn-requestid": "ca9c1260-fbb4-464d-a67f-2d45a43be552",
+                "content-length": "1032",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListAccelerators_3.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListAccelerators_3.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 23,
+                    "second": 59,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "da8e0d85-e778-4cf4-b720-9f2f8b3e114d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:27 GMT",
+                "x-amzn-requestid": "da8e0d85-e778-4cf4-b720-9f2f8b3e114d",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [],
+        "ResponseMetadata": {
+            "RequestId": "1b254ba6-351c-4cb7-9863-7013fa9994a8",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:26 GMT",
+                "x-amzn-requestid": "1b254ba6-351c-4cb7-9863-7013fa9994a8",
+                "content-length": "16",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListListeners_2.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListListeners_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [],
+        "ResponseMetadata": {
+            "RequestId": "f19bb12e-91a1-4946-a717-848ffd5b33c8",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:26 GMT",
+                "x-amzn-requestid": "f19bb12e-91a1-4946-a717-848ffd5b33c8",
+                "content-length": "16",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListListeners_3.json
+++ b/tests/data/placebo/test_global_accelerator_delete_instance/globalaccelerator.ListListeners_3.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [],
+        "ResponseMetadata": {
+            "RequestId": "5687c157-68e0-480e-9d1c-14173bb75c4d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:35:26 GMT",
+                "x-amzn-requestid": "5687c157-68e0-480e-9d1c-14173bb75c4d",
+                "content-length": "16",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_instances/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_global_accelerator_instances/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": false
+        },
+        "ResponseMetadata": {
+            "RequestId": "f41e249a-6148-4418-9101-75a1bcadf6b8",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 15:19:00 GMT",
+                "x-amzn-requestid": "f41e249a-6148-4418-9101-75a1bcadf6b8",
+                "content-length": "51",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_instances/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_global_accelerator_instances/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": false,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 10,
+                    "minute": 9,
+                    "second": 0,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "b8509fbb-e052-42ca-873f-2ebb16e53ebc",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 15:18:59 GMT",
+                "x-amzn-requestid": "b8509fbb-e052-42ca-873f-2ebb16e53ebc",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_instances/globalaccelerator.ListEndpointGroups_1.json
+++ b/tests/data/placebo/test_global_accelerator_instances/globalaccelerator.ListEndpointGroups_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroups": [
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/17a532f0/endpoint-group/ffa6c354e002",
+                "EndpointGroupRegion": "us-east-1",
+                "EndpointDescriptions": [
+                    {
+                        "EndpointId": "eipalloc-0b0cb213820a08ae6",
+                        "Weight": 100,
+                        "HealthState": "UNHEALTHY"
+                    }
+                ],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 82,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            },
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/17a532f0/endpoint-group/bad9bd37b005",
+                "EndpointGroupRegion": "us-west-2",
+                "EndpointDescriptions": [],
+                "TrafficDialPercentage": 0.0,
+                "HealthCheckPort": 80,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 4
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "ddb53d23-b38a-46ce-8a72-b8eab9c687ed",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 15:19:01 GMT",
+                "x-amzn-requestid": "ddb53d23-b38a-46ce-8a72-b8eab9c687ed",
+                "content-length": "796",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_instances/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_global_accelerator_instances/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/17a532f0",
+                "PortRanges": [
+                    {
+                        "FromPort": 82,
+                        "ToPort": 83
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "SOURCE_IP"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "4ebb3d29-9fda-47fb-badf-bd6c66277af1",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 15:19:01 GMT",
+                "x-amzn-requestid": "4ebb3d29-9fda-47fb-badf-bd6c66277af1",
+                "content-length": "229",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_instances_with_listeners/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_global_accelerator_instances_with_listeners/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": false
+        },
+        "ResponseMetadata": {
+            "RequestId": "d53f7e42-254c-45cd-8f54-b0afc9778b7e",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 15 Jan 2019 22:08:10 GMT",
+                "x-amzn-requestid": "d53f7e42-254c-45cd-8f54-b0afc9778b7e",
+                "content-length": "51",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_instances_with_listeners/globalaccelerator.DescribeAccelerator_2.json
+++ b/tests/data/placebo/test_global_accelerator_instances_with_listeners/globalaccelerator.DescribeAccelerator_2.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerator": {
+            "AcceleratorArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876",
+            "Name": "test-custodian-accelerator",
+            "IpAddressType": "IPV4",
+            "Enabled": true,
+            "IpSets": [
+                {
+                    "IpFamily": "IPv4",
+                    "IpAddresses": [
+                        "13.248.138.26",
+                        "76.223.13.90"
+                    ]
+                }
+            ],
+            "Status": "DEPLOYED",
+            "CreatedTime": {
+                "__class__": "datetime",
+                "year": 2018,
+                "month": 12,
+                "day": 31,
+                "hour": 9,
+                "minute": 10,
+                "second": 55,
+                "microsecond": 0
+            },
+            "LastModifiedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 9,
+                "hour": 14,
+                "minute": 24,
+                "second": 41,
+                "microsecond": 0
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "4fbaa686-531d-4134-8a2e-4eeba851e89e",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 15 Jan 2019 22:08:11 GMT",
+                "x-amzn-requestid": "4fbaa686-531d-4134-8a2e-4eeba851e89e",
+                "content-length": "358",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_global_accelerator_instances_with_listeners/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_global_accelerator_instances_with_listeners/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876",
+                "Name": "test-custodian-accelerator",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.138.26",
+                            "76.223.13.90"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 12,
+                    "day": 31,
+                    "hour": 9,
+                    "minute": 10,
+                    "second": 55,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 9,
+                    "hour": 14,
+                    "minute": 24,
+                    "second": 41,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "18edbe62-a500-4bf8-9c5f-7a846a2eb022",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 15 Jan 2019 22:08:10 GMT",
+                "x-amzn-requestid": "18edbe62-a500-4bf8-9c5f-7a846a2eb022",
+                "content-length": "361",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": true,
+            "FlowLogsS3Bucket": "test-for-global-accelerator-bucket/test-custodian",
+            "FlowLogsS3Prefix": "us-west-2"
+        },
+        "ResponseMetadata": {
+            "RequestId": "2da15906-a706-4b6e-a784-abb386e0d454",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:03 GMT",
+                "x-amzn-requestid": "2da15906-a706-4b6e-a784-abb386e0d454",
+                "content-length": "152",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeEndpointGroup_1.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeEndpointGroup_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+            "EndpointGroupRegion": "us-east-1",
+            "EndpointDescriptions": [
+                {
+                    "EndpointId": "eipalloc-0b0cb213820a08ae6",
+                    "Weight": 100,
+                    "HealthState": "UNHEALTHY"
+                }
+            ],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 80,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 30,
+            "ThresholdCount": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "d592d45a-ef28-4c2d-95a4-69611999085d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:02 GMT",
+                "x-amzn-requestid": "d592d45a-ef28-4c2d-95a4-69611999085d",
+                "content-length": "447",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeEndpointGroup_2.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeEndpointGroup_2.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+            "EndpointGroupRegion": "us-east-1",
+            "EndpointDescriptions": [
+                {
+                    "EndpointId": "eipalloc-0b0cb213820a08ae6",
+                    "Weight": 100,
+                    "HealthState": "UNHEALTHY"
+                }
+            ],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 80,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 30,
+            "ThresholdCount": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "6f9ee7a4-f557-453f-b064-acb55591bbf7",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:05 GMT",
+                "x-amzn-requestid": "6f9ee7a4-f557-453f-b064-acb55591bbf7",
+                "content-length": "447",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeEndpointGroup_3.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeEndpointGroup_3.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+            "EndpointGroupRegion": "us-east-1",
+            "EndpointDescriptions": [
+                {
+                    "EndpointId": "eipalloc-0b0cb213820a08ae6",
+                    "Weight": 0,
+                    "HealthState": "HEALTHY"
+                }
+            ],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 80,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 30,
+            "ThresholdCount": 4
+        },
+        "ResponseMetadata": {
+            "RequestId": "6fefbf91-9f75-454a-9bf3-b7d8c5e83981",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:58 GMT",
+                "x-amzn-requestid": "6fefbf91-9f75-454a-9bf3-b7d8c5e83981",
+                "content-length": "443",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeListener_1.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.DescribeListener_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listener": {
+            "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+            "PortRanges": [
+                {
+                    "FromPort": 82,
+                    "ToPort": 83
+                }
+            ],
+            "Protocol": "TCP",
+            "ClientAffinity": "SOURCE_IP"
+        },
+        "ResponseMetadata": {
+            "RequestId": "299b61c9-4591-483a-96ef-d3cd793cb586",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:04 GMT",
+                "x-amzn-requestid": "299b61c9-4591-483a-96ef-d3cd793cb586",
+                "content-length": "226",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 18,
+                    "hour": 13,
+                    "minute": 19,
+                    "second": 39,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "2763b764-036a-4b81-8c62-c941f57bb58f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:03 GMT",
+                "x-amzn-requestid": "2763b764-036a-4b81-8c62-c941f57bb58f",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.ListEndpointGroups_1.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.ListEndpointGroups_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroups": [
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+                "EndpointGroupRegion": "us-east-1",
+                "EndpointDescriptions": [
+                    {
+                        "EndpointId": "eipalloc-0b0cb213820a08ae6",
+                        "Weight": 100,
+                        "HealthState": "UNHEALTHY"
+                    }
+                ],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 80,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "7f3fbb15-97da-4b17-b96a-3ae3dafae0ce",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:04 GMT",
+                "x-amzn-requestid": "7f3fbb15-97da-4b17-b96a-3ae3dafae0ce",
+                "content-length": "450",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+                "PortRanges": [
+                    {
+                        "FromPort": 82,
+                        "ToPort": 83
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "SOURCE_IP"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "51f2c10d-ba83-4de7-b4f2-5a9a770c76b1",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:03 GMT",
+                "x-amzn-requestid": "51f2c10d-ba83-4de7-b4f2-5a9a770c76b1",
+                "content-length": "229",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.UpdateEndpointGroup_1.json
+++ b/tests/data/placebo/test_modify_endpoint_configuration_1/globalaccelerator.UpdateEndpointGroup_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002",
+            "EndpointGroupRegion": "us-east-1",
+            "EndpointDescriptions": [
+                {
+                    "EndpointId": "eipalloc-0b0cb213820a08ae6",
+                    "Weight": 0,
+                    "HealthState": "HEALTHY"
+                }
+            ],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 80,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 30,
+            "ThresholdCount": 4
+        },
+        "ResponseMetadata": {
+            "RequestId": "b04e2ae5-8722-4356-922c-7c46d632a03d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:53:58 GMT",
+                "x-amzn-requestid": "b04e2ae5-8722-4356-922c-7c46d632a03d",
+                "content-length": "443",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": false
+        },
+        "ResponseMetadata": {
+            "RequestId": "1f7a939c-dbfd-4a6a-bcf3-5980070fc00e",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 08 Jan 2019 16:58:07 GMT",
+                "x-amzn-requestid": "1f7a939c-dbfd-4a6a-bcf3-5980070fc00e",
+                "content-length": "51",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.DescribeEndpointGroup_1.json
+++ b/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.DescribeEndpointGroup_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876/listener/dea15d95/endpoint-group/53b7f8f91002",
+            "EndpointGroupRegion": "us-east-1",
+            "EndpointDescriptions": [
+                {
+                    "EndpointId": "eipalloc-0bb0a4cc0513471c8",
+                    "Weight": 100,
+                    "HealthState": "UNHEALTHY"
+                }
+            ],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 81,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 30,
+            "ThresholdCount": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "31856066-dbee-47a4-a749-0bd7e2fbe064",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 08 Jan 2019 16:58:07 GMT",
+                "x-amzn-requestid": "31856066-dbee-47a4-a749-0bd7e2fbe064",
+                "content-length": "447",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.DescribeEndpointGroup_2.json
+++ b/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.DescribeEndpointGroup_2.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876/listener/dea15d95/endpoint-group/53b7f8f91002",
+            "EndpointGroupRegion": "us-east-1",
+            "EndpointDescriptions": [
+                {
+                    "EndpointId": "eipalloc-0bb0a4cc0513471c8",
+                    "Weight": 100,
+                    "HealthState": "HEALTHY"
+                }
+            ],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 81,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 10,
+            "ThresholdCount": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "603f0ef0-f79f-4f55-8791-b2a6c360cab2",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 08 Jan 2019 16:58:15 GMT",
+                "x-amzn-requestid": "603f0ef0-f79f-4f55-8791-b2a6c360cab2",
+                "content-length": "445",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876",
+                "Name": "test-custodian-accelerator",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.138.26",
+                            "76.223.13.90"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 12,
+                    "day": 31,
+                    "hour": 9,
+                    "minute": 10,
+                    "second": 55,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 7,
+                    "hour": 14,
+                    "minute": 56,
+                    "second": 47,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "46b1f0dd-f93e-48b3-8aa6-e43a4ab43f89",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 08 Jan 2019 16:58:07 GMT",
+                "x-amzn-requestid": "46b1f0dd-f93e-48b3-8aa6-e43a4ab43f89",
+                "content-length": "361",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.ListEndpointGroups_1.json
+++ b/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.ListEndpointGroups_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroups": [
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876/listener/dea15d95/endpoint-group/53b7f8f91002",
+                "EndpointGroupRegion": "us-east-1",
+                "EndpointDescriptions": [
+                    {
+                        "EndpointId": "eipalloc-0bb0a4cc0513471c8",
+                        "Weight": 100,
+                        "HealthState": "UNHEALTHY"
+                    }
+                ],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 81,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            },
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876/listener/dea15d95/endpoint-group/31510563d005",
+                "EndpointGroupRegion": "us-west-2",
+                "EndpointDescriptions": [],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 81,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "5cba9ad9-5a99-4f42-80a8-1a4eed437562",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 08 Jan 2019 16:58:08 GMT",
+                "x-amzn-requestid": "5cba9ad9-5a99-4f42-80a8-1a4eed437562",
+                "content-length": "798",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876/listener/dea15d95",
+                "PortRanges": [
+                    {
+                        "FromPort": 81,
+                        "ToPort": 81
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "NONE"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "0eb4d737-7035-4b67-b6cb-15c2b7953ac1",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 08 Jan 2019 16:58:07 GMT",
+                "x-amzn-requestid": "0eb4d737-7035-4b67-b6cb-15c2b7953ac1",
+                "content-length": "224",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.UpdateEndpointGroup_1.json
+++ b/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.UpdateEndpointGroup_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876/listener/dea15d95/endpoint-group/53b7f8f91002",
+            "EndpointGroupRegion": "us-east-1",
+            "EndpointDescriptions": [
+                {
+                    "EndpointId": "eipalloc-0bb0a4cc0513471c8",
+                    "Weight": 100,
+                    "HealthState": "HEALTHY"
+                }
+            ],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 81,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 10,
+            "ThresholdCount": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "ac4cbfb6-86c1-4da1-892d-8a9560ab4214",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 08 Jan 2019 16:58:12 GMT",
+                "x-amzn-requestid": "ac4cbfb6-86c1-4da1-892d-8a9560ab4214",
+                "content-length": "445",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.UpdateEndpointGroup_2.json
+++ b/tests/data/placebo/test_modify_endpoint_instance_1/globalaccelerator.UpdateEndpointGroup_2.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroup": {
+            "EndpointGroupArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876/listener/dea15d95/endpoint-group/31510563d005",
+            "EndpointGroupRegion": "us-west-2",
+            "EndpointDescriptions": [],
+            "TrafficDialPercentage": 100.0,
+            "HealthCheckPort": 81,
+            "HealthCheckProtocol": "TCP",
+            "HealthCheckIntervalSeconds": 30,
+            "ThresholdCount": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "c12e448b-dbf8-4deb-8ef4-e096006836d7",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Tue, 08 Jan 2019 16:58:12 GMT",
+                "x-amzn-requestid": "c12e448b-dbf8-4deb-8ef4-e096006836d7",
+                "content-length": "365",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": false
+        },
+        "ResponseMetadata": {
+            "RequestId": "ac04ad20-8021-4437-b096-b2051e668ef3",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:41 GMT",
+                "x-amzn-requestid": "ac04ad20-8021-4437-b096-b2051e668ef3",
+                "content-length": "51",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.DescribeAcceleratorAttributes_2.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.DescribeAcceleratorAttributes_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": false
+        },
+        "ResponseMetadata": {
+            "RequestId": "1bd0b3c5-5bd9-47dc-b8ba-2f5b4d53969e",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:42 GMT",
+                "x-amzn-requestid": "1bd0b3c5-5bd9-47dc-b8ba-2f5b4d53969e",
+                "content-length": "51",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.DescribeAccelerator_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.DescribeAccelerator_1.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerator": {
+            "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+            "Name": "test-custodian",
+            "IpAddressType": "IPV4",
+            "Enabled": false,
+            "IpSets": [
+                {
+                    "IpFamily": "IPv4",
+                    "IpAddresses": [
+                        "13.248.152.148",
+                        "76.223.30.202"
+                    ]
+                }
+            ],
+            "Status": "DEPLOYED",
+            "CreatedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 16,
+                "hour": 16,
+                "minute": 27,
+                "second": 50,
+                "microsecond": 0
+            },
+            "LastModifiedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 17,
+                "hour": 14,
+                "minute": 12,
+                "second": 22,
+                "microsecond": 0
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "4a5a1588-83f4-4b3a-a03c-4f1c416bb673",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:41 GMT",
+                "x-amzn-requestid": "4a5a1588-83f4-4b3a-a03c-4f1c416bb673",
+                "content-length": "348",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": false,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 12,
+                    "second": 22,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "ea82b99d-3563-4ff3-97f8-dd8b1a049517",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:41 GMT",
+                "x-amzn-requestid": "ea82b99d-3563-4ff3-97f8-dd8b1a049517",
+                "content-length": "351",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.ListAccelerators_2.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.ListAccelerators_2.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": false,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 14,
+                    "minute": 12,
+                    "second": 22,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "87bdae80-018c-4b61-ab66-dd1f09a0e19c",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:42 GMT",
+                "x-amzn-requestid": "87bdae80-018c-4b61-ab66-dd1f09a0e19c",
+                "content-length": "351",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.ListEndpointGroups_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.ListEndpointGroups_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "EndpointGroups": [
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/17a532f0/endpoint-group/ffa6c354e002",
+                "EndpointGroupRegion": "us-east-1",
+                "EndpointDescriptions": [
+                    {
+                        "EndpointId": "eipalloc-0b0cb213820a08ae6",
+                        "Weight": 100,
+                        "HealthState": "UNHEALTHY"
+                    }
+                ],
+                "TrafficDialPercentage": 100.0,
+                "HealthCheckPort": 82,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 3
+            },
+            {
+                "EndpointGroupArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/17a532f0/endpoint-group/bad9bd37b005",
+                "EndpointGroupRegion": "us-west-2",
+                "EndpointDescriptions": [],
+                "TrafficDialPercentage": 0.0,
+                "HealthCheckPort": 80,
+                "HealthCheckProtocol": "TCP",
+                "HealthCheckIntervalSeconds": 30,
+                "ThresholdCount": 4
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "21d5123f-d15c-4fb4-a13f-a0eb8d6f7a7d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:42 GMT",
+                "x-amzn-requestid": "21d5123f-d15c-4fb4-a13f-a0eb8d6f7a7d",
+                "content-length": "796",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/17a532f0",
+                "PortRanges": [
+                    {
+                        "FromPort": 82,
+                        "ToPort": 83
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "SOURCE_IP"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "9e8dfd9f-da82-4c12-8935-f2db0c464054",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:42 GMT",
+                "x-amzn-requestid": "9e8dfd9f-da82-4c12-8935-f2db0c464054",
+                "content-length": "229",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.UpdateAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.UpdateAcceleratorAttributes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": true,
+            "FlowLogsS3Bucket": "test-for-global-accelerator-bucket/test-custodian",
+            "FlowLogsS3Prefix": "us-west-2"
+        },
+        "ResponseMetadata": {
+            "RequestId": "2358a030-572c-4917-8da3-bcbf45e78f79",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:43 GMT",
+                "x-amzn-requestid": "2358a030-572c-4917-8da3-bcbf45e78f79",
+                "content-length": "152",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.UpdateAccelerator_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.UpdateAccelerator_1.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerator": {
+            "AcceleratorArn": "arn:aws:globalaccelerator::471176887411:accelerator/98f51dc5-3e22-4a05-8f0d-262d3ae9a876",
+            "Name": "test-custodian",
+            "IpAddressType": "IPV4",
+            "Enabled": false,
+            "IpSets": [
+                {
+                    "IpFamily": "IPv4",
+                    "IpAddresses": [
+                        "13.248.138.26",
+                        "76.223.13.90"
+                    ]
+                }
+            ],
+            "Status": "IN_PROGRESS",
+            "CreatedTime": {
+                "__class__": "datetime",
+                "year": 2018,
+                "month": 12,
+                "day": 31,
+                "hour": 9,
+                "minute": 10,
+                "second": 55,
+                "microsecond": 0
+            },
+            "LastModifiedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 3,
+                "hour": 14,
+                "minute": 34,
+                "second": 45,
+                "microsecond": 0
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "19d0bc40-d7b8-4938-9d60-2af5497eaea6",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 03 Jan 2019 19:34:45 GMT",
+                "x-amzn-requestid": "19d0bc40-d7b8-4938-9d60-2af5497eaea6",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.UpdateAccelerator_2.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket/globalaccelerator.UpdateAccelerator_2.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerator": {
+            "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+            "Name": "test-custodian",
+            "IpAddressType": "IPV4",
+            "Enabled": true,
+            "IpSets": [
+                {
+                    "IpFamily": "IPv4",
+                    "IpAddresses": [
+                        "13.248.152.148",
+                        "76.223.30.202"
+                    ]
+                }
+            ],
+            "Status": "IN_PROGRESS",
+            "CreatedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 16,
+                "hour": 16,
+                "minute": 27,
+                "second": 50,
+                "microsecond": 0
+            },
+            "LastModifiedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 17,
+                "hour": 14,
+                "minute": 12,
+                "second": 43,
+                "microsecond": 0
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "74c2ac3a-a78d-4e39-b586-35355ea878fc",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:43 GMT",
+                "x-amzn-requestid": "74c2ac3a-a78d-4e39-b586-35355ea878fc",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket_2/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket_2/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": true,
+            "FlowLogsS3Bucket": "test-for-global-accelerator-bucket/test-custodian",
+            "FlowLogsS3Prefix": "us-west-2"
+        },
+        "ResponseMetadata": {
+            "RequestId": "af1529e1-9967-453d-8f09-2441f4ad0395",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:44 GMT",
+                "x-amzn-requestid": "af1529e1-9967-453d-8f09-2441f4ad0395",
+                "content-length": "152",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket_2/globalaccelerator.DescribeAccelerator_1.json
+++ b/tests/data/placebo/test_modify_global_accelerator_instance_with_bucket_2/globalaccelerator.DescribeAccelerator_1.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerator": {
+            "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+            "Name": "test-custodian",
+            "IpAddressType": "IPV4",
+            "Enabled": true,
+            "IpSets": [
+                {
+                    "IpFamily": "IPv4",
+                    "IpAddresses": [
+                        "13.248.152.148",
+                        "76.223.30.202"
+                    ]
+                }
+            ],
+            "Status": "IN_PROGRESS",
+            "CreatedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 16,
+                "hour": 16,
+                "minute": 27,
+                "second": 50,
+                "microsecond": 0
+            },
+            "LastModifiedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 17,
+                "hour": 14,
+                "minute": 12,
+                "second": 43,
+                "microsecond": 0
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "a39562b1-4750-4353-9cd2-20bd2c52ec9f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 17 Jan 2019 19:12:43 GMT",
+                "x-amzn-requestid": "a39562b1-4750-4353-9cd2-20bd2c52ec9f",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_listener_1/globalaccelerator.DescribeAcceleratorAttributes_1.json
+++ b/tests/data/placebo/test_modify_listener_1/globalaccelerator.DescribeAcceleratorAttributes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "AcceleratorAttributes": {
+            "FlowLogsEnabled": true,
+            "FlowLogsS3Bucket": "test-for-global-accelerator-bucket/test-custodian",
+            "FlowLogsS3Prefix": "us-west-2"
+        },
+        "ResponseMetadata": {
+            "RequestId": "5be6c2f0-724b-48ff-9fdb-8a80c361d4bb",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:19:36 GMT",
+                "x-amzn-requestid": "5be6c2f0-724b-48ff-9fdb-8a80c361d4bb",
+                "content-length": "152",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_listener_1/globalaccelerator.DescribeListener_1.json
+++ b/tests/data/placebo/test_modify_listener_1/globalaccelerator.DescribeListener_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listener": {
+            "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+            "PortRanges": [
+                {
+                    "FromPort": 80,
+                    "ToPort": 80
+                }
+            ],
+            "Protocol": "TCP",
+            "ClientAffinity": "NONE"
+        },
+        "ResponseMetadata": {
+            "RequestId": "9bfc9d80-6c62-4168-a83a-164de87a69fd",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:19:35 GMT",
+                "x-amzn-requestid": "9bfc9d80-6c62-4168-a83a-164de87a69fd",
+                "content-length": "221",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_listener_1/globalaccelerator.DescribeListener_2.json
+++ b/tests/data/placebo/test_modify_listener_1/globalaccelerator.DescribeListener_2.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listener": {
+            "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+            "PortRanges": [
+                {
+                    "FromPort": 80,
+                    "ToPort": 80
+                }
+            ],
+            "Protocol": "TCP",
+            "ClientAffinity": "NONE"
+        },
+        "ResponseMetadata": {
+            "RequestId": "b2917697-14fc-4236-8645-35d9cff7523d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:19:37 GMT",
+                "x-amzn-requestid": "b2917697-14fc-4236-8645-35d9cff7523d",
+                "content-length": "221",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_listener_1/globalaccelerator.ListAccelerators_1.json
+++ b/tests/data/placebo/test_modify_listener_1/globalaccelerator.ListAccelerators_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "Accelerators": [
+            {
+                "AcceleratorArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e",
+                "Name": "test-custodian",
+                "IpAddressType": "IPV4",
+                "Enabled": true,
+                "IpSets": [
+                    {
+                        "IpFamily": "IPv4",
+                        "IpAddresses": [
+                            "13.248.152.148",
+                            "76.223.30.202"
+                        ]
+                    }
+                ],
+                "Status": "DEPLOYED",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 16,
+                    "hour": 16,
+                    "minute": 27,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "LastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 18,
+                    "hour": 10,
+                    "minute": 59,
+                    "second": 22,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "82b99ea1-1260-41c6-9dcc-ed6417355419",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:19:36 GMT",
+                "x-amzn-requestid": "82b99ea1-1260-41c6-9dcc-ed6417355419",
+                "content-length": "350",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_listener_1/globalaccelerator.ListListeners_1.json
+++ b/tests/data/placebo/test_modify_listener_1/globalaccelerator.ListListeners_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listeners": [
+            {
+                "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+                "PortRanges": [
+                    {
+                        "FromPort": 80,
+                        "ToPort": 80
+                    }
+                ],
+                "Protocol": "TCP",
+                "ClientAffinity": "NONE"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "2de8dcad-e966-42c9-8d99-d4640c93cfda",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:19:36 GMT",
+                "x-amzn-requestid": "2de8dcad-e966-42c9-8d99-d4640c93cfda",
+                "content-length": "224",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_listener_1/globalaccelerator.UpdateListener_1.json
+++ b/tests/data/placebo/test_modify_listener_1/globalaccelerator.UpdateListener_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listener": {
+            "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+            "PortRanges": [
+                {
+                    "FromPort": 82,
+                    "ToPort": 83
+                }
+            ],
+            "Protocol": "TCP",
+            "ClientAffinity": "SOURCE_IP"
+        },
+        "ResponseMetadata": {
+            "RequestId": "c055a4f0-724a-4ce1-9b1d-cd77920e5985",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:19:39 GMT",
+                "x-amzn-requestid": "c055a4f0-724a-4ce1-9b1d-cd77920e5985",
+                "content-length": "226",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_modify_listener_2/globalaccelerator.DescribeListener_1.json
+++ b/tests/data/placebo/test_modify_listener_2/globalaccelerator.DescribeListener_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Listener": {
+            "ListenerArn": "arn:aws:globalaccelerator::644160558196:accelerator/1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3",
+            "PortRanges": [
+                {
+                    "FromPort": 82,
+                    "ToPort": 83
+                }
+            ],
+            "Protocol": "TCP",
+            "ClientAffinity": "SOURCE_IP"
+        },
+        "ResponseMetadata": {
+            "RequestId": "b0666a2d-be93-4f36-aab2-b9e7d5031d5a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Fri, 18 Jan 2019 18:19:40 GMT",
+                "x-amzn-requestid": "b0666a2d-be93-4f36-aab2-b9e7d5031d5a",
+                "content-length": "226",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_global_accelerator.py
+++ b/tests/test_global_accelerator.py
@@ -1,0 +1,282 @@
+# Copyright 2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .common import BaseTest
+
+
+class TestEndpointInstance(BaseTest):
+
+    def test_modify_endpoint_configuration(self):
+
+        session_factory = self.replay_flight_data('test_modify_endpoint_configuration_1')
+        client = session_factory().client('globalaccelerator',
+            region_name='us-west-2')
+        endpoint_group_arn = 'arn:aws:globalaccelerator::644160558196:accelerator/' \
+            '1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3/endpoint-group/db9a1ad66002'
+
+        result = client.describe_endpoint_group(
+            EndpointGroupArn=endpoint_group_arn)['EndpointGroup']
+        endpoint_id = 'eipalloc-0b0cb213820a08ae6'
+        self.assertEqual(result['EndpointGroupArn'], endpoint_group_arn)
+        self.assertEqual(result['ThresholdCount'], 3)
+        endpoint_descriptions = result['EndpointDescriptions']
+        self.assertEqual(endpoint_descriptions[0]['EndpointId'], endpoint_id)
+        self.assertEqual(endpoint_descriptions[0]['Weight'], 100)
+        p = self.load_policy(
+            {
+                'name': 'modify-global-accelerator-endpoint',
+                'resource': 'global-accelerator-endpoint-group',
+                'filters': [
+                    {
+                        'type': 'value', 'key': 'HealthCheckProtocol', 'value': 'HTTPS',
+                        'op': 'not-equal'
+                    }, ],
+                'actions': [{'type': 'modify',
+                    'update-accelerator-endpoint': [
+                        {
+                            'property': 'ThresholdCount',
+                            'value': 4,
+                        },
+                        {
+                            'EndpointConfigurations': [
+                                {'EndpointId': endpoint_id, 'Weight': 0},
+                            ]
+                        },
+                    ],
+                }],
+            },
+            session_factory=session_factory,
+        )
+        p.run()
+
+        result = client.describe_endpoint_group(
+            EndpointGroupArn=endpoint_group_arn)['EndpointGroup']
+        self.assertEqual(result['EndpointGroupArn'], endpoint_group_arn)
+        self.assertEqual(result['ThresholdCount'], 4)
+        endpoint_descriptions = result['EndpointDescriptions']
+        self.assertEqual(endpoint_descriptions[0]['EndpointId'], endpoint_id)
+        self.assertEqual(endpoint_descriptions[0]['Weight'], 0)
+
+    def test_delete_endpoint_group(self):
+
+        session_factory = self.replay_flight_data('test_delete_endpoint_groups_1')
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+        listener_arn = 'arn:aws:globalaccelerator::644160558196:accelerator/' \
+            '1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3'
+
+        result = client.list_endpoint_groups(ListenerArn=listener_arn)
+        self.assertEqual(len(result['EndpointGroups']), 2)
+
+        p = self.load_policy(
+            {
+                'name': 'delete-accelerator-endpoint-group',
+                'resource': 'global-accelerator-endpoint-group',
+                'filters': [{'EndpointGroupRegion': 'us-east-2'}],
+                'actions': [{'type': 'delete'}],
+            },
+            session_factory=session_factory,
+        )
+        p.run()
+
+        session_factory = self.replay_flight_data('test_delete_endpoint_groups_2')
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+        result = client.list_endpoint_groups(ListenerArn=listener_arn)
+        self.assertEqual(len(result['EndpointGroups']), 1)
+
+
+class TestListener(BaseTest):
+
+    def test_delete_listener(self):
+        accelerator_arn = 'arn:aws:globalaccelerator::644160558196:accelerator/' \
+            '1460ad64-e386-41e4-9715-d8bcc665963e'
+        session_factory = self.replay_flight_data('test_delete_listeners1')
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+        accelerator_arn = 'arn:aws:globalaccelerator::644160558196:accelerator/' \
+            '1460ad64-e386-41e4-9715-d8bcc665963e'
+        result = client.list_listeners(AcceleratorArn=accelerator_arn)
+        self.assertEqual(len(result['Listeners']), 2)
+
+        p = self.load_policy(
+            {
+                'name': 'delete-accelerator-listener',
+                'resource': 'global-accelerator-listener',
+                'filters': [{'Protocol': 'UDP'}],
+                'actions': [{'type': 'delete'}],
+            },
+            session_factory=session_factory,
+        )
+        p.run()
+
+        session_factory = self.replay_flight_data('test_delete_listeners_2')
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+        result = client.list_listeners(AcceleratorArn=accelerator_arn)
+        self.assertEqual(len(result['Listeners']), 1)
+
+    def test_modify_listener(self):
+
+        session_factory = self.replay_flight_data('test_modify_listener_1')
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+        listener_arn = 'arn:aws:globalaccelerator::644160558196:accelerator/' \
+            '1460ad64-e386-41e4-9715-d8bcc665963e/listener/56de20d3'
+
+        result = client.describe_listener(ListenerArn=listener_arn)['Listener']
+
+        self.assertEqual(result['ListenerArn'], listener_arn)
+        self.assertEqual(result['ClientAffinity'], 'NONE')
+        self.assertEqual(result['PortRanges'][0]['FromPort'], 80)
+        self.assertEqual(result['PortRanges'][0]['ToPort'], 80)
+
+        p = self.load_policy(
+            {
+                'name': 'modify-global-accelerator-listener',
+                'resource': 'global-accelerator-listener',
+                'actions': [{'type': 'modify',
+                    'update-accelerator-listener': [
+                        {
+                            'property': 'ClientAffinity',
+                            'value': 'SOURCE_IP',
+                        },
+                        {
+                            'PortRanges': [
+                                {'FromPort': 82, 'ToPort': 83}
+                            ]
+                        },
+                    ],
+                }],
+            },
+            session_factory=session_factory,
+        )
+        p.run()
+
+        session_factory = self.replay_flight_data('test_modify_listener_2')
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+        result = client.describe_listener(ListenerArn=listener_arn)['Listener']
+        self.assertEqual(result['ListenerArn'], listener_arn)
+        self.assertEqual(result['ClientAffinity'], 'SOURCE_IP')
+        self.assertEqual(result['PortRanges'][0]['FromPort'], 82)
+        self.assertEqual(result['PortRanges'][0]['ToPort'], 83)
+
+
+class TestAcceleratorInstance(BaseTest):
+
+    def test_list_accelerator_instances(self):
+        session_factory = self.replay_flight_data('test_global_accelerator_instances')
+        p = self.load_policy(
+            {
+                'name': 'list-ga',
+                'resource': 'global-accelerator',
+                'filters': [
+                    {'type': 'value', 'key': 'Name', 'value': 'test-custodian'}
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_delete_global_accelerator_instance(self):
+
+        session_factory = self.replay_flight_data(
+            'test_global_accelerator_delete_instance'
+        )
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+
+        result = client.list_accelerators(MaxResults=100)
+        counts = self.count_enabled(result['Accelerators'])
+        self.assertEqual(counts['enabled'], 1)
+        self.assertEqual(counts['disabled'], 2)
+
+        p = self.load_policy(
+            {
+                'name': 'delete-disabled-accelerator-instance',
+                'resource': 'global-accelerator',
+                'filters': [{'Enabled': False}],
+                'actions': [{'type': 'delete'}],
+            },
+            session_factory=session_factory,
+        )
+        p.run()
+
+        result = client.list_accelerators()
+        counts = self.count_enabled(result['Accelerators'])
+        self.assertEqual(counts['enabled'], 1)
+        self.assertEqual(counts['disabled'], 0)
+
+    def test_modify_global_accelerator_instance(self):
+
+        # test attributes set with update_accelerator_attributes()
+
+        session_factory = self.replay_flight_data(
+            'test_modify_global_accelerator_instance_with_bucket'
+        )
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+        result = client.list_accelerators(MaxResults=100)
+        self.assertEqual(len(result['Accelerators']), 1)
+        accelerator_arn = 'arn:aws:globalaccelerator::644160558196:accelerator/' \
+            '1460ad64-e386-41e4-9715-d8bcc665963e'
+        result = client.describe_accelerator(AcceleratorArn=accelerator_arn)['Accelerator']
+        self.assertEqual(result['Enabled'], False)
+        result = client.describe_accelerator_attributes(AcceleratorArn=accelerator_arn)
+        self.assertFalse(result['AcceleratorAttributes']['FlowLogsEnabled'])
+        bucket_name = 'test-for-global-accelerator-bucket/test-custodian'
+        p = self.load_policy(
+            {
+                'name': 'modify-global-accelerator-attributes',
+                'resource': 'global-accelerator',
+                'filters': [
+                    {'type': 'value', 'key': 'Name', 'value': 'test-custodian'}
+                ],
+                'actions': [
+                    {
+                        'type': 'modify-global-accelerator',
+                        'update-accelerator': [{'property': 'Enabled', 'value': True}],
+                        'update-accelerator-attributes': [
+                            {'property': 'FlowLogsEnabled', 'value': True},
+                            {'property': 'FlowLogsS3Bucket', 'value': bucket_name},
+                            {'property': 'FlowLogsS3Prefix', 'value': 'us-west-2'},
+                        ],
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        p.run()
+
+        session_factory = self.replay_flight_data(
+            'test_modify_global_accelerator_instance_with_bucket_2'
+        )
+        client = session_factory().client('globalaccelerator', region_name='us-west-2')
+
+        result = client.describe_accelerator(AcceleratorArn=accelerator_arn)['Accelerator']
+        self.assertEqual(result['Enabled'], True)
+
+        result = client.describe_accelerator_attributes(
+            AcceleratorArn=accelerator_arn)
+
+        self.assertTrue(result['AcceleratorAttributes']['FlowLogsEnabled'])
+        self.assertEqual(result['AcceleratorAttributes']['FlowLogsS3Bucket'], bucket_name)
+        self.assertEqual(result['AcceleratorAttributes']['FlowLogsS3Prefix'], 'us-west-2')
+
+    def count_enabled(self, list_output):
+        enabled_count = 0
+        disabled_count = 0
+        for accelerator in list_output:
+            if accelerator['Enabled']:
+                enabled_count += 1
+            else:
+                disabled_count += 1
+        return {
+            'enabled': enabled_count,
+            'disabled': disabled_count
+        }


### PR DESCRIPTION
This is the functionality to add the global accelerator. I believe this PR is superior to recent PR "wip - aws.global-accelerator - new resource #3386". There are some very minor improvements (like slightly better doc strings for the BaseAction classes). The man improvement is using the _parent_spec_ to save unnecessary API calls. I think the old PR should be deleted. 