### PR TITLE
 gcp - add initial setup for LoadBalancing resources

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/entry.py
+++ b/tools/c7n_gcp/c7n_gcp/entry.py
@@ -30,7 +30,8 @@ import c7n_gcp.resources.resourcemanager
 import c7n_gcp.resources.service
 import c7n_gcp.resources.source
 import c7n_gcp.resources.storage
-import c7n_gcp.resources.sql  # noqa: F401
+import c7n_gcp.resources.sql
+import c7n_gcp.resources.loadbalancing  # noqa: F401
 
 from c7n_gcp.provider import resources as gcp_resources
 

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -88,3 +88,21 @@ class LoadBalancingTargetSslProxy(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'targetSslProxy': resource_info['name']})
+
+
+@resources.register('loadbalancing-ssl-policy')
+class LoadBalancingSslPolicy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'sslPolicies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'sslPolicy': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -31,3 +31,19 @@ class LoadBalancingAddress(QueryResourceManager):
         @staticmethod
         def get(client, resource_info):
             return client.execute_command('get', resource_info)
+
+
+@resources.register('loadbalancing-url-map')
+class LoadBalancingUrlMap(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'urlMaps'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', resource_info)

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -58,6 +58,23 @@ class LoadBalancingTargetTcpProxy(QueryResourceManager):
         component = 'targetTcpProxies'
         enum_spec = ('list', 'items[]', None)
         scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', resource_info)
+
+
+@resources.register('loadbalancing-target-ssl-proxy')
+class LoadBalancingTargetSslProxy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetSslProxies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
 
         @staticmethod
         def get(client, resource_info):

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -47,3 +47,18 @@ class LoadBalancingUrlMap(QueryResourceManager):
         @staticmethod
         def get(client, resource_info):
             return client.execute_command('get', resource_info)
+
+
+@resources.register('loadbalancing-target-tcp-proxy')
+class LoadBalancingTargetTcpProxy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetTcpProxies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', resource_info)

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from c7n_gcp.provider import resources
+from c7n_gcp.query import QueryResourceManager, TypeInfo
+
+
+@resources.register('loadbalancing-address')
+class LoadBalancingAddress(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'addresses'
+        enum_spec = ('aggregatedList', 'items.*.addresses[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', resource_info)

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -30,7 +30,10 @@ class LoadBalancingAddress(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command('get', resource_info)
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'region': resource_info['region'],
+                'address': resource_info['name']})
 
 
 @resources.register('loadbalancing-url-map')
@@ -46,7 +49,9 @@ class LoadBalancingUrlMap(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command('get', resource_info)
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'urlMap': resource_info['name']})
 
 
 @resources.register('loadbalancing-target-tcp-proxy')
@@ -62,7 +67,9 @@ class LoadBalancingTargetTcpProxy(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command('get', resource_info)
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'targetTcpProxy': resource_info['name']})
 
 
 @resources.register('loadbalancing-target-ssl-proxy')
@@ -78,4 +85,6 @@ class LoadBalancingTargetSslProxy(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command('get', resource_info)
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'targetSslProxy': resource_info['name']})

