### PR TITLE
policy support for logic app

### DIFF
--- a/c7n/actions/notify.py
+++ b/c7n/actions/notify.py
@@ -46,14 +46,14 @@ class BaseNotify(EventAction):
         return p
 
     def pack(self, message, encode_ascii=True):
-        #encode_ascii=False
         dumped = utils.dumps(message)
         compressed = zlib.compress(dumped.encode('utf8'))
         b64encoded = base64.b64encode(compressed)
-        if not encode_ascii: 
+        if not encode_ascii:
             return str(b64encoded)
         else:
             return b64encoded.decode('ascii')
+
 
 class Notify(BaseNotify):
     """
@@ -141,7 +141,7 @@ class Notify(BaseNotify):
                      'properties': {
                          'queue': {'type': 'string'},
                          'type': {'enum': ['sqs']},
-                         'encode_ascii' : {'type': 'boolean'}}},
+                         'encode_ascii': {'type': 'boolean'}}},
                     {'type': 'object',
                      'required': ['type', 'topic'],
                      'properties': {
@@ -162,8 +162,8 @@ class Notify(BaseNotify):
         if self.data.get('transport', {}).get('type') == 'sns' and \
                 self.data.get('transport').get('attributes') and \
                 'mtype' in self.data.get('transport').get('attributes').keys():
-                    raise PolicyValidationError(
-                        "attribute: mtype is a reserved attribute for sns transport")
+            raise PolicyValidationError(
+                "attribute: mtype is a reserved attribute for sns transport")
         return self
 
     def get_permissions(self):

--- a/c7n/actions/notify.py
+++ b/c7n/actions/notify.py
@@ -45,12 +45,15 @@ class BaseNotify(EventAction):
             p.setdefault('cc', []).extend(ValuesFrom(cc_from, self.manager).get_values())
         return p
 
-    def pack(self, message):
+    def pack(self, message, encode_ascii=True):
+        #encode_ascii=False
         dumped = utils.dumps(message)
         compressed = zlib.compress(dumped.encode('utf8'))
         b64encoded = base64.b64encode(compressed)
-        return b64encoded.decode('ascii')
-
+        if not encode_ascii: 
+            return str(b64encoded)
+        else:
+            return b64encoded.decode('ascii')
 
 class Notify(BaseNotify):
     """
@@ -137,7 +140,8 @@ class Notify(BaseNotify):
                      'required': ['type', 'queue'],
                      'properties': {
                          'queue': {'type': 'string'},
-                         'type': {'enum': ['sqs']}}},
+                         'type': {'enum': ['sqs']},
+                         'encode_ascii' : {'type': 'boolean'}}},
                     {'type': 'object',
                      'required': ['type', 'topic'],
                      'properties': {

--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -456,7 +456,8 @@ class Notify(BaseNotify):
                      'required': ['type', 'queue'],
                      'properties': {
                          'queue': {'type': 'string'},
-                         'type': {'enum': ['asq']}
+                         'type': {'enum': ['asq']},
+                         'encode_ascii' : {'type': 'boolean'}
                      }}],
             },
         }
@@ -491,7 +492,9 @@ class Notify(BaseNotify):
 
     def send_to_azure_queue(self, queue_uri, message, session):
         queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(queue_uri, session)
-        return StorageUtilities.put_queue_message(queue_service, queue_name, self.pack(message)).id
+        encode_ascii = True if 'encode_ascii' not in self.data['transport'] else self.data['transport']['encode_ascii']
+
+        return StorageUtilities.put_queue_message(queue_service, queue_name, self.pack(message, encode_ascii)).id
 
 
 DEFAULT_TAG = "custodian_status"

--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -457,7 +457,7 @@ class Notify(BaseNotify):
                      'properties': {
                          'queue': {'type': 'string'},
                          'type': {'enum': ['asq']},
-                         'encode_ascii' : {'type': 'boolean'}
+                         'encode_ascii': {'type': 'boolean'}
                      }}],
             },
         }
@@ -492,9 +492,12 @@ class Notify(BaseNotify):
 
     def send_to_azure_queue(self, queue_uri, message, session):
         queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(queue_uri, session)
-        encode_ascii = True if 'encode_ascii' not in self.data['transport'] else self.data['transport']['encode_ascii']
+        encode_ascii = True
+        if 'encode_ascii' in self.data['transport']:
+            encode_ascii = self.data['transport']['encode_ascii']
+        message_contents = self.pack(message, encode_ascii)
 
-        return StorageUtilities.put_queue_message(queue_service, queue_name, self.pack(message, encode_ascii)).id
+        return StorageUtilities.put_queue_message(queue_service, queue_name, message_contents).id
 
 
 DEFAULT_TAG = "custodian_status"


### PR DESCRIPTION
@aluong @priyaanathasankar @brandonh-msft @isaacsgi @logachev @erwelch 

Looking to use this encoding path to support python function + logic app processing.

Happy to chat about it further but it's currently pushing json to queue, and python function is processing it for a logic app (for teams / email).

![image](https://user-images.githubusercontent.com/2498998/52266404-2b46da00-28eb-11e9-9369-16fbc8a834c4.png)

![image](https://user-images.githubusercontent.com/2498998/52258357-aef4cc80-28d3-11e9-971d-0c6f71da64d4.png)

![image](https://user-images.githubusercontent.com/2498998/52258359-b1efbd00-28d3-11e9-93fe-b502164def27.png)

Related guidance:
https://github.com/isaacsgi/CloudCustodianAzureGuide/pull/1

https://github.com/plooploops/azure-functions-c7n-test/blob/master/scenarios-read-me/azure-functions-logic-apps-readme.md
