### PR TITLE
tools/c7n-org - py3 compat update cli.py to open files in binary mode

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -172,7 +172,7 @@ def init(config, use, debug, verbose, accounts, tags, policies, resource=None, p
         if isinstance(h, logging.StreamHandler):
             h.addFilter(LogFilter())
 
-    with open(config) as fh:
+    with open(config, 'rb') as fh:
         accounts_config = yaml.safe_load(fh.read())
         jsonschema.validate(accounts_config, CONFIG_SCHEMA)
 


### PR DESCRIPTION
Modified file open mode to Read Bytes to solve for an issue with Python 3 (#3732)