### PR TITLE
aws - asg tag implementation normalize signature to match other resources

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1031,7 +1031,7 @@ class RemoveTag(Action):
             futures = {}
             for asg_set in chunks(asgs, self.batch_size):
                 futures[w.submit(
-                    self.process_asg_set, client, asg_set, tags)] = asg_set
+                    self.process_resource_set, client, asg_set, tags)] = asg_set
             for f in as_completed(futures):
                 asg_set = futures[f]
                 if f.exception():
@@ -1045,7 +1045,7 @@ class RemoveTag(Action):
         if error:
             raise error
 
-    def process_asg_set(self, client, asgs, tags):
+    def process_resource_set(self, client, asgs, tags):
         tag_set = []
         for a in asgs:
             for t in tags:
@@ -1084,6 +1084,7 @@ class Tag(Action):
         'tag',
         key={'type': 'string'},
         value={'type': 'string'},
+        tags={'type': 'object'},
         # Backwards compatibility
         tag={'type': 'string'},
         msg={'type': 'string'},
@@ -1093,14 +1094,26 @@ class Tag(Action):
     permissions = ('autoscaling:CreateOrUpdateTags',)
     batch_size = 1
 
-    def process(self, asgs):
+    def get_tag_set(self):
+        tags = []
+        propagate = self.data.get('propagate', False)
         key = self.data.get('key', self.data.get('tag', DEFAULT_TAG))
         value = self.data.get(
             'value', self.data.get(
                 'msg', 'AutoScaleGroup does not meet policy guidelines'))
-        return self.tag(asgs, key, value)
+        if key and value:
+            tags.append({'Key': key, 'Value': value})
 
-    def tag(self, asgs, key, value):
+        for k, v in self.data.get('tags').items():
+            tags.append({'Key': k, 'Value': v})
+
+        if propagate:
+            for t in tags:
+                t['PropagateAtLaunch'] = propagate
+        return tags
+
+    def process(self, asgs):
+        tags = self.get_tag_set()
         error = None
 
         client = local_session(self.manager.session_factory).client('autoscaling')
@@ -1109,26 +1122,27 @@ class Tag(Action):
             futures = {}
             for asg_set in chunks(asgs, self.batch_size):
                 futures[w.submit(
-                    self.process_asg_set, client, asg_set, key, value)] = asg_set
+                    self.process_resource_set, client, asg_set, tags)] = asg_set
             for f in as_completed(futures):
                 asg_set = futures[f]
                 if f.exception():
                     self.log.exception(
-                        "Exception untagging tag:%s error:%s asg:%s" % (
-                            self.data.get('key', DEFAULT_TAG),
+                        "Exception tagging tag:%s error:%s asg:%s" % (
+                            tags,
                             f.exception(),
                             ", ".join([a['AutoScalingGroupName']
                                        for a in asg_set])))
         if error:
             raise error
 
-    def process_asg_set(self, client, asgs, key, value):
-        propagate = self.data.get('propagate_launch', True)
-        tags = [
-            dict(Key=key, ResourceType='auto-scaling-group', Value=value,
-                 PropagateAtLaunch=propagate,
-                 ResourceId=a['AutoScalingGroupName']) for a in asgs]
-        self.manager.retry(client.create_or_update_tags, Tags=tags)
+    def process_resource_set(self, client, asgs, tags):
+        tag_params = []
+        for a in asgs:
+            atags = dict(tags)
+            atags['ResourceType'] = 'auto-scaling-group'
+            atags['ResourceId'] = a['AutoScalingGroupName']
+            tag_params.append(atags)
+        self.manager.retry(client.create_or_update_tags, Tags=tag_params)
 
 
 @ASG.action_registry.register('propagate-tags')

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1425,7 +1425,8 @@ class MarkForOp(Tag):
 
         self.log.info("Tagging %d asgs for %s on %s" % (
             len(asgs), op, action_date))
-        self.tag(asgs, key, msg)
+        client = local_session(self.manager.session_factory).client('asg')
+        self.process_resource_set(client, asgs, [{'Key': key, 'Value': msg}])
 
     def _generate_timestamp(self, days, hours):
         n = datetime.now(tz=self.tz)

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1353,7 +1353,7 @@ class RenameTag(Action):
             Resources=[i['InstanceId'] for i in asg['Instances']],
             Tags=[{"Key": source['Key']}])
         client.create_tags(
-            Resources=[i['InstanceId'] for i in asg['Instances']],
+           Resources=[i['InstanceId'] for i in asg['Instances']],
             Tags=[{'Key': destination_tag, 'Value': source['Value']}])
 
 
@@ -1425,7 +1425,7 @@ class MarkForOp(Tag):
 
         self.log.info("Tagging %d asgs for %s on %s" % (
             len(asgs), op, action_date))
-        client = local_session(self.manager.session_factory).client('asg')
+        client = local_session(self.manager.session_factory).client('autoscaling')
         self.process_resource_set(client, asgs, [{'Key': key, 'Value': msg}])
 
     def _generate_timestamp(self, days, hours):

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1103,7 +1103,7 @@ class Tag(Action):
         if key and value:
             tags.append({'Key': key, 'Value': value})
 
-        for k, v in self.data.get('tags').items():
+        for k, v in self.data.get('tags', {}).items():
             tags.append({'Key': k, 'Value': v})
 
         return tags
@@ -1353,7 +1353,7 @@ class RenameTag(Action):
             Resources=[i['InstanceId'] for i in asg['Instances']],
             Tags=[{"Key": source['Key']}])
         client.create_tags(
-           Resources=[i['InstanceId'] for i in asg['Instances']],
+            Resources=[i['InstanceId'] for i in asg['Instances']],
             Tags=[{'Key': destination_tag, 'Value': source['Value']}])
 
 

--- a/c7n/resources/elb.py
+++ b/c7n/resources/elb.py
@@ -163,9 +163,10 @@ class Tag(tags.Tag):
     permissions = ('elasticloadbalancing:AddTags',)
 
     def process_resource_set(self, client, resource_set, tags):
-        client.add_tags(
-            LoadBalancerNames=[r['LoadBalancerName'] for r in resource_set],
-            Tags=tags)
+        for r in resource_set:
+            client.add_tags(
+                LoadBalancerNames=[r['LoadBalancerName'] for r in resource_set],
+                Tags=tags)
 
 
 @actions.register('remove-tag')


### PR DESCRIPTION
while exercising tag implementations across resources, i noticed that asgs have a nonstandard interface to process_resource_set on tagger, which gets by a few callers generically. this updates that to use the same interface as other implementations. Also drive by on elb tagging which expected the caller to respect batch size (1), to just have that inline to the process resource set to process elbs individually.
