### PR TITLE
Typo Fix for Validate

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -371,7 +371,7 @@ class ValueFilter(Filter):
             'key': {'type': 'string'},
             'value_type': {'$ref': '#/definitions/filters_common/value_types'},
             'default': {'type': 'object'},
-            'value_from': {'$ref': '#/definitions/filters_common/values_from'},
+            'value_from': {'$ref': '#/definitions/filters_common/value_from'},
             'value': {'$ref': '#/definitions/filters_common/value'},
             'op': {'$ref': '#/definitions/filters_common/comparison_operators'}
         }


### PR DESCRIPTION
typo from an earlier commit causing a `KeyError` when validating policy files

```
Traceback (most recent call last):
  File "/Users/me/cloud-custodian/lib/python3.7/site-packages/jsonschema/validators.py", line 776, in resolve_fragment
    document = document[part]
KeyError: 'values_from'
```