### PR TITLE
gcp - add support for nested resources

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -17,7 +17,7 @@ import re
 from c7n.utils import type_schema
 from c7n_gcp.actions import MethodAction
 from c7n_gcp.provider import resources
-from c7n_gcp.query import QueryResourceManager, TypeInfo
+from c7n_gcp.query import QueryResourceManager, TypeInfo, ChildResourceManager, ChildTypeInfo
 
 
 @resources.register('sql-instance')
@@ -68,3 +68,26 @@ class SqlInstanceStop(MethodAction):
         return {'project': project,
                 'instance': instance,
                 'body': {'settings': {'activationPolicy': 'NEVER'}}}
+
+
+@resources.register('sql-database')
+class SqlDatabase(ChildResourceManager):
+
+    class resource_type(ChildTypeInfo):
+        service = 'sqladmin'
+        version = 'v1beta4'
+        component = 'databases'
+        enum_spec = ('list', 'items[]', None)
+        id = 'name'
+        parent_spec = {
+            'resource': 'sql-instance',
+            'arg_name': 'instance'
+        }
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command(
+                'get', {'project': resource_info['project'],
+                        'database': resource_info['name'],
+                        'instance': resource_info['instance']}
+            )

--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -81,7 +81,13 @@ class SqlDatabase(ChildResourceManager):
         id = 'name'
         parent_spec = {
             'resource': 'sql-instance',
-            'arg_name': 'instance'
+            'child_enum_params': [
+                ('name', 'instance')
+            ],
+            'parent_get_params': [
+                ('project', 'project'),
+                ('instance', 'name')
+            ]
         }
 
         @staticmethod

