### PR TITLE
aws - ami correcting method name for remove launch permissions

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -126,7 +126,7 @@ class RemoveLaunchPermissions(BaseAction):
     def process(self, images):
         client = local_session(self.manager.session_factory).client('ec2')
         for i in images:
-            self.process(client, i)
+            self.process_image(client, i)
 
     def process_image(self, client, image):
         client.reset_image_attribute(


### PR DESCRIPTION
It appears in the update of the ami.py file there was a misnamed function calls in the 'remove-launch-permissions'. This breaks when you attempt to use the remove-launch-permissions functionality in a policy. It will give the error:

> Traceback (most recent call last):
 File "/codebuild/output/src751369243/src/cloud-custodian/tests/test_tr_ami.py", line 59, in test_tr_ami_depermission
 resources = p.run()
 File "/codebuild/output/src751369243/src/cloud-custodian/c7n/policy.py", line 880, in __call__
 resources = mode.run()
 File "/codebuild/output/src751369243/src/cloud-custodian/c7n/policy.py", line 264, in run
 results = a.process(resources)
 File "/codebuild/output/src751369243/src/cloud-custodian/c7n/resources/ami.py", line 129, in process
 self.process(client, i)
TypeError: process() takes exactly 2 arguments (3 given)

This PR is to revert the name back to 'process_image' to fix this bug.