### PR TITLE
c7n.report - add raw output option

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -130,9 +130,9 @@ def _report_options(p):
         '--no-default-fields', action="store_true",
         help='Exclude default fields for report.')
     p.add_argument(
-        '--format', default='csv', choices=['csv', 'grid', 'simple'],
+        '--format', default='csv', choices=['csv', 'grid', 'simple', 'raw'],
         help="Format to output data in (default: %(default)s). "
-        "Options include simple, grid, csv")
+        "Options include simple, grid, csv, raw")
 
 
 def _metrics_options(p):

--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -130,9 +130,9 @@ def _report_options(p):
         '--no-default-fields', action="store_true",
         help='Exclude default fields for report.')
     p.add_argument(
-        '--format', default='csv', choices=['csv', 'grid', 'simple', 'raw'],
+        '--format', default='csv', choices=['csv', 'grid', 'simple', 'json'],
         help="Format to output data in (default: %(default)s). "
-        "Options include simple, grid, csv, raw")
+        "Options include simple, grid, csv, json")
 
 
 def _metrics_options(p):

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -102,7 +102,7 @@ def report(policies, start_date, options, output_fh, raw_output_fh=None):
         writer = UnicodeWriter(output_fh, formatter.headers())
         writer.writerow(formatter.headers())
         writer.writerows(rows)
-    elif options.format == 'raw':
+    elif options.format == 'json':
         print(dumps(records, indent=2))
     else:
         # We special case CSV, and for other formats we pass to tabulate

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -103,7 +103,7 @@ def report(policies, start_date, options, output_fh, raw_output_fh=None):
         writer.writerow(formatter.headers())
         writer.writerows(rows)
     elif options.format == 'raw':
-        print(json.dumps(formatter.extract_raw(records)))
+        print(dumps(records, indent=2))
     else:
         # We special case CSV, and for other formats we pass to tabulate
         print(tabulate(rows, formatter.headers(), tablefmt=options.format))

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -97,10 +97,13 @@ def report(policies, start_date, options, output_fh, raw_output_fh=None):
         records += policy_records
 
     rows = formatter.to_csv(records)
+
     if options.format == 'csv':
         writer = UnicodeWriter(output_fh, formatter.headers())
         writer.writerow(formatter.headers())
         writer.writerows(rows)
+    elif options.format == 'raw':
+        print(json.dumps(formatter.extract_raw(records)))
     else:
         # We special case CSV, and for other formats we pass to tabulate
         print(tabulate(rows, formatter.headers(), tablefmt=options.format))
@@ -181,6 +184,14 @@ class Formatter(object):
 
     def headers(self):
         return self.fields.keys()
+
+    def extract_raw(self, arr):
+        # Remove the datetime field in order to use as JSON
+        for record in arr:
+            for k in record.copy():
+                if k == "CustodianDate":
+                    del record[k]
+        return arr
 
     def extract_csv(self, record):
         tag_map = {t['Key']: t['Value'] for t in record.get('Tags', ())}

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -185,14 +185,6 @@ class Formatter(object):
     def headers(self):
         return self.fields.keys()
 
-    def extract_raw(self, arr):
-        # Remove the datetime field in order to use as JSON
-        for record in arr:
-            for k in record.copy():
-                if k == "CustodianDate":
-                    del record[k]
-        return arr
-
     def extract_csv(self, record):
         tag_map = {t['Key']: t['Value'] for t in record.get('Tags', ())}
         return _get_values(record, self.fields.values(), tag_map)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,6 +253,12 @@ class ReportTest(CliTest):
         self.assertIn("InstanceId", output)
         self.assertIn("i-014296505597bf519", output)
 
+        # RAW format
+        output = self.get_output(
+            ["custodian", "report", "--format", "raw", "-s", self.output_dir, yaml_file]
+        )
+        self.assertTrue("i-014296505597bf519", json.loads(output)[0]['InstanceId'])
+
         # empty file
         temp_dir = self.get_temp_dir()
         empty_policies = {"policies": []}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -253,9 +253,9 @@ class ReportTest(CliTest):
         self.assertIn("InstanceId", output)
         self.assertIn("i-014296505597bf519", output)
 
-        # RAW format
+        # json format
         output = self.get_output(
-            ["custodian", "report", "--format", "raw", "-s", self.output_dir, yaml_file]
+            ["custodian", "report", "--format", "json", "-s", self.output_dir, yaml_file]
         )
         self.assertTrue("i-014296505597bf519", json.loads(output)[0]['InstanceId'])
 


### PR DESCRIPTION
c7n.report - add raw output option

Description: This adds `--format raw` option to the c7n report command. Using this will spit out the JSON to standard out. This is useful when we want the raw JSON instead of CSV or some other filtered/sorted output.