### PR TITLE
ci - doc test redux

### DIFF
--- a/c7n/actions/policy.py
+++ b/c7n/actions/policy.py
@@ -60,9 +60,7 @@ class ModifyPolicyBase(BaseAction):
         **{
             'add-statements': {
                 'type': 'array',
-                'required': True,
                 'items': {'$ref': '#/definitions/iam-statement'},
-                'additionalProperties': False
             },
             'remove-statements': {
                 'type': ['array', 'string'],
@@ -70,8 +68,6 @@ class ModifyPolicyBase(BaseAction):
                     {'enum': ['matched', '*']},
                     {'type': 'array', 'items': {'type': 'string'}}
                 ],
-                'required': True,
-                'additionalProperties': False
             }
         }
     )

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -61,8 +61,8 @@ def load(options, path, format='yaml', validate=True, vars=None):
         from c7n.schema import validate
         errors = validate(data)
         if errors:
-            raise Exception(
-                "Failed to validate on policy %s \n %s" % (
+            raise PolicyValidationError(
+                "Failed to validate policy %s \n %s" % (
                     errors[1], errors[0]))
 
     collection = PolicyCollection.from_data(data, options)

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1078,7 +1078,6 @@ class SetPolicyStatement(BucketActionBase):
         **{
             'statements': {
                 'type': 'array',
-                'required': True,
                 'items': {
                     'type': 'object',
                     'properties': {
@@ -2615,7 +2614,6 @@ class Lifecycle(BucketActionBase):
         **{
             'rules': {
                 'type': 'array',
-                'required': True,
                 'items': {
                     'type': 'object',
                     'required': ['ID', 'Status'],

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -304,10 +304,7 @@ class SetRetentionPeriod(BaseAction):
     """
     schema = type_schema(
         'set-retention-period',
-        period={'type': 'integer',
-                'minimum': 60, 'exclusiveMinimum': True,
-                'maximum': 1209600, 'exclusiveMaximum': True})
-
+        period={'type': 'integer', 'minimum': 60, 'maximum': 1209600})
     permissions = ('sqs:SetQueueAttributes',)
 
     def process(self, queues):

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -252,7 +252,7 @@ def generate(resource_types=()):
                 ))
 
     schema = {
-        '$schema': 'http://json-schema.org/schema#',
+        "$schema": "http://json-schema.org/draft-07/schema#",
         'id': 'http://schema.cloudcustodian.io/v0/custodian.json',
         'definitions': definitions,
         'type': 'object',

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -45,21 +45,18 @@ def validate(data, schema=None):
         schema = generate()
         Validator.check_schema(schema)
 
+    counter = Counter([p['name'] for p in data.get('policies')])
+    for k, v in list(counter.items()):
+        if v == 1:
+            counter.pop(k)
+    if counter:
+        return [ValueError(
+            "Only one policy with a given name allowed, duplicates: {}".format(counter)),
+            list(counter.keys())[0]]
+
+
     validator = Validator(schema)
-
     errors = list(validator.iter_errors(data))
-
-    if not errors:
-        counter = Counter([p['name'] for p in data.get('policies')])
-        dupes = []
-        for k, v in counter.items():
-            if v > 1:
-                dupes.append(k)
-        if dupes:
-            return [ValueError(
-                "Only one policy with a given name allowed, duplicates: %s" % (
-                    ", ".join(dupes))), dupes[0]]
-        return []
     try:
         resp = specific_error(errors[0])
         name = isinstance(

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -45,19 +45,10 @@ def validate(data, schema=None):
         schema = generate()
         Validator.check_schema(schema)
 
-    counter = Counter([p['name'] for p in data.get('policies')])
-    for k, v in list(counter.items()):
-        if v == 1:
-            counter.pop(k)
-    if counter:
-        return [ValueError(
-            "Only one policy with a given name allowed, duplicates: {}".format(counter)),
-            list(counter.keys())[0]]
-
     validator = Validator(schema)
     errors = list(validator.iter_errors(data))
     if not errors:
-        return []
+        return check_unique(data) or []
     try:
         resp = specific_error(errors[0])
         name = isinstance(
@@ -74,6 +65,17 @@ def validate(data, schema=None):
         errors[0],
         best_match(validator.iter_errors(data)),
     ]))
+
+
+def check_unique(data):
+    counter = Counter([p['name'] for p in data.get('policies', [])])
+    for k, v in list(counter.items()):
+        if v == 1:
+            counter.pop(k)
+    if counter:
+        return [ValueError(
+            "Only one policy with a given name allowed, duplicates: {}".format(counter)),
+            list(counter.keys())[0]]
 
 
 def specific_error(error):

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -56,6 +56,8 @@ def validate(data, schema=None):
 
     validator = Validator(schema)
     errors = list(validator.iter_errors(data))
+    if not errors:
+        return []
     try:
         resp = specific_error(errors[0])
         name = isinstance(

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -54,7 +54,6 @@ def validate(data, schema=None):
             "Only one policy with a given name allowed, duplicates: {}".format(counter)),
             list(counter.keys())[0]]
 
-
     validator = Validator(schema)
     errors = list(validator.iter_errors(data))
     try:

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -28,7 +28,7 @@ import six
 import yaml
 
 from c7n import policy
-from c7n.schema import validate as schema_validate
+from c7n.schema import generate, validate as schema_validate
 from c7n.ctx import ExecutionContext
 from c7n.utils import reset_session_cache
 from c7n.config import Bag, Config
@@ -100,6 +100,8 @@ class TestUtils(unittest.TestCase):
         cache=False,
     ):
         if validate:
+            if not self.custodian_schema:
+                self.custodian_schema = generate()
             errors = schema_validate({"policies": [data]}, self.custodian_schema)
             if errors:
                 raise errors[0]

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -660,7 +660,7 @@ class AccountTests(BaseTest):
                     "percent-increase": 10,
                 }
             ],
-        },
+        }
         self.assertRaises(ValidationError, self.load_policy, policy, validate=True)
 
     def test_enable_trail(self):

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -43,12 +43,15 @@ def get_doc_examples():
 class DocExampleTest(BaseTest):
 
     skip_condition = not (
-        # Okay slightly gross, basically if we're explicitly told via env var to run doc tests
-        # do it.
+        # Okay slightly gross, basically if we're explicitly told via
+        # env var to run doc tests do it.
         (os.environ.get("C7N_TEST_DOC") not in ('yes', 'true') or
-         # Or for ci to avoid some tox pain, we'll auto configure here to run on the py3.6 test
-         # runner, as its the only one without additional responsibilities.
-         (os.environ.get('C7N_TEST_RUN') and sys.version_info.major == 3 and sys.version_info.minor == 6)))
+         # Or for ci to avoid some tox pain, we'll auto configure here
+         # to run on the py3.6 test runner, as its the only one
+         # without additional responsibilities.
+         (os.environ.get('C7N_TEST_RUN') and
+          sys.version_info.major == 3 and
+          sys.version_info.minor == 6)))
 
     @skipif(skip_condition, reason="Doc tests must be explicitly enabled with C7N_DOC_TEST")
     def test_doc_examples(self):
@@ -57,9 +60,11 @@ class DocExampleTest(BaseTest):
         for ptext, resource_name, el_name in get_doc_examples():
             data = yaml.safe_load(ptext)
             for p in data.get('policies', []):
-                # Give each policy a unique name with enough context that we can identify the origin
-                # on failures, note max size here is 54 if its a lambda policy.
-                p['name'] = "%s-%s-%s-%d" % (resource_name.split('.')[-1], el_name, p.get('name', 'unknown'), idx)
+                # Give each policy a unique name with enough context
+                # that we can identify the origin on failures, note
+                # max size here is 54 if its a lambda policy.
+                p['name'] = "%s-%s-%s-%d" % (
+                    resource_name.split('.')[-1], el_name, p.get('name', 'unknown'), idx)
                 policies.append(p)
                 idx += 1
         self.load_policy_set({'policies': policies})

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -23,7 +23,7 @@ try:
     import pytest
     skipif = pytest.mark.skipif
 except ImportError:
-    skipif = lambda func, reasion="": func  # noqa E731
+    skipif = lambda func, reason="": func  # noqa E731
 
 
 def get_doc_examples():

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -11,11 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import yaml
 import itertools
+import os
+import yaml
 
 from c7n.provider import resources
 from .common import BaseTest
+
+try:
+    import pytest
+    skipif = pytest.mark.skipif
+except ImportError:
+    skipif = lambda func, reasion="": func
 
 
 def get_doc_examples():
@@ -34,6 +41,8 @@ def get_doc_examples():
 
 class DocExampleTest(BaseTest):
 
+    @skipif(os.environ.get("C7N_TEST_DOC") not in ('yes', 'true'),
+            reason="Doc tests must be explicitly enabled with C7N_DOC_TEST")
     def test_doc_examples(self):
         policies = []
         idx = 1

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -22,7 +22,7 @@ try:
     import pytest
     skipif = pytest.mark.skipif
 except ImportError:
-    skipif = lambda func, reasion="": func
+    skipif = lambda func, reasion="": func  # noqa E731
 
 
 def get_doc_examples():

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -18,8 +18,6 @@ import os
 from c7n.provider import resources
 from .common import BaseTest
 
-C7N_TEST_DOCS = bool(os.environ.get("C7N_TEST_DOCS", False))
-
 
 def get_doc_examples():
     policies = []
@@ -42,7 +40,7 @@ class DocExampleTest(BaseTest):
         for policy, module, cls_name in get_doc_examples():
             try:
                 parsed_policy = yaml.safe_load(policy)
-                list(map(lambda p: self.load_policy(p, validate=C7N_TEST_DOCS),
+                list(map(lambda p: self.load_policy(p, validate=True),
                          parsed_policy["policies"]))
             except Exception as e:
                 errors.append((module, cls_name, e))

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -15,7 +15,6 @@ import yaml
 import itertools
 
 from c7n.provider import resources
-from c7n.schema import validate, generate
 from .common import BaseTest
 
 
@@ -36,7 +35,6 @@ def get_doc_examples():
 class DocExampleTest(BaseTest):
 
     def test_doc_examples(self):
-        errors = []
         policies = []
         idx = 1
         for ptext, resource_name, el_name in get_doc_examples():

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import itertools
 import os
+import sys
 import yaml
 
 from c7n.provider import resources
@@ -44,12 +45,11 @@ class DocExampleTest(BaseTest):
     @skipif(
         # Okay slightly gross, basically if we're explicitly told via env var to run doc tests
         # do it.
-        (os.environ.get("C7N_TEST_DOC") not in ('yes', 'true')
-         or
+        (os.environ.get("C7N_TEST_DOC") not in ('yes', 'true') or
          # Or for ci to avoid some tox pain, we'll auto configure here to run the py3.6 test
          # runner.
-         os.environ.get('C7N_TEST_RUN') and sys.version.major == 3 and sys.version.minor == 6)
-            reason="Doc tests must be explicitly enabled with C7N_DOC_TEST")
+         os.environ.get('C7N_TEST_RUN') and sys.version.major == 3 and sys.version.minor == 6),
+        reason="Doc tests must be explicitly enabled with C7N_DOC_TEST")
     def test_doc_examples(self):
         policies = []
         idx = 1

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -41,7 +41,14 @@ def get_doc_examples():
 
 class DocExampleTest(BaseTest):
 
-    @skipif(os.environ.get("C7N_TEST_DOC") not in ('yes', 'true'),
+    @skipif(
+        # Okay slightly gross, basically if we're explicitly told via env var to run doc tests
+        # do it.
+        (os.environ.get("C7N_TEST_DOC") not in ('yes', 'true')
+         or
+         # Or for ci to avoid some tox pain, we'll auto configure here to run the py3.6 test
+         # runner.
+         os.environ.get('C7N_TEST_RUN') and sys.version.major == 3 and sys.version.minor == 6)
             reason="Doc tests must be explicitly enabled with C7N_DOC_TEST")
     def test_doc_examples(self):
         policies = []

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -48,7 +48,7 @@ class DocExampleTest(BaseTest):
         (os.environ.get("C7N_TEST_DOC") not in ('yes', 'true') or
          # Or for ci to avoid some tox pain, we'll auto configure here to run the py3.6 test
          # runner.
-         os.environ.get('C7N_TEST_RUN') and sys.version.major == 3 and sys.version.minor == 6),
+         (os.environ.get('C7N_TEST_RUN') and sys.version.major == 3 and sys.version.minor == 6)),
         reason="Doc tests must be explicitly enabled with C7N_DOC_TEST")
     def test_doc_examples(self):
         policies = []

--- a/tox.ini
+++ b/tox.ini
@@ -35,23 +35,23 @@ setenv =
 
 [testenv:py27]
 commands =
-    py.test -n {env:C7N_TEST_WORKERS:auto} --junitxml=junit/test-results.xml tests tools {posargs}
+    py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
 
 [testenv:py27-cov]
 commands =
-    py.test -n {env:C7N_TEST_WORKERS:auto} --junitxml=junit/test-results.xml --cov c7n --cov tools/c7n_azure/c7n_azure --cov tools/c7n_gcp/c7n_gcp --cov tools/c7n_kube/c7n_kube --cov tools/c7n_mailer/c7n_mailer --durations 20 tests tools {posargs}
+    py.test -n {env:C7N_TEST_WORKERS:auto} --cov c7n --cov tools/c7n_azure/c7n_azure --cov tools/c7n_gcp/c7n_gcp --cov tools/c7n_kube/c7n_kube --cov tools/c7n_mailer/c7n_mailer tests tools {posargs}
 
 [testenv:py36]
 commands =
-    py.test -n {env:C7N_TEST_WORKERS:auto} --junitxml=junit/test-results.xml tests tools {posargs}
+    py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
 
 [testenv:py37]
 commands =
-    py.test -n {env:C7N_TEST_WORKERS:auto} --junitxml=junit/test-results.xml tests tools {posargs}
+    py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
 
 [testenv:pypy]
 commands =
-    py.test -n {env:C7N_TEST_WORKERS:auto} --junitxml=junit/test-results.xml tests tools {posargs}
+    py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
 
 [testenv:lint]
 commands = make lint
@@ -62,4 +62,4 @@ commands = make sphinx
 
 [pytest]
 ; for travis, we set this up as env var that we can override to limit concurrency
-addopts= --tb=native
+addopts= --tb=native --durations 20 --junitxml=junit/test-results.xml

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ commands =
     py.test -n {env:C7N_TEST_WORKERS:auto} --cov c7n --cov tools/c7n_azure/c7n_azure --cov tools/c7n_gcp/c7n_gcp --cov tools/c7n_kube/c7n_kube --cov tools/c7n_mailer/c7n_mailer tests tools {posargs}
 
 [testenv:py36]
+setenv =
+    C7N_TEST_DOC=true
 commands =
     py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,6 @@ commands =
     py.test -n {env:C7N_TEST_WORKERS:auto} --cov c7n --cov tools/c7n_azure/c7n_azure --cov tools/c7n_gcp/c7n_gcp --cov tools/c7n_kube/c7n_kube --cov tools/c7n_mailer/c7n_mailer tests tools {posargs}
 
 [testenv:py36]
-setenv =
-    C7N_TEST_DOC=true
 commands =
     py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
 


### PR DESCRIPTION
Merging #3767 required turning off schema validation due to a massive test time regression (+10m worst case). This pr will address that for ci, so to ensure that full validation is run on doc examples as part of ci. To avoid slowing down ci across the build matrix, we'll have it run only on the python3.6 test runner, as its the only runner thats not doing additional activities (py27 is doing coverage, py37 is doing doc builds).