### PR TITLE
cli - validate check and error on duplicate mapping keys

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -17,7 +17,6 @@ from collections import Counter, defaultdict
 from datetime import timedelta, datetime
 from functools import wraps
 import inspect
-import json
 import logging
 import os
 import pprint

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -26,11 +26,12 @@ import time
 
 import six
 import yaml
+from yaml.constructor import ConstructorError
 
 from c7n.exceptions import ClientError
 from c7n.provider import clouds
 from c7n.policy import Policy, PolicyCollection, load as policy_load
-from c7n.utils import dumps, load_file, local_session
+from c7n.utils import dumps, load_file, local_session, SafeLoader
 from c7n.config import Bag, Config
 from c7n import provider
 from c7n.resources import load_resources
@@ -171,6 +172,27 @@ def _print_no_policies_warning(options, policies):
         log.warning('Empty policy file(s).  Nothing to do.')
 
 
+class DuplicateKeyCheckLoader(SafeLoader):
+
+    def construct_mapping(self, node, deep=False):
+        if not isinstance(node, yaml.MappingNode):
+            raise ConstructorError(None, None,
+                    "expected a mapping node, but found %s" % node.id,
+                    node.start_mark)
+        key_set = set()
+        for key_node, value_node in node.value:
+            if not isinstance(key_node, yaml.ScalarNode):
+                continue
+            k = key_node.value
+            if k in key_set:
+                raise ConstructorError(
+                    "while constructing a mapping", node.start_mark,
+                    "found duplicate key", key_node.start_mark)
+            key_set.add(k)
+
+        return super(DuplicateKeyCheckLoader, self).construct_mapping(node, deep)
+
+
 def validate(options):
     from c7n import schema
     load_resources()
@@ -189,11 +211,10 @@ def validate(options):
 
         options.dryrun = True
         fmt = config_file.rsplit('.', 1)[-1]
+
         with open(config_file) as fh:
-            if fmt in ('yml', 'yaml'):
-                data = yaml.safe_load(fh.read())
-            elif fmt in ('json',):
-                data = json.load(fh)
+            if fmt in ('yml', 'yaml', 'json'):
+                data = yaml.load(fh.read(), Loader=DuplicateKeyCheckLoader)
             else:
                 log.error("The config file must end in .json, .yml or .yaml.")
                 raise ValueError("The config file must end in .json, .yml or .yaml.")

--- a/tests/data/test_policies/dup-policies.yml
+++ b/tests/data/test_policies/dup-policies.yml
@@ -1,0 +1,4 @@
+policies: []
+policies:
+  - name: ec2
+    resource: aws.ec2

--- a/tests/data/test_policies/dup-policy-keys.yml
+++ b/tests/data/test_policies/dup-policy-keys.yml
@@ -1,0 +1,4 @@
+policies:
+  - name: scooter
+    resource: aws.ec2
+    resource: ec2

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -14,12 +14,42 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
+import yaml
 
 from .common import BaseTest
 from c7n.commands import validate as validate_yaml_policies
 
 
 class CommandsValidateTest(BaseTest):
+
+    def test_duplicate_key(self):
+        # try dupes with top level keys
+        yaml_validate_options = argparse.Namespace(
+            command="c7n.commands.validate",
+            config=None,
+            configs=[
+                "tests/data/test_policies/dup-policies.yml"],
+            debug=False,
+            subparser="validate",
+            verbose=False)
+
+        with self.assertRaises(yaml.YAMLError) as err:
+            validate_yaml_policies(yaml_validate_options)
+        self.assertTrue('found duplicate key' in str(err.exception))
+
+        # try dupes with policy attributes
+        yaml_validate_options = argparse.Namespace(
+            command="c7n.commands.validate",
+            config=None,
+            configs=[
+                "tests/data/test_policies/dup-policy-keys.yml"],
+            debug=False,
+            subparser="validate",
+            verbose=False)
+
+        with self.assertRaises(yaml.YAMLError) as err:
+            validate_yaml_policies(yaml_validate_options)
+        self.assertTrue('found duplicate key' in str(err.exception))
 
     def test_failed_validation(self):
         yaml_validate_options = argparse.Namespace(


### PR DESCRIPTION
Check for duplicate keys on any mapping in a policy. Default pyyaml behavior is to let last key wins, but from a configuration file this often hides invalid or unexpected configuration errors. 

On validate explicitly check for these. For compatibility concerns on run preserve extant behavior.

closes #3668