### PR TITLE
docs - readme c7n-org spelling and syntax changes

### DIFF
--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -157,15 +157,15 @@ specifying `-p` or selecting groups of policies via their tags with
 
 See `c7n-org run --help` for more information.
 
-## Defining and using variables.
+## Defining and using variables
 
 Each account/subscription/project configuration in the config file can
-also define a variables section `vars` that can be used in policies
+also define a variables section `vars` that can be used in policies'
 definitions and are interpolated at execution time. These are in
 addition to the default runtime variables custodian provides like
 `account_id`, `now`, and `region`.
 
-Example of defining in c7n-org config file
+Example of defining in c7n-org config file:
 
 ```yaml
 accounts:
@@ -176,7 +176,7 @@ accounts:
     charge_code: xyz
 ```
 
-Example of using in a policy file
+Example of using in a policy file:
 
 ```yaml
 policies:
@@ -186,11 +186,11 @@ policies:
       - "tag:CostCenter": "{charge_code}"
 ```
 
-**Note** variable interpolation is senstive to proper quoting and spacing
-ie. `{ charge_code }` would be invalid due to the extra white space. Additionally
-yaml parsing can transform a value like `{charge_code}` to null, unless its quoteda
+**Note** Variable interpolation is sensitive to proper quoting and spacing,
+i.e., `{ charge_code }` would be invalid due to the extra white space. Additionally,
+yaml parsing can transform a value like `{charge_code}` to null, unless it's quoted
 in strings like the above example. Values that do interpolation into other content
-dont require quoting ie. "my_{charge_code}"
+don't require quoting, i.e., "my_{charge_code}".
 
 ## Other commands
 


### PR DESCRIPTION
Updated grammar/punctuation around variable interpolation note and small punctuation changes throughout the c7n-org readme. 

[update removed closing issue reference]