### PR TITLE
policy - support concatenation of strings/vars in policy

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -30,7 +30,7 @@ from yaml.constructor import ConstructorError
 from c7n.exceptions import ClientError
 from c7n.provider import clouds
 from c7n.policy import Policy, PolicyCollection, load as policy_load
-from c7n.utils import dumps, load_file, local_session, SafeLoader
+from c7n.utils import dumps, load_file, local_session, SafeLoader, yaml_load
 from c7n.config import Bag, Config
 from c7n import provider
 from c7n.resources import load_resources
@@ -213,7 +213,7 @@ def validate(options):
 
         with open(config_file) as fh:
             if fmt in ('yml', 'yaml', 'json'):
-                data = yaml.load(fh.read(), Loader=DuplicateKeyCheckLoader)
+                data = yaml_load(fh.read(), DuplicateKeyCheckLoader)
             else:
                 log.error("The config file must end in .json, .yml or .yaml.")
                 raise ValueError("The config file must end in .json, .yml or .yaml.")

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -29,6 +29,7 @@ import six
 import sys
 
 from six.moves.urllib import parse as urlparse
+from yaml.constructor import ConstructorError
 
 from c7n.exceptions import ClientError, PolicyValidationError
 from c7n import ipaddress, config
@@ -103,6 +104,8 @@ def yaml_join(loader, node):
     """
     Simple join tag to allow string concatenation in yaml file
     """
+    if not isinstance(node.value, list):
+        raise ConstructorError('!join expects a list of items, not %s' % type(node.value))
     seq = loader.construct_sequence(node)
     return ''.join([str(i) for i in seq])
 

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -99,10 +99,19 @@ def load_file(path, format=None, vars=None):
             return loads(contents)
 
 
-def yaml_load(value):
+def yaml_join(loader, node):
+    """
+    Simple join tag to allow string concatenation in yaml file
+    """
+    seq = loader.construct_sequence(node)
+    return ''.join([str(i) for i in seq])
+
+
+def yaml_load(value, loader=SafeLoader):
     if yaml is None:
         raise RuntimeError("Yaml not available")
-    return yaml.load(value, Loader=SafeLoader)
+    yaml.add_constructor('!join', yaml_join, loader)
+    return yaml.load(value, Loader=loader)
 
 
 def loads(body):

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -14,9 +14,10 @@
 import itertools
 import os
 import sys
-import yaml
 
 from c7n.provider import resources
+from c7n.utils import yaml_load
+from c7n.commands import DuplicateKeyCheckLoader
 from .common import BaseTest
 
 try:
@@ -59,7 +60,7 @@ class DocExampleTest(BaseTest):
         policy_map = {}
         idx = 1
         for ptext, resource_name, el_name in get_doc_examples():
-            data = yaml.safe_load(ptext)
+            data = yaml_load(ptext, DuplicateKeyCheckLoader)
             for p in data.get('policies', []):
                 # We unique based on name and content to avoid duplicates
                 # from inherited docs.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ import os
 import sys
 import tempfile
 import time
+import yaml
 
 from botocore.exceptions import ClientError
 from dateutil.parser import parse as parse_date
@@ -453,3 +454,11 @@ class UtilTest(BaseTest):
                  'b': '{account_id}'}, account_id=21),
             {'k': '{limit}',
              'b': '21'})
+
+    def test_yaml_join(self):
+        data = utils.yaml_load("baz: !join ['foo', 'bar']")
+        self.assertEqual(data['baz'], 'foobar')
+
+    def test_yaml_load_bad_value(self):
+        with self.assertRaises(yaml.YAMLError):
+            utils.yaml_load("baz: !join 'foo'")


### PR DESCRIPTION
Use case: referencing vars in policy and concatenating them together

```yaml
vars:
  account_name: &account_name my-account

  output_dir: &output_dir !join ['s3://my-bucket', '/custodian-outputs/', *account_name, '/{region'}]
  log_group: &log_group !join ['/cloud-custodian/', *account_name, '{region}']

policies:
  - name: !join ['my-first-serverless-policy-', *account_name]
    description: My first serverless policy that outputs to s3
    resource: ec2
    mode:
      type: periodic
      schedule: rate(1 day)
      execution-options:
        output_dir: *output_dir
        log_group: *log_group
```

this sort of matches the cloudformation and terraform syntax (barring delimiter-- which i can go either way on)