### PR TITLE
aws - dax skip augment for get-resources

### DIFF
--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -424,6 +424,9 @@ class DynamoDbAccelerator(query.QueryResourceManager):
         raise ValueError('invalid source %s' % source_type)
 
     def get_resources(self, ids, cache=True, augment=True):
+        """Override in order to disable the augment for serverless policies.
+           list_tags on dax resources always fail until the cluster is finished creating.
+        """
         return super(DynamoDbAccelerator, self).get_resources(ids, cache, augment=False)
 
 

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -423,8 +423,16 @@ class DynamoDbAccelerator(query.QueryResourceManager):
             return query.ConfigSource(self)
         raise ValueError('invalid source %s' % source_type)
 
+    def get_resources(self, ids, cache=True, augment=True):
+        return super(DynamoDbAccelerator, self).get_resources(ids, cache, augment=False)
 
 class DescribeDaxCluster(query.DescribeSource):
+
+    def get_resources(self, ids, cache=True):
+        """Retrieve dax resources for serverless policies or related resources
+        """
+        client = local_session(self.manager.session_factory).client('dax')
+        return client.describe_clusters(ClusterNames=ids).get('Clusters')
 
     def augment(self, clusters):
         resources = super(DescribeDaxCluster, self).augment(clusters)

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -426,6 +426,7 @@ class DynamoDbAccelerator(query.QueryResourceManager):
     def get_resources(self, ids, cache=True, augment=True):
         return super(DynamoDbAccelerator, self).get_resources(ids, cache, augment=False)
 
+
 class DescribeDaxCluster(query.DescribeSource):
 
     def get_resources(self, ids, cache=True):

--- a/tests/data/placebo/test_dax_get_resource/dax.DescribeClusters_1.json
+++ b/tests/data/placebo/test_dax_get_resource/dax.DescribeClusters_1.json
@@ -1,0 +1,69 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "ClusterName": "c7n-test-cluster",
+                "ClusterArn": "arn:aws:dax:us-east-1:644160558196:cache/c7n-test-cluster",
+                "TotalNodes": 1,
+                "ActiveNodes": 1,
+                "NodeType": "dax.r4.large",
+                "Status": "available",
+                "ClusterDiscoveryEndpoint": {
+                    "Address": "c7n-test-cluster.qgcgte.clustercfg.dax.use1.cache.amazonaws.com",
+                    "Port": 8111
+                },
+                "Nodes": [
+                    {
+                        "NodeId": "c7n-test-cluster-a",
+                        "Endpoint": {
+                            "Address": "c7n-test-cluster-a.qgcgte.0001.dax.use1.cache.amazonaws.com",
+                            "Port": 8111
+                        },
+                        "NodeCreateTime": {
+                            "__class__": "datetime",
+                            "year": 2019,
+                            "month": 3,
+                            "day": 4,
+                            "hour": 0,
+                            "minute": 33,
+                            "second": 9,
+                            "microsecond": 419000
+                        },
+                        "AvailabilityZone": "us-east-1a",
+                        "NodeStatus": "available",
+                        "ParameterGroupStatus": "in-sync"
+                    }
+                ],
+                "PreferredMaintenanceWindow": "sun:03:30-sun:04:30",
+                "SubnetGroup": "test-subnetgroup",
+                "SecurityGroups": [
+                    {
+                        "SecurityGroupIdentifier": "sg-0fd0c04f0c434d68d",
+                        "Status": "active"
+                    }
+                ],
+                "IamRoleArn": "arn:aws:iam::644160558196:role/aws-service-role/dax.amazonaws.com/AWSServiceRoleForDAX",
+                "ParameterGroup": {
+                    "ParameterGroupName": "default.dax1.0",
+                    "ParameterApplyStatus": "in-sync",
+                    "NodeIdsToReboot": []
+                },
+                "SSEDescription": {
+                    "Status": "ENABLED"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "ccd58dc9-3e3f-11e9-ba86-d12b8123c9bd",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ccd58dc9-3e3f-11e9-ba86-d12b8123c9bd",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "1099",
+                "date": "Mon, 04 Mar 2019 05:38:55 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -492,3 +492,14 @@ class DynamoDbAccelerator(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['ClusterName'], 'c7n-test')
+
+    def test_dax_get_resource(self):
+        session_factory = self.replay_flight_data('test_dax_get_resource')
+
+        p = self.load_policy({
+            'name': 'dax-cluster-gr', 'resource': 'dax'},
+            session_factory=session_factory)
+        resources = p.resource_manager.get_resources(
+            ["c7n-test-cluster"])
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['TotalNodes'], 1)


### PR DESCRIPTION
Adding get_resources along with an override in order to avoid the list_tags call in the augment when executing a serverless policy. list_tags will fail if the dax cluster is still is still in a provisioning state