### PR TITLE
tools/mailer - send email to owner absent contact in slack with email address

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/ldap_lookup.py
+++ b/tools/c7n_mailer/c7n_mailer/ldap_lookup.py
@@ -188,6 +188,7 @@ class LocalSqlite(object):
     def set(self, key, value):
         # note, the ? marks are required to ensure escaping into the database.
         self.sqlite.execute("INSERT INTO ldap_cache VALUES (?, ?)", (key, json.dumps(value)))
+        self.sqlite.commit()
 
 
 # redis can't write complex python objects like dictionaries as values (the way memcache can)

--- a/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
@@ -169,7 +169,8 @@ class MailerSqsQueueProcessor(object):
 
         # this section sends a notification to the resource owner via Slack
         if any(e.startswith('slack') or e.startswith('https://hooks.slack.com/')
-                for e in sqs_message.get('action', ()).get('to')):
+                for e in sqs_message.get('action', ()).get('to', []) +
+                sqs_message.get('action', ()).get('owner_absent_contact', [])):
             from .slack_delivery import SlackDelivery
 
             if self.config.get('slack_token'):


### PR DESCRIPTION
\+ small fix on sqlite cache

per my comments in https://github.com/cloud-custodian/cloud-custodian/issues/3521, to fully support the entire array of slack delivery addresses (slack://, hooks.slack.com, slack://#channel, etc.) this will require a larger change in email_delivery or slack_delivery as the existing implementation of mapping to addrs to resources assumes that the values in `owner_absent_contact` will be an email address. For now this adds support to specify a slack user's email address for notification