### PR TITLE
azure - remove policies where the objects are not found in graph

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -106,11 +106,14 @@ class WhiteListFilter(Filter):
         # GraphHelper.get_principal_dictionary returns empty AADObject if not found with graph
         # or if graph is not available.
         principal_dics = GraphHelper.get_principal_dictionary(self.graph_client, object_ids)
-
+        remove = []
         for policy in access_policies:
             aad_object = principal_dics[policy['objectId']]
+            if aad_object.object_id is None:
+                remove.append(policy)
+                continue
             policy['displayName'] = aad_object.display_name
             policy['aadType'] = aad_object.object_type
             policy['principalName'] = GraphHelper.get_principal_name(aad_object)
 
-        return access_policies
+        return [a for a in access_policies if a not in remove]

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -110,6 +110,7 @@ class WhiteListFilter(Filter):
         for policy in access_policies:
             aad_object = principal_dics[policy['objectId']]
             if aad_object.object_id is None:
+                self.log.debug('Unable to find principal for %s' % policy['objectId'])
                 unknown_principals.append(policy)
                 continue
             policy['displayName'] = aad_object.display_name
@@ -118,6 +119,5 @@ class WhiteListFilter(Filter):
 
         if unknown_principals:
             self.log.warning('%s Principals not found' % len(unknown_principals))
-            access_policies = list(set(access_policies).difference(set(unknown_principals)))
-
+            access_policies = [a for a in access_policies if a not in unknown_principals]
         return access_policies

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -69,7 +69,11 @@ class WhiteListFilter(Filter):
                     }
                 })
             # Enhance access policies with displayName, aadType and principalName
-            i['accessPolicies'] = self.enhance_policies(access_policies)
+            augment = self.enhance_policies(access_policies)
+            if augment:
+                i['accessPolicies'] = augment
+            else:
+                return False
 
         # Ensure each policy is
         #   - User is whitelisted

--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -28,6 +28,7 @@ from c7n_azure import constants
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import parse_resource_id
 
+from c7n.exceptions import PolicyExecutionError
 from c7n.utils import chunks
 
 from c7n.utils import local_session
@@ -204,9 +205,9 @@ class GraphHelper(object):
             for aad_object in aad_objects:
                 principal_dics[aad_object.object_id] = aad_object
         except CloudError:
-            GraphHelper.log.warning(
-                'Credentials not authorized for access to read from Microsoft Graph. \n '
-                'Can not query on principalName, displayName, or aadType. \n')
+            raise PolicyExecutionError(
+                'Credentials not authorized for access to read from Microsoft Graph. ' +
+                'Can not query on principalName, displayName, or aadType.')
 
         return principal_dics
 


### PR DESCRIPTION
Getting the following error when the vault object id is not found in the graph

```
Traceback (most recent call last):
File "/src/c7n/commands.py", line 248, in run
policy()
File "/src/c7n/policy.py", line 937, in __call__
resources = PullMode(self).run()
File "/src/c7n/policy.py", line 232, in run
resources = self.policy.resource_manager.resources()
File "/src/tools/c7n_azure/c7n_azure/query.py", line 122, in resources
return self.filter_resources(resources)
File "/src/c7n/manager.py", line 105, in filter_resources
resources = f.process(resources, event)
File "/src/c7n/filters/core.py", line 181, in process
return list(filter(self, resources))
File "/src/tools/c7n_azure/c7n_azure/resources/key_vault.py", line 72, in __call__
i['accessPolicies'] = self.enhance_policies(access_policies)
File "/src/tools/c7n_azure/c7n_azure/resources/key_vault.py", line 112, in enhance_policies
policy['displayName'] = aad_object.display_name
AttributeError: 'DirectoryObject' object has no attribute 'display_name'
```

policy example:
```yaml
policies:
  - name: keyvault-test
    resource: azure.keyvault
    filters:
      - type: whitelist
        key: principalName
        users:
          - hello@example.com
        permissions:
          keys:
            - get
            - list
          secrets:
            - get
            - list
          certificates:
            - get
            - list
```

@aluong let me know if i'm misinterpreting the error here or if there's a better way to do this