### PR TITLE
tools/c7n-org - add metrics option for specifying full metrics uri instead of just bool/flag

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -570,7 +570,8 @@ def run_account(account, region, policies_config, output_path,
 @click.option('--debug', default=False, is_flag=True)
 @click.option('-v', '--verbose', default=False, help="Verbose", is_flag=True)
 def run(config, use, output_dir, accounts, tags, region,
-        policy, policy_tags, cache_period, cache_path, metrics, dryrun, debug, verbose, metrics_url):
+        policy, policy_tags, cache_period, cache_path, metrics,
+        dryrun, debug, verbose, metrics_uri):
     """run a custodian policy across accounts"""
     accounts_config, custodian_config, executor = init(
         config, use, debug, verbose, accounts, tags, policy, policy_tags=policy_tags)

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -578,8 +578,8 @@ def run(config, use, output_dir, accounts, tags, region,
     policy_counts = Counter()
     success = True
 
-    if metrics_url:
-        metrics = metrics_url
+    if metrics_uri:
+        metrics = metrics_uri
 
     if not cache_path:
         cache_path = os.path.expanduser("~/.cache/c7n-org")

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -565,16 +565,20 @@ def run_account(account, region, policies_config, output_path,
                   file_okay=False, dir_okay=True),
               default=None)
 @click.option("--metrics", default=False, is_flag=True)
+@click.option("--metrics-uri", default=None, help="Configure provider metrics target")
 @click.option("--dryrun", default=False, is_flag=True)
 @click.option('--debug', default=False, is_flag=True)
 @click.option('-v', '--verbose', default=False, help="Verbose", is_flag=True)
 def run(config, use, output_dir, accounts, tags, region,
-        policy, policy_tags, cache_period, cache_path, metrics, dryrun, debug, verbose):
+        policy, policy_tags, cache_period, cache_path, metrics, dryrun, debug, verbose, metrics_url):
     """run a custodian policy across accounts"""
     accounts_config, custodian_config, executor = init(
         config, use, debug, verbose, accounts, tags, policy, policy_tags=policy_tags)
     policy_counts = Counter()
     success = True
+
+    if metrics_url:
+        metrics = metrics_url
 
     if not cache_path:
         cache_path = os.path.expanduser("~/.cache/c7n-org")

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -74,7 +74,8 @@ class OrgTest(TestUtils):
         result = runner.invoke(
             org.cli,
             ['run', '-c', 'accounts.yml', '-u', 'policies.yml',
-             '--debug', '-s', 'output', '--cache-path', 'cache'],
+             '--debug', '-s', 'output', '--cache-path', 'cache',
+             '--metrics-uri', 'aws://'],
             catch_exceptions=False)
 
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
unfortunately its not clear that we can cleanly change the extant boolean flag, like we did with argparse on custodian cli entrypoint. so instead this adds a new cli option for specifying the full metrics uri.