### PR TITLE
aws - rds fix start/stop permissions

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -509,7 +509,7 @@ class Stop(BaseAction):
 
     schema = type_schema('stop')
 
-    permissions = ("rds:StopDBInstance")
+    permissions = ("rds:StopDBInstance",)
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('rds')
@@ -530,7 +530,7 @@ class Start(BaseAction):
 
     schema = type_schema('start')
 
-    permissions = ("rds:StartDBInstance")
+    permissions = ("rds:StartDBInstance",)
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('rds')

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -509,8 +509,7 @@ class Stop(BaseAction):
 
     schema = type_schema('stop')
 
-    # permissions are unclear, and not currrently documented or in iam gen
-    permissions = ("rds:RebootDBInstance",)
+    permissions = ("rds:StopDBInstance")
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('rds')
@@ -531,8 +530,7 @@ class Start(BaseAction):
 
     schema = type_schema('start')
 
-    # permissions are unclear, and not currrently documented or in iam gen
-    permissions = ("rds:RebootDBInstance",)
+    permissions = ("rds:StartDBInstance")
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('rds')


### PR DESCRIPTION
* Fixing permissions list for stopping/starting RDS DB instances.