### PR TITLE
filters/security-group - cidr overlap op

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -970,6 +970,28 @@ class SGPermission(Filter):
             - "::/0"
           op: in
 
+    Additionally, it is possible to check if a Cidr overlaps with another one.
+
+    .. code-block:: yaml
+
+      - type: egress
+        Cidr:
+          value: 10.0.0.0/8
+          op: cidr_overlap
+          value_type: cidr
+
+    or a list of Cidr's:
+
+
+    .. code-block:: yaml
+
+      - type: egress
+        Cidr:
+          value:
+            - 10.0.0.0/8
+            - 20.0.0.0/8
+          op: cidr_overlap
+          value_type: cidr
 
     """
 


### PR DESCRIPTION
Adds functionality to find security groups that have ip ranges that overlap with user defined cidrs

e.g.

```yaml
policies:
  - name: find-sgs-outside-of-approved-cidrs
    resource: security-group
    filters:
      - not:
        - type: egress
          Cidr:
            op: cidr_overlap
            value_type: cidr
            value:
              - 10.0.0.0/8
              - 20.0.0.0/8
    actions:
      - type: notify
        subject: [custodian] Security Group references unapproved cidr block
...
```

todo:
- tests
- add validation in the SGPermission class for cidr_overlap op