### PR TITLE
aws - adding kinesis to service code mapping

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -600,6 +600,7 @@ class RequestLimitIncrease(BaseAction):
         'VPC': 'amazon-virtual-private-cloud',
         'IAM': 'aws-identity-and-access-management',
         'CloudFormation': 'aws-cloudformation',
+        'Kinesis': 'amazon-kinesis',
     }
 
     def process(self, resources):


### PR DESCRIPTION
## Summary
Receiving error upon running our service limit increase policy. I think that the information for the classic check-id **'eW7HH0l7J9'** may have been updated to include new resources like kinesis.

## Error Message
> 2019-02-25 09:00:14,812: c7n_org:ERROR Exception running policy:account-service-limits account:test-account region:us-east-1 error:Parameter validation failed:
> Invalid type for parameter serviceCode, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>

The error indicates that the key of 'Kinesis' is not present in the service_code_mapping dictionary. (cloud-custodian\c7n\resources\account.py - ln 594)
![image](https://user-images.githubusercontent.com/43418865/53360593-8cb30500-38fb-11e9-96c4-a539b4906e20.png)

A call using AWS CLI using the following command: `aws support describe-trusted-advisor-check-result --region us-east-1 --check-id 'eW7HH0l7J9'` returns a response that now includes information on kinesis.
![image](https://user-images.githubusercontent.com/43418865/53361656-e0bee900-38fd-11e9-8ab0-cb46b8b9d9f9.png)

The previous behavior of kinesis being not supported by custodian using the classic trusted advisor check is referenced here #2293
## Changes
This PR adds the 'Kinesis': 'amazon-kinesis' mapping to the service_code_mapping so that the service-limit-increase action can properly function.

** Note: I am unsure of the other resources have been added to the classic check-id but Kinesis is the only one which we saw cause errors in our daily runs.