### PR TITLE
gcp - add initial setup for LoadBalancing additional resources

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -178,3 +178,21 @@ class LoadBalancingHttpsHealthCheck(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'httpsHealthCheck': resource_info['name']})
+
+
+@resources.register('loadbalancing-http-health-check')
+class LoadBalancingHttpHealthCheck(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'httpHealthChecks'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'httpHealthCheck': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -142,3 +142,21 @@ class LoadBalancingTargetHttpsProxy(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'targetHttpsProxy': resource_info['name']})
+
+
+@resources.register('loadbalancing-backend-bucket')
+class LoadBalancingBackendBucket(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'backendBuckets'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'backendBucket': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -106,3 +106,39 @@ class LoadBalancingSslPolicy(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'sslPolicy': resource_info['name']})
+
+
+@resources.register('loadbalancing-ssl-certificate')
+class LoadBalancingSslCertificate(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'sslCertificates'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'sslCertificate': resource_info['name']})
+
+
+@resources.register('loadbalancing-target-https-proxy')
+class LoadBalancingTargetHttpsProxy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetHttpsProxies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'targetHttpsProxy': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -196,3 +196,21 @@ class LoadBalancingHttpHealthCheck(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'httpHealthCheck': resource_info['name']})
+
+
+@resources.register('loadbalancing-health-check')
+class LoadBalancingHealthCheck(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'healthChecks'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'healthCheck': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -160,3 +160,21 @@ class LoadBalancingBackendBucket(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'backendBucket': resource_info['name']})
+
+
+@resources.register('loadbalancing-https-health-check')
+class LoadBalancingHttpsHealthCheck(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'httpsHealthChecks'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'httpsHealthCheck': resource_info['name']})

