### PR TITLE
aws.tags - Universal augment handle missing tags

### DIFF
--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -104,8 +104,6 @@ class ECRCrossAccountAccessFilter(CrossAccountAccessFilter):
         client = local_session(self.manager.session_factory).client('ecr')
 
         def _augment(r):
-            if 'Policy' in r:
-                return r
             try:
                 r['Policy'] = client.get_repository_policy(
                     repositoryName=r['repositoryName'])['policyText']

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 
 from c7n.actions import RemovePolicyBase, Action
-from c7n.exceptions import PolicyValidationError, ClientError
+from c7n.exceptions import PolicyValidationError
 from c7n.filters import CrossAccountAccessFilter, Filter, ValueFilter
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
@@ -111,13 +111,6 @@ class ECRCrossAccountAccessFilter(CrossAccountAccessFilter):
                     repositoryName=r['repositoryName'])['policyText']
             except client.exceptions.RepositoryPolicyNotFoundException:
                 return None
-            except ClientError as e:
-                if e.response['Error']['Code'] == 'AccessDeniedException':
-                    self.log.warning('Access Denied on GetRepositoryPolicy for repository: %s' %
-                        r['repositoryName'])
-                    return None
-                else:
-                    raise
             return r
 
         self.log.debug("fetching policy for %d repos" % len(resources))
@@ -220,13 +213,6 @@ class LifecycleRule(Filter):
                             'lifecyclePolicyText', ''))
             except client.exceptions.LifecyclePolicyNotFoundException:
                 r[self.policy_annotation] = {}
-            except ClientError as e:
-                if e.response['Error']['Code'] == 'AccessDeniedException':
-                    self.log.warning('Access Denied on GetLifecyclePolicy for repository: %s' %
-                        r['repositoryName'])
-                    r[self.policy_annotation] = {}
-                else:
-                    raise
 
         state = self.data.get('state', False)
         matchers = []
@@ -334,13 +320,6 @@ class RemovePolicyStatement(RemovePolicyBase):
                     repositoryName=resource['repositoryName'])['policyText']
             except client.exceptions.RepositoryPolicyNotFoundException:
                 return
-            except ClientError as e:
-                if e.response['Error']['Code'] == 'AccessDeniedException':
-                    self.log.warning('Access Denied on GetRepositoryPolicy for repository: %s' %
-                        resource['repositoryName'])
-                    return None
-                else:
-                    raise
 
         p = json.loads(resource['Policy'])
         statements, found = self.process_policy(

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 
 from c7n.actions import RemovePolicyBase, Action
-from c7n.exceptions import PolicyValidationError
+from c7n.exceptions import PolicyValidationError, ClientError
 from c7n.filters import CrossAccountAccessFilter, Filter, ValueFilter
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
@@ -104,11 +104,20 @@ class ECRCrossAccountAccessFilter(CrossAccountAccessFilter):
         client = local_session(self.manager.session_factory).client('ecr')
 
         def _augment(r):
+            if 'Policy' in r:
+                return r
             try:
                 r['Policy'] = client.get_repository_policy(
                     repositoryName=r['repositoryName'])['policyText']
             except client.exceptions.RepositoryPolicyNotFoundException:
                 return None
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AccessDeniedException':
+                    self.log.warning('Access Denied on GetRepositoryPolicy for repository: %s' %
+                        r['repositoryName'])
+                    return None
+                else:
+                    raise
             return r
 
         self.log.debug("fetching policy for %d repos" % len(resources))
@@ -211,6 +220,13 @@ class LifecycleRule(Filter):
                             'lifecyclePolicyText', ''))
             except client.exceptions.LifecyclePolicyNotFoundException:
                 r[self.policy_annotation] = {}
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AccessDeniedException':
+                    self.log.warning('Access Denied on GetLifecyclePolicy for repository: %s' %
+                        r['repositoryName'])
+                    r[self.policy_annotation] = {}
+                else:
+                    raise
 
         state = self.data.get('state', False)
         matchers = []
