### PR TITLE
docker file create a top level /output dir owned by the custodian user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,10 @@ RUN apt-get --yes update && apt-get --yes upgrade \
  && rm -Rf /var/cache/apt/ \
  && rm -Rf /var/lib/apt/lists/* \
  && rm -Rf /src/ \
- && rm -Rf /root/.cache/
+ && rm -Rf /root/.cache/ \
+ && mkdir /output \
+ && chown custodian: /output
+
 
 USER custodian
 WORKDIR /home/custodian

--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get --yes update && apt-get --yes upgrade \
  && rm -Rf /var/cache/apt/ \
  && rm -Rf /var/lib/apt/lists/* \
  && rm -Rf /src/ \
- && rm -Rf /root/.cache/
+ && rm -Rf /root/.cache/ \
+ && mkdir /output \
+ && chown custodian: /output
 
 USER custodian
 WORKDIR /home/custodian

--- a/tools/c7n_policystream/Dockerfile
+++ b/tools/c7n_policystream/Dockerfile
@@ -30,7 +30,9 @@ RUN apt-get --yes update && apt-get --yes upgrade \
 	&& rm -Rf /var/cache/apt/ \
 	&& rm -Rf /var/lib/apt/lists/* \
 	&& rm -Rf /src/ \
-	&& rm -Rf /root/.cache/
+	&& rm -Rf /root/.cache/ \
+        && mkdir /output \
+        && chown custodian: /output
 
 USER custodian
 WORKDIR /home/custodian


### PR DESCRIPTION
we had a few examples in our own docs of using /output for docker, with the change to a non root user, we need to make this dir owned by that user for it to work ootb per previous examples.