### PR TITLE
aws - serverless policy fix role name expansion

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -848,7 +848,7 @@ class Policy(object):
 
         if 'mode' in self.data:
             if 'role' in self.data['mode'] and not self.data['mode']['role'].startswith("arn:aws"):
-                self.data['mode']['role'] = "arn:aws:iam::%s/role/%s" % \
+                self.data['mode']['role'] = "arn:aws:iam::%s:role/%s" % \
                                             (self.options.account_id, self.data['mode']['role'])
 
         variables.update({

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -372,8 +372,8 @@ class TestPolicy(BaseTest):
             'resource': 'aws.ec2',
             'mode': {
                 'type': 'config-rule',
-                'member-role': 'arn:aws:iam::{account_id}/role/BarFoo',
-                'role': 'arn:aws:iam::{account_id}/role/FooBar'},
+                'member-role': 'arn:aws:iam::{account_id}:role/BarFoo',
+                'role': 'arn:aws:iam::{account_id}:role/FooBar'},
             'actions': [
                 {'type': 'tag',
                  'value': 'bad monkey {account_id} {region} {now:+2d%Y-%m-%d}'},
@@ -387,7 +387,7 @@ class TestPolicy(BaseTest):
             ]}, config={'account_id': '12312311', 'region': 'zanzibar'})
 
         p.expand_variables(p.get_variables())
-        self.assertEqual(p.data['mode']['role'], 'arn:aws:iam::12312311/role/FooBar')
+        self.assertEqual(p.data['mode']['role'], 'arn:aws:iam::12312311:role/FooBar')
 
     def test_policy_variable_interpolation(self):
 
@@ -396,7 +396,7 @@ class TestPolicy(BaseTest):
             'resource': 'aws.ec2',
             'mode': {
                 'type': 'config-rule',
-                'member-role': 'arn:aws:iam::{account_id}/role/BarFoo',
+                'member-role': 'arn:aws:iam::{account_id}:role/BarFoo',
                 'role': 'FooBar'},
             'actions': [
                 {'type': 'tag',
@@ -417,8 +417,8 @@ class TestPolicy(BaseTest):
         self.assertEqual(
             p.data['actions'][1]['subject'],
             "S3 - Cross-Account -[custodian {{ account }} - {{ region }}]")
-        self.assertEqual(p.data['mode']['role'], 'arn:aws:iam::12312311/role/FooBar')
-        self.assertEqual(p.data['mode']['member-role'], 'arn:aws:iam::{account_id}/role/BarFoo')
+        self.assertEqual(p.data['mode']['role'], 'arn:aws:iam::12312311:role/FooBar')
+        self.assertEqual(p.data['mode']['member-role'], 'arn:aws:iam::{account_id}:role/BarFoo')
         self.assertEqual(p.resource_manager.actions[0].data['value'], ivalue)
 
     def test_child_resource_trail_validation(self):


### PR DESCRIPTION

The specification of mode's `role` per #3661 was intended to allow just specifying name, but the role generation was not valid resulting in errors like

```
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the CreateFunction operation: 1 validation error detected: Value 'arn:aws:iam::124699101/role/CloudCustodianRole' at 'role' failed to satisfy constraint: Member must satisfy```

this fixes the role name expansion to arn to be a valid role arn.
