### PR TITLE
cli - s3 reporting do key fetch with prefix sans extra date

### DIFF
--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -82,8 +82,8 @@ def report(policies, start_date, options, output_fh, raw_output_fh=None):
         if policy.ctx.output.type == 's3':
             policy_records = record_set(
                 policy.session_factory,
-                policy.ctx.output.bucket,
-                policy.ctx.output.key_prefix,
+                policy.ctx.output.config['netloc'],
+                policy.ctx.output.config['path'].strip('/'),
                 start_date)
         else:
             policy_records = fs_record_set(policy.ctx.log_dir, policy.name)

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -397,7 +397,7 @@ class S3Output(DirectoryOutput):
 
     def get_output_path(self, output_url):
         if '{' not in output_url:
-            date_path = datetime.datetime.now().strftime('%Y/%m/%d/%H')
+            date_path = datetime.datetime.utcnow().strftime('%Y/%m/%d/%H')
             return self.join(
                 output_url, self.ctx.policy.name, date_path)
         return output_url.format(**self.get_output_vars())


### PR DESCRIPTION
closes #3834 .. refactor on outputs, meant the key prefix we handed off to reporting code had the current date suffix'd on to it, which was used with reporting date to construct the starting marker, generally this still returned results, but was typically an underflow on keys to query for results. The change here hands off to the reporting code without any current date suffix so all result keys in s3 are examined.