### PR TITLE
[SecurityHub] Add title to schema for post-findings

### DIFF
--- a/c7n/actions/securityhub.py
+++ b/c7n/actions/securityhub.py
@@ -135,6 +135,7 @@ class PostFinding(BaseAction):
     schema = type_schema(
         "post-finding",
         required=["types"],
+        title={"type": "string"},
         severity={"type": "number", 'default': 0},
         severity_normalized={"type": "number", "min": 0, "max": 100, 'default': 0},
         confidence={"type": "number", "min": 0, "max": 100},


### PR DESCRIPTION
We are using the `post-findings` action to create findings in Security Hub when listening to CloudTrail events. This works great but we also want to change the status from `FAILED` to `PASSED` when the issue has been resolved. To do this we create two policies, one for the `FAILED` state and one for the `PASSED` state. The problem is that by default `post-findings` uses the policy name as the `Title` for the finding and since we cannot have two policies with the same name we cannot update the existing finding. When going through the source code I see this (or similar) in several places:
```
self.data.get('title', self.manager.ctx.policy.name)
```
So I suspect that title should be part of the schema. I have tested this change and it works great for the following policies:
```
policies:
  - name: security-group-test-resolve
    resource: security-group
    filters:
    - not:
      - type: ingress
        Ports: [22]
        Cidr:
          value: 0.0.0.0/0
          op: eq
          value_type: cidr
    mode:
      type: cloudtrail
      role: arn:aws:iam::{my-account-id}:role/cloud-custodian-lambda-role
      events:
        - source: ec2.amazonaws.com
          event: RevokeSecurityGroupIngress
          ids: "requestParameters.groupId"
      member-role: arn:aws:iam::{account_id}:role/cloud-custodian-role
      packages: [boto3, botocore, urllib3]
    actions:
    - type: post-finding
      title: security-group-test
      severity_normalized: 30
      batch_size: 1
      compliance_status: PASSED
      types:
        - "Software and Configuration Checks/AWS Security Best Practices"
    - type: untag
      tags: [c7n:FindingId:security-group-test]

  - name: security-group-test-trigger
    resource: security-group
    filters:
    - type: ingress
      Ports: [22]
      Cidr:
        value: 0.0.0.0/0
        op: eq
        value_type: cidr
    mode:
      type: cloudtrail
      role: arn:aws:iam::{my-account-id}:role/cloud-custodian-lambda-role
      events:
        - source: ec2.amazonaws.com
          event: AuthorizeSecurityGroupIngress
          ids: "requestParameters.groupId"
      member-role: arn:aws:iam::{account_id}:role/cloud-custodian-role
      packages: [boto3, botocore, urllib3]
    actions:
    - type: post-finding
      title: security-group-test
      severity_normalized: 30
      batch_size: 1
      compliance_status: FAILED
      types:
        - "Software and Configuration Checks/AWS Security Best Practices"
```
Let me know if there is a better way of solving this but this solution works for me with the small modification in the PR.