### PR TITLE
filters - explicitly cast value to str, sometimes it might be None

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -534,7 +534,7 @@ class ValueFilter(Filter):
 
         elif self.vtype == 'integer':
             try:
-                value = int(value.strip())
+                value = int(str(value).strip())
             except ValueError:
                 value = 0
         elif self.vtype == 'size':


### PR DESCRIPTION
reported on gitter:

```
Traceback (most recent call last):
File "/var/task/custodian_policy.py", line 4, in run
return handler.dispatch_event(event, context)
File "/var/task/c7n/handler.py", line 105, in dispatch_event
p.push(event, context)
File "/var/task/c7n/policy.py", line 832, in push
return mode.run(event, lambda_ctx)
File "/var/task/c7n/policy.py", line 510, in run
return PullMode.run(self)
File "/var/task/c7n/policy.py", line 232, in run
resources = self.policy.resource_manager.resources()
File "/var/task/c7n/query.py", line 413, in resources
resources = self.filter_resources(resources)
File "/var/task/c7n/manager.py", line 105, in filter_resources
resources = f.process(resources, event)
File "/var/task/c7n/filters/core.py", line 284, in process
return self.process_set(resources, event)
File "/var/task/c7n/filters/core.py", line 303, in process_set
resources = f.process(resources, event)
File "/var/task/c7n/filters/core.py", line 243, in process
return self.process_set(resources, event)
File "/var/task/c7n/filters/core.py", line 259, in process_set
r[resource_type.id] for r in f.process(resources, event)])
File "/var/task/c7n/filters/core.py", line 448, in process
return super(ValueFilter, self).process(resources, event)
File "/var/task/c7n/filters/core.py", line 181, in process
return list(filter(self, resources))
File "/var/task/c7n/filters/core.py", line 435, in call
matched = self.match(i)
File "/var/task/c7n/filters/core.py", line 501, in match
v, r = self.process_value_type(self.v, r, i)
File "/var/task/c7n/filters/core.py", line 534, in process_value_type
value = int(value.strip())
AttributeError: 'NoneType' object has no attribute 'strip'
```

Sample policy:

```yaml
policies:
  - name: test-s3
    resource: s3
    filters:
      - type: value
        value_type: integer
        key: tag:Application
        value: 0
        op: eq
```

when tag:Application is missing, the value is `None`, leading to a Attribute Error, this pull request explicitly casts value to str type before stripping.