--- a/tools/c7n_gcp/tests/data/flights/sqldatabase-get/get-sql-v1beta4-projects-mitropject-instances-testpg-databases-postgres_1.json
+++ b/tools/c7n_gcp/tests/data/flights/sqldatabase-get/get-sql-v1beta4-projects-mitropject-instances-testpg-databases-postgres_1.json
@@ -1,0 +1,29 @@
+{
+  "body": {
+    "kind": "sql#database", 
+    "name": "postgres", 
+    "charset": "UTF8", 
+    "project": "mitropject", 
+    "instance": "testpg", 
+    "etag": "c810bbd8ba48a4bc177025288822b64b55f952d6b184a7fa31384e075a2454e1", 
+    "collation": "en_US.UTF8", 
+    "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/mitropject/instances/testpg/databases/postgres"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "334", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/sql/v1beta4/projects/mitropject/instances/testpg/databases/postgres?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "expires": "Fri, 29 Mar 2019 17:35:05 GMT", 
+    "vary": "Origin, X-Origin", 
+    "server": "GSE", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "date": "Fri, 29 Mar 2019 17:35:05 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/sqldatabase-get/get-sql-v1beta4-projects-mitropject-instances-testpg_1.json
+++ b/tools/c7n_gcp/tests/data/flights/sqldatabase-get/get-sql-v1beta4-projects-mitropject-instances-testpg_1.json
@@ -1,0 +1,83 @@
+{
+  "body": {
+    "kind": "sql#instance", 
+    "name": "testpg", 
+    "settings": {
+      "kind": "sql#settings", 
+      "dataDiskType": "PD_SSD", 
+      "maintenanceWindow": {
+        "kind": "sql#maintenanceWindow", 
+        "day": 0, 
+        "hour": 0
+      }, 
+      "authorizedGaeApplications": [], 
+      "activationPolicy": "ALWAYS", 
+      "backupConfiguration": {
+        "replicationLogArchivingEnabled": false, 
+        "kind": "sql#backupConfiguration", 
+        "enabled": true, 
+        "startTime": "21:00"
+      }, 
+      "ipConfiguration": {
+        "ipv4Enabled": true, 
+        "authorizedNetworks": []
+      }, 
+      "pricingPlan": "PER_USE", 
+      "replicationType": "SYNCHRONOUS", 
+      "storageAutoResizeLimit": "0", 
+      "tier": "db-custom-1-3840", 
+      "settingsVersion": "1", 
+      "storageAutoResize": true, 
+      "locationPreference": {
+        "kind": "sql#locationPreference", 
+        "zone": "us-central1-a"
+      }, 
+      "dataDiskSizeGb": "10", 
+      "availabilityType": "ZONAL"
+    }, 
+    "region": "us-central1", 
+    "backendType": "SECOND_GEN", 
+    "gceZone": "us-central1-a", 
+    "project": "mitropject", 
+    "state": "RUNNABLE", 
+    "etag": "21bfa7aea117bfbb0406d839d9e307fd9560b7b1c1f63d5a457a406fb389b77a", 
+    "serviceAccountEmailAddress": "wkor34e355cnffscvvy5sva4t4@speckle-umbrella-pg-6.iam.gserviceaccount.com", 
+    "serverCaCert": {
+      "certSerialNumber": "0", 
+      "kind": "sql#sslCert", 
+      "sha1Fingerprint": "f42855004f78f5e98d6c5429d0b87c085e73239e", 
+      "commonName": "C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA", 
+      "instance": "testpg", 
+      "cert": "-----BEGIN CERTIFICATE-----\nMIIDITCCAgmgAwIBAgIBADANBgkqhkiG9w0BAQsFADBIMSMwIQYDVQQDExpHb29n\nbGUgQ2xvdWQgU1FMIFNlcnZlciBDQTEUMBIGA1UEChMLR29vZ2xlLCBJbmMxCzAJ\nBgNVBAYTAlVTMB4XDTE5MDMyOTE1NDgxOFoXDTI5MDMyNjE1NDkxOFowSDEjMCEG\nA1UEAxMaR29vZ2xlIENsb3VkIFNRTCBTZXJ2ZXIgQ0ExFDASBgNVBAoTC0dvb2ds\nZSwgSW5jMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\nggEBAKJOPI2e5pswGU0rh4sAsT1H9n7oBsFgTjBSO4BzPX+m/UtlqgypzONVoKpY\nqZggIz+IHdFze57ZRvR8xvbZVe+ImTTn+++XuFZ7yY6P9Ls1rYEsBvZ++HdcJ8fD\n4K0JS3HB+JuxKmxRJvM+qZ3SSc0xPRPvkq75PgNW1FOJXip8KfDxgQ1ykiwnwdBt\n6DL+L3CvebhVBxoaPSQ+CGfZdxGlU6WfgGhmMZpztpfS6ERxCuHtzY+z/zmP0qqJ\nc07zlzrOu9tdXr+OKKTwGRE7svWIguv/EHA0BdwELciF6NrKfazlfaHCB/s5A5w/\n/ieydNWfV0n1TJou0GDOSjg7tG8CAwEAAaMWMBQwEgYDVR0TAQH/BAgwBgEB/wIB\nADANBgkqhkiG9w0BAQsFAAOCAQEAky2TwhQ2uhqGxvH9zyjwh7+Smi2dAKmSM5cF\nZ1o4scMhey/7CLOJRwmMTTA6+adj0pQC+B95TJ2vDvT+S53M2haY3p0jUmHdWerZ\nsFS2Mbyg4VnmMEvZ2qAJJw+tx/HxCztn8k3ZN4mam1kUgNa0gFA5hWYCwT0BxY15\nH5k5MwFoi5Jbb4/RRW50w/FwiRTv3lNO6MjaPXtnrMDY88FSLoWWfdmm27Cjq0Da\nPKv2b0dysPY3fWk8iJ5sQ2DHbv0mUJ1OE1Nl0rkKpbKmSg/HdogIc8QG4iM++H5D\nXdBescYL4RCINoNuVVWs+PR3WBurKvLGOXzM8A93GvS5I9/UjQ==\n-----END CERTIFICATE-----", 
+      "expirationTime": "2029-03-26T15:49:18.782Z", 
+      "createTime": "2019-03-29T15:48:18.782Z"
+    }, 
+    "ipAddresses": [
+      {
+        "type": "PRIMARY", 
+        "ipAddress": "35.184.78.158"
+      }
+    ], 
+    "connectionName": "mitropject:us-central1:testpg", 
+    "databaseVersion": "POSTGRES_9_6", 
+    "instanceType": "CLOUD_SQL_INSTANCE", 
+    "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/mitropject/instances/testpg"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "2973", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/sql/v1beta4/projects/mitropject/instances/testpg?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "expires": "Fri, 29 Mar 2019 17:35:03 GMT", 
+    "vary": "Origin, X-Origin", 
+    "server": "GSE", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "date": "Fri, 29 Mar 2019 17:35:03 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/sqldatabase-query/get-sql-v1beta4-projects-mitropject-instances-testpg-databases_1.json
+++ b/tools/c7n_gcp/tests/data/flights/sqldatabase-query/get-sql-v1beta4-projects-mitropject-instances-testpg-databases_1.json
@@ -1,0 +1,33 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "sql#database", 
+        "name": "postgres", 
+        "charset": "UTF8", 
+        "project": "mitropject", 
+        "instance": "testpg", 
+        "etag": "c810bbd8ba48a4bc177025288822b64b55f952d6b184a7fa31384e075a2454e1", 
+        "collation": "en_US.UTF8", 
+        "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/mitropject/instances/testpg/databases/postgres"
+      }
+    ], 
+    "kind": "sql#databasesList"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "434", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/sql/v1beta4/projects/mitropject/instances/testpg/databases?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "vary": "Origin, X-Origin, Referer", 
+    "server": "ESF", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private", 
+    "date": "Fri, 29 Mar 2019 16:18:52 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/sqldatabase-query/get-sql-v1beta4-projects-mitropject-instances_1.json
+++ b/tools/c7n_gcp/tests/data/flights/sqldatabase-query/get-sql-v1beta4-projects-mitropject-instances_1.json
@@ -1,0 +1,88 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "sql#instance", 
+        "name": "testpg", 
+        "settings": {
+          "kind": "sql#settings", 
+          "dataDiskType": "PD_SSD", 
+          "maintenanceWindow": {
+            "kind": "sql#maintenanceWindow", 
+            "day": 0, 
+            "hour": 0
+          }, 
+          "authorizedGaeApplications": [], 
+          "activationPolicy": "ALWAYS", 
+          "backupConfiguration": {
+            "replicationLogArchivingEnabled": false, 
+            "kind": "sql#backupConfiguration", 
+            "enabled": true, 
+            "startTime": "21:00"
+          }, 
+          "ipConfiguration": {
+            "ipv4Enabled": true, 
+            "authorizedNetworks": []
+          }, 
+          "pricingPlan": "PER_USE", 
+          "replicationType": "SYNCHRONOUS", 
+          "storageAutoResizeLimit": "0", 
+          "tier": "db-custom-1-3840", 
+          "settingsVersion": "1", 
+          "storageAutoResize": true, 
+          "locationPreference": {
+            "kind": "sql#locationPreference", 
+            "zone": "us-central1-a"
+          }, 
+          "dataDiskSizeGb": "10", 
+          "availabilityType": "ZONAL"
+        }, 
+        "region": "us-central1", 
+        "backendType": "SECOND_GEN", 
+        "gceZone": "us-central1-a", 
+        "project": "mitropject", 
+        "state": "RUNNABLE", 
+        "etag": "21bfa7aea117bfbb0406d839d9e307fd9560b7b1c1f63d5a457a406fb389b77a", 
+        "serviceAccountEmailAddress": "wkor34e355cnffscvvy5sva4t4@speckle-umbrella-pg-6.iam.gserviceaccount.com", 
+        "serverCaCert": {
+          "certSerialNumber": "0", 
+          "kind": "sql#sslCert", 
+          "sha1Fingerprint": "f42855004f78f5e98d6c5429d0b87c085e73239e", 
+          "commonName": "C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA", 
+          "instance": "testpg", 
+          "cert": "-----BEGIN CERTIFICATE-----\nMIIDITCCAgmgAwIBAgIBADANBgkqhkiG9w0BAQsFADBIMSMwIQYDVQQDExpHb29n\nbGUgQ2xvdWQgU1FMIFNlcnZlciBDQTEUMBIGA1UEChMLR29vZ2xlLCBJbmMxCzAJ\nBgNVBAYTAlVTMB4XDTE5MDMyOTE1NDgxOFoXDTI5MDMyNjE1NDkxOFowSDEjMCEG\nA1UEAxMaR29vZ2xlIENsb3VkIFNRTCBTZXJ2ZXIgQ0ExFDASBgNVBAoTC0dvb2ds\nZSwgSW5jMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\nggEBAKJOPI2e5pswGU0rh4sAsT1H9n7oBsFgTjBSO4BzPX+m/UtlqgypzONVoKpY\nqZggIz+IHdFze57ZRvR8xvbZVe+ImTTn+++XuFZ7yY6P9Ls1rYEsBvZ++HdcJ8fD\n4K0JS3HB+JuxKmxRJvM+qZ3SSc0xPRPvkq75PgNW1FOJXip8KfDxgQ1ykiwnwdBt\n6DL+L3CvebhVBxoaPSQ+CGfZdxGlU6WfgGhmMZpztpfS6ERxCuHtzY+z/zmP0qqJ\nc07zlzrOu9tdXr+OKKTwGRE7svWIguv/EHA0BdwELciF6NrKfazlfaHCB/s5A5w/\n/ieydNWfV0n1TJou0GDOSjg7tG8CAwEAAaMWMBQwEgYDVR0TAQH/BAgwBgEB/wIB\nADANBgkqhkiG9w0BAQsFAAOCAQEAky2TwhQ2uhqGxvH9zyjwh7+Smi2dAKmSM5cF\nZ1o4scMhey/7CLOJRwmMTTA6+adj0pQC+B95TJ2vDvT+S53M2haY3p0jUmHdWerZ\nsFS2Mbyg4VnmMEvZ2qAJJw+tx/HxCztn8k3ZN4mam1kUgNa0gFA5hWYCwT0BxY15\nH5k5MwFoi5Jbb4/RRW50w/FwiRTv3lNO6MjaPXtnrMDY88FSLoWWfdmm27Cjq0Da\nPKv2b0dysPY3fWk8iJ5sQ2DHbv0mUJ1OE1Nl0rkKpbKmSg/HdogIc8QG4iM++H5D\nXdBescYL4RCINoNuVVWs+PR3WBurKvLGOXzM8A93GvS5I9/UjQ==\n-----END CERTIFICATE-----", 
+          "expirationTime": "2029-03-26T15:49:18.782Z", 
+          "createTime": "2019-03-29T15:48:18.782Z"
+        }, 
+        "ipAddresses": [
+          {
+            "type": "PRIMARY", 
+            "ipAddress": "35.184.78.158"
+          }
+        ], 
+        "connectionName": "mitropject:us-central1:testpg", 
+        "databaseVersion": "POSTGRES_9_6", 
+        "instanceType": "CLOUD_SQL_INSTANCE", 
+        "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/mitropject/instances/testpg"
+      }
+    ], 
+    "kind": "sql#instancesList"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "3150", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/sql/v1beta4/projects/mitropject/instances?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "expires": "Fri, 29 Mar 2019 16:18:50 GMT", 
+    "vary": "Origin, X-Origin", 
+    "server": "GSE", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "date": "Fri, 29 Mar 2019 16:18:50 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/test_sql.py
+++ b/tools/c7n_gcp/tests/test_sql.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+
 from gcp_common import BaseTest
 from googleapiclient.errors import HttpError
 
