### PR TITLE
Feature/infra (GCP)

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/actions/core.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/core.py
@@ -63,12 +63,20 @@ class MethodAction(Action):
             )
         return resources
 
+    def include_default_project(self, resources, session):
+        updated_resources = list(resources)
+        default_project = session.get_default_project()
+        for resource in resources:
+            resource['c7n:default_project'] = default_project
+        return updated_resources
+
     def process(self, resources):
         if self.attr_filter:
             resources = self.filter_resources(resources)
         m = self.manager.get_model()
         session = local_session(self.manager.session_factory)
         client = self.get_client(session, m)
+        resources = self.include_default_project(resources, session)
         for resource_set in chunks(resources, self.chunk_size):
             self.process_resource_set(client, m, resource_set)
 

--- a/tools/c7n_gcp/c7n_gcp/actions/core.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/core.py
@@ -77,18 +77,25 @@ class MethodAction(Action):
         session = local_session(self.manager.session_factory)
         client = self.get_client(session, m)
         resources = self.include_default_project(resources, session)
+        results = []
         for resource_set in chunks(resources, self.chunk_size):
-            self.process_resource_set(client, m, resource_set)
+            result = self.process_resource_set(client, m, resource_set)
+            if result:
+                results.append(result)
+        return None if len(results) == 0 else results
 
     def process_resource_set(self, client, model, resources):
         op_name = self.method_spec['op']
         result_key = self.method_spec.get('result_key')
         annotation_key = self.method_spec.get('annotation_key')
+        results = []
         for r in resources:
             params = self.get_resource_params(model, r)
             result = self.invoke_api(client, op_name, params)
             if result_key and annotation_key:
                 r[annotation_key] = result.get(result_key)
+                results.append(result)
+        return None if len(results) == 0 else results
 
     def invoke_api(self, client, op_name, params):
         try:


### PR DESCRIPTION
Initial infrastructure changes for:
- GCP tag support;
- writing GCP action execution results;
- ability to use 'default_project' (set in environment variables) for resources that do not have any reference to it (e.g. selfLink is not returned by their API) in GCP;
- supporting actions that are supposed to be executed regardless of resource presence.
Actually, resources depending on other resources (could be called 'parent') require one more change not included in this PR since currently we agreed to override get_resource_query method locally (lines 81-84 in https://github.com/cloud-custodian/cloud-custodian/commit/110228f9a91191208187817f4db17f462a1d8676).