### PR TITLE
aws - policy validation when running in lambda mode

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -162,6 +162,9 @@ def dispatch_event(event, context):
     if policies:
         for p in policies:
             try:
+                # validation provides for an initialization point for
+                # some filters/actions.
+                p.validate()
                 p.push(event, context)
             except Exception:
                 log.exception("error during policy execution")

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -131,11 +131,16 @@ class HandleTest(BaseTest):
         self.change_environment(C7N_OUTPUT_DIR=self.run_dir)
 
         policy_execution = []
+        validation_called = []
+
+        def validate(self):
+            validation_called.append(True)
 
         def push(self, event, context):
             policy_execution.append((event, context))
 
         self.patch(Policy, "push", push)
+        self.patch(Policy, "validate", validate)
 
         from c7n import handler
 
@@ -161,6 +166,7 @@ class HandleTest(BaseTest):
         )
         self.assertEqual(handler.dispatch_event({"detail": {}}, None), True)
         self.assertEqual(policy_execution, [({"detail": {}, "debug": True}, None)])
+        self.assertEqual(validation_called, [True])
 
         config = handler.Config.empty()
         self.assertEqual(config.assume_role, None)


### PR DESCRIPTION
always perform validation in lambda mode to allow for lazy initialization on some filters/actions that do extraction of instance values from config during validation.

closes #3022