### PR TITLE
aws - Check for BlockDeviceMappings in SnapshotUnusedFilter in ebs resource

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -289,7 +289,7 @@ class SnapshotUnusedFilter(Filter):
         tmpl_mgr = self.manager.get_resource_manager('launch-template-version')
         for tversion in tmpl_mgr.get_resources(
                 list(tmpl_mgr.get_asg_templates(asgs).keys())):
-            for bd in tversion['LaunchTemplateData']['BlockDeviceMappings']:
+            for bd in tversion['LaunchTemplateData'].get('BlockDeviceMappings', ()):
                 if 'Ebs' in bd and 'SnapshotId' in bd['Ebs']:
                     snap_ids.add(bd['Ebs']['SnapshotId'])
         return snap_ids


### PR DESCRIPTION
Solves this error

```
KeyError: u'BlockDeviceMappings'
Traceback (most recent call last):
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/cli.py", line 368, in main
    command(config)
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/commands.py", line 136, in _load_policies
    return f(options, list(policies))
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/commands.py", line 268, in run
    policy()
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/policy.py", line 943, in __call__
    resources = PullMode(self).run()
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/policy.py", line 232, in run
    resources = self.policy.resource_manager.resources()
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/resources/ebs.py", line 84, in resources
    return super(Snapshot, self).resources(query=query)
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/query.py", line 431, in resources
    resources = self.filter_resources(resources)
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/manager.py", line 108, in filter_resources
    resources = f.process(resources, event)
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/resources/ebs.py", line 307, in process
    snaps = self._pull_asg_snapshots().union(self._pull_ami_snapshots())
  File "/Users/user/.local/share/virtualenvs/cloudcustodian-yc_Lr_zo/lib/python2.7/site-packages/c7n/resources/ebs.py", line 292, in _pull_asg_snapshots
    for bd in tversion['LaunchTemplateData']['BlockDeviceMappings']:
KeyError: u'BlockDeviceMappings'
```

From policy

```
policies:
- name: remove-unused-ebs-snapshots
  resource: ebs-snapshot
  description: |
    Delete unused EBS snapshots
    - type: unused
      value: true
  actions:
    - delete
```