### PR TITLE
azure - add future dependency

### DIFF
--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -78,6 +78,7 @@ setup(
                       "azure-cli-core",
                       "adal",
                       "backports.functools_lru_cache",
+                      "future",
                       "futures>=3.1.1"],
     package_data={str(''): [str('function_binding_resources/bin/*.dll'),
                             str('function_binding_resources/*.csproj'),


### PR DESCRIPTION
This is a dependency in c7n_azure for the Dependency Manager for Functions.

(custodian) # custodian schema
Traceback (most recent call last):
  File "/root/custodian/bin/custodian", line 10, in <module>
    sys.exit(main())
  File "/root/custodian/local/lib/python2.7/site-packages/c7n/cli.py", line 368, in main
    command(config)
  File "/root/custodian/local/lib/python2.7/site-packages/c7n/commands.py", line 360, in schema_cmd
    load_resources()
  File "/root/custodian/local/lib/python2.7/site-packages/c7n/resources/__init__.py", line 102, in load_resources
    resources.load_plugins()
  File "/root/custodian/local/lib/python2.7/site-packages/c7n/registry.py", line 117, in load_plugins
    f = ep.load()
  File "/root/custodian/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/root/custodian/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/root/custodian/local/lib/python2.7/site-packages/c7n_azure/entry.py", line 19, in <module>
    import c7n_azure.policy
  File "/root/custodian/local/lib/python2.7/site-packages/c7n_azure/policy.py", line 30, in <module>
    from c7n_azure.function_package import FunctionPackage
  File "/root/custodian/local/lib/python2.7/site-packages/c7n_azure/function_package.py", line 28, in <module>
    from c7n_azure.dependency_manager import DependencyManager
  File "/root/custodian/local/lib/python2.7/site-packages/c7n_azure/dependency_manager.py", line 8, in <module>
    from builtins import bytes
ImportError: No module named builtins