### PR TITLE
tools/c7n-org - fix docker build

### DIFF
--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -14,19 +14,19 @@ ADD . /src
 
 # Install Custodian Core & AWS
 WORKDIR /src
-RUN pip2 install -r requirements.txt -e .
+RUN pip3 install -r requirements.txt -e .
 
 # Install Custodian Azure
 WORKDIR /src/tools/c7n_azure
-RUN pip2 install -r requirements.txt -e .
+RUN pip3 install -r requirements.txt -e .
 
 # Install Custodian GCP
 WORKDIR /src/tools/c7n_gcp
-RUN pip2 install -r requirements.txt -e .
+RUN pip3 install -r requirements.txt -e .
 
 # Install Custodian Org
 WORKDIR /src/tools/c7n_org
-RUN pip2 install -e .
+RUN pip3 install -e .
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
 ENTRYPOINT ["c7n-org"]


### PR DESCRIPTION
attempt to switch to py3.7 left some stray pip2 commands that need updating.