--- a/tools/c7n_gcp/tests/data/flights/lb-addresses-get/get-compute-v1-projects-cloud-custodian-regions-us-central1-addresses-new1_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-addresses-get/get-compute-v1-projects-cloud-custodian-regions-us-central1-addresses-new1_1.json
@@ -1,0 +1,32 @@
+{
+  "headers": {
+    "expires": "Tue, 05 Mar 2019 10:26:16 GMT",
+    "date": "Tue, 05 Mar 2019 10:26:16 GMT",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "etag": "\"AIRMFkoY8YjJYfvNisNXJV7nEnQ=/u0DnQFqBn2MpIu85qWIblb-lPs0=\"",
+    "vary": "Origin, X-Origin",
+    "content-type": "application/json; charset=UTF-8",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-xss-protection": "1; mode=block",
+    "server": "GSE",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "450",
+    "-content-encoding": "gzip",
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/addresses/new1?alt=json"
+  },
+  "body": {
+    "kind": "compute#address",
+    "id": "8149548791059677337",
+    "creationTimestamp": "2019-03-05T01:16:38.474-08:00",
+    "name": "new1",
+    "description": "",
+    "address": "35.193.10.19",
+    "status": "RESERVED",
+    "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/dcloud-custodian/regions/us-central1/addresses/new1",
+    "networkTier": "PREMIUM"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-addresses-query/get-compute-v1-projects-cloud-custodian-aggregated-addresses_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-addresses-query/get-compute-v1-projects-cloud-custodian-aggregated-addresses_1.json
@@ -1,0 +1,259 @@
+{
+  "headers": {
+    "expires": "Tue, 05 Mar 2019 09:27:05 GMT",
+    "date": "Tue, 05 Mar 2019 09:27:05 GMT",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "etag": "\"rYPkhItTdpx_do5KgRCVkj15NeA=/RgOQS9vmqswMCiZmWLzM07OCRiM=\"",
+    "vary": "Origin, X-Origin",
+    "content-type": "application/json; charset=UTF-8",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-xss-protection": "1; mode=block",
+    "server": "GSE",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5592",
+    "-content-encoding": "gzip",
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/addresses?alt=json"
+  },
+  "body": {
+    "kind": "compute#addressAggregatedList",
+    "id": "projects/cloud-custodian/aggregated/addresses",
+    "items": {
+      "global": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'global' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "global"
+            }
+          ]
+        }
+      },
+      "regions/us-central1": {
+        "addresses": [
+          {
+            "kind": "compute#address",
+            "id": "8149548791059677337",
+            "creationTimestamp": "2019-03-05T01:16:38.474-08:00",
+            "name": "new1",
+            "description": "",
+            "address": "35.193.10.19",
+            "status": "RESERVED",
+            "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/addresses/new1",
+            "networkTier": "PREMIUM"
+          }
+        ]
+      },
+      "regions/europe-west1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-west1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west1"
+            }
+          ]
+        }
+      },
+      "regions/us-west1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/us-west1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-west1"
+            }
+          ]
+        }
+      },
+      "regions/asia-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-east1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-east1"
+            }
+          ]
+        }
+      },
+      "regions/us-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/us-east1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-east1"
+            }
+          ]
+        }
+      },
+      "regions/asia-northeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-northeast1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-northeast1"
+            }
+          ]
+        }
+      },
+      "regions/asia-southeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-southeast1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-southeast1"
+            }
+          ]
+        }
+      },
+      "regions/us-east4": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/us-east4' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-east4"
+            }
+          ]
+        }
+      },
+      "regions/australia-southeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/australia-southeast1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/australia-southeast1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-west2' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west2"
+            }
+          ]
+        }
+      },
+      "regions/europe-west3": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-west3' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west3"
+            }
+          ]
+        }
+      },
+      "regions/southamerica-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/southamerica-east1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/southamerica-east1"
+            }
+          ]
+        }
+      },
+      "regions/asia-south1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-south1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-south1"
+            }
+          ]
+        }
+      },
+      "regions/northamerica-northeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/northamerica-northeast1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/northamerica-northeast1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west4": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-west4' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west4"
+            }
+          ]
+        }
+      },
+      "regions/europe-north1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-north1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-north1"
+            }
+          ]
+        }
+      },
+      "regions/us-west2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/us-west2' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-west2"
+            }
+          ]
+        }
+      },
+      "regions/asia-east2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-east2' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-east2"
+            }
+          ]
+        }
+      }
+    },
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/decoded-pier-228312/aggregated/addresses"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-ssl-policies-get/get-compute-v1-projects-cloud-custodian-global-sslPolicies-newpolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-ssl-policies-get/get-compute-v1-projects-cloud-custodian-global-sslPolicies-newpolicy_1.json
@@ -1,0 +1,47 @@
+{
+  "body": {
+    "profile": "COMPATIBLE", 
+    "kind": "compute#sslPolicy", 
+    "name": "newpolicy", 
+    "minTlsVersion": "TLS_1_0", 
+    "fingerprint": "BoVS1G-KySQ=", 
+    "creationTimestamp": "2019-03-11T05:40:52.917-07:00", 
+    "id": "4540081266450229691", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies/newpolicy", 
+    "enabledFeatures": [
+      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", 
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", 
+      "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", 
+      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", 
+      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", 
+      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", 
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 
+      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", 
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 
+      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", 
+      "TLS_RSA_WITH_3DES_EDE_CBC_SHA", 
+      "TLS_RSA_WITH_AES_128_CBC_SHA", 
+      "TLS_RSA_WITH_AES_128_GCM_SHA256", 
+      "TLS_RSA_WITH_AES_256_CBC_SHA", 
+      "TLS_RSA_WITH_AES_256_GCM_SHA384"
+    ]
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "981", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 07:31:09 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 07:31:09 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies/newpolicy?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"5YamndKM9WW73PHdKEZ714lkJMo=/QugbCU9qv-6vpC-rSZa1UXwUmlA=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-ssl-policies-query/get-compute-v1-projects-cloud-custodian-global-sslPolicies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-ssl-policies-query/get-compute-v1-projects-cloud-custodian-global-sslPolicies_1.json
@@ -1,0 +1,37 @@
+{
+  "body": {
+    "items": [
+      {
+        "profile": "COMPATIBLE", 
+        "kind": "compute#sslPolicy", 
+        "name": "newpolicy", 
+        "minTlsVersion": "TLS_1_0", 
+        "fingerprint": "BoVS1G-KySQ=", 
+        "creationTimestamp": "2019-03-11T05:40:52.917-07:00", 
+        "id": "4540081266450229691", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies/newpolicy"
+      }
+    ], 
+    "kind": "compute#sslPoliciesList", 
+    "id": "projects/cloud-custodian/global/sslPolicies", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "574", 
+    "transfer-encoding": "chunked", 
+    "expires": "Mon, 11 Mar 2019 13:47:58 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Mon, 11 Mar 2019 13:47:58 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"BO6OAgfn40fb55us8CD5L5r-epc=/mL-qYVUneYpP6_H1kvEFR7Vp5LY=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-ssl-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetSslProxies-lb2-target-proxy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-ssl-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetSslProxies-lb2-target-proxy_1.json
@@ -1,0 +1,32 @@
+{
+  "body": {
+    "kind": "compute#targetSslProxy", 
+    "name": "lb2-target-proxy", 
+    "service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/lb2", 
+    "proxyHeader": "NONE", 
+    "sslCertificates": [
+      "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+    ], 
+    "creationTimestamp": "2019-03-06T07:34:34.302-08:00", 
+    "id": "1917928467246241381", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies/lb2-target-proxy"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "538", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 06 Mar 2019 15:52:27 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Wed, 06 Mar 2019 15:52:27 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies/lb2-target-proxy?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"0GDkhZBjF4Vl_NZyDhDapyfB20Y=/fqK7bOxgEqUDindToHnwaiDdIUo=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-ssl-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetSslProxies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-ssl-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetSslProxies_1.json
@@ -1,0 +1,39 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#targetSslProxy", 
+        "name": "lb2-target-proxy", 
+        "service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/lb2", 
+        "proxyHeader": "NONE", 
+        "sslCertificates": [
+          "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+        ], 
+        "creationTimestamp": "2019-03-06T07:34:34.302-08:00", 
+        "id": "1917928467246241381", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies/lb2-target-proxy"
+      }
+    ], 
+    "kind": "compute#targetSslProxyList", 
+    "id": "projects/cloud-custodian/global/targetSslProxies", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "790", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 06 Mar 2019 15:43:36 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Wed, 06 Mar 2019 15:43:36 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"jX1ObjVrPdjOKpn9s7Q9IbijGiE=/9mMCTQywZIr1ASzGq-GHI3Ah8Lg=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-tcp-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetTcpProxies-newlb1-target-proxy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-tcp-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetTcpProxies-newlb1-target-proxy_1.json
@@ -1,0 +1,29 @@
+{
+  "body": {
+    "kind": "compute#targetTcpProxy", 
+    "name": "newlb1-target-proxy", 
+    "service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/newlb1",
+    "proxyHeader": "NONE", 
+    "creationTimestamp": "2019-03-05T05:49:38.606-08:00", 
+    "id": "3552848673737261213", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies/newlb1-target-proxy"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "418", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 05 Mar 2019 14:12:17 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 05 Mar 2019 14:12:17 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies/newlb1-target-proxy?alt=json",
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"gYA0b9KQ4ktU6RX4y1bWgvSsav8=/klbwc7Cui-xUB-l_RDnJK9dGtQs=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-tcp-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetTcpProxies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-tcp-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetTcpProxies_1.json
@@ -1,0 +1,36 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#targetTcpProxy", 
+        "name": "newlb1-target-proxy", 
+        "service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/newlb1",
+        "proxyHeader": "NONE", 
+        "creationTimestamp": "2019-03-05T05:49:38.606-08:00", 
+        "id": "3552848673737261213", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies/newlb1-target-proxy"
+      }
+    ], 
+    "kind": "compute#targetTcpProxyList", 
+    "id": "projects/cloud-custodian/global/targetTcpProxies",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "664", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 05 Mar 2019 14:03:40 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 05 Mar 2019 14:03:40 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies?alt=json",
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"BoLeW5srDJVlcBxw0SzFLfo-ad0=/0obzakJ-_dWI3wmY1iTLBu43BDo=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-url-maps-get/get-compute-v1-projects-cloud-custodian-global-urlMaps-lb_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-url-maps-get/get-compute-v1-projects-cloud-custodian-global-urlMaps-lb_1.json
@@ -1,0 +1,29 @@
+{
+  "body": {
+    "kind": "compute#urlMap", 
+    "name": "lb", 
+    "defaultService": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket",
+    "fingerprint": "GMqHBoGzLDY=", 
+    "creationTimestamp": "2019-03-05T04:30:37.636-08:00", 
+    "id": "1361403814964614402", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/lb"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "384", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 05 Mar 2019 12:57:18 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 05 Mar 2019 12:57:18 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/lb?alt=json",
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"BX6bAoC-XMD-cmKexD3O7zolrRU=/DJhFiC07cecs8EJmUCxjab7iQKA=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-url-maps-query/get-compute-v1-projects-cloud-custodian-global-urlMaps_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-url-maps-query/get-compute-v1-projects-cloud-custodian-global-urlMaps_1.json
@@ -1,0 +1,36 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#urlMap", 
+        "name": "lb", 
+        "defaultService": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket",
+        "fingerprint": "GMqHBoGzLDY=", 
+        "creationTimestamp": "2019-03-05T04:30:37.636-08:00", 
+        "id": "1361403814964614402", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/lb"
+      }
+    ], 
+    "kind": "compute#urlMapList", 
+    "id": "projects/decoded-pier-228312/global/urlMaps", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "604", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 05 Mar 2019 12:40:15 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 05 Mar 2019 12:40:15 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps?alt=json",
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"YImFd31hoU8xJL-6lFwB5eFe_e8=/ERkA9A1vX3FdxQwbWfgCfVbjsDw=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -42,3 +42,31 @@ class LoadBalancingAddressTest(BaseTest):
              'region': 'us-central1'})
         self.assertEqual(instance['kind'], 'compute#address')
         self.assertEqual(instance['address'], '35.193.10.19')
+
+
+class LoadBalancingUrlMapTest(BaseTest):
+
+    def test_loadbalancing_url_map_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-url-maps-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-url-maps',
+             'resource': 'gcp.loadbalancing-url-map'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#urlMap')
+        self.assertEqual(resources[0]['fingerprint'], 'GMqHBoGzLDY=')
+
+    def test_loadbalancing_url_map_get(self):
+        factory = self.replay_flight_data('lb-url-maps-get')
+        p = self.load_policy(
+            {'name': 'one-lb-url-map',
+             'resource': 'gcp.loadbalancing-url-map'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project': 'cloud-custodian',
+             'urlMap': 'lb'})
+        self.assertEqual(instance['kind'], 'compute#urlMap')
+        self.assertEqual(instance['fingerprint'], 'GMqHBoGzLDY=')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -37,8 +37,8 @@ class LoadBalancingAddressTest(BaseTest):
              'resource': 'gcp.loadbalancing-address'},
             session_factory=factory)
         instance = p.resource_manager.get_resource(
-            {'project': 'cloud-custodian',
-             'address': 'new1',
+            {'project_id': 'cloud-custodian',
+             'name': 'new1',
              'region': 'us-central1'})
         self.assertEqual(instance['kind'], 'compute#address')
         self.assertEqual(instance['address'], '35.193.10.19')
@@ -66,8 +66,8 @@ class LoadBalancingUrlMapTest(BaseTest):
              'resource': 'gcp.loadbalancing-url-map'},
             session_factory=factory)
         instance = p.resource_manager.get_resource(
-            {'project': 'cloud-custodian',
-             'urlMap': 'lb'})
+            {'project_id': 'cloud-custodian',
+             'name': 'lb'})
         self.assertEqual(instance['kind'], 'compute#urlMap')
         self.assertEqual(instance['fingerprint'], 'GMqHBoGzLDY=')
 
