### PR TITLE
aws.ec2 -Network Location sg_space referenced before assignment

### DIFF
--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -173,7 +173,6 @@ class NetworkLocation(Filter):
         self.missing_ok = self.data.get('missing-ok', False)
 
         results = []
-
         for r in resources:
             resource_sgs = self.filter_ignored(
                 [related_sg[sid] for sid in self.sg.get_related_ids([r])])
@@ -204,6 +203,9 @@ class NetworkLocation(Filter):
 
     def process_resource(self, r, resource_sgs, resource_subnets, key):
         evaluation = []
+        sg_space = set()
+        subnet_space = set()
+
         if 'subnet' in self.compare and resource_subnets:
             subnet_values = {
                 rsub[self.subnet_model.id]: self.subnet.get_resource_value(key, rsub)
@@ -230,6 +232,7 @@ class NetworkLocation(Filter):
                     'security-groups': sg_values})
 
             sg_space = set(filter(None, sg_values.values()))
+
             if len(sg_space) > self.max_cardinality:
                 evaluation.append({
                     'reason': 'SecurityGroupLocationCardinality',

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -189,9 +189,6 @@ class VpcFilter(net_filters.VpcFilter):
     RelatedIdsExpression = "VpcId"
 
 
-filters.register('network-location', net_filters.NetworkLocation)
-
-
 @filters.register('state-age')
 class StateTransitionAge(AgeFilter):
     """Age an instance has been in the given state.
@@ -510,6 +507,19 @@ class InstanceOffHour(OffHour, StateTransitionFilter):
     def process(self, resources, event=None):
         return super(InstanceOffHour, self).process(
             self.filter_instance_state(resources))
+
+
+@filters.register('network-location')
+class EC2NetworkLocation(net_filters.NetworkLocation, StateTransitionFilter):
+
+    valid_origin_states = ('pending', 'running', 'shutting-down', 'stopping',
+                           'stopped')
+
+    def process(self, resources, event=None):
+        resources = self.filter_instance_state(resources)
+        if not resources:
+            return []
+        return super(EC2NetworkLocation, self).process(resources)
 
 
 @filters.register('onhour')

--- a/tests/data/placebo/test_ec2_network_location/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_network_location/ec2.DescribeInstances_1.json
@@ -1,0 +1,81 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0799ad445b5727125",
+                        "InstanceId": "i-06942813abca96f71",
+                        "InstanceType": "t2.micro",
+                        "KeyName": "caponeaws",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2019,
+                            "month": 2,
+                            "day": 28,
+                            "hour": 21,
+                            "minute": 58,
+                            "second": 36,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-west-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2019-02-28 21:58:47 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-03daddd97f501bdd2"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "360de0bf-eb76-487e-bc39-c211bb1d2cf4",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "date": "Thu, 28 Feb 2019 22:22:02 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_network_location/ec2.DescribeInstances_2.json
+++ b/tests/data/placebo/test_ec2_network_location/ec2.DescribeInstances_2.json
@@ -1,0 +1,81 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0799ad445b5727125",
+                        "InstanceId": "i-06942813abca96f71",
+                        "InstanceType": "t2.micro",
+                        "KeyName": "caponeaws",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2019,
+                            "month": 2,
+                            "day": 28,
+                            "hour": 21,
+                            "minute": 58,
+                            "second": 36,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-west-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2019-02-28 21:58:47 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-03daddd97f501bdd2"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "09838295-a54f-4695-8347-d5d0262c1245",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "date": "Thu, 28 Feb 2019 22:22:03 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_network_location/ec2.DescribeTags_1.json
+++ b/tests/data/placebo/test_ec2_network_location/ec2.DescribeTags_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [],
+        "ResponseMetadata": {
+            "RequestId": "fe356c7e-ba0a-431a-a363-0d691e704da7",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "212",
+                "date": "Thu, 28 Feb 2019 22:22:03 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -49,7 +49,8 @@ class TestEc2NetworkLocation(BaseTest):
                 'resource': 'ec2',
                 'filters': [
                     {'State.Name': 'terminated'},
-                    {'type': 'network-location'}
+                    {'type': 'network-location',
+                     "key": "tag:some-value"},
                 ]
             },
             session_factory=factory

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -31,6 +31,33 @@ from c7n import tags, utils
 from .common import BaseTest
 
 
+class TestEc2NetworkLocation(BaseTest):
+    def test_ec2_network_location_terminated(self):
+        factory = self.replay_flight_data("test_ec2_network_location")
+        client = factory().client('ec2')
+        resp = client.describe_instances()
+
+        self.assertTrue(len(resp['Reservations'][0]['Instances']), 1)
+        self.assertTrue(
+            len(resp['Reservations'][0]['Instances'][0]['State']['Name']),
+            'terminated'
+        )
+
+        policy = self.load_policy(
+            {
+                'name': 'ec2-network-location',
+                'resource': 'ec2',
+                'filters': [
+                    {'State.Name': 'terminated'},
+                    {'type': 'network-location'}
+                ]
+            },
+            session_factory=factory
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 0)
+
+
 class TestTagAugmentation(BaseTest):
 
     def test_tag_augment_empty(self):


### PR DESCRIPTION
``` 
2019-02-28 03:12:32,627: custodian.aws:ERROR Error while executing policy
Traceback (most recent call last):
File "/src/c7n/policy.py", line 232, in run
resources = self.policy.resource_manager.resources()
File "/src/c7n/resources/ec2.py", line 93, in resources
return super(EC2, self).resources(query=query)
File "/src/c7n/query.py", line 419, in resources
resources = self.filter_resources(resources)
File "/src/c7n/manager.py", line 105, in filter_resources
resources = f.process(resources, event)
File "/src/c7n/filters/core.py", line 284, in process
return self.process_set(resources, event)
File "/src/c7n/filters/core.py", line 303, in process_set
resources = f.process(resources, event)
File "/src/c7n/filters/vpc.py", line 174, in process
found = self.process_resource(r, resource_sgs, resource_subnets, key)
File "/src/c7n/filters/vpc.py", line 232, in process_resource
sg_space != subnet_space):
UnboundLocalError: local variable 'sg_space' referenced before assignment
```

Resolves an issue where terminated instances lose their subnet and or security group details causing 
sg_space and subnet_space to be missing. Moving the variable decelerations up to ensure their set within function scope. 

Subclasses network location filter on EC2 to handle valid origin states. 

@thisisshi Big shout - DKHS

