### PR TITLE
azure - utils don't import builtins, just use them

### DIFF
--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -18,7 +18,6 @@ import logging
 import re
 import time
 import uuid
-from builtins import bytes
 from concurrent.futures import as_completed
 
 import six

--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -80,7 +80,9 @@ class StringUtils(object):
 
     @staticmethod
     def naming_hash(string, length=8):
-        return hashlib.sha256(bytes(string, 'utf-8')).hexdigest().lower()[:length]
+        if isinstance(string, six.string_types):
+            string = string.encode('utf8')
+        return hashlib.sha256(string.hexdigest().lower()[:length]
 
 
 def utcnow():

--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -79,10 +79,10 @@ class StringUtils(object):
         return components[0] + ''.join(x.title() for x in components[1:])
 
     @staticmethod
-    def naming_hash(string, length=8):
-        if isinstance(string, six.string_types):
-            string = string.encode('utf8')
-        return hashlib.sha256(string.hexdigest().lower()[:length]
+    def naming_hash(val, length=8):
+        if isinstance(val, six.string_types):
+            val = val.encode('utf8')
+        return hashlib.sha256(val).hexdigest().lower()[:length]
 
 
 def utcnow():

--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -1,5 +1,10 @@
-FROM pypy:2
-MAINTAINER Cloud Custodian Developers http://github.com/capitalone/cloud-custodian
+FROM python:3.7
+
+LABEL name="custodian" \
+      description="Cloud Management Rules Engine" \
+      repository="http://github.com/cloud-custodian/cloud-custodian" \
+      homepage="http://github.com/cloud-custodian/cloud-custodian" \
+      maintainer="Custodian Community <https://cloudcustodian.io>"
 
 # Note this must be run from the root directory of the checkout
 # as we install custodian w/ aws, azure, and gcp support from the same


### PR DESCRIPTION
fixes an issue reported on gitter wrt to c7n-org docker image

also change the docker image for c7n-org to use one of the runtimes in ci (py3.7)