### PR TITLE
aws - serverless policy default execution options from cli

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -36,8 +36,9 @@ logging.getLogger('botocore').setLevel(logging.WARNING)
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 log = logging.getLogger('custodian.lambda')
 
-## Env serverless specific configuration options, these are part of "public" interface
-
+#
+# Env serverless specific configuration options, these are part of "public" interface
+#
 # We default to skipping events which denote they have errors
 C7N_SKIP_ERROR = os.environ.get('C7N_SKIP_ERROR', 'yes') == 'yes' and True or False
 
@@ -45,8 +46,9 @@ C7N_SKIP_ERROR = os.environ.get('C7N_SKIP_ERROR', 'yes') == 'yes' and True or Fa
 C7N_DEBUG_EVENT = os.environ.get('C7N_DEBUG_EVENT', 'yes') == 'yes' and True or False
 
 
-## Internal global variables
-
+#
+# Internal global variables
+#
 # Default global cache of execution account id for initial configuration setup.
 account_id = None
 

--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -124,6 +124,7 @@ def init_config(policy_config):
     elif account_id is None:
         session = boto3.Session()
         account_id = get_account_id_from_sts(session)
+    exec_options['account_id'] = account_id
 
     # Historical compatibility with manually set execution options
     # previously this was a boolean, its now a string value with the
@@ -133,7 +134,6 @@ def init_config(policy_config):
        and exec_options['metrics_enabled']:
         exec_options['metrics_enabled'] = 'aws'
 
-    exec_options['account_id'] = account_id
     return Config.empty(**exec_options)
 
 

--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -74,7 +74,7 @@ def get_local_output_dir():
     return output_dir
 
 
