### PR TITLE
aws - related resource match validation

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -369,6 +369,7 @@ class ValueFilter(Filter):
             'op': {'enum': list(OPERATORS.keys())}}}
 
     annotate = True
+    required_keys = set(('value', 'key'))
 
     def __init__(self, data, manager=None):
         super(ValueFilter, self).__init__(data, manager)
@@ -409,10 +410,12 @@ class ValueFilter(Filter):
         if self.data.get('value_type') == 'resource_count':
             return self._validate_resource_count()
 
-        if 'key' not in self.data:
+        if 'key' not in self.data and 'key' in self.required_keys:
             raise PolicyValidationError(
                 "Missing 'key' in value filter %s" % self.data)
-        if 'value' not in self.data and 'value_from' not in self.data:
+        if ('value' not in self.data and
+                'value_from' not in self.data and
+                'value' in self.required_keys):
             raise PolicyValidationError(
                 "Missing 'value' in value filter %s" % self.data)
         if 'op' in self.data:

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -20,7 +20,15 @@ from .core import Filter, ValueFilter
 from .related import RelatedResourceFilter
 
 
-class SecurityGroupFilter(RelatedResourceFilter):
+class MatchResourceValidator(object):
+
+    def validate(self):
+        if self.data.get('match-resource'):
+            self.required_keys = set('key',)
+        return super(MatchResourceValidator, self).validate()
+
+
+class SecurityGroupFilter(MatchResourceValidator, RelatedResourceFilter):
     """Filter a resource by its associated security groups."""
     schema = type_schema(
         'security-group', rinherit=ValueFilter.schema,
@@ -32,7 +40,7 @@ class SecurityGroupFilter(RelatedResourceFilter):
     AnnotationKey = "matched-security-groups"
 
 
-class SubnetFilter(RelatedResourceFilter):
+class SubnetFilter(MatchResourceValidator, RelatedResourceFilter):
     """Filter a resource by its associated subnets."""
     schema = type_schema(
         'subnet', rinherit=ValueFilter.schema,
@@ -44,7 +52,7 @@ class SubnetFilter(RelatedResourceFilter):
     AnnotationKey = "matched-subnets"
 
 
-class VpcFilter(RelatedResourceFilter):
+class VpcFilter(MatchResourceValidator, RelatedResourceFilter):
     """Filter a resource by its associated vpc."""
     schema = type_schema(
         'vpc', rinherit=ValueFilter.schema,

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1049,6 +1049,22 @@ class SecurityGroupTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
+    def test_match_resource_validator(self):
+
+        try:
+            self.load_policy(
+                {'name': 'related-sg',
+                 'resource': 'elb',
+                 'filters': [
+                     {'type': 'security-group',
+                      'match-resource': True,
+                      'key': "tag:Application",
+                      'op': 'not-equal',
+                      'operator': 'or'}]},
+                validate=True)
+        except PolicyValidationError:
+            self.fail("should pass validation")
+
     @functional
     def test_only_ports(self):
         factory = self.replay_flight_data("test_security_group_only_ports")


### PR DESCRIPTION
as an improvement to the extant validation behavior, when doing match-resource on a related resource policy, don't make the user specify a dummy value.

closes #3522 