--- a/tools/c7n_gcp/tests/data/flights/lb-backend-buckets-get/get-compute-v1-projects-cloud-custodian-global-backendBuckets-newbucket_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-backend-buckets-get/get-compute-v1-projects-cloud-custodian-global-backendBuckets-newbucket_1.json
@@ -1,0 +1,30 @@
+{
+  "body": {
+    "kind": "compute#backendBucket", 
+    "description": "", 
+    "enableCdn": false, 
+    "bucketName": "newbucket_em", 
+    "creationTimestamp": "2019-03-12T02:55:51.212-07:00", 
+    "id": "1200379941928713416", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket", 
+    "name": "newbucket"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "331", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 13 Mar 2019 17:39:45 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Wed, 13 Mar 2019 17:39:45 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"jcSou3GFDYsczJSpiYniFcvc0bc=/r6goSRbOgpOAvxsuPDb35JNsG0o=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-backend-buckets-query/get-compute-v1-projects-cloud-custodian-global-backendBuckets_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-backend-buckets-query/get-compute-v1-projects-cloud-custodian-global-backendBuckets_1.json
@@ -1,0 +1,37 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#backendBucket", 
+        "description": "", 
+        "enableCdn": false, 
+        "bucketName": "newbucket_em", 
+        "creationTimestamp": "2019-03-12T02:55:51.212-07:00", 
+        "id": "1200379941928713416", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket", 
+        "name": "newbucket"
+      }
+    ], 
+    "kind": "compute#backendBucketList", 
+    "id": "projects/cloud-custodian/global/backendBuckets", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "574", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 13 Mar 2019 17:37:05 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Wed, 13 Mar 2019 17:37:05 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"Vigi4KrCJsAk6dAcCrpUcsJTBw8=/4_bmPo5kV8sGBzCB9oBsXFGv9fE=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-health-checks-get/get-compute-v1-projects-cloud-custodian-global-healthChecks-new-tcp-health-check_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-health-checks-get/get-compute-v1-projects-cloud-custodian-global-healthChecks-new-tcp-health-check_1.json
@@ -1,0 +1,36 @@
+{
+  "body": {
+    "kind": "compute#healthCheck", 
+    "name": "new-tcp-health-check", 
+    "timeoutSec": 5, 
+    "type": "TCP", 
+    "checkIntervalSec": 5, 
+    "unhealthyThreshold": 2, 
+    "healthyThreshold": 2, 
+    "tcpHealthCheck": {
+      "proxyHeader": "NONE", 
+      "port": 80
+    }, 
+    "creationTimestamp": "2019-03-14T02:39:31.684-07:00", 
+    "id": "275508814053613500", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks/new-tcp-health-check"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "447", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 09:48:36 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 09:48:36 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks/new-tcp-health-check?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"7je52W_149pfYxaOG0NSQZspioo=/gSCSB42qmdNipsKa3J1G2HlhG8E=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-health-checks-query/get-compute-v1-projects-cloud-custodian-global-healthChecks_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-health-checks-query/get-compute-v1-projects-cloud-custodian-global-healthChecks_1.json
@@ -1,0 +1,43 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#healthCheck", 
+        "name": "new-tcp-health-check", 
+        "timeoutSec": 5, 
+        "type": "TCP", 
+        "checkIntervalSec": 5, 
+        "unhealthyThreshold": 2, 
+        "healthyThreshold": 2, 
+        "tcpHealthCheck": {
+          "proxyHeader": "NONE", 
+          "port": 80
+        }, 
+        "creationTimestamp": "2019-03-14T02:39:31.684-07:00", 
+        "id": "275508814053613500", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks/new-tcp-health-check"
+      }
+    ], 
+    "kind": "compute#healthCheckList", 
+    "id": "projects/cloud-custodian/global/healthChecks", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "696", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 09:46:29 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 09:46:29 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"IVRGXwcz7iD8cOynpbKL98egBqk=/h96BRJCM1LT4PON7vR2yY5eMXaQ=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-http-health-checks-get/get-compute-v1-projects-cloud-custodian-global-httpHealthChecks-newhttphealthcheck_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-http-health-checks-get/get-compute-v1-projects-cloud-custodian-global-httpHealthChecks-newhttphealthcheck_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "kind": "compute#httpHealthCheck", 
+    "description": "", 
+    "timeoutSec": 5, 
+    "checkIntervalSec": 10, 
+    "port": 80, 
+    "healthyThreshold": 2, 
+    "host": "", 
+    "requestPath": "/", 
+    "unhealthyThreshold": 3, 
+    "creationTimestamp": "2019-03-14T00:45:36.570-07:00", 
+    "id": "7550768777334863951", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks/newhttphealthcheck", 
+    "name": "newhttphealthcheck"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "441", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 07:56:35 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 07:56:35 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks/newhttphealthcheck?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"UIx2Dvpqy8KrCmmYGrEZyNjt5ak=/FasiAVALgZgA4fuqwO5tLBVD-R8=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-http-health-checks-query/get-compute-v1-projects-cloud-custodian-global-httpHealthChecks_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-http-health-checks-query/get-compute-v1-projects-cloud-custodian-global-httpHealthChecks_1.json
@@ -1,0 +1,42 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#httpHealthCheck", 
+        "description": "", 
+        "timeoutSec": 5, 
+        "checkIntervalSec": 10, 
+        "port": 80, 
+        "healthyThreshold": 2, 
+        "host": "", 
+        "requestPath": "/", 
+        "unhealthyThreshold": 3, 
+        "creationTimestamp": "2019-03-14T00:45:36.570-07:00", 
+        "id": "7550768777334863951", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks/newhttphealthcheck", 
+        "name": "newhttphealthcheck"
+      }
+    ], 
+    "kind": "compute#httpHealthCheckList", 
+    "id": "projects/cloud-custodian/global/httpHealthChecks", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "700", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 07:54:24 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 07:54:24 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"Bd4cnXe-clokjVT1_aiSi9pIn-U=/iRYqB4Zldlz_brdFzsSLelqqpgA=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-https-health-checks-get/get-compute-v1-projects-cloud-custodian-global-httpsHealthChecks-newhealthcheck_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-https-health-checks-get/get-compute-v1-projects-cloud-custodian-global-httpsHealthChecks-newhealthcheck_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "kind": "compute#httpsHealthCheck", 
+    "description": "", 
+    "timeoutSec": 5, 
+    "checkIntervalSec": 10, 
+    "port": 443, 
+    "healthyThreshold": 2, 
+    "host": "", 
+    "requestPath": "/", 
+    "unhealthyThreshold": 3, 
+    "creationTimestamp": "2019-03-13T23:57:20.595-07:00", 
+    "id": "1274526500684842431", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks/newhealthcheck", 
+    "name": "newhealthcheck"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "436", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 07:40:19 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 07:40:19 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks/newhealthcheck?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"XpxFoVv_I_4ZMZpFaSbzEEVFNFg=/bYYwIJWMM_EYA5YNMMdEoKyRgL8=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-https-health-checks-query/get-compute-v1-projects-cloud-custodian-global-httpsHealthChecks_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-https-health-checks-query/get-compute-v1-projects-cloud-custodian-global-httpsHealthChecks_1.json
@@ -1,0 +1,42 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#httpsHealthCheck", 
+        "description": "", 
+        "timeoutSec": 5, 
+        "checkIntervalSec": 10, 
+        "port": 443, 
+        "healthyThreshold": 2, 
+        "host": "", 
+        "requestPath": "/", 
+        "unhealthyThreshold": 3, 
+        "creationTimestamp": "2019-03-13T23:57:20.595-07:00", 
+        "id": "1274526500684842431", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks/newhealthcheck", 
+        "name": "newhealthcheck"
+      }
+    ], 
+    "kind": "compute#httpsHealthCheckList", 
+    "id": "projects/cloud-custodian/global/httpsHealthChecks", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "698", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 07:37:55 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 07:37:55 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"QbldhMMo_fTxJaG8W-5Z64RsGDo=/2ER5cKJYjunZPElIaM5b0MiM6ug=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-ssl-certificates-get/get-compute-v1-projects-cloud-custodian-global-sslCertificates-testcert_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-ssl-certificates-get/get-compute-v1-projects-cloud-custodian-global-sslCertificates-testcert_1.json
@@ -1,0 +1,28 @@
+{
+  "body": {
+    "kind": "compute#sslCertificate", 
+    "name": "testcert", 
+    "certificate": "-----BEGIN CERTIFICATE-----\nMIIDAjCCAeqgAwIBAgIJAPUXF8V4YbOEMA0GCSqGSIb3DQEBCwUAMBYxFDASBgNV\nBAMMC2V4YW1wbGUuY29tMB4XDTE5MDMwNjE0MjE1NFoXDTIwMDMwNTE0MjE1NFow\nFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\nggEKAoIBAQDRrclYoZV7DoERFHJKRIK8wPUr4VVj4dsJn+SsMb96J5EsVNMd0QFp\nDsvn6E7Dg/Ujn1HohEUg+EsqFmDJSMcZO9nJxpTLGNP2GTgs3T5Z6ddouhBqXovG\ncY5c7t5TzRfZBbZPbhZu4nd6sJFbVIE90dRiqszPKuwHYBW5cV4n2zhMwx4BpgHT\nFGBqzIUaQhOWhV+STqlsKzWW6UpZrX4552pycJKIIHPEfU50dEnnr/z9laf3zf2i\nX+yBwGB2uJKix9rN5zfXOXC2JwYZ+8UE1kJ2b8RV93Qvnuc7htbUCCvZWqhOuPzB\nDQisYkL1XQv+LzQzWYj0ulC/AMd4ChU5AgMBAAGjUzBRMB0GA1UdDgQWBBTWGDWJ\n0cu9uR5LMdPc3pRhHw7ARzAfBgNVHSMEGDAWgBTWGDWJ0cu9uR5LMdPc3pRhHw7A\nRzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAmNR9sCJbIvSy8\nV8+CdFCZH+utP3sAtK4WY15lOlgBgfgGuXK9snfWU3B6SOFKttX0vsbQTzONShEX\nc9NDE+mbtlfYhiaAlUKUyV+w0N9xoenS1jIhrz0KByaKklAfPSJdSBwtzRZ9psIr\ncSueI2K1KTj4dxyYj4M78j/Z7LXgOVwBlInlTKGcSJd+qDRM0lSiZLQKt09qZFg8\nf6D8otR/o4LlauQONPAB91Vm/fJRVdiM5KD3aBK5jy0LMRA3iCVpItQf8gRH4ItO\n77+fpa0SHU58Gf+fDgyDCcXn77M0Ht5sBvuS5PB9BJHzc3VEWZeQXANXdM9e+zJj\nlpvn3RPW\n-----END CERTIFICATE-----\n\n", 
+    "creationTimestamp": "2019-03-06T07:33:58.591-08:00", 
+    "id": "733338214555866761", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "1402", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 08:57:07 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 08:57:07 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"ROdJYUw3NredrVJUI61-Wzgttbw=/a4I_lxU9_0Ym7B4yAuAIu9Avgwg=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-ssl-certificates-query/get-compute-v1-projects-cloud-custodian-global-sslCertificates_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-ssl-certificates-query/get-compute-v1-projects-cloud-custodian-global-sslCertificates_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#sslCertificate", 
+        "name": "testcert", 
+        "certificate": "-----BEGIN CERTIFICATE-----\nMIIDAjCCAeqgAwIBAgIJAPUXF8V4YbOEMA0GCSqGSIb3DQEBCwUAMBYxFDASBgNV\nBAMMC2V4YW1wbGUuY29tMB4XDTE5MDMwNjE0MjE1NFoXDTIwMDMwNTE0MjE1NFow\nFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\nggEKAoIBAQDRrclYoZV7DoERFHJKRIK8wPUr4VVj4dsJn+SsMb96J5EsVNMd0QFp\nDsvn6E7Dg/Ujn1HohEUg+EsqFmDJSMcZO9nJxpTLGNP2GTgs3T5Z6ddouhBqXovG\ncY5c7t5TzRfZBbZPbhZu4nd6sJFbVIE90dRiqszPKuwHYBW5cV4n2zhMwx4BpgHT\nFGBqzIUaQhOWhV+STqlsKzWW6UpZrX4552pycJKIIHPEfU50dEnnr/z9laf3zf2i\nX+yBwGB2uJKix9rN5zfXOXC2JwYZ+8UE1kJ2b8RV93Qvnuc7htbUCCvZWqhOuPzB\nDQisYkL1XQv+LzQzWYj0ulC/AMd4ChU5AgMBAAGjUzBRMB0GA1UdDgQWBBTWGDWJ\n0cu9uR5LMdPc3pRhHw7ARzAfBgNVHSMEGDAWgBTWGDWJ0cu9uR5LMdPc3pRhHw7A\nRzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAmNR9sCJbIvSy8\nV8+CdFCZH+utP3sAtK4WY15lOlgBgfgGuXK9snfWU3B6SOFKttX0vsbQTzONShEX\nc9NDE+mbtlfYhiaAlUKUyV+w0N9xoenS1jIhrz0KByaKklAfPSJdSBwtzRZ9psIr\ncSueI2K1KTj4dxyYj4M78j/Z7LXgOVwBlInlTKGcSJd+qDRM0lSiZLQKt09qZFg8\nf6D8otR/o4LlauQONPAB91Vm/fJRVdiM5KD3aBK5jy0LMRA3iCVpItQf8gRH4ItO\n77+fpa0SHU58Gf+fDgyDCcXn77M0Ht5sBvuS5PB9BJHzc3VEWZeQXANXdM9e+zJj\nlpvn3RPW\n-----END CERTIFICATE-----\n\n", 
+        "creationTimestamp": "2019-03-06T07:33:58.591-08:00", 
+        "id": "733338214555866761", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+      }
+    ], 
+    "kind": "compute#sslCertificateList", 
+    "id": "projects/cloud-custodian/global/sslCertificates", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "1644", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 08:46:39 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 08:46:39 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"RqU1K4OGAIAU7BH9JXDsX6WnOJg=/q00WLCXHZi0U13t-w9EfyTkVKr0=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-https-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetHttpsProxies-newhttpslb-target-proxy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-https-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetHttpsProxies-newhttpslb-target-proxy_1.json
@@ -1,0 +1,32 @@
+{
+  "body": {
+    "kind": "compute#targetHttpsProxy", 
+    "name": "newhttpslb-target-proxy", 
+    "sslCertificates": [
+      "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+    ], 
+    "quicOverride": "NONE", 
+    "urlMap": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/newhttpslb", 
+    "creationTimestamp": "2019-03-12T02:55:59.482-07:00", 
+    "id": "4375728720756489408", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies/newhttpslb-target-proxy"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "555", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 10:11:46 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 10:11:46 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies/newhttpslb-target-proxy?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"NMHHfBnpRQTEvpTAtMvq4U-PaFo=/5qUEP7dlMP_W0xECWdgpcDba_gw=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-https-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetHttpsProxies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-https-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetHttpsProxies_1.json
@@ -1,0 +1,39 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#targetHttpsProxy", 
+        "name": "newhttpslb-target-proxy", 
+        "sslCertificates": [
+          "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+        ], 
+        "quicOverride": "NONE", 
+        "urlMap": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/newhttpslb", 
+        "creationTimestamp": "2019-03-12T02:55:59.482-07:00", 
+        "id": "4375728720756489408", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies/newhttpslb-target-proxy"
+      }
+    ], 
+    "kind": "compute#targetHttpsProxyList", 
+    "id": "projects/cloud-custodian/global/targetHttpsProxies", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "813", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 10:05:06 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 10:05:06 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"K0ucKTIWbwDgbFV42ExeJSVnNt8=/2PmAVLbG_MKMajWkizyohnfhiIQ=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -294,3 +294,31 @@ class LoadBalancingHttpHealthCheckTest(BaseTest):
              'name': 'newhttphealthcheck'})
         self.assertEqual(instance['kind'], 'compute#httpHealthCheck')
         self.assertEqual(instance['name'], 'newhttphealthcheck')
