### PR TITLE
tools/c7n-mailer - add additional resources to resource_format utility

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -302,8 +302,8 @@ def resource_format(resource, resource_type):
             resource['VpcId']
         )
     elif resource_type == "app-elb":
-        return "name: %s  zones: %s  scheme: %s" % (
-            resource['LoadBalancerName'],
+        return "arn: %s  zones: %s  scheme: %s" % (
+            resource['LoadBalancerArn'],
             len(resource['AvailabilityZones']),
             resource['Scheme'])
     elif resource_type == "nat-gateway":

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -284,6 +284,37 @@ def resource_format(resource, resource_type):
         return "QueueURL: %s QueueArn: %s " % (
             resource['QueueUrl'],
             resource['QueueArn'])
+    elif resource_type == "efs":
+        return "name: %s  id: %s  state: %s" % (
+            resource['Name'],
+            resource['FileSystemId'],
+            resource['LifeCycleState']
+        )
+    elif resource_type == "network-addr":
+        return "ip: %s  id: %s  scope: %s" % (
+            resource['PublicIp'],
+            resource['AllocationId'],
+            resource['Domain']
+        )
+    elif resource_type == "route-table":
+        return "id: %s  vpc: %s" % (
+            resource['RouteTableId'],
+            resource['VpcId']
+        )
+    elif resource_type == "app-elb":
+        return "name: %s  zones: %s  scheme: %s" % (
+            resource['LoadBalancerName'],
+            len(resource['AvailabilityZones']),
+            resource['Scheme'])
+    elif resource_type == "nat-gateway":
+        return "id: %s  state: %s  vpc: %s" % (
+            resource['NatGatewayId'],
+            resource['State'],
+            resource['VpcId'])
+    elif resource_type == "internet-gateway":
+        return "id: %s  attachments: %s" % (
+            resource['InternetGatewayId'],
+            len(resource['Attachments']))
     else:
         return "%s" % format_struct(resource)
 

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -47,6 +47,11 @@ class ResourceFormat(unittest.TestCase):
     def test_alb(self):
         self.assertEqual(
             utils.resource_format(
-                {'LoadBalancerName': 'dev', 'AvailabilityZones': [], 'Scheme': 'internal'},
+                {'LoadBalancerArn':
+                    'arn:aws:elasticloadbalancing:us-east-1:367930536793:'
+                    'loadbalancer/app/dev/1234567890',
+                 'AvailabilityZones': [], 'Scheme': 'internal'},
                 'app-elb'),
-            'name: dev  zones: 0  scheme: internal')
+            'arn: arn:aws:elasticloadbalancing:us-east-1:367930536793:'
+            'loadbalancer/app/dev/1234567890'
+            '  zones: 0  scheme: internal')

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -12,3 +12,41 @@ class FormatStruct(unittest.TestCase):
         expected = '{\n  "foo": "bar"\n}'
         actual = utils.format_struct({'foo': 'bar'})
         self.assertEqual(expected, actual)
+
+
+class ResourceFormat(unittest.TestCase):
+
+    def test_efs(self):
+        self.assertEqual(
+            utils.resource_format(
+                {'Name': 'abc', 'FileSystemId': 'fsid', 'LifeCycleState': 'available'},
+                'efs'),
+            'name: abc  id: fsid  state: available')
+
+    def test_eip(self):
+        self.assertEqual(
+            utils.resource_format(
+                {'PublicIp': '8.8.8.8', 'Domain': 'vpc', 'AllocationId': 'eipxyz'},
+                'network-addr'),
+            'ip: 8.8.8.8  id: eipxyz  scope: vpc')
+
+    def test_nat(self):
+        self.assertEqual(
+            utils.resource_format(
+                {'NatGatewayId': 'nat-xyz', 'State': 'available', 'VpcId': 'vpc-123'},
+                'nat-gateway'),
+            'id: nat-xyz  state: available  vpc: vpc-123')
+
+    def test_igw(self):
+        self.assertEqual(
+            utils.resource_format(
+                {'InternetGatewayId': 'igw-x', 'Attachments': []},
+                'internet-gateway'),
+            'id: igw-x  attachments: 0')
+
+    def test_alb(self):
+        self.assertEqual(
+            utils.resource_format(
+                {'LoadBalancerName': 'dev', 'AvailabilityZones': [], 'Scheme': 'internal'},
+                'app-elb'),
+            'name: dev  zones: 0  scheme: internal')


### PR DESCRIPTION
Add additional resources to resource_format() in c7n_mailer

Adding the following AWS resources to resource_format() in c7n_mailer. This creates additional functionality for easily processing out the information you want to see from certain resources. 

efs, network-addr, route-table, app-elb, nat-gateway, internet-gateway