### PR TITLE
Azure - include_package_data doesn't. 

### DIFF
--- a/tools/c7n_azure/MANIFEST.in
+++ b/tools/c7n_azure/MANIFEST.in
@@ -1,2 +1,0 @@
-include c7n_azure/templates/dedicated_functionapp.json
-include c7n_azure/templates/dedicated_functionapp.parameters.json

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -26,11 +26,10 @@ if path.exists(readme):
 
 setup(
     name="c7n_azure",
-    version='0.5.2',
+    version='0.5.3',
     description="Cloud Custodian - Azure Support",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    include_package_data=True,
     classifiers=[
         "Topic :: System :: Systems Administration",
         "Topic :: System :: Distributed Computing"


### PR DESCRIPTION
`include_package_data: true` should not be in the `setup.py` - it literally does the opposite - it prevents reading the `package_data` and generating a manifest file.  It actually is an old feature to read metadata from SVN of all things 😕 

Additionally we had an invalid manifest committed. 

Fixing it all, revving versions, pushing a new sdist.