@@ -82,3 +83,41 @@ class SqlInstanceTest(BaseTest):
             self.fail('found deleted instance: %s' % result)
         except HttpError as e:
             self.assertTrue("does not exist" in str(e))
+
+    def test_sqldatabase_query(self):
+        project_id = 'mitropject'
+        session_factory = self.replay_flight_data('sqldatabase-query', project_id=project_id)
+
+        database_name = 'postgres'
+
+        policy = self.load_policy(
+            {'name': 'all-sql-databases',
+             'resource': 'gcp.sql-database'},
+            session_factory=session_factory)
+
+        databases = policy.run()
+        self.assertEqual(databases[0]['name'], database_name)
+
+    def test_sqldatabase_get(self):
+        project_id = 'mitropject'
+        session_factory = self.replay_flight_data('sqldatabase-get', project_id=project_id)
+
+        database_name = 'postgres'
+        instance_name = 'testpg'
+
+        policy = self.load_policy(
+            {'name': 'one-sql-database',
+             'resource': 'gcp.sql-database'},
+            session_factory=session_factory)
+
+        resource_manager = policy.resource_manager
+
+        database = resource_manager.get_resource(
+            {'project': 'mitropject',
+             'name': database_name,
+             'instance': instance_name})
+
+        annotation_key = resource_manager.resource_type.get_parent_annotation_key()
+
+        self.assertEqual(database['name'], database_name)
+        self.assertEqual(database[annotation_key]['name'], instance_name)

