### PR TITLE
aws.ebs - skip missing ebs volumes when snapshotting

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1085,7 +1085,14 @@ class CreateSnapshot(BaseAction):
         retry = get_retry(['Throttled'], max_attempts=5)
         for vol in volumes:
             vol_id = vol['VolumeId']
-            retry(client.create_snapshot, VolumeId=vol_id)
+            retry(self.process_volume, client=client, volume=vol_id)
+
+    def process_volume(self, client, volume):
+        try:
+            client.create_snapshot(VolumeId=volume)
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'InvalidVolume.NotFound':
+                pass
 
 
 @actions.register('delete')

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1092,7 +1092,8 @@ class CreateSnapshot(BaseAction):
             client.create_snapshot(VolumeId=volume)
         except ClientError as e:
             if e.response['Error']['Code'] == 'InvalidVolume.NotFound':
-                pass
+                return
+            raise e
 
 
 @actions.register('delete')

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1093,7 +1093,7 @@ class CreateSnapshot(BaseAction):
         except ClientError as e:
             if e.response['Error']['Code'] == 'InvalidVolume.NotFound':
                 return
-            raise e
+            raise
 
 
 @actions.register('delete')


### PR DESCRIPTION
volume may be missing for any number of reasons, maybe due to cache, or the instance being terminated and its volumes deleted, etc. This pull request adds error handling around the create_snapshot call to filter out those volumes.

also doesn't look like the ec2 client has a way of referencing the error cleanly, e.g. `client.exceptions.InvalidVolumeNotFound`