### PR TITLE
aws - trail status handle out of region/org trails

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -257,7 +257,7 @@ class EmailDelivery(object):
             smtp_connection.ehlo()
         if self.config.get('smtp_username') or self.config.get('smtp_password'):
             smtp_username = self.config.get('smtp_username')
-            smtp_password = self.config.get('smtp_password')
+            smtp_password = kms_decrypt(self.config, self.logger, self.session, 'smtp_password')
             smtp_connection.login(smtp_username, smtp_password)
         smtp_connection.sendmail(message['From'], to_addrs, message.as_string())
         smtp_connection.quit()

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -257,7 +257,7 @@ class EmailDelivery(object):
             smtp_connection.ehlo()
         if self.config.get('smtp_username') or self.config.get('smtp_password'):
             smtp_username = self.config.get('smtp_username')
-            smtp_password = kms_decrypt(self.config, self.logger, self.session, 'smtp_password')
+            smtp_password = self.config.get('smtp_password')
             smtp_connection.login(smtp_username, smtp_password)
         smtp_connection.sendmail(message['From'], to_addrs, message.as_string())
         smtp_connection.quit()


### PR DESCRIPTION
the trail may be in a different region then we're executing in (shadow trail), if its in the same account, use a client thats targeted to the correct region to inspect its status.