--- a/tools/c7n_gcp/tests/test_sql.py
+++ b/tools/c7n_gcp/tests/test_sql.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Capital One Services, LLC
+# Copyright 2019 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,6 +83,9 @@ class SqlInstanceTest(BaseTest):
             self.fail('found deleted instance: %s' % result)
         except HttpError as e:
             self.assertTrue("does not exist" in str(e))
+
+
+class SqlDatabaseTest(BaseTest):
 
     def test_sqldatabase_query(self):
         project_id = 'mitropject'


### PR DESCRIPTION
**Changes**: 
- New field in the `resource_type` which describes a parent in case its required. It's a tuple with the following elements:
    - parent resource type;
    - parent field required to execute a child's list API call;
    - a name of an argument used for a value described in the previous clause
- Introduced a new manager `ChildResourceManager` which will be used for definitions of those resources depending on others. Algorithm of retrieval:
    1. Fetch all parent resources
    2. For each parent fetch its children (extracting required info from the parent)
    3. Inject reference to a parent into each child.

**Motivation**:
There are quite a lot of GCP resources whose `list` method requires information about some other resources. This can be considered as parent-child relationship. We may not know in the advance which parent have to be used so we need to be able to retrieve children for a set of parent resources. Also it would be nice to filter some of the parents out of the set.

