### PR TITLE
tags - defer to batch_size from tag action in mark-for-op

### DIFF
--- a/c7n/resources/elb.py
+++ b/c7n/resources/elb.py
@@ -139,6 +139,8 @@ class TagDelayedAction(tags.TagDelayedAction):
                     days: 7
     """
 
+    batch_size = 1
+
 
 @actions.register('tag')
 class Tag(tags.Tag):

--- a/c7n/resources/elb.py
+++ b/c7n/resources/elb.py
@@ -139,8 +139,6 @@ class TagDelayedAction(tags.TagDelayedAction):
                     days: 7
     """
 
-    batch_size = 1
-
 
 @actions.register('tag')
 class Tag(tags.Tag):

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -678,7 +678,12 @@ class TagDelayedAction(Action):
 
         tags = [{'Key': tag, 'Value': msg}]
 
-        batch_size = self.data.get('batch_size', self.batch_size)
+        if hasattr(self.manager.action_registry.get('tag'), 'batch_size'):
+            # if the tag implementation has a specified batch size, it's typically
+            # due to some restraint on the api so we defer to that.
+            batch_size = self.manager.action_registry.get('tag').batch_size
+        else:
+            batch_size = self.data.get('batch_size', self.batch_size)
 
         client = self.get_client()
         _common_tag_processer(

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -678,12 +678,10 @@ class TagDelayedAction(Action):
 
         tags = [{'Key': tag, 'Value': msg}]
 
-        if hasattr(self.manager.action_registry.get('tag'), 'batch_size'):
-            # if the tag implementation has a specified batch size, it's typically
-            # due to some restraint on the api so we defer to that.
-            batch_size = self.manager.action_registry.get('tag').batch_size
-        else:
-            batch_size = self.data.get('batch_size', self.batch_size)
+        # if the tag implementation has a specified batch size, it's typically
+        # due to some restraint on the api so we defer to that.
+        batch_size = getattr(
+            self.manager.action_registry.get('tag'), 'batch_size', self.batch_size)
 
         client = self.get_client()
         _common_tag_processer(


### PR DESCRIPTION
example policy running on master breaks:

```yaml
policies:
  - name: elb-mark-for-op
    resource: elb
    filters:
      - Instances: []
      - "tag:keep-empty-elb": absent
      - "tag:maid_status": absent
    actions:
      - type: mark-for-op
        op: delete
        days: 7
```

error:

```
Traceback (most recent call last):
File "/src/c7n/commands.py", line 248, in run
policy()
File "/src/c7n/policy.py", line 932, in __call__
resources = mode.run()
File "/src/c7n/policy.py", line 264, in run
results = a.process(resources)
File "/src/c7n/tags.py", line 686, in process
self.process_resource_set, self.id_key, resources, tags, self.log)
File "/src/c7n/tags.py", line 137, in _common_tag_processer
raise error
File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
result = self.fn(*self.args, **self.kwargs)
File "/src/c7n/tags.py", line 690, in process_resource_set
tagger.process_resource_set(client, resource_set, tags)
File "/src/c7n/resources/elb.py", line 167, in process_resource_set
Tags=tags)
File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
return self._make_api_call(operation_name, kwargs)
File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the AddTags operation: Exactly 1 LoadBalancerName can be specified.
```
resolves #192