### PR TITLE
Error handling for create tag operation

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -440,7 +440,7 @@ class Tag(Action):
                 DryRun=self.manager.config.dryrun)
         except ClientError as e:
             if e.error['Code'] == 'InvalidSnapshot.NotFound':
-                continue
+                pass
 
     def interpolate_values(self, tags):
         params = {

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -35,7 +35,7 @@ import time
 from c7n.manager import resources as aws_resources
 from c7n.actions import BaseAction as Action, AutoTagUser
 from c7n.exceptions import PolicyValidationError, PolicyExecutionError, ClientError
-from c7n.filters imporCop Filter, OPERATORS
+from c7n.filters import Filter, OPERATORS
 from c7n.filters.offhours import Time
 from c7n import utils
 


### PR DESCRIPTION
Looks like there's an operation attempting to tag deleted snapshots. 
Error:

```
2019-03-04 02:50:59,268: custodian.actions:ERROR Exception with tags: [{'Key': 'x', 'Value': 'y'}] An error occurred (InvalidSnapshot.NotFound) when calling the CreateTags operation: The snapshot 'snap-0dbxxxxxx' does not exist.
```
```
botocore.exceptions.ClientError: An error occurred (InvalidSnapshot.NotFound) when calling the CreateTags operation: The snapshot 'snap-0dbxxxxxx' does not exist.
```