### PR TITLE
serverless py3 pkg assembly skip pycache dirs

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -128,6 +128,9 @@ class PythonPackageArchive(object):
         """
         for root, dirs, files in os.walk(path):
             arc_prefix = os.path.relpath(root, os.path.dirname(path))
+            # py3 remove pyc cache dirs.
+            if '__pycache__' in dirs:
+                dirs.remove('__pycache__')
             for f in files:
                 dest_path = os.path.join(arc_prefix, f)
 


### PR DESCRIPTION
merge to master of #3568 triggered a build failure on py3.6 which looked like a transient issue due to cache file write out timing. we were explicitly skipping cache files on py2.7, do the same for cache dirs on py3.6

https://dev.azure.com/cloud-custodian/a73f0a6a-a507-4857-93f8-daef87db809b/_build/results?buildId=926
