### PR TITLE
Azure - Example Child Resource Query

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/arm.py
+++ b/tools/c7n_azure/c7n_azure/resources/arm.py
@@ -77,4 +77,19 @@ class ArmResourceManager(QueryResourceManager):
                     klass.filter_registry.register('diagnostic-settings', DiagnosticSettingsFilter)
 
 
+@six.add_metaclass(QueryMeta)
+class ChildArmResourceManager(ArmResourceManager):
+
+    child_source = 'describe-child'
+
+    @property
+    def source_type(self):
+        source = self.data.get('source', self.child_source)
+        if source == 'describe':
+            source = self.child_source
+        return source
+
+    def get_parent_manager(self):
+        return self.get_resource_manager(self.resource_type.parent_spec[0])
+
 resources.subscribe(resources.EVENT_FINAL, ArmResourceManager.register_arm_specific)

--- a/tools/c7n_azure/c7n_azure/resources/sqlserver.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqlserver.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from c7n_azure.provider import resources
-from c7n_azure.resources.arm import ArmResourceManager
+from c7n_azure.resources.arm import ArmResourceManager, ChildArmResourceManager
 
 
 @resources.register('sqlserver')
@@ -23,3 +23,13 @@ class SqlServer(ArmResourceManager):
         service = 'azure.mgmt.sql'
         client = 'SqlManagementClient'
         enum_spec = ('servers', 'list', None)
+
+
+@resources.register('sqldatabase')
+class SqlDatabase(ChildArmResourceManager):
+
+    class resource_type(ArmResourceManager.resource_type):
+        service = 'azure.mgmt.sql'
+        client = 'SqlManagementClient'
+        enum_spec = ('databases', 'list_by_server', {'resource_group_name': 'resourceGroup', 'server_name': 'name'})
+        parent_spec = ('sqlserver', True)


### PR DESCRIPTION
Per disussion in #3846 I quickly hacked in the implementation of ChildResourceQuery and put together an example with SqlDatabase.

It seems to work excellent.

Example policy:

```
policies:
  - name: sqltest
    resource: azure.sqldatabase
```

Parent and child resource:

```
@resources.register('sqlserver')
class SqlServer(ArmResourceManager):
    class resource_type(ArmResourceManager.resource_type):
        service = 'azure.mgmt.sql'
        client = 'SqlManagementClient'
        enum_spec = ('servers', 'list', None)

@resources.register('sqldatabase')
class SqlDatabase(ChildArmResourceManager):
    class resource_type(ArmResourceManager.resource_type):
        service = 'azure.mgmt.sql'
        client = 'SqlManagementClient'
        enum_spec = ('databases', 'list_by_server', {'resource_group_name': 'resourceGroup', 'server_name': 'name'})
        parent_spec = ('sqlserver', True)
```

We can clean this up and add tests if we think it is the right direction?