### PR TITLE
tools/c7n_mailer - require c7n in setup.py

### DIFF
--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -28,6 +28,7 @@ requires = [
     "datadog",
     "sendgrid",
     "ldap3",
+    "c7n",
     "redis"]
 
 


### PR DESCRIPTION
c7n was removed from requirements.txt with the expectation it was in setup.py for pip installs, but its not present, so adding it.

reported on gitter