### PR TITLE
schema for phd (personal health dashboard) mode missing role 

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -531,7 +531,8 @@ class PHDMode(LambdaMode):
         categories={'type': 'array', 'items': {
             'enum': ['issue', 'accountNotification', 'scheduledChange']}},
         statuses={'type': 'array', 'items': {
-            'enum': ['open', 'upcoming', 'closed']}})
+            'enum': ['open', 'upcoming', 'closed']}},
+        rinherit=LambdaMode.schema)
 
     def validate(self):
         super(PHDMode, self).validate()


### PR DESCRIPTION
schema for phd mode is missing role specification and failing to create lambdas with the following error when trying to deploy policies with phd . Updated the schema to inherit schema from Lambda Mode
```
  File "venv_pe/src/c7n/c7n/mu.py", line 299, in publish
    func, role, s3_uri, qualifier=alias)
  File "venv_pe/src/c7n/c7n/mu.py", line 419, in _create_or_update
    assert role, "Lambda function role must be specified"
AssertionError: Lambda function role must be specified
```