### PR TITLE
tools/c7n_guardian - compatibility with guard duty api change

### DIFF
--- a/tools/c7n_guardian/c7n_guardian/cli.py
+++ b/tools/c7n_guardian/c7n_guardian/cli.py
@@ -340,7 +340,7 @@ def get_or_create_detector_id(client):
     if detectors:
         return detectors[0]
     else:
-        return client.create_detector().get('DetectorId')
+        return client.create_detector(Enable=True).get('DetectorId')
 
 
 def get_master_info(accounts_config, master):


### PR DESCRIPTION
fixes #3209 

it looks like the guard duty api changed to require Enable flag on creation