### PR TITLE
gcp tests - work offline

### DIFF
--- a/tools/c7n_gcp/tests/data/flights/mu-gcp-abstract/empty
+++ b/tools/c7n_gcp/tests/data/flights/mu-gcp-abstract/empty
@@ -1,0 +1,1 @@
+this space intentionally left blank

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -94,7 +94,12 @@ class FunctionTest(BaseTest):
         self.addCleanup(shutil.rmtree, tmp_dir)
 
     def test_abstract_gcp_mode(self):
-        p = self.load_policy({'name': 'instance', 'resource': 'gcp.instance'})
+        # this will fetch a discovery
+        factory = self.replay_flight_data(
+            'mu-gcp-abstract', project_id='test-226520')
+        p = self.load_policy({
+            'name': 'instance', 'resource': 'gcp.instance'},
+            session_factory=factory)
         exec_mode = policy.FunctionMode(p)
         self.assertRaises(NotImplementedError, exec_mode.run)
         self.assertRaises(NotImplementedError, exec_mode.provision)


### PR DESCRIPTION
sdk was attempting to download api metadata at client creation even though its not actually being used for an api call. using an empty replay session addresses.