### PR TITLE
aws - launch template resource fixes

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1788,12 +1788,13 @@ class LaunchTemplate(query.QueryResourceManager):
 
     def augment(self, resources):
         client = utils.local_session(
-            self.manager.session_factory).client('ec2')
+            self.session_factory).client('ec2')
         template_versions = []
         for r in resources:
             template_versions.extend(
                 client.describe_launch_template_versions(
-                    LaunchTemplateId=r['LaunchTemplateId']))
+                    LaunchTemplateId=r['LaunchTemplateId']).get(
+                        'LaunchTemplateVersions', ()))
         return template_versions
 
     def get_resources(self, rids, cache=True):
@@ -1829,10 +1830,12 @@ class LaunchTemplate(query.QueryResourceManager):
         results = []
         # We may end up fetching duplicates on $Latest and $Version
         for tid, tversions in t_versions.items():
-            for tversion, t in zip(
-                tversions, client.describe_launch_template_versions(
-                    LaunchTemplateId=tid, Versions=tversions).get(
-                        'LaunchTemplateVersions')):
+            ltv = client.describe_launch_template_versions(
+                LaunchTemplateId=tid, Versions=tversions).get(
+                    'LaunchTemplateVersions')
+            if not tversions:
+                tversions = [str(t['VersionNumber']) for t in ltv]
+            for tversion, t in zip(tversions, ltv):
                 if not tversion.isdigit():
                     t['c7n:VersionAlias'] = tversion
                 results.append(t)

