### PR TITLE
Improve the developer documentation

### DIFF
--- a/docs/source/developer/documentation.rst
+++ b/docs/source/developer/documentation.rst
@@ -1,0 +1,92 @@
+.. _developer-documentation:
+
+Documentation For Developers
+============================
+
+Cloud Custodian makes every effort to provide comprehensive documentation.
+Any new features you add should be documented.
+
+The documentation is built using `sphinx <http://www.sphinx-doc.org>`_.
+The documentation is written using reStructured Text (``rst``).
+The sphinx documentation contains `a useful introduction <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_ to ``rst`` syntax.
+
+Find the Documentation
+----------------------
+
+The root of the documentation is located in the ``docs`` directory.
+Within the documentation, topics are organized according into the following main areas:
+
+* Overview
+* Quickstart
+* AWS
+* Azure
+* Developer
+
+In addition, the api documentation will be built from docstrings on classes and methods in source code.
+The ``rst`` files for these may be found in the ``generated`` subdirectory.
+
+Edit the Documentation
+----------------------
+
+In most cases, documentation edits will be made in docstrings on source code.
+Docstrings should be written following the principles of `pep 257 <https://www.python.org/dev/peps/pep-0257/>`_.
+Within docstrings, ``rst`` directives allow for highlighting code examples:
+
+.. code-block:: python
+
+    class AutoTagUser(EventAction):
+        """Tag a resource with the user who created/modified it.
+
+        .. code-block:: yaml
+
+          policies:
+            - name: ec2-auto-tag-ownercontact
+              resource: ec2
+              description: |
+                Triggered when a new EC2 Instance is launched. Checks to see if
+                it's missing the OwnerContact tag. If missing it gets created
+                with the value of the ID of whomever called the RunInstances API
+              mode:
+                type: cloudtrail
+                role: arn:aws:iam::123456789000:role/custodian-auto-tagger
+                events:
+                  - RunInstances
+              filters:
+               - tag:OwnerContact: absent
+              actions:
+               - type: auto-tag-user
+                 tag: OwnerContact
+
+        There's a number of caveats to usage. Resources which don't
+        include tagging as part of their api may have some delay before
+        automation kicks in to create a tag. Real world delay may be several
+        minutes, with worst case into hours[0]. This creates a race condition
+        between auto tagging and automation.
+
+        In practice this window is on the order of a fraction of a second, as
+        we fetch the resource and evaluate the presence of the tag before
+        attempting to tag it.
+
+        References
+
+         CloudTrail User
+         https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html
+        """
+
+Render the Documentation
+------------------------
+
+In general, you should use tox to build the documentation:
+
+.. code-block::
+
+    $ tox -e docs
+
+This command will clean previously built files and rebuild the entire documentation tree.
+
+When developing, you may prefer to build only those files you have edited.
+To do so, use the following command:
+
+.. code-block::
+
+    $ make -f docs/Makefile.sphinx html

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -7,3 +7,4 @@ This section is for developers who are contributing to custodian.
 
 * :ref:`developer-installing`
 * :ref:`developer-tests`
+* :ref:`developer-documentation`

--- a/docs/source/developer/installing.rst
+++ b/docs/source/developer/installing.rst
@@ -86,7 +86,7 @@ Then build the software with `tox <https://tox.readthedocs.io/en/latest/>`_:
 
 .. code-block:: bash
 
-    $ python3.7 -m tox
+    $ tox
 
 Tox creates a sandboxed "virtual environment" ("virtualenv") for each Python version, 2.7, 3.6, and 3.7.
 These are stored in the ``.tox/`` directory.
@@ -98,7 +98,7 @@ You can run the test suite in a single enviroment with the ``-e`` flag:
 
 .. code-block:: bash
 
-    $ python3.7 -m tox -e py37
+    $ tox -e py37
 
 To access the executables installed in one or the other virtual environment,
 source the virtualenv into your current shell, e.g.:

--- a/docs/source/developer/installing.rst
+++ b/docs/source/developer/installing.rst
@@ -6,36 +6,70 @@ Installing for Developers
 Installing Prerequisites
 ------------------------
 
-Developing the Custodian requires a make/C toolchain, Python 2.7, Python
-3.6, and some basic Python tools.
+Cloud Custodian supports Python 2.7, 3.6, and 3.7.
+To develop the Custodian, you will need to have a make/C toolchain, Python 3.7 and some basic Python tools.
+
+We strongly recommend any development be done in Python 3.
+
+Install Python 3.7
+~~~~~~~~~~~~~~~~~~
+
+You'll need to have a Python 3.7 environment set up.
+You may have a preferred way of doing this.
+Here are instructions for a way to do it on Ubuntu and Mac OS X.
 
 On Ubuntu
-~~~~~~~~~
+*********
 
-For Python 2.7:
+On most recent versions of Ubuntu, Python 3.6 is included by default.
+To get Python 3.7, first add the deadsnakes package repository:
 
 .. code-block:: bash
 
-    $ sudo apt-get install python2.7 python2.7-dev python-pip
+    $ sudo add-apt-repository ppa:deadsnakes/ppa
 
-Python 3.6 is `more complicated
-<https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get>`_.
+Next, install python3.7 and the development headers for it:
+
+.. code-block:: bash
+
+    $ sudo apt-get install python3.7 python3.7-dev
+
+Then, install ``pip``:
+
+.. code-block::
+
+    $ sudo apt-get install python3-pip
+
+When this is complete you should be able to check that you have pip properly installed:
+
+.. code-block::
+
+    $ python3.7 -m pip --version
+    pip 9.0.1 from /usr/lib/python3/dist-packages (python 3.7)
+
+(your exact version numbers will likely differ)
 
 
 On macOS with Homebrew
