### PR TITLE
gcp - fix resourcemanager organization resource

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
@@ -23,7 +23,13 @@ class Organization(QueryResourceManager):
         version = 'v1'
         component = 'organizations'
         scope = 'global'
+        enum_spec = ('search', 'organizations[]', {'body': {}})
         id = "name"
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_query(
+                'get', {'name': resource_info['name']})
 
 
 @resources.register('folder')

--- a/tools/c7n_gcp/tests/data/flights/organization-get/get-v1-organizations-851339424791_1.json
+++ b/tools/c7n_gcp/tests/data/flights/organization-get/get-v1-organizations-851339424791_1.json
@@ -1,0 +1,27 @@
+{
+  "body": {
+    "displayName": "example.io",
+    "owner": {
+      "directoryCustomerId": "D14a97w5s"
+    },
+    "creationTime": "2018-07-28T07:02:05.547Z",
+    "lifecycleState": "ACTIVE",
+    "name": "organizations/851339424791"
+  },
+  "headers": {
+    "status": "200",
+    "content-length": "214",
+    "x-xss-protection": "1; mode=block", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "vary": "Origin, X-Origin, Referer", 
+    "server": "ESF", 
+    "server-timing": "gfet4t7; dur=762", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private", 
+    "date": "Fri, 12 Apr 2019 11:46:25 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/organization-query/post-v1-organizations-search_1.json
+++ b/tools/c7n_gcp/tests/data/flights/organization-query/post-v1-organizations-search_1.json
@@ -1,0 +1,31 @@
+{
+  "body": {
+    "organizations": [
+      {
+        "displayName": "example.io",
+        "owner": {
+          "directoryCustomerId": "D14a97w5s"
+        },
+        "creationTime": "2018-07-28T07:02:05.547Z",
+        "lifecycleState": "ACTIVE",
+        "name": "organizations/851339424791"
+      }
+    ]
+  },
+  "headers": {
+    "status": "200", 
+    "content-length": "279",
+    "x-xss-protection": "1; mode=block", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "vary": "Origin, X-Origin, Referer", 
+    "server": "ESF", 
+    "server-timing": "gfet4t7; dur=738", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private", 
+    "date": "Fri, 12 Apr 2019 10:35:56 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -1,0 +1,44 @@
+# Copyright 2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gcp_common import BaseTest
+
+
+class OrganizationTest(BaseTest):
+
+    def test_organization_query(self):
+        organization_name = 'organizations/851339424791'
+        session_factory = self.replay_flight_data('organization-query')
+
+        policy = self.load_policy(
+            {'name': 'gcp-organization-dryrun',
+             'resource': 'gcp.organization'},
+            session_factory=session_factory)
+
+        organization_resources = policy.run()
+        self.assertEqual(organization_resources[0]['name'], organization_name)
+
+    def test_organization_get(self):
+        organization_name = 'organizations/851339424791'
+        session_factory = self.replay_flight_data(
+            'organization-get')
+
+        policy = self.load_policy(
+            {'name': 'gcp-organization-dryrun',
+             'resource': 'gcp.organization'},
+            session_factory=session_factory)
+
+        organization_resource = policy.resource_manager.get_resource(
+            {'name': organization_name})
+        self.assertEqual(organization_resource['name'], organization_name)


### PR DESCRIPTION
Add `enum_spec` and `get` method to `Organization`'s `resource_type` in order for `query` and `get` to work.