### PR TITLE
aws - config rule mode add match-compliant to schema

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -682,7 +682,10 @@ class ConfigRuleMode(LambdaMode):
     """
 
     cfg_event = None
-    schema = utils.type_schema('config-rule', rinherit=LambdaMode.schema)
+    schema = utils.type_schema(
+        'config-rule',
+        rinherit=LambdaMode.schema,
+        **{"match-compliant": {'type': 'boolean'}})
 
     def resolve_resources(self, event):
         source = self.policy.resource_manager.get_source('config')


### PR DESCRIPTION
default value is to put any resources that match filters as non compliant, there's a separate value supported in the code, but not exposed in the schema to put matched resources as compliant. this is probably a wip, because i think there's at least one other logic bit that needs to happen for this to work e2e