### PR TITLE
fix app-elb example for set-s3-logging to use correct action name and…

### DIFF
--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -309,9 +309,10 @@ class SetS3Logging(BaseAction):
                     key: Attributes."access_logs.s3.enabled"
                     value: False
                 actions:
-                  - type: enable-s3-logging
+                  - type: set-s3-logging
                     bucket: elbv2logtest
                     prefix: dahlogs
+                    state: enabled
     """
     schema = type_schema(
         'set-s3-logging',


### PR DESCRIPTION
proposed fix for #3726 

fix app-elb example for set-s3-logging to use correct action name (set-s3-logging) and to include the missing required parameter: state