### PR TITLE
cli - Generate iam role

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -307,8 +307,10 @@ def setup_parser():
     generate_role = subs.add_parser("generate-role", description=generate_role_desc,
                                     help=generate_role_desc)
     generate_role.set_defaults(command="c7n.commands.generate_role")
-    generate_role.add_argument("--name", help="Name for the generated role")
-    _default_options(generate_role)
+    generate_role.add_argument("-n", "--name", help="Name for the generated role")
+    generate_role.add_argument("-d", "--dryrun", default=False, action="store_true",
+                               help="Only print generated policy")
+    _default_options(generate_role, blacklist=["dryrun", "output-dir"])
 
     return parser
 

--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -307,7 +307,8 @@ def setup_parser():
     generate_role = subs.add_parser("generate-role", description=generate_role_desc,
                                     help=generate_role_desc)
     generate_role.set_defaults(command="c7n.commands.generate_role")
-    generate_role.add_argument("-n", "--name", help="Name for the generated role")
+    generate_role.add_argument("--policy", help="Name for the generated policy")
+    generate_role.add_argument("--role", help="Name for the generated role")
     generate_role.add_argument("-d", "--dryrun", default=False, action="store_true",
                                help="Only print generated policy")
     _default_options(generate_role, blacklist=["dryrun", "output-dir"])

--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -303,6 +303,13 @@ def setup_parser():
     validate.add_argument("-q", "--quiet", action="count", help="Less logging (repeatable)")
     validate.add_argument("--debug", default=False, help=argparse.SUPPRESS)
 
+    generate_role_desc = "Generate iam role with oermissions required from yaml policies"
+    generate_role = subs.add_parser("generate-role", description=generate_role_desc,
+                                    help=generate_role_desc)
+    generate_role.set_defaults(command="c7n.commands.generate_role")
+    generate_role.add_argument("--name", help="Name for the generated role")
+    _default_options(generate_role)
+
     return parser
 
 

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -22,6 +22,7 @@ import os
 import pprint
 import sys
 import time
+import uuid
 
 import six
 import yaml
@@ -312,6 +313,26 @@ def logs(options, policies):
                 "%Y-%m-%d %H:%M:%S", time.localtime(e['timestamp'] / 1000)),
             e['message']))
 
+
+@policy_command
+def generate_role(options, policies):
+    permissions = [policy.get_permissions() for policy in policies]
+    if not options.name:
+        options.name = str(uuid.uuid4())
+    policy_doc = _generate_policy_doc(permissions)
+    print(policy_doc)
+
+
+def _generate_policy_doc(permissions):
+    """Given a list of policy dicts, return a policy document"""
+    statement = [{
+        "Effect": "Allow",
+        "Action": list(p)
+    } for p in permissions]
+    return {
+        "Version": "2012-10-17",
+        "Statement": statement
+    }
 
 def _schema_get_docstring(starting_class):
     """ Given a class, return its docstring.

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -320,7 +320,8 @@ def generate_role(options, policies):
     if not options.name:
         options.name = str(uuid.uuid4())
     policy_doc = _generate_policy_doc(permissions)
-    print(policy_doc)
+    if options.dryrun:
+        print(policy_doc)
 
 
 def _generate_policy_doc(permissions):
@@ -329,10 +330,12 @@ def _generate_policy_doc(permissions):
         "Effect": "Allow",
         "Action": list(p)
     } for p in permissions]
+
     return {
         "Version": "2012-10-17",
         "Statement": statement
     }
+
 
 def _schema_get_docstring(starting_class):
     """ Given a class, return its docstring.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,25 +225,27 @@ class SchemaTest(CliTest):
 
 class GenerateRoleTest(CliTest):
 
-        def test_generate_role(self):
-            valid_policies = {
-                "policies": [
-                    {
-                        "name": "foo",
-                        "resource": "vpn-gateway",
-                        "actions": [{"type": "mark"}],
-                    }
-                ]
-            }
-            yaml_file = self.write_policy_file(valid_policies)
+    def test_generate_role(self):
+        valid_policies = {
+            "policies": [
+                {
+                    "name": "foo",
+                    "resource": "vpn-gateway",
+                    "actions": [{"type": "mark"}],
+                }
+            ]
+        }
+        yaml_file = self.write_policy_file(valid_policies)
 
-            self.run_and_expect_success(["custodian", "generate-role", yaml_file])
+        self.run_and_expect_success(["custodian", "generate-role", yaml_file])
 
-            # requires config file
-            self.run_and_expect_failure(["custodian", "generate-role"])
+        # requires config file
+        self.run_and_expect_failure(["custodian", "generate-role", "no_file"], 1)
 
-            output = self.get_output(["custodian", "generate-role", "--dryrun", yaml_file])
-            self.assertIn("{'Effect': 'Allow', 'Action': ['ec2:DescribeVpnGateways', 'ec2:CreateTags']}]", output)
+        output = self.get_output(["custodian", "generate-role", "--dryrun", yaml_file])
+        self.assertIn("'Action': ['ec2:DescribeVpnGateways', 'ec2:CreateTags']",
+                      output)
+        self.assertIn("'Effect': 'Allow'", output)
 
 
 class ReportTest(CliTest):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,6 +223,29 @@ class SchemaTest(CliTest):
         self.assertIn("Help", output)
 
 
+class GenerateRoleTest(CliTest):
+
+        def test_generate_role(self):
+            valid_policies = {
+                "policies": [
+                    {
+                        "name": "foo",
+                        "resource": "vpn-gateway",
+                        "actions": [{"type": "mark"}],
+                    }
+                ]
+            }
+            yaml_file = self.write_policy_file(valid_policies)
+
+            self.run_and_expect_success(["custodian", "generate-role", yaml_file])
+
+            # requires config file
+            self.run_and_expect_failure(["custodian", "generate-role"])
+
+            output = self.get_output(["custodian", "generate-role", "--dryrun", yaml_file])
+            self.assertIn("{'Effect': 'Allow', 'Action': ['ec2:DescribeVpnGateways', 'ec2:CreateTags']}]", output)
+
+
 class ReportTest(CliTest):
 
     def test_report(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,15 +237,12 @@ class GenerateRoleTest(CliTest):
         }
         yaml_file = self.write_policy_file(valid_policies)
 
-        self.run_and_expect_success(["custodian", "generate-role", yaml_file])
-
         # requires config file
         self.run_and_expect_failure(["custodian", "generate-role", "no_file"], 1)
 
         output = self.get_output(["custodian", "generate-role", "--dryrun", yaml_file])
-        self.assertIn("'Action': ['ec2:DescribeVpnGateways', 'ec2:CreateTags']",
-                      output)
-        self.assertIn("'Effect': 'Allow'", output)
+        self.assertIn("'ec2:DescribeVpnGateways'", output)
+        self.assertIn("ec2:CreateTags'", output)
 
 
 class ReportTest(CliTest):


### PR DESCRIPTION
#888 Allow users to generate iam roles from the cli based on their policies. 
``` custodian generate-role custodian.yaml ```

can be run with ```--dryrun``` to just output the policy doc

can also specify ```--role``` and ```--policy``` to set the role and policy name otherwise a random hash will be created for them. 
