### PR TITLE
gcp - init new resources scope billing_account, organization and folder

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -356,6 +356,16 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None, d
     if type_name == 'ec2':
         resource_policy['allOf'][1]['properties']['query'] = {}
 
+    r_type = resource_type.resource_type
+    if getattr(r_type, 'scope', '') == 'billing_account':
+        definitions['policy']['properties']['billing_account_id'] = {'type': 'string'}
+
+    if getattr(r_type, 'scope', '') == 'organization':
+        definitions['policy']['properties']['organization_id'] = {'type': 'string'}
+
+    if getattr(r_type, 'scope', '') == 'folder':
+        definitions['policy']['properties']['folder_id'] = {'type': 'string'}
+
     r['policy'] = resource_policy
     return {'$ref': '#/definitions/resources/%s/policy' % type_name}
 

--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -54,6 +54,16 @@ class ResourceQuery(object):
             if session.get_default_zone():
                 params['zone'] = session.get_default_zone()
 
+        data = resource_manager.data
+        if m.scope == 'billing_account':
+            params[m.scope_key] = m.scope_template.format(data['billing_account_id'])
+
+        if m.scope == 'organization':
+            params[m.scope_key] = m.scope_template.format(data['organization_id'])
+
+        if m.scope == 'folder':
+            params[m.scope_key] = m.scope_template.format(data['folder_id'])
+
         enum_op, path, extra_args = m.enum_spec
         if extra_args:
             params.update(extra_args)

--- a/tools/c7n_gcp/c7n_gcp/resources/logging.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/logging.py
@@ -35,3 +35,17 @@ class LogSink(QueryResourceManager):
             return client.get('get', {
                 'sinkName': 'projects/{project_id}/sinks/{name}'.format(
                     **resource_info)})
+
+
+@resources.register('log-billing-account-exclusion')
+class LogBillingAccountExclusion(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'logging'
+        version = 'v2'
+        component = 'exclusions'
+        enum_spec = ('list', 'exclusions[]', None)
+        scope_key = 'parent'
+        scope = 'billing_account'
+        scope_template = "billingAccounts/{}"
+        type_field = 'billing_account_id'


### PR DESCRIPTION
**Changes:**

- Add new resource scope billing_account
- Add new resource scope organization
- Add new resource scope folder

**Motivation:**

There are resources with URLs where do we have one of parameter billing_account_id or organization_id or folder_id and we must have the possibility to manage them in policy definition.

**Example:**

[Stackdriver Logging resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.exclusions/list)
```python
@resources.register('log-billing-account-exclusion')
class LogBillingAccountExclusion(QueryResourceManager):

    class resource_type(TypeInfo):
        service = 'logging'
        version = 'v2'
        component = 'exclusions'
        enum_spec = ('list', 'exclusions[]', None)
        scope_key = 'parent'
        scope = 'billing_account'
        scope_template = "billingAccounts/{}"
        type_field = 'billing_account_id'
```