### PR TITLE
aws.tags - Use default of 4 days ResourceTaggingAPI

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -668,7 +668,7 @@ class TagDelayedAction(Action):
 
         op = self.data.get('op', 'stop')
         tag = self.data.get('tag', DEFAULT_TAG)
-        days = self.data.get('days', 0)
+        days = self.data.get('days', None)
         hours = self.data.get('hours', 0)
         action_date = self.generate_timestamp(days, hours)
 
@@ -925,7 +925,7 @@ class UniversalTagDelayedAction(TagDelayedAction):
 
         op = self.data.get('op', 'stop')
         tag = self.data.get('tag', DEFAULT_TAG)
-        days = self.data.get('days', 0)
+        days = self.data.get('days', None)
         hours = self.data.get('hours', 0)
         action_date = self.generate_timestamp(days, hours)
 


### PR DESCRIPTION
**Problem:** A policy using `mark-for-op` without specifying the `days`, will result in the resource being tagged for operation the same day, for resources using the ResourceTaggingAPI. The default days is assumed to be 4 days as shown in the code. However the default value for days if none exists is set to 0 -- thus not triggering the logic to set the default to 4.

**Fix:** Set the default days to None if the tag is not provided. This way, the logic is hit when it checks if Days == None then the default value of 4 will be used.

This _does not_ provide a fix to resources that are not using the ResourceTaggingAPI.

I think PR broke the default when the check was added for None: https://github.com/cloud-custodian/cloud-custodian/pull/2498

