### PR TITLE
c7n_mailer - docker image fix typo on base image name

### DIFF
--- a/tools/c7n_mailer/Dockerfile
+++ b/tools/c7n_mailer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-strech
+FROM python:3.7-slim-stretch
 LABEL name="mailer" \
       description="Cloud Custodian Notification Delivery" \
       repository="http://github.com/cloud-custodian/cloud-custodian" \

--- a/tools/c7n_mailer/Dockerfile
+++ b/tools/c7n_mailer/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.7-slim-stretch
+
 LABEL name="mailer" \
       description="Cloud Custodian Notification Delivery" \
       repository="http://github.com/cloud-custodian/cloud-custodian" \


### PR DESCRIPTION
working copy fix that didn't make it to branch pr #3837 