Examples of the parent-child relationship:
- To [list](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/list) all the SQL databases we have to pass an instance name (dependency on an instance)
- To [list](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/list) all the crypto keys we have to pass a location and a keyring (dependency on a keyring which in turn depends on a location)
- etc.

**Example**:
Cloud SQL Database resource:
```python
@resources.register('sql-database')
class SqlDatabase(ChildResourceManager):

    def _get_parent_resource_info(self, resource_info):
        return {
            'name': resource_info['instance'],
            'project': resource_info['project']
        }

    class resource_type(TypeInfo):
        service = 'sqladmin'
        version = 'v1beta4'
        component = 'databases'
        enum_spec = ('list', "items[]", None)
        id = 'name'
        parent = ('sql-instance', 'name', 'instance')

        @staticmethod
        def get(client, resource_info):
            parent_annotation_key = SqlDatabase.get_parent_annotation_key()
            instance = resource_info[parent_annotation_key]

            database = client.execute_command(
                'get', {'project': resource_info['project'],
                        'database': resource_info['name'],
                        'instance': instance['name']})
            database[parent_annotation_key] = instance

            return database
```
Policy retrieving all the databases for MySQL instances only:
```yml
policies:
  - name: gcp-sql-database-list
    resource: gcp.sql-database
    filters:
      - type: value
        key: "\"c7n:sql-instance\".databaseVersion"
        op: regex
        value: MYSQL.*
```
**Issues**:
If we want to filter out some parents, their children have to be fetched first. Obviously there will be excess API calls (we won't need those children).