### PR TITLE
docker images size shrink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-slim-stretch
 
 LABEL name="custodian" \
       description="Cloud Management Rules Engine" \
@@ -6,21 +6,25 @@ LABEL name="custodian" \
       homepage="http://github.com/cloud-custodian/cloud-custodian" \
       maintainer="Custodian Community <https://cloudcustodian.io>"
 
-ADD . /src
+# Transfer Custodian source into container by directory
+# to minimize size
+ADD setup.py README.rst requirements.txt /src/
+ADD c7n /src/c7n/
+ADD tools /src/tools/
 
-# Install Custodian Core & AWS
 WORKDIR /src
-RUN pip3 install -r requirements.txt -e .
 
-# Install Custodian Azure
-WORKDIR /src/tools/c7n_azure
-RUN pip3 install -r requirements.txt -e .
+RUN apt-get --yes update && apt-get --yes upgrade \
+ && apt-get --yes install build-essential \
+ && pip3 install -r requirements.txt  . \
+ && pip3 install -r tools/c7n_gcp/requirements.txt tools/c7n_gcp \
+ && pip3 install -r tools/c7n_azure/requirements.txt tools/c7n_azure \
+ && apt-get --yes remove build-essential \
+ && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+ && rm -Rf /var/cache/apt/ \
+ && rm -Rf /var/lib/apt/lists/* \
+ && rm -Rf /src/
 
-# Install Custodian GCP
-WORKDIR /src/tools/c7n_gcp
-RUN pip3 install -r requirements.txt -e .
-
-# Setup for EntryPoint
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 VOLUME ["/var/log/cloud-custodian", "/etc/cloud-custodian"]
 ENTRYPOINT ["/usr/local/bin/custodian"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get --yes update && apt-get --yes upgrade \
  && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
  && rm -Rf /var/cache/apt/ \
  && rm -Rf /var/lib/apt/lists/* \
- && rm -Rf /src/
+ && rm -Rf /src/ \
+ && rm -Rf /root/.cache/
 
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 VOLUME ["/var/log/cloud-custodian", "/etc/cloud-custodian"]

--- a/tools/c7n_mailer/Dockerfile
+++ b/tools/c7n_mailer/Dockerfile
@@ -6,7 +6,8 @@ LABEL name="mailer" \
       homepage="https://cloudcustodian.io" \
       maintainer="Custodian Community <https://cloudcustodian.io>"
 
-# Assemble custodian bits by parent dir.
+# Transfer Custodian source into container by directory
+# to minimize size
 ADD setup.py README.rst requirements.txt /src/
 ADD c7n /src/c7n/
 ADD tools /src/tools/
@@ -14,11 +15,11 @@ ADD tools /src/tools/
 WORKDIR /src
 
 RUN apt-get --yes update && apt-get --yes upgrade \
- && apt-get --yes install python-dev build-essential \
+ && apt-get --yes install build-essential \
  && pip3 install -r requirements.txt  . \
  && pip3 install -r tools/c7n_azure/requirements.txt tools/c7n_azure \
  && pip3 install -r tools/c7n_mailer/requirements.txt tools/c7n_mailer \
- && apt-get --yes remove build-essential python-dev \
+ && apt-get --yes remove build-essential \
  && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
  && rm -Rf /var/cache/apt/ \
  && rm -Rf /var/lib/apt/lists/* \

--- a/tools/c7n_mailer/Dockerfile
+++ b/tools/c7n_mailer/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get --yes update && apt-get --yes upgrade \
  && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
  && rm -Rf /var/cache/apt/ \
  && rm -Rf /var/lib/apt/lists/* \
- && rm -Rf /src/
+ && rm -Rf /src/ \
+ && rm -Rf /root/.cache/
 
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 ENTRYPOINT ["c7n-mailer"]

--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -1,33 +1,32 @@
-FROM python:3.7
+FROM python:3.7-slim-stretch
 
-LABEL name="custodian" \
-      description="Cloud Management Rules Engine" \
+LABEL name="c7n-org" \
+      description="Cloud Custodian Organization Runner" \
       repository="http://github.com/cloud-custodian/cloud-custodian" \
       homepage="http://github.com/cloud-custodian/cloud-custodian" \
       maintainer="Custodian Community <https://cloudcustodian.io>"
 
-# Note this must be run from the root directory of the checkout
-# as we install custodian w/ aws, azure, and gcp support from the same
-# repo.
+# Transfer Custodian source into container by directory
+# to minimize size.
+# Note: build root is the root of the checkout.
+ADD setup.py README.rst requirements.txt /src/
+ADD c7n /src/c7n/
+ADD tools /src/tools/
 
-ADD . /src
-
-# Install Custodian Core & AWS
 WORKDIR /src
-RUN pip3 install -r requirements.txt -e .
 
-# Install Custodian Azure
-WORKDIR /src/tools/c7n_azure
-RUN pip3 install -r requirements.txt -e .
+RUN apt-get --yes update && apt-get --yes upgrade \
+ && apt-get --yes install build-essential \
+ && pip3 install -r requirements.txt  . \
+ && pip3 install -r tools/c7n_gcp/requirements.txt tools/c7n_gcp \
+ && pip3 install -r tools/c7n_azure/requirements.txt tools/c7n_azure \
+ && pip3 install -r tools/c7n_org \
+ && apt-get --yes remove build-essential \
+ && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+ && rm -Rf /var/cache/apt/ \
+ && rm -Rf /var/lib/apt/lists/* \
+ && rm -Rf /src/
 
-# Install Custodian GCP
-WORKDIR /src/tools/c7n_gcp
-RUN pip3 install -r requirements.txt -e .
-
-# Install Custodian Org
-WORKDIR /src/tools/c7n_org
-RUN pip3 install -e .
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
-
-ENTRYPOINT ["c7n-org"]
+ENTRYPOINT ["/usr/local/bin/c7n-org"]
 

--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -20,13 +20,13 @@ RUN apt-get --yes update && apt-get --yes upgrade \
  && pip3 install -r requirements.txt  . \
  && pip3 install -r tools/c7n_gcp/requirements.txt tools/c7n_gcp \
  && pip3 install -r tools/c7n_azure/requirements.txt tools/c7n_azure \
- && pip3 install -r tools/c7n_org \
+ && pip3 install tools/c7n_org \
  && apt-get --yes remove build-essential \
  && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
  && rm -Rf /var/cache/apt/ \
  && rm -Rf /var/lib/apt/lists/* \
- && rm -Rf /src/
+ && rm -Rf /src/ \
+ && rm -Rf /root/.cache/
 
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 ENTRYPOINT ["/usr/local/bin/c7n-org"]
-


### PR DESCRIPTION
This revisits some of the work done for c7n-mailer docker image (#3869) and applies it to the custodian and c7n-org images. The net effect is slimming the docker images from ~1.4GB to 480MB. One additional saving found was not needing to install python-dev package (which was pointing to py2 anyways) resulting in another 100mb of savings from the previous mailer work.