+
+
+class LoadBalancingHealthCheckTest(BaseTest):
+
+    def test_loadbalancing_health_check_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-health-checks-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-health-checks',
+             'resource': 'gcp.loadbalancing-health-check'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#healthCheck')
+        self.assertEqual(resources[0]['name'], 'new-tcp-health-check')
+
+    def test_loadbalancing_health_check_get(self):
+        factory = self.replay_flight_data('lb-health-checks-get')
+        p = self.load_policy(
+            {'name': 'one-lb-health-checks',
+             'resource': 'gcp.loadbalancing-health-check'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'new-tcp-health-check'})
+        self.assertEqual(instance['kind'], 'compute#healthCheck')
+        self.assertEqual(instance['name'], 'new-tcp-health-check')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -266,3 +266,31 @@ class LoadBalancingHttpsHealthCheckTest(BaseTest):
              'name': 'newhealthcheck'})
         self.assertEqual(instance['kind'], 'compute#httpsHealthCheck')
         self.assertEqual(instance['name'], 'newhealthcheck')
+
+
+class LoadBalancingHttpHealthCheckTest(BaseTest):
+
+    def test_loadbalancing_http_health_check_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-http-health-checks-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-http-health-checks',
+             'resource': 'gcp.loadbalancing-http-health-check'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#httpHealthCheck')
+        self.assertEqual(resources[0]['name'], 'newhttphealthcheck')
+
+    def test_loadbalancing_http_health_check_get(self):
+        factory = self.replay_flight_data('lb-http-health-checks-get')
+        p = self.load_policy(
+            {'name': 'one-lb-http-health-checks',
+             'resource': 'gcp.loadbalancing-http-health-check'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newhttphealthcheck'})
+        self.assertEqual(instance['kind'], 'compute#httpHealthCheck')
+        self.assertEqual(instance['name'], 'newhttphealthcheck')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -210,3 +210,31 @@ class LoadBalancingTargetHttpsProxyTest(BaseTest):
              'name': 'newhttpslb-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetHttpsProxy')
         self.assertEqual(instance['name'], 'newhttpslb-target-proxy')
+
+
+class LoadBalancingBackendBucketTest(BaseTest):
+
+    def test_loadbalancing_backend_bucket_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-backend-buckets-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-backend-buckets',
+             'resource': 'gcp.loadbalancing-backend-bucket'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#backendBucket')
+        self.assertEqual(resources[0]['name'], 'newbucket')
+
+    def test_loadbalancing_backend_bucket_get(self):
+        factory = self.replay_flight_data('lb-backend-buckets-get')
+        p = self.load_policy(
+            {'name': 'one-lb-backend-buckets',
+             'resource': 'gcp.loadbalancing-backend-bucket'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newbucket'})
+        self.assertEqual(instance['kind'], 'compute#backendBucket')
+        self.assertEqual(instance['name'], 'newbucket')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -238,3 +238,31 @@ class LoadBalancingBackendBucketTest(BaseTest):
              'name': 'newbucket'})
         self.assertEqual(instance['kind'], 'compute#backendBucket')
         self.assertEqual(instance['name'], 'newbucket')
+
+
+class LoadBalancingHttpsHealthCheckTest(BaseTest):
+
+    def test_loadbalancing_https_health_check_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-https-health-checks-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-https-health-checks',
+             'resource': 'gcp.loadbalancing-https-health-check'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#httpsHealthCheck')
+        self.assertEqual(resources[0]['name'], 'newhealthcheck')
+
+    def test_loadbalancing_https_health_check_get(self):
+        factory = self.replay_flight_data('lb-https-health-checks-get')
+        p = self.load_policy(
+            {'name': 'one-lb-https-health-checks',
+             'resource': 'gcp.loadbalancing-https-health-check'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newhealthcheck'})
+        self.assertEqual(instance['kind'], 'compute#httpsHealthCheck')
+        self.assertEqual(instance['name'], 'newhealthcheck')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -154,3 +154,59 @@ class LoadBalancingSslPolicyTest(BaseTest):
              'name': 'newpolicy'})
         self.assertEqual(instance['kind'], 'compute#sslPolicy')
         self.assertEqual(instance['name'], 'newpolicy')
+
+
+class LoadBalancingSslCertificateTest(BaseTest):
+
+    def test_loadbalancing_ssl_certificate_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-ssl-certificates-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-ssl-certificates',
+             'resource': 'gcp.loadbalancing-ssl-certificate'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#sslCertificate')
+        self.assertEqual(resources[0]['name'], 'testcert')
+
+    def test_loadbalancing_ssl_certificate_get(self):
+        factory = self.replay_flight_data('lb-ssl-certificates-get')
+        p = self.load_policy(
+            {'name': 'one-lb-ssl-certificates',
+             'resource': 'gcp.loadbalancing-ssl-certificate'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'testcert'})
+        self.assertEqual(instance['kind'], 'compute#sslCertificate')
+        self.assertEqual(instance['name'], 'testcert')
+
+
+class LoadBalancingTargetHttpsProxyTest(BaseTest):
+
+    def test_loadbalancing_target_https_proxy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-https-proxies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-https-proxies',
+             'resource': 'gcp.loadbalancing-target-https-proxy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetHttpsProxy')
+        self.assertEqual(resources[0]['name'], 'newhttpslb-target-proxy')
+
+    def test_loadbalancing_target_https_proxy_get(self):
+        factory = self.replay_flight_data('lb-target-https-proxies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-https-proxies',
+             'resource': 'gcp.loadbalancing-target-https-proxy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newhttpslb-target-proxy'})
+        self.assertEqual(instance['kind'], 'compute#targetHttpsProxy')
+        self.assertEqual(instance['name'], 'newhttpslb-target-proxy')


### PR DESCRIPTION
Added initial classes with `query` and `get` functionality for the following resources in `LoadBalancing` service
- SSL certificates
- Backend buckets
- HTTPS health checks
- HTTP health checks
- Health checks