### PR TITLE
Adding error handling for deleted resources | describe listener api call | appelb

### DIFF
--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -502,7 +502,7 @@ class AppELBListenerFilterBase(object):
                     LoadBalancerArn=alb['LoadBalancerArn'])
                 self.listener_map[alb['LoadBalancerArn']] = results['Listeners']
             except client.exception.LoadBalancerNotFoundException:
-                pass
+                continue
 
 
 def parse_attribute_value(v):

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -497,9 +497,12 @@ class AppELBListenerFilterBase(object):
         client = local_session(self.manager.session_factory).client('elbv2')
         self.listener_map = defaultdict(list)
         for alb in albs:
-            results = client.describe_listeners(
-                LoadBalancerArn=alb['LoadBalancerArn'])
-            self.listener_map[alb['LoadBalancerArn']] = results['Listeners']
+            try:
+                results = client.describe_listeners(
+                    LoadBalancerArn=alb['LoadBalancerArn'])
+                self.listener_map[alb['LoadBalancerArn']] = results['Listeners']
+            except client.exception.LoadBalancerNotFoundException:
+                pass
 
 
 def parse_attribute_value(v):

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -501,7 +501,7 @@ class AppELBListenerFilterBase(object):
                 results = client.describe_listeners(
                     LoadBalancerArn=alb['LoadBalancerArn'])
                 self.listener_map[alb['LoadBalancerArn']] = results['Listeners']
-            except client.exception.LoadBalancerNotFoundException:
+            except client.exceptions.LoadBalancerNotFoundException:
                 continue
 
 

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -500,9 +500,9 @@ class AppELBListenerFilterBase(object):
             try:
                 results = client.describe_listeners(
                     LoadBalancerArn=alb['LoadBalancerArn'])
-                self.listener_map[alb['LoadBalancerArn']] = results['Listeners']
             except client.exceptions.LoadBalancerNotFoundException:
                 continue
+            self.listener_map[alb['LoadBalancerArn']] = results['Listeners']
 
 
 def parse_attribute_value(v):


### PR DESCRIPTION
error:

```botocore.errorfactory.LoadBalancerNotFoundException: An error occurred (LoadBalancerNotFound) when calling the DescribeListeners operation: Load balancer 'arn:aws:elasticloadbalancing:us-east-1:00000000:loadbalancer/app/name/x' not found
```