### PR TITLE
In c7n_mailer, enable 'subject' to interpolate from more data sources

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -86,6 +86,9 @@ def get_message_subject(sqs_message):
     subject = jinja_template.render(
         account=sqs_message.get('account', ''),
         account_id=sqs_message.get('account_id', ''),
+        event=sqs_message.get('event', None),
+        action=sqs_message['action'],
+        policy=sqs_message['policy'],
         region=sqs_message.get('region', '')
     )
     return subject


### PR DESCRIPTION
    The following new variables are accessible:
    - event
    - action
    - policy

    'subject' interpolation is now closer to 'body' interpolation, the only
    missing variables being 'recipient' and 'resources'.
    'resources' could be useful (to display the count).