### PR TITLE
aws.asg - bug fix for launch templates

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -97,7 +97,7 @@ class LaunchInfo(object):
             return {}
         return {
             (t['LaunchTemplateId'],
-             t.get('c7n:VersionAlias', t['VersionNumber'])): t['LaunchTemplateData']
+             str(t.get('c7n:VersionAlias', t['VersionNumber']))): t['LaunchTemplateData']
             for t in tmpl_mgr.get_resources(template_ids)}
 
     def get_launch_configs(self, asgs):


### PR DESCRIPTION
In LaunchInfo, self.templates is initialized by get_launch_templates() which creates tuples using information from the describe_launch_template() boto3 function. However, this tuple includes the version number as an integer.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_launch_templates
```
{
    'LaunchTemplates': [
        {
            'LaunchTemplateId': 'string',
            'LaunchTemplateName': 'string',
            'CreateTime': datetime(2015, 1, 1),
            'CreatedBy': 'string',
            'DefaultVersionNumber': 123,
            'LatestVersionNumber': 123,
            'Tags': [
                {
                    'Key': 'string',
                    'Value': 'string'
                },
            ]
        },
    ],
    'NextToken': 'string'
}
```

Furthermore, get_launch_id() creates this same tuple using information from the describe_autoscaling_groups() boto3 function. This is inconsistent with the information retrieved from describe_launch_templates() as this function returns launch template version information as a string.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/autoscaling.html#AutoScaling.Client.describe_auto_scaling_groups

```
                    'LaunchTemplateSpecification': {
                        'LaunchTemplateId': 'string',
                        'LaunchTemplateName': 'string',
                        'Version': 'string'
                    },
```

In order to fix the discrepancy I cast the version variable in the tuple stored in self.templates as a string. This avoids comparison problems generated in the get() function which uses the tuple that contains version information as a string to index into self.templates which contains the tuple which stores version information as an int. 