-def init_config(policy_config, default_output_dir):
+def init_config(policy_config):
     """Get policy lambda execution configuration.
 
     cli parameters are serialized into the policy lambda config,

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -866,7 +866,8 @@ class PolicyLambda(AbstractLambdaFunction):
     def get_archive(self):
         self.archive.add_contents(
             'config.json', json.dumps(
-                {'policies': [self.policy.data]}, indent=2))
+                {'execution-options': dict(self.policy.config),
+                 'policies': [self.policy.data]}, indent=2))
         self.archive.add_contents('custodian_policy.py', PolicyHandlerTemplate)
         self.archive.close()
         return self.archive

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -866,7 +866,7 @@ class PolicyLambda(AbstractLambdaFunction):
     def get_archive(self):
         self.archive.add_contents(
             'config.json', json.dumps(
-                {'execution-options': dict(self.policy.config),
+                {'execution-options': dict(self.policy.options),
                  'policies': [self.policy.data]}, indent=2))
         self.archive.add_contents('custodian_policy.py', PolicyHandlerTemplate)
         self.archive.close()

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -162,7 +162,8 @@ class TestUtils(unittest.TestCase):
             os.environ.update(original_environ)
 
         os.environ.clear()
-        for key, value in kwargs.items():
+
+        for key, value in list(kwargs.items()):
             if value is None:
                 del (kwargs[key])
         os.environ.update(kwargs)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -15,13 +15,107 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import logging
+import mock
 import os
 
 from .common import BaseTest
+from c7n.exceptions import PolicyExecutionError
 from c7n.policy import Policy
+from c7n import handler
 
 
 class HandleTest(BaseTest):
+
+    def test_get_local_output_dir(self):
+        temp_dir = self.get_temp_dir()
+        os.rmdir(temp_dir)
+        self.change_environment(C7N_OUTPUT_DIR=temp_dir)
+        self.assertEqual(
+            handler.get_local_output_dir(), temp_dir)
+
+    def test_init_config_exec_option_merge(self):
+        policy_config = {
+            'execution-options': {
+                'region': 'us-east-1',
+                'assume_role': 'arn:::',
+                'profile': 'dev',
+                'tracer': 'xray',
+                'account_id': '004',
+                'dryrun': True,
+                'cache': '/foobar.cache'},
+            'policies': [
+                {'mode': {
+                    'type': 'period',
+                    'schedule': "rate(1 minute)",
+                    'execution-options': {
+                        'metrics_enabled': True,
+                        'assume_role': 'arn::::007:foo',
+                        'output_dir': 's3://mybucket/output'}},
+                 'resource': 'aws.ec2',
+                 'name': 'check-dev'}
+            ]}
+        self.assertEqual(
+            dict(handler.init_config(policy_config)),
+            {'assume_role': 'arn::::007:foo',
+             'metrics_enabled': 'aws',
+             'tracer': 'xray',
+             'account_id': '007',
+             'region': 'us-east-1',
+             'output_dir': 's3://mybucket/output',
+
+             # defaults
+             'external_id': None,
+             'dryrun': False,
+             'profile': None,
+             'authorization_file': None,
+             'cache': '',
+             'regions': (),
+             'cache_period': 0,
+             'log_group': None})
+
+    def test_dispatch_log_event(self):
+        self.patch(handler, 'policy_config', {'policies': []})
+        output = self.capture_logging('custodian.lambda', level=logging.INFO)
+        self.change_environment(C7N_DEBUG_EVENT=None)
+        handler.dispatch_event({'detail': {'resource': 'xyz'}}, {})
+        self.assertTrue('xyz' in output.getvalue())
+
+        self.patch(handler, 'C7N_DEBUG_EVENT', False)
+        handler.dispatch_event({'detail': {'resource': 'abc'}}, {})
+        self.assertFalse('abc' in output.getvalue())
+
+    @mock.patch('c7n.handler.PolicyCollection')
+    def test_dispatch_err_event(self, mock_collection):
+        self.patch(handler, 'policy_config', {
+            'execution-options': {'output_dir': 's3://xyz'},
+            'policies': [{'resource': 'ec2', 'name': 'xyz'}]})
+        mock_collection.from_data.return_value = []
+        output = self.capture_logging('custodian.lambda', level=logging.DEBUG)
+        handler.dispatch_event({'detail': {'errorCode': 'unauthorized'}}, None)
+        self.assertTrue('Skipping failed operation: unauthorized' in output.getvalue())
+        self.patch(handler, 'C7N_SKIP_EVTERR', False)
+        handler.dispatch_event({'detail': {'errorCode': 'foi'}}, None)
+        self.assertFalse('Skipping failed operation: foi' in output.getvalue())
+        mock_collection.from_data.assert_called_once()
+
+    @mock.patch('c7n.handler.PolicyCollection')
+    def test_dispatch_err_handle(self, mock_collection):
+        self.patch(handler, 'policy_config', {
+            'execution-options': {'output_dir': 's3://xyz'},
+            'policies': [{'resource': 'ec2', 'name': 'xyz'}]})
+        output = self.capture_logging('custodian.lambda', level=logging.WARNING)
+        pmock = mock.MagicMock()
+        pmock.push.side_effect = PolicyExecutionError("foo")
+        mock_collection.from_data.return_value = [pmock]
+
+        self.assertRaises(
+            PolicyExecutionError,
+            handler.dispatch_event,
+            {'detail': {'xyz': 'oui'}}, None)
+
+        self.patch(handler, 'C7N_CATCH_ERR', True)
+        handler.dispatch_event({'detail': {'xyz': 'oui'}}, None)
+        self.assertEqual(output.getvalue().count('error during'), 2)
 
     def test_handler(self):
         level = logging.root.level

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -87,7 +87,7 @@ class HandleTest(BaseTest):
     @mock.patch('c7n.handler.PolicyCollection')
     def test_dispatch_err_event(self, mock_collection):
         self.patch(handler, 'policy_config', {
-            'execution-options': {'output_dir': 's3://xyz'},
+            'execution-options': {'output_dir': 's3://xyz', 'account_id': '004'},
             'policies': [{'resource': 'ec2', 'name': 'xyz'}]})
         mock_collection.from_data.return_value = []
         output = self.capture_logging('custodian.lambda', level=logging.DEBUG)
@@ -101,7 +101,7 @@ class HandleTest(BaseTest):
     @mock.patch('c7n.handler.PolicyCollection')
     def test_dispatch_err_handle(self, mock_collection):
         self.patch(handler, 'policy_config', {
-            'execution-options': {'output_dir': 's3://xyz'},
+            'execution-options': {'output_dir': 's3://xyz', 'account_id': '004'},
             'policies': [{'resource': 'ec2', 'name': 'xyz'}]})
         output = self.capture_logging('custodian.lambda', level=logging.WARNING)
         pmock = mock.MagicMock()


### PR DESCRIPTION
For at least the last year, serverless policies that wanted to configure metrics/output/etc had to include `execution-options` which lead to redundant configuration per policy. By default we should be using the cli options as the default for lambda executions wherever that makes sense.

There's alot of contextual sensitivities to the option interpretation, so its worthwhile to review the behavior on each parameter in a lambda environment and whether the value is used if its passed in on the cli or if its specified in policy `execution-options`. most of the cli ignored are due to their use in provisioning the lambda versus targeting the lambda's execution environment which would cause ambiguity.

cli passed parameters are used as defaults and are overridden by any policy specified values, which ensures compatibility with extant configurations. 

| Key        | Cli           | Policy  |
| ------------- |:-------------:| -----:|
| log group      | yes| yes|
| output dir     | yes**     |   yes|
| metrics | yes     |    yes |
| tracer | yes | yes |
| external_id | yes | yes |
| cache file | ignored      |    yes |
| region | ignored      |    yes |
| profile | ignored      |    yes |
| assume | ignored      |    yes |
| dryrun | ignored      |    yes |



- log group (`-l`) values will be respected, but note this is in addition to the lambda's default log group.
- output dir (`-s`) will only be respected if they are blob store (s3) locations, local directories are ignored.
- cache file are ignored as the lambda environment
- dryrun should never be true in cli lambda env (no lambda would be provisioned), but ignored if found.

Additionally this adds a few new environment variables for controlling behavior of the lambda function/entrypoint. 

 - C7N_SKIP_ERR_EVENT (default yes) will allow processing events which have errors (fixes #3122)
 - C7N_DEBUG_EVENT (default yes) controls logging of the event being processed.
 - C7N_CATCH_ERROR (default no..) controls if a policy error exits the lambda as an error. This has implications on lambda error metrics, and retries. (closes #3454)

Additionally this also fixes metrics handling to close #3471