### PR TITLE
new custodian flag / notify_on_failure

### DIFF
--- a/c7n/actions/notify.py
+++ b/c7n/actions/notify.py
@@ -184,7 +184,7 @@ class Notify(BaseNotify):
             message['resources'] = self.prepare_resources(batch)
             receipt = self.send_data_message(message)
             self.log.info("sent message:%s policy:%s template:%s count:%s" % (
-                receipt, self.manager.data['name'],
+                receipt, self.manager.data.get('name'),
                 self.data.get('template', 'default'), len(batch)))
 
     def prepare_resources(self, resources):

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -953,12 +953,10 @@ class Policy(object):
         except Exception as e:
             if self.notify_on_failure:
                 from c7n.actions import Notify
-                # breakpoint()
+                self.notify_on_failure['name'] = self.ctx.policy.resource_manager.data['name']
                 self.ctx.policy.resource_manager.data = self.notify_on_failure
                 notify = Notify(manager=self.ctx.policy.resource_manager, data=self.notify_on_failure)
-                # notify = Notify(policy.notify_on_failure)
-                notify.process([], event=e)
-                # breakpoint()
+                notify.process(self.ctx.policy.resource_manager.resources(), event=str(e))
                 raise e
 
         # clear out resource manager post run, to clear cache

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -34,6 +34,7 @@ from c7n.registry import PluginRegistry
 from c7n.provider import clouds
 from c7n import utils
 from c7n.version import version
+from c7n.actions import Notify
 
 log = logging.getLogger('c7n.policy')
 
@@ -952,10 +953,10 @@ class Policy(object):
                 resources = mode.run()
         except Exception as e:
             if self.notify_on_failure:
-                from c7n.actions import Notify
                 self.notify_on_failure['name'] = self.ctx.policy.resource_manager.data['name']
                 self.ctx.policy.resource_manager.data = self.notify_on_failure
-                notify = Notify(manager=self.ctx.policy.resource_manager, data=self.notify_on_failure)
+                notify = Notify(manager=self.ctx.policy.resource_manager,
+                                data=self.notify_on_failure)
                 notify.process(self.ctx.policy.resource_manager.resources(), event=str(e))
                 raise e
 

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -100,7 +100,7 @@ class ValuesFrom(object):
     # intent is that callers embed this schema
     schema = {
         'type': 'object',
-        'additionalProperties': 'False',
+        'additionalProperties': False,
         'required': ['url'],
         'properties': {
             'url': {'type': 'string'},

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -38,7 +38,7 @@ from c7n.policy import execution
 from c7n.provider import clouds
 from c7n.resources import load_resources
 from c7n.filters import ValueFilter, EventFilter, AgeFilter
-
+from c7n.actions import Notify
 
 def validate(data, schema=None):
     if schema is None:
@@ -197,6 +197,7 @@ def generate(resource_types=()):
                 'description': {'type': 'string'},
                 'tags': {'type': 'array', 'items': {'type': 'string'}},
                 'mode': {'$ref': '#/definitions/policy-mode'},
+                'notify-on-failure': Notify.schema,
                 'source': {'enum': ['describe', 'config']},
                 'actions': {
                     'type': 'array',

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -40,6 +40,7 @@ from c7n.resources import load_resources
 from c7n.filters import ValueFilter, EventFilter, AgeFilter
 from c7n.actions import Notify
 
+
 def validate(data, schema=None):
     if schema is None:
         schema = generate()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -741,7 +741,7 @@ class TestPolicy(BaseTest):
         logs = list(policy.get_logs("2016-10-01 00:00:00", "2016-10-31 11:59:59"))
         self.assertEqual(len(logs), 0)
 
-    def xtest_policy_run(self):
+    def test_policy_run(self):
         manager.resources.register("dummy", DummyResource)
         self.addCleanup(manager.resources.unregister, "dummy")
         self.output_dir = tempfile.mkdtemp()
@@ -806,6 +806,24 @@ class TestPolicy(BaseTest):
         p = self.load_policy(data)
         result = p.validate_policy_start_stop()
         self.assertEqual(result, None)
+
+    def test_notify_on_failure(self):
+        p = self.load_policy(
+            {'name': 'notify_on_failure',
+             'resource': 'ec2',
+             'notify_on_failure': {
+                 'type': 'notify',
+                 'to': ['me@example.com'],
+                 'transport': {
+                     'type': 'sns',
+                     'topic': 'arn:::::',
+                 },
+             }
+             },
+            config={'validate': True},
+            session_factory=None)
+        pull_mode = policy.PullMode(p)
+        self.assertEqual(pull_mode.is_runnable(), True)
 
 
 class PolicyExecutionModeTest(BaseTest):


### PR DESCRIPTION
Allow users to specify a notify action that would get triggered on an exception while running a policy. Currently if there is a failure there is no way to still run any actions. Based partly on the discussion #3531 where I agree that since we don't know why the error arose it is best not to allow the user to run any action, but notify seems to be a reasonable response in most cases. 

example policy would look like this
```
policies:
  - name: my-first-policy
    max-resources: 1
    notify-on-failure:
      type: 'notify'
      to: ['me']
      transport:
        type: sqs
        queue: https://sqs.us-east-1.amazonaws.com/12345678/test
        region: us-east-1
    resource: sns
```