-~~~~~~~~~~~~~~~~~~~~~~
+**********************
 
 .. code-block:: bash
 
-    $ brew install python python3
+    $ brew install python3
+
+Installing ``python3`` will get you the latest version of Python 3 supported by Homebrew, currently Python 3.7.
 
 
 Basic Python Tools
 ~~~~~~~~~~~~~~~~~~
 
+Once your Python installation is squared away, you will need to install ``tox`` and ``virtualenv``:
+
 .. code-block:: bash
 
-    $ pip install -U pip virtualenv tox
+    $ python3.7 -m pip install -U pip virtualenv tox
+
+(note that we also updated ``pip`` in order to get the latest version)
 
 
 Installing Custodian

--- a/docs/source/developer/installing.rst
+++ b/docs/source/developer/installing.rst
@@ -86,29 +86,32 @@ Then build the software with `tox <https://tox.readthedocs.io/en/latest/>`_:
 
 .. code-block:: bash
 
-    $ tox
+    $ python3.7 -m tox
 
-Tox creates a sandboxed "virtual environment" ("virtualenv") for each Python
-version, 2.7 and 3.6. These are stored in the ``.tox/`` directory. It then runs
-the test suite under both versions of Python, per the ``tox.ini`` file. You can
-run the test suite in a single enviroment with the ``-e`` flag:
+Tox creates a sandboxed "virtual environment" ("virtualenv") for each Python version, 2.7, 3.6, and 3.7.
+These are stored in the ``.tox/`` directory.
+It then runs the test suite under all versions of Python, per the ``tox.ini`` file.
+If tox is unable to find a Python executable on your system for one of the supported versions, it will fail for that environment.
+You can safely ignore these failures when developing locally.
+
+You can run the test suite in a single enviroment with the ``-e`` flag:
 
 .. code-block:: bash
 
-    $ tox -e py27
+    $ tox -e py37
 
 To access the executables installed in one or the other virtual environment,
 source the virtualenv into your current shell, e.g.:
 
 .. code-block:: bash
 
-    $ source .tox/py27/bin/activate
+    $ source .tox/py37/bin/activate
 
 You should then have, e.g., the ``custodian`` command available:
 
 .. code-block:: bash
 
-    (py27)$ custodian -h
+    (py37)$ custodian -h
 
 You'll also be able to invoke `nosetests
 <http://nose.readthedocs.io/en/latest/>`_ or `pytest
@@ -117,4 +120,4 @@ choosing, e.g.:
 
 .. code-block:: bash
 
-    (py27) $ pytest tests/test_s3.py -x
+    (py37) $ pytest tests/test_s3.py -x

--- a/docs/source/developer/installing.rst
+++ b/docs/source/developer/installing.rst
@@ -98,7 +98,7 @@ You can run the test suite in a single enviroment with the ``-e`` flag:
 
 .. code-block:: bash
 
-    $ tox -e py37
+    $ python3.7 -m tox -e py37
 
 To access the executables installed in one or the other virtual environment,
 source the virtualenv into your current shell, e.g.:

--- a/docs/source/developer/tests.rst
+++ b/docs/source/developer/tests.rst
@@ -10,7 +10,7 @@ Unit tests can be run with:
 
 .. code-block:: bash
 
-   $ tox
+   $ python -m tox
 
 Linting can be run with:
 
@@ -40,6 +40,12 @@ Decorating tests
 
 The ``functional`` decorator marks tests that don't require any pre-existing
 AWS context, and can therefore be run cleanly against live AWS.
+
+To run only the tests decorated by ``functional``:
+
+.. code-block::
+
+    (py37)$ pytest tests/test_vpc.py -x -m functional
 
 Writing Placebo Tests for AWS Resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/developer/tests.rst
+++ b/docs/source/developer/tests.rst
@@ -10,7 +10,7 @@ Unit tests can be run with:
 
 .. code-block:: bash
 
-   $ python -m tox
+   $ tox
 
 Linting can be run with:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,7 @@ Navigate below and get started with Cloud Custodian!
    developer/index.rst
    developer/installing.rst
    developer/tests.rst
+   developer/documentation.rst
 
 .. toctree::
    :maxdepth: 2

--- a/tools/c7n_salactus/c7n_salactus/cli.py
+++ b/tools/c7n_salactus/c7n_salactus/cli.py
@@ -691,7 +691,7 @@ def inspect_queue(queue, state, limit, bucket):
     conn = worker.connection
 
     def job_row(j):
-        if isinstance(j.args[0], basestring):
+        if isinstance(j.args[0], basestring):  # noqa: F821
             account, bucket = j.args[0].split(':', 1)
         elif isinstance(j.args[0], dict):
             account, bucket = j.args[0]['name'], "set %d" % len(j.args[1])

--- a/tools/c7n_salactus/c7n_salactus/worker.py
+++ b/tools/c7n_salactus/c7n_salactus/worker.py
@@ -187,7 +187,7 @@ def bulk_invoke(func, args, nargs):
         with connection.pipeline() as pipe:
             for s in n:
                 argv[-1] = s
-                job._id = unicode(uuid4())
+                job._id = unicode(uuid4())  # noqa: F821
                 job.args = argv
                 q.enqueue_job(job, pipeline=pipe)
             pipe.execute()


### PR DESCRIPTION
This PR improves the documentation for developers who wish to contribute to Cloud Custodian.

The instructions for installation have been simplified to encourage installing and using Python 3.7 as the default installation strategy.

The testing instructions have been enhanced with information about how to run tests marked with the `functional` decorator.

Documentation has been added on how to write and build the project documentation.

Refs: #3942 