### PR TITLE
tools/mugc log level set urllib to err

### DIFF
--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -177,6 +177,7 @@ def main():
         level=log_level,
         format="%(asctime)s: %(name)s:%(levelname)s %(message)s")
     logging.getLogger('botocore').setLevel(logging.ERROR)
+    logging.getLogger('urllib3').setLevel(logging.ERROR)
     logging.getLogger('c7n.cache').setLevel(logging.WARNING)
 
     if not options.regions:


### PR DESCRIPTION
boto3's switch out to urllib3 means we also have to squelch it explicitly to avoid log pollution when running in verbose.