### PR TITLE
tools/c7n_mailer - on slack error show err text and status code

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -183,7 +183,8 @@ class SlackDelivery(object):
                 int(response.headers['retry-after']))
             time.sleep(int(response.headers['Retry-After']))
             return
-        elif response.status_code != 200:
-            self.logger.info("Error in sending Slack message status:%s : %s",
-                             response.status_code, response.text())
+        elif response.status_code != 200: # pragma: no cover
+            self.logger.info(
+                "Error in sending Slack message status:%s response: %s",
+                response.status_code, response.text())
             return

--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -184,5 +184,6 @@ class SlackDelivery(object):
             time.sleep(int(response.headers['Retry-After']))
             return
         elif response.status_code != 200:
-            self.logger.info("Error in sending Slack message: %s" % response.json())
+            self.logger.info("Error in sending Slack message status:%s : %s",
+                             response.status_code, response.text())
             return

--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -183,7 +183,7 @@ class SlackDelivery(object):
                 int(response.headers['retry-after']))
             time.sleep(int(response.headers['Retry-After']))
             return
-        elif response.status_code != 200: # pragma: no cover
+        elif response.status_code != 200:  # pragma: no cover
             self.logger.info(
                 "Error in sending Slack message status:%s response: %s",
                 response.status_code, response.text())


### PR DESCRIPTION
Trying to address and issue reported on gitter, basically the error log tries to decode json from the slack api response, and barfs if its not json, which obscures the original message.

from chat

Looking for some help, how would it be possible that the json response c7n_mailer is trying to send to my slack incoming webhook could not be decoded?
[WARNING] 2019-03-08T17:24:34.882Z f125ba06-c7ad-4751-9dde-8c98a5207dfd Error: Incorrect padding Unable to base64 decode slack_token, will assume plaintext. Traceback (most recent call last): File "/var/task/c7n_mailer/sqs_queue_processor.py", line 182, in process_sqs_message slack_delivery.slack_handler(sqs_message, slack_messages) File "/var/task/c7n_mailer/slack_delivery.py", line 116, in slack_handler self.send_slack_msg(key, payload) File "/var/task/c7n_mailer/slack_delivery.py", line 187, in send_slack_msg self.logger.info("Error in sending Slack message: %s" % response.json()) File "/var/task/requests/models.py", line 897, in json return complexjson.loads(self.text, **kwargs) File "/usr/lib64/python2.7/json/__init__.py", line 339, in loads return _default_decoder.decode(s) File "/usr/lib64/python2.7/json/decoder.py", line 364, in decode obj, end = self.raw_decode(s, idx=_w(s, 0).end()) File "/usr/lib64/python2.7/json/decoder.py", line 382, in raw_decode raise ValueError("No JSON object could be decoded") ValueError: No JSON object could be decoded END RequestId: f125ba06-c7ad-4751-9dde-8c98a5207dfd