### PR TITLE
aws - flow-log filter support s3 destination arn filtering

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -100,6 +100,7 @@ class FlowLogFilter(Filter):
            'set-op': {'enum': ['or', 'and'], 'default': 'or'},
            'status': {'enum': ['active']},
            'deliver-status': {'enum': ['success', 'failure']},
+           'destination': {'type': 'string'},
            'destination-type': {'enum': ['s3', 'cloud-watch-logs']},
            'traffic-type': {'enum': ['accept', 'reject', 'all']},
            'log-group': {'type': 'string'}})
@@ -123,6 +124,7 @@ class FlowLogFilter(Filter):
         log_group = self.data.get('log-group')
         traffic_type = self.data.get('traffic-type')
         destination_type = self.data.get('destination-type')
+        destination = self.data.get('destination')
         status = self.data.get('status')
         delivery_status = self.data.get('deliver-status')
         op = self.data.get('op', 'equal') == 'equal' and operator.eq or operator.ne
@@ -131,7 +133,6 @@ class FlowLogFilter(Filter):
         results = []
         # looping over vpc resources
         for r in resources:
-
             if r[m.id] not in resource_map:
                 # we didn't find a flow log for this vpc
                 if enabled:
@@ -146,8 +147,10 @@ class FlowLogFilter(Filter):
             if enabled:
                 fl_matches = []
                 for fl in flogs:
-                    dest_match = (destination_type is None) or op(
+                    dest_type_match = (destination_type is None) or op(
                         fl['LogDestinationType'], destination_type)
+                    dest_match = (destination is None) or op(
+                        fl['LogDestination'], destination)
                     status_match = (status is None) or op(fl['FlowLogStatus'], status.upper())
                     delivery_status_match = (delivery_status is None) or op(
                         fl['DeliverLogsStatus'], delivery_status.upper())
@@ -158,8 +161,8 @@ class FlowLogFilter(Filter):
                     log_group_match = (log_group is None) or op(fl['LogGroupName'], log_group)
 
                     # combine all conditions to check if flow log matches the spec
-                    fl_match = (status_match and traffic_type_match and
-                                log_group_match and dest_match and delivery_status_match)
+                    fl_match = (status_match and traffic_type_match and dest_match and
+                                log_group_match and dest_type_match and delivery_status_match)
                     fl_matches.append(fl_match)
 
                 if set_op == 'or':

--- a/tests/data/placebo/test_vpc_flow_log_s3_dest/ec2.DescribeFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_flow_log_s3_dest/ec2.DescribeFlowLogs_1.json
@@ -1,0 +1,39 @@
+{
+    "status_code": 200,
+    "data": {
+        "FlowLogs": [
+            {
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 11,
+                    "day": 4,
+                    "hour": 3,
+                    "minute": 49,
+                    "second": 34,
+                    "microsecond": 527000
+                },
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/testing-vpc-flow-log-role",
+                "DeliverLogsStatus": "SUCCESS",
+                "FlowLogId": "fl-0873b1d6eacd0a14d",
+                "FlowLogStatus": "ACTIVE",
+                "ResourceId": "vpc-d2d616b5",
+                "TrafficType": "ALL",
+                "LogDestinationType": "s3",
+                "LogDestination": "arn:aws:s3:::c7n-vpc-flow-logs"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "31722e35-eabf-443a-a393-c6dba1c694e9",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "date": "Sun, 20 Jan 2019 14:24:14 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_flow_log_s3_dest/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_flow_log_s3_dest/ec2.DescribeVpcs_1.json
@@ -1,0 +1,128 @@
+{
+    "status_code": 200,
+    "data": {
+        "Vpcs": [
+            {
+                "CidrBlock": "10.0.42.0/24",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-f1516b97",
+                "OwnerId": "644160558196",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-98ba93f0",
+                        "CidrBlock": "10.0.42.0/24",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "FancyTestVPC"
+                    },
+                    {
+                        "Key": "tagfancykey",
+                        "Value": "tagfanncyvalue"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "10.0.0.0/16",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-f8c6d983",
+                "OwnerId": "644160558196",
+                "InstanceTenancy": "default",
+                "Ipv6CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-caff12a6",
+                        "Ipv6CidrBlock": "2600:1f18:2466:4b00::/56",
+                        "Ipv6CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-c9ff12a5",
+                        "CidrBlock": "10.0.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "IpV6"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "10.205.0.0/18",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-03005fb9b8740263d",
+                "OwnerId": "644160558196",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-0f6765530d80dc044",
+                        "CidrBlock": "10.205.0.0/18",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "testing-vpc"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "172.31.0.0/16",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-d2d616b5",
+                "OwnerId": "644160558196",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-33669f5a",
+                        "CidrBlock": "172.31.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": true,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "FlowLogTest"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "04d9f787-9fb4-4155-bcf0-a1b7772b5d9b",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "4418",
+                "vary": "Accept-Encoding",
+                "date": "Sun, 20 Jan 2019 14:24:14 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -77,6 +77,20 @@ class VpcTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
+    def test_flow_logs_s3_destination(self):
+        factory = self.replay_flight_data('test_vpc_flow_log_s3_dest')
+        p = self.load_policy({
+            'name': 'flow-s3',
+            'resource': 'vpc',
+            'filters': [{
+                'type': 'flow-logs',
+                'enabled': True,
+                'destination': 'arn:aws:s3:::c7n-vpc-flow-logs'}]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['VpcId'], 'vpc-d2d616b5')
+
     def test_flow_logs_absent(self):
         # Test that ONLY vpcs with no flow logs are retained
         #


### PR DESCRIPTION

reported on gitter, looks like an oversight when adding in destination-type to not include destination as well.