### PR TITLE
ci - fix drone doc update redux 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,8 +5,7 @@ build:
        - git config --global user.email "cibot@cloud-custodian.io"
        - git config --global user.name "Custodian CI"
        - pip install tox
-       - tox -e doc --notest
-       - make sphinx
+       - tox -e docs
        - git remote update origin --prune
        - make ghpages
        - git branch

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ build:
        - git config --global user.email "cibot@cloud-custodian.io"
        - git config --global user.name "Custodian CI"
        - pip install tox
-       - tox -e py37 --notest
+       - tox -e doc --notest
        - make sphinx
        - git remote update origin --prune
        - make ghpages


### PR DESCRIPTION
sigh :-( previous pr to address drone doc build had a typo .. 'doc' vs 'docs' .. unfortunately there isn't a good way to dry run these changes since drone is not configured on branches only on master, azure pipelines does doc build/test, but not publishing.