### PR TITLE
cli - dryrun only in applicable modes (pull, periodic)

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -940,7 +940,11 @@ class Policy(object):
         """Run policy in default mode"""
         mode = self.get_execution_mode()
         if self.options.dryrun:
-            resources = PullMode(self).run()
+            if self.ctx.policy.execution_mode == 'pull':
+                resources = PullMode(self).run()
+            else:
+                self.log.warning('Skipping dryrun for non-pull mode policy:%s' % self.ctx.policy.name)
+                return []
         elif isinstance(mode, ServerlessExecutionMode):
             resources = mode.provision()
         else:

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -940,10 +940,12 @@ class Policy(object):
         """Run policy in default mode"""
         mode = self.get_execution_mode()
         if self.options.dryrun:
-            if self.ctx.policy.execution_mode == 'pull':
+            mode = self.ctx.policy.execution_mode
+            if mode == 'pull' or 'periodic' in mode:
                 resources = PullMode(self).run()
             else:
-                self.log.warning('Skipping dryrun for non-pull mode policy:%s' % self.ctx.policy.name)
+                self.log.warning(
+                    'Skipping dryrun for non-pull mode policy:%s' % self.ctx.policy.name)
                 return []
         elif isinstance(mode, ServerlessExecutionMode):
             resources = mode.provision()


### PR DESCRIPTION
when dryrunning policies, cloudtrail mode policies will report the wrong resource count-- making CICD difficult to properly perform because policies may report the wrong number of expected resources