### PR TITLE
cli - schema validation errors include policy name and resource if any

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,7 +18,7 @@ from json import dumps
 from jsonschema.exceptions import best_match
 
 from c7n.manager import resources
-from c7n.schema import Validator, validate, generate, specific_error
+from c7n.schema import Validator, validate, generate, specific_error, policy_error_scope
 from .common import BaseTest
 
 
@@ -103,6 +103,28 @@ class SchemaTest(BaseTest):
         )
         self.assertTrue("'scheduled' was unexpected" in str(error))
         self.assertTrue(len(str(error)) < 2000)
+
+    def test_semantic_error_policy_scope(self):
+
+        data = {
+            'policies': [
+                {'actions': [{'key': 'TagPolicyCompliance',
+                              'type': 'tag',
+                              'value': 'This resource should have tags following policy'}],
+                 'description': 'Identify resources which lack our accounting tags',
+                 'filters': [{'tag:Environment': 'absent'},
+                             {'tag:Service': 'absent'},
+                             {'or': [{'tag:Owner': 'absent'},
+                                     {'tag:ResponsibleParty': 'absent'},
+                                     {'tag:Contact': 'absent'},
+                                     {'tag:Creator': 'absent'}]}],
+                 'name': 'tagging-compliance-waf',
+                 'resource': 'aws.waf'}]}
+
+        errors = list(self.validator.iter_errors(data))
+        self.assertEqual(len(errors), 1)
+        error = policy_error_scope(specific_error(errors[0]), data)
+        self.assertTrue("policy:tagging-compliance-waf" in error.message)
 
     def test_semantic_error(self):
         data = {


### PR DESCRIPTION
closes #3777

policy name and resource that triggered the error are now displayed at the top of the validation message

ie using the policy from the issue

```shell
$ custodian validate example.yml
2019-04-15 15:47:02,334: custodian.commands:ERROR Configuration invalid: x.yml
2019-04-15 15:47:02,335: custodian.commands:ERROR Error on policy:tagging-compliance-waf resource:aws.waf
{'type': 'tag', 'key': 'TagPolicyCompliance', 'value': 'This resource should have tags following policy'} is not valid under any of the given schemas

```