### PR TITLE
ci - fix drone doc build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ build:
        - git config --global user.email "cibot@cloud-custodian.io"
        - git config --global user.name "Custodian CI"
        - pip install tox
-       - tox -e py37 --notest
+       - tox -e doc --notest
        - make sphinx
        - git remote update origin --prune
        - make ghpages


### PR DESCRIPTION
trunk is currently red.

this fixes the drone setup doc build setup post the ci changes from earlier today that switched the tox doc target to being self-contained instead of relying on an existing py37 install (which avoided the need to reinstall).