@@ -318,6 +334,13 @@ class RemovePolicyStatement(RemovePolicyBase):
                     repositoryName=resource['repositoryName'])['policyText']
             except client.exceptions.RepositoryPolicyNotFoundException:
                 return
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AccessDeniedException':
+                    self.log.warning('Access Denied on GetRepositoryPolicy for repository: %s' %
+                        resource['repositoryName'])
+                    return None
+                else:
+                    raise
 
         p = json.loads(resource['Policy'])
         statements, found = self.process_policy(

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -110,9 +110,16 @@ def universal_augment(self, resources):
     resource_tag_map = {
         r['ResourceARN']: r['Tags'] for r in resource_tag_map_list}
 
-    for arn, r in zip(self.get_arns(resources), resources):
+    all_arns = set(self.get_arns(resources))
+    tagged_arns = set(resource_tag_map.keys())
+    missing_tags = all_arns.difference(tagged_arns)
+
+    for arn, r in zip(all_arns, resources):
         if arn in resource_tag_map:
             r['Tags'] = resource_tag_map[arn]
+        elif arn in missing_tags:
+            r['Tags'] = []
+
     return resources
 
 

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -110,15 +110,10 @@ def universal_augment(self, resources):
     resource_tag_map = {
         r['ResourceARN']: r['Tags'] for r in resource_tag_map_list}
 
-    all_arns = set(self.get_arns(resources))
-    tagged_arns = set(resource_tag_map.keys())
-    missing_tags = all_arns.difference(tagged_arns)
-
-    for arn, r in zip(all_arns, resources):
-        if arn in resource_tag_map:
-            r['Tags'] = resource_tag_map[arn]
-        elif arn in missing_tags:
-            r['Tags'] = []
+    for arn, r in zip(self.get_arns(resources), resources):
+        if 'Tags' in r:
+            continue
+        r['Tags'] = resource_tag_map.get(arn, [])
 
     return resources
 

--- a/tests/data/placebo/test_tags_universal_augment_missing_tags/elasticache.DescribeCacheClusters_1.json
+++ b/tests/data/placebo/test_tags_universal_augment_missing_tags/elasticache.DescribeCacheClusters_1.json
@@ -1,0 +1,59 @@
+{
+    "status_code": 200,
+    "data": {
+        "CacheClusters": [
+            {
+                "CacheClusterId": "test",
+                "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
+                "CacheNodeType": "cache.t2.micro",
+                "Engine": "redis",
+                "EngineVersion": "5.0.3",
+                "CacheClusterStatus": "available",
+                "NumCacheNodes": 1,
+                "PreferredAvailabilityZone": "us-east-1a",
+                "CacheClusterCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 3,
+                    "day": 4,
+                    "hour": 22,
+                    "minute": 16,
+                    "second": 30,
+                    "microsecond": 0
+                },
+                "PreferredMaintenanceWindow": "thu:10:00-thu:11:00",
+                "PendingModifiedValues": {},
+                "CacheSecurityGroups": [],
+                "CacheParameterGroup": {
+                    "CacheParameterGroupName": "default.redis5.0",
+                    "ParameterApplyStatus": "in-sync",
+                    "CacheNodeIdsToReboot": []
+                },
+                "CacheSubnetGroupName": "test",
+                "AutoMinorVersionUpgrade": true,
+                "SecurityGroups": [
+                    {
+                        "SecurityGroupId": "sg-0fd0c04f0c434d68d",
+                        "Status": "active"
+                    }
+                ],
+                "SnapshotRetentionLimit": 0,
+                "SnapshotWindow": "04:30-05:30",
+                "AuthTokenEnabled": false,
+                "TransitEncryptionEnabled": false,
+                "AtRestEncryptionEnabled": false
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "bf2fc4d2-3ecc-11e9-8ee5-178dc921cc46",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "bf2fc4d2-3ecc-11e9-8ee5-178dc921cc46",
+                "content-type": "text/xml",
+                "content-length": "1930",
+                "date": "Mon, 04 Mar 2019 22:27:50 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_tags_universal_augment_missing_tags/elasticache.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_tags_universal_augment_missing_tags/elasticache.ListTagsForResource_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [],
+        "ResponseMetadata": {
+            "RequestId": "beff6681-3ecc-11e9-bec0-31c5d0122230",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "beff6681-3ecc-11e9-bec0-31c5d0122230",
+                "content-type": "text/xml",
+                "content-length": "301",
+                "date": "Mon, 04 Mar 2019 22:27:51 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_tags_universal_augment_missing_tags/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_tags_universal_augment_missing_tags/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {
+            "RequestId": "bf6fdace-3ecc-11e9-a702-712fa41e3bf9",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "bf6fdace-3ecc-11e9-a702-712fa41e3bf9",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "50",
+                "date": "Mon, 04 Mar 2019 22:27:51 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -65,7 +65,7 @@ class DynamodbTest(BaseTest):
         # verify they are equivalent but account for some fundamental
         # deltas.  size and count aren't in config, datetimes we
         # normalize but are still tz delta on recording.
-        for k in ('ItemCount', 'CreationDateTime', 'TableSizeBytes', 'BillingModeSummary'):
+        for k in ('ItemCount', 'CreationDateTime', 'TableSizeBytes', 'BillingModeSummary', 'Tags'):
             describe_table.pop(k, None)
             config_table.pop(k, None)
         self.assertEqual(describe_table, config_table)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -25,6 +25,28 @@ from c7n.exceptions import PolicyExecutionError, PolicyValidationError
 from .common import BaseTest
 
 
+class UniversalAugmentTest(BaseTest):
+
+    def test_universal_augment_resource_missing_tags(self):
+        session_factory = self.replay_flight_data('test_tags_universal_augment_missing_tags')
+        cache_cluster_id = 'arn:aws:elasticache:us-east-1:644160558196:cluster:test'
+        client = session_factory().client('elasticache')
+        tags = client.list_tags_for_resource(ResourceName=cache_cluster_id)
+        self.assertEqual(len(tags['TagList']), 0)
+        policy = self.load_policy(
+            {
+                'name': 'elasticache-no-tags',
+                'resource': 'cache-cluster',
+                'filters': [
+                    {'CacheClusterId': 'test'}
+                ]
+            },
+            session_factory=session_factory
+        )
+        results = policy.run()
+        self.assertTrue('Tags' in results[0])
+
+
 class UniversalTagRetry(BaseTest):
 
     def test_retry_no_error(self):


### PR DESCRIPTION
Universal augment on tags does not return an empty list if no tags are found which is contrary to other resource behavior (see: ec2). This pr returns an empty list for tags if it's not found. Additionally, downstream actions or filters may be reliant on `Tags` being present (for example elasticache snapshot's `copy-cluster-tags')