--- a/tests/data/placebo/test_launch_template_get/ec2.DescribeLaunchTemplateVersions_1.json
+++ b/tests/data/placebo/test_launch_template_get/ec2.DescribeLaunchTemplateVersions_1.json
@@ -1,0 +1,213 @@
+{
+    "status_code": 200,
+    "data": {
+        "LaunchTemplateVersions": [
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "VersionNumber": 4,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 31,
+                    "hour": 11,
+                    "minute": 39,
+                    "second": 44,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersion": true,
+                "LaunchTemplateData": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sdb",
+                            "Ebs": {
+                                "Encrypted": false,
+                                "VolumeSize": 1
+                            }
+                        }
+                    ],
+                    "ImageId": "ami-0ac019f4fcb7cb7e6",
+                    "InstanceType": "t2.small",
+                    "TagSpecifications": [
+                        {
+                            "ResourceType": "instance",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        },
+                        {
+                            "ResourceType": "volume",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        }
+                    ],
+                    "SecurityGroupIds": [
+                        "sg-0b090df1c1f95bc13"
+                    ]
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "VersionNumber": 3,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 31,
+                    "hour": 11,
+                    "minute": 31,
+                    "second": 35,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sdb",
+                            "Ebs": {
+                                "Encrypted": false,
+                                "VolumeSize": 1
+                            }
+                        }
+                    ],
+                    "ImageId": "ami-0ac019f4fcb7cb7e6",
+                    "InstanceType": "t2.small",
+                    "TagSpecifications": [
+                        {
+                            "ResourceType": "instance",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        },
+                        {
+                            "ResourceType": "volume",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        }
+                    ],
+                    "SecurityGroupIds": [
+                        "sg-034c1e48ec56c8bcb",
+                        "sg-0b090df1c1f95bc13"
+                    ]
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "VersionNumber": 2,
+                "VersionDescription": "dev2",
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 31,
+                    "hour": 11,
+                    "minute": 30,
+                    "second": 6,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sdb",
+                            "Ebs": {
+                                "Encrypted": false,
+                                "VolumeSize": 1
+                            }
+                        }
+                    ],
+                    "ImageId": "ami-0ac019f4fcb7cb7e6",
+                    "InstanceType": "t2.small",
+                    "TagSpecifications": [
+                        {
+                            "ResourceType": "instance",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        },
+                        {
+                            "ResourceType": "volume",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        }
+                    ],
+                    "SecurityGroupIds": [
+                        "sg-015ed77d59ea1c12f"
+                    ]
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "VersionNumber": 1,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 3,
+                    "hour": 15,
+                    "minute": 12,
+                    "second": 36,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sdb",
+                            "Ebs": {
+                                "Encrypted": false,
+                                "VolumeSize": 1
+                            }
+                        }
+                    ],
+                    "ImageId": "ami-009d6802948d06e52",
+                    "InstanceType": "t2.small",
+                    "SecurityGroupIds": [
+                        "sg-015ed77d59ea1c12f"
+                    ]
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "25acc2e2-0cb8-42c1-83c4-04c63efa1fd4",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "date": "Fri, 01 Mar 2019 22:10:55 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_launch_template_query/ec2.DescribeLaunchTemplateVersions_1.json
+++ b/tests/data/placebo/test_launch_template_query/ec2.DescribeLaunchTemplateVersions_1.json
@@ -1,0 +1,107 @@
+{
+    "status_code": 200,
+    "data": {
+        "LaunchTemplateVersions": [
+            {
+                "LaunchTemplateId": "lt-0877401c93c294001",
+                "LaunchTemplateName": "test",
+                "VersionNumber": 4,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 25,
+                    "second": 48,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/Samson.Shi@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "ImageId": "ami-04bfee437f38a691e",
+                    "InstanceType": "t1.micro",
+                    "SecurityGroupIds": [
+                        "sg-02ec691909b2a4753"
+                    ]
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-0877401c93c294001",
+                "LaunchTemplateName": "test",
+                "VersionNumber": 3,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 24,
+                    "second": 34,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/Samson.Shi@capitalone.com",
+                "DefaultVersion": true,
+                "LaunchTemplateData": {
+                    "ImageId": "ami-04bfee437f38a691e",
+                    "InstanceType": "t1.micro",
+                    "SecurityGroupIds": [
+                        "sg-00cd07381bc482d51"
+                    ]
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-0877401c93c294001",
+                "LaunchTemplateName": "test",
+                "VersionNumber": 2,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 23,
+                    "second": 8,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/Samson.Shi@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "InstanceType": "t1.micro"
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-0877401c93c294001",
+                "LaunchTemplateName": "test",
+                "VersionNumber": 1,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 21,
+                    "second": 58,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/Samson.Shi@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "ImageId": "ami-04bfee437f38a691e"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "a85e4bc1-930b-4da9-84a3-0f7072c7de4a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "date": "Fri, 01 Mar 2019 19:50:57 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_launch_template_query/ec2.DescribeLaunchTemplateVersions_2.json
+++ b/tests/data/placebo/test_launch_template_query/ec2.DescribeLaunchTemplateVersions_2.json
@@ -1,0 +1,213 @@
+{
+    "status_code": 200,
+    "data": {
+        "LaunchTemplateVersions": [
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "VersionNumber": 4,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 31,
+                    "hour": 11,
+                    "minute": 39,
+                    "second": 44,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersion": true,
+                "LaunchTemplateData": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sdb",
+                            "Ebs": {
+                                "Encrypted": false,
+                                "VolumeSize": 1
+                            }
+                        }
+                    ],
+                    "ImageId": "ami-0ac019f4fcb7cb7e6",
+                    "InstanceType": "t2.small",
+                    "TagSpecifications": [
+                        {
+                            "ResourceType": "instance",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        },
+                        {
+                            "ResourceType": "volume",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        }
+                    ],
+                    "SecurityGroupIds": [
+                        "sg-0b090df1c1f95bc13"
+                    ]
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "VersionNumber": 3,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 31,
+                    "hour": 11,
+                    "minute": 31,
+                    "second": 35,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sdb",
+                            "Ebs": {
+                                "Encrypted": false,
+                                "VolumeSize": 1
+                            }
+                        }
+                    ],
+                    "ImageId": "ami-0ac019f4fcb7cb7e6",
+                    "InstanceType": "t2.small",
+                    "TagSpecifications": [
+                        {
+                            "ResourceType": "instance",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        },
+                        {
+                            "ResourceType": "volume",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        }
+                    ],
+                    "SecurityGroupIds": [
+                        "sg-034c1e48ec56c8bcb",
+                        "sg-0b090df1c1f95bc13"
+                    ]
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "VersionNumber": 2,
+                "VersionDescription": "dev2",
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 31,
+                    "hour": 11,
+                    "minute": 30,
+                    "second": 6,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sdb",
+                            "Ebs": {
+                                "Encrypted": false,
+                                "VolumeSize": 1
+                            }
+                        }
+                    ],
+                    "ImageId": "ami-0ac019f4fcb7cb7e6",
+                    "InstanceType": "t2.small",
+                    "TagSpecifications": [
+                        {
+                            "ResourceType": "instance",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        },
+                        {
+                            "ResourceType": "volume",
+                            "Tags": [
+                                {
+                                    "Key": "Env",
+                                    "Value": "Dev"
+                                }
+                            ]
+                        }
+                    ],
+                    "SecurityGroupIds": [
+                        "sg-015ed77d59ea1c12f"
+                    ]
+                }
+            },
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "VersionNumber": 1,
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 3,
+                    "hour": 15,
+                    "minute": 12,
+                    "second": 36,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersion": false,
+                "LaunchTemplateData": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sdb",
+                            "Ebs": {
+                                "Encrypted": false,
+                                "VolumeSize": 1
+                            }
+                        }
+                    ],
+                    "ImageId": "ami-009d6802948d06e52",
+                    "InstanceType": "t2.small",
+                    "SecurityGroupIds": [
+                        "sg-015ed77d59ea1c12f"
+                    ]
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "8617e1fd-d32b-488f-9392-299d888f92b1",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "date": "Fri, 01 Mar 2019 19:50:57 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_launch_template_query/ec2.DescribeLaunchTemplates_1.json
+++ b/tests/data/placebo/test_launch_template_query/ec2.DescribeLaunchTemplates_1.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": {
+        "LaunchTemplates": [
+            {
+                "LaunchTemplateId": "lt-0877401c93c294001",
+                "LaunchTemplateName": "test",
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 21,
+                    "second": 58,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/Samson.Shi@capitalone.com",
+                "DefaultVersionNumber": 3,
+                "LatestVersionNumber": 4
+            },
+            {
+                "LaunchTemplateId": "lt-00b3b2755218e3fdd",
+                "LaunchTemplateName": "test-template",
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 3,
+                    "hour": 15,
+                    "minute": 12,
+                    "second": 36,
+                    "microsecond": 0
+                },
+                "CreatedBy": "arn:aws:iam::644160558196:user/faizan.ahmed@capitalone.com",
+                "DefaultVersionNumber": 4,
+                "LatestVersionNumber": 4
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "e2c0cea1-2d77-472e-a801-51ac415cc83f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "date": "Fri, 01 Mar 2019 19:50:57 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1519,6 +1519,29 @@ class TestUserData(BaseTest):
         self.assertGreater(len(resources), 0)
 
 
+class TestLaunchTemplate(BaseTest):
+
+    def test_template_get_resources(self):
+        factory = self.replay_flight_data(
+            'test_launch_template_get')
+        p = self.load_policy({
+            'name': 'ec2-reserved',
+            'resource': 'aws.launch-template-version'},
+            session_factory=factory)
+        resources = p.resource_manager.get_resources([
+            'lt-00b3b2755218e3fdd'])
+        self.assertEqual(len(resources), 4)
+
+    def test_launch_template_versions(self):
+        factory = self.replay_flight_data('test_launch_template_query')
+        p = self.load_policy({
+            'name': 'ec2-reserved',
+            'resource': 'aws.launch-template-version'}, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 8)
+        self.assertTrue(all(['LaunchTemplateData' in r for r in resources]))
+
+
 class TestReservedInstance(BaseTest):
 
     def test_reserved_instance_query(self):


### PR DESCRIPTION
fix for get resources using just a launch template id, and fix for augment on the resource manager

without this a policy on launch-template-versions would fail on the augment.