### PR TITLE
aws - enable offhours for rds cluster

### DIFF
--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -20,6 +20,7 @@ from concurrent.futures import as_completed
 
 from c7n.actions import BaseAction
 from c7n.filters import AgeFilter
+from c7n.filters.offhours import OffHour, OnHour
 import c7n.filters.vpc as net_filters
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
@@ -69,6 +70,8 @@ class RDSCluster(QueryResourceManager):
 
 RDSCluster.filter_registry.register('tag-count', tags.TagCountFilter)
 RDSCluster.filter_registry.register('marked-for-op', tags.TagActionFilter)
+RDSCluster.filter_registry.register('offhour', OffHour)
+RDSCluster.filter_registry.register('onhour', OnHour)
 
 
 def _rds_cluster_tags(model, dbs, session_factory, generator, retry):


### PR DESCRIPTION
This is a followup to https://github.com/cloud-custodian/cloud-custodian/pull/3556 to automate stopping/starting of rds cluster