### PR TITLE
ci - address test deprecation warnings on 3.7

### DIFF
--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -525,7 +525,7 @@ class TestSNS(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertEquals(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         sns = session_factory().client('sns')
         attributes = sns.get_topic_attributes(TopicArn=topic)
         self.assertTrue(attributes['Attributes']['KmsMasterKeyId'], 'alias/aws/sns')
@@ -590,6 +590,6 @@ class TestSNS(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertEquals(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         attributes = sns.get_topic_attributes(TopicArn=topic)['Attributes']
         self.assertEqual(attributes.get('KmsMasterKeyId'), key_alias)

--- a/tools/c7n_azure/tests/test_deployment_units.py
+++ b/tools/c7n_azure/tests/test_deployment_units.py
@@ -98,7 +98,7 @@ class DeploymentUnitsTest(BaseTest):
         func_app = self._validate(func_unit, func_params)
 
         # verify settings are properly configured
-        self.assertEquals(func_app.kind, 'functionapp,linux')
+        self.assertEqual(func_app.kind, 'functionapp,linux')
         self.assertTrue(func_app.reserved)
 
     def test_function_app_dedicated(self):
@@ -136,14 +136,14 @@ class DeploymentUnitsTest(BaseTest):
         func_app = self._validate(func_unit, func_params)
 
         # verify settings are properly configured
-        self.assertEquals(func_app.kind, 'functionapp,linux,container')
+        self.assertEqual(func_app.kind, 'functionapp,linux,container')
         self.assertTrue(func_app.reserved)
 
         wc = self.session.client('azure.mgmt.web.WebSiteManagementClient')
 
         site_config = wc.web_apps.get_configuration(self.rg_name, func_app_name)
         self.assertTrue(site_config.always_on)
-        self.assertEquals(site_config.linux_fx_version, FUNCTION_DOCKER_VERSION)
+        self.assertEqual(site_config.linux_fx_version, FUNCTION_DOCKER_VERSION)
 
         app_settings = wc.web_apps.list_application_settings(self.rg_name, func_app_name)
         self.assertIsNotNone(app_settings.properties['MACHINEKEY_DecryptionKey'])

--- a/tools/c7n_azure/tests/test_functionapp_utils.py
+++ b/tools/c7n_azure/tests/test_functionapp_utils.py
@@ -97,7 +97,7 @@ class FunctionAppUtilsTest(BaseTest):
             function_app_name='cloud-custodian-test')
 
         FunctionAppUtilities.deploy_function_app(parameters)
-        self.assertEquals(parameters.service_plan['sku_tier'], 'Basic')
+        self.assertEqual(parameters.service_plan['sku_tier'], 'Basic')
 
     def test_get_function_name_replacements(self):
         test_cases = [


### PR DESCRIPTION
addresses one class of deprecations from #3363 