### PR TITLE
aws.ecr - log warning on access denied instead of raising

### DIFF
--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 
 from c7n.actions import RemovePolicyBase, Action
-from c7n.exceptions import PolicyValidationError
+from c7n.exceptions import PolicyValidationError, ClientError
 from c7n.filters import CrossAccountAccessFilter, Filter, ValueFilter
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
@@ -104,11 +104,20 @@ class ECRCrossAccountAccessFilter(CrossAccountAccessFilter):
         client = local_session(self.manager.session_factory).client('ecr')
 
         def _augment(r):
+            if 'Policy' in r:
+                return r
             try:
                 r['Policy'] = client.get_repository_policy(
                     repositoryName=r['repositoryName'])['policyText']
             except client.exceptions.RepositoryPolicyNotFoundException:
                 return None
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AccessDeniedException':
+                    self.log.warning('Access Denied on GetRepositoryPolicy for repository: %s' %
+                        r['repositoryName'])
+                    return None
+                else:
+                    raise
             return r
 
         self.log.debug("fetching policy for %d repos" % len(resources))
@@ -211,6 +220,13 @@ class LifecycleRule(Filter):
                             'lifecyclePolicyText', ''))
             except client.exceptions.LifecyclePolicyNotFoundException:
                 r[self.policy_annotation] = {}
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AccessDeniedException':
+                    self.log.warning('Access Denied on GetLifecyclePolicy for repository: %s' %
+                        r['repositoryName'])
+                    r[self.policy_annotation] = {}
+                else:
+                    raise
 
         state = self.data.get('state', False)
         matchers = []
@@ -318,6 +334,13 @@ class RemovePolicyStatement(RemovePolicyBase):
                     repositoryName=resource['repositoryName'])['policyText']
             except client.exceptions.RepositoryPolicyNotFoundException:
                 return
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AccessDeniedException':
+                    self.log.warning('Access Denied on GetRepositoryPolicy for repository: %s' %
+                        resource['repositoryName'])
+                    return None
+                else:
+                    raise
 
         p = json.loads(resource['Policy'])
         statements, found = self.process_policy(


### PR DESCRIPTION
ECR's resource level IAM policies causes custodian to error out if a single repository denies access to custodian's role. This pr logs the error as a warning in the logs and continues on to the rest of the resources. Also fixes this for get lifecycle policy

```
Traceback (most recent call last):
File "/src/c7n/policy.py", line 232, in run
resources = self.policy.resource_manager.resources()
File "/src/c7n/query.py", line 421, in resources
resources = self.filter_resources(resources)
File "/src/c7n/manager.py", line 105, in filter_resources
resources = f.process(resources, event)
File "/src/c7n/resources/ecr.py", line 116, in process
resources = list(filter(None, w.map(_augment, resources)))
File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 586, in result_iterator
yield fs.pop().result()
File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 432, in result
return self.__get_result()
File "/usr/local/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
raise self._exception
File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
result = self.fn(*self.args, **self.kwargs)
File "/src/c7n/resources/ecr.py", line 109, in _augment
repositoryName=r['repositoryName'])['policyText']
File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
return self._make_api_call(operation_name, kwargs)
File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the GetRepositoryPolicy operation: User: arn:aws:sts::xxxxxxxxxxxx:assumed-role/CloudCustodian is not authorized to perform: ecr:GetRepositoryPolicy on resource: arn:aws:ecr:us-east-1:xxxxxxxxxxxx:repository/test with an explicit deny
```