@@ -94,8 +94,8 @@ class LoadBalancingTargetTcpProxyTest(BaseTest):
              'resource': 'gcp.loadbalancing-target-tcp-proxy'},
             session_factory=factory)
         instance = p.resource_manager.get_resource(
-            {'project': 'cloud-custodian',
-             'targetTcpProxy': 'newlb1-target-proxy'})
+            {'project_id': 'cloud-custodian',
+             'name': 'newlb1-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetTcpProxy')
         self.assertEqual(instance['name'], 'newlb1-target-proxy')
 
@@ -122,7 +122,7 @@ class LoadBalancingTargetSslProxyTest(BaseTest):
              'resource': 'gcp.loadbalancing-target-ssl-proxy'},
             session_factory=factory)
         instance = p.resource_manager.get_resource(
-            {'project': 'cloud-custodian',
-             'targetSslProxy': 'lb2-target-proxy'})
+            {'project_id': 'cloud-custodian',
+             'name': 'lb2-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetSslProxy')
         self.assertEqual(instance['name'], 'lb2-target-proxy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -98,3 +98,31 @@ class LoadBalancingTargetTcpProxyTest(BaseTest):
              'targetTcpProxy': 'newlb1-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetTcpProxy')
         self.assertEqual(instance['name'], 'newlb1-target-proxy')
+
+
+class LoadBalancingTargetSslProxyTest(BaseTest):
+
+    def test_loadbalancing_target_ssl_proxy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-ssl-proxies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-ssl-proxies',
+             'resource': 'gcp.loadbalancing-target-ssl-proxy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetSslProxy')
+        self.assertEqual(resources[0]['name'], 'lb2-target-proxy')
+
+    def test_loadbalancing_target_ssl_proxy_get(self):
+        factory = self.replay_flight_data('lb-target-ssl-proxies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-ssl-proxy',
+             'resource': 'gcp.loadbalancing-target-ssl-proxy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project': 'cloud-custodian',
+             'targetSslProxy': 'lb2-target-proxy'})
+        self.assertEqual(instance['kind'], 'compute#targetSslProxy')
+        self.assertEqual(instance['name'], 'lb2-target-proxy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -126,3 +126,31 @@ class LoadBalancingTargetSslProxyTest(BaseTest):
              'name': 'lb2-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetSslProxy')
         self.assertEqual(instance['name'], 'lb2-target-proxy')
+
+
+class LoadBalancingSslPolicyTest(BaseTest):
+
+    def test_loadbalancing_ssl_policy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-ssl-policies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-ssl-policies',
+             'resource': 'gcp.loadbalancing-ssl-policy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#sslPolicy')
+        self.assertEqual(resources[0]['name'], 'newpolicy')
+
+    def test_loadbalancing_ssl_policy_get(self):
+        factory = self.replay_flight_data('lb-ssl-policies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-ssl-policies',
+             'resource': 'gcp.loadbalancing-ssl-policy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newpolicy'})
+        self.assertEqual(instance['kind'], 'compute#sslPolicy')
+        self.assertEqual(instance['name'], 'newpolicy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -70,3 +70,31 @@ class LoadBalancingUrlMapTest(BaseTest):
              'urlMap': 'lb'})
         self.assertEqual(instance['kind'], 'compute#urlMap')
         self.assertEqual(instance['fingerprint'], 'GMqHBoGzLDY=')
+
+
+class LoadBalancingTargetTcpProxyTest(BaseTest):
+
+    def test_loadbalancing_target_tcp_proxy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-tcp-proxies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-tcp-proxies',
+             'resource': 'gcp.loadbalancing-target-tcp-proxy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetTcpProxy')
+        self.assertEqual(resources[0]['name'], 'newlb1-target-proxy')
+
+    def test_loadbalancing_target_tcp_proxy_get(self):
+        factory = self.replay_flight_data('lb-target-tcp-proxies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-tcp-proxy',
+             'resource': 'gcp.loadbalancing-target-tcp-proxy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project': 'cloud-custodian',
+             'targetTcpProxy': 'newlb1-target-proxy'})
+        self.assertEqual(instance['kind'], 'compute#targetTcpProxy')
+        self.assertEqual(instance['name'], 'newlb1-target-proxy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -1,0 +1,44 @@
+# Copyright 2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gcp_common import BaseTest
+
+
+class LoadBalancingAddressTest(BaseTest):
+
+    def test_loadbalancing_address_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-addresses-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-addresses',
+             'resource': 'gcp.loadbalancing-address'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#address')
+        self.assertEqual(resources[0]['address'], '35.193.10.19')
+
+    def test_loadbalancing_address_get(self):
+        factory = self.replay_flight_data('lb-addresses-get')
+        p = self.load_policy(
+            {'name': 'one-region-address',
+             'resource': 'gcp.loadbalancing-address'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project': 'cloud-custodian',
+             'address': 'new1',
+             'region': 'us-central1'})
+        self.assertEqual(instance['kind'], 'compute#address')
+        self.assertEqual(instance['address'], '35.193.10.19')


### PR DESCRIPTION
Added initial classes with `query` and `get` functionality for the following resources in `LoadBalancing` service
- Addresses
- UrlMaps
- Target SSL Proxies
- Target TCP Proxies
- SSL Policies