### PR TITLE
tools/c7n-org chained role support

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -17,12 +17,17 @@
 from collections import Counter
 import logging
 import os
-import multiprocessing
 import time
 import subprocess
 import six
 import sys
 
+# Try to set this early if offers any help against this OSX issue
+# https://bugs.python.org/issue33725
+if sys.platform == 'darwin':
+    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
+
+import multiprocessing
 from concurrent.futures import (
     ProcessPoolExecutor,
     as_completed)
@@ -47,7 +52,6 @@ from c7n_org.utils import environ, account_tags
 from c7n.utils import UnicodeWriter
 
 log = logging.getLogger('c7n_org')
-
 
 WORKER_COUNT = int(
     os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count() * 4))

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -24,8 +24,8 @@ import sys
 
 # Try to set this early if offers any help against this OSX issue
 # https://bugs.python.org/issue33725
-if sys.platform == 'darwin':
-    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
+# if sys.platform == 'darwin':
+#    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
 
 import multiprocessing
 from concurrent.futures import (

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -48,10 +48,6 @@ from c7n.utils import UnicodeWriter
 
 log = logging.getLogger('c7n_org')
 
-# On OSX High Sierra Workaround
-# https://github.com/ansible/ansible/issues/32499
-if sys.platform == 'darwin':
-    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
 
 WORKER_COUNT = int(
     os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count() * 4))


### PR DESCRIPTION
accounts config file already allowed users to specify arrays of roles for chained role assumption, this enables it in practice for run-script/run-policy.

it seems pretty common for a locked down iam setup, to need some degree of role chaining to get access to a privileged role across account boundaries.