### PR TITLE
aws.asg - not-encrypted filter with launch templates KeyError fix

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -126,7 +126,7 @@ class LaunchInfo(object):
 
         lid = asg.get('LaunchTemplate')
         if lid is not None:
-            return (lid['LaunchTemplateId'], lid['LaunchTemplateVersion'])
+            return (lid['LaunchTemplateId'], lid['Version'])
 
         # we've noticed some corner cases where the asg name is the lc name, but not
         # explicitly specified as launchconfiguration attribute.


### PR DESCRIPTION
```yaml
policies:
  - name: not-encrpted-asg
    resource: asg
    filters:
      - type: not-encrypted
```

This occurs when using the Not encrypted filter against ASG's with launch templates. Per the docs:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/autoscaling.html#AutoScaling.Client.describe_auto_scaling_groups


Credits: shout out @thisisshi 

```
Traceback (most recent call last):
  File "/Users/cloud-custodian/c7n/policy.py", line 232, in run
    resources = self.policy.resource_manager.resources()
  File "/Users/cloud-custodian/c7n/query.py", line 421, in resources
    resources = self.filter_resources(resources)
  File "/Users/cloud-custodian/c7n/manager.py", line 105, in filter_resources
    resources = f.process(resources, event)
  File "/Users/cloud-custodian/c7n/resources/asg.py", line 465, in process
    return super(NotEncryptedFilter, self).process(asgs, event)
  File "/Users/cloud-custodian/c7n/filters/core.py", line 181, in process
    return list(filter(self, resources))
  File "/Users/cloud-custodian/c7n/resources/asg.py", line 468, in __call__
    launch = self.launch_info.get(asg)
  File "/Users/cloud-custodian/c7n/resources/asg.py", line 137, in get
    lid = self.get_launch_id(asg)
KeyError: 'LaunchTemplateVersion
```