### PR TITLE
docker - build w/ readme.md instead of rst

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL name="custodian" \
 
 # Transfer Custodian source into container by directory
 # to minimize size
-ADD setup.py README.rst requirements.txt /src/
+ADD setup.py README.md requirements.txt /src/
 ADD c7n /src/c7n/
 ADD tools /src/tools/
 

--- a/tools/c7n_mailer/Dockerfile
+++ b/tools/c7n_mailer/Dockerfile
@@ -8,7 +8,7 @@ LABEL name="mailer" \
 
 # Transfer Custodian source into container by directory
 # to minimize size
-ADD setup.py README.rst requirements.txt /src/
+ADD setup.py README.md requirements.txt /src/
 ADD c7n /src/c7n/
 ADD tools /src/tools/
 

--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -9,7 +9,7 @@ LABEL name="c7n-org" \
 # Transfer Custodian source into container by directory
 # to minimize size.
 # Note: build root is the root of the checkout.
-ADD setup.py README.rst requirements.txt /src/
+ADD setup.py README.md requirements.txt /src/
 ADD c7n /src/c7n/
 ADD tools /src/tools/
 

--- a/tools/c7n_policystream/Dockerfile
+++ b/tools/c7n_policystream/Dockerfile
@@ -12,7 +12,7 @@ LABEL name="policystream" \
 
 # Transfer Custodian source into container by directory
 # to minimize size
-ADD setup.py README.rst requirements.txt /src/
+ADD setup.py README.md requirements.txt /src/
 ADD c7n /src/c7n/
 ADD tools /src/tools/
 


### PR DESCRIPTION
the docs sprint broke docker building since Dockerfiles were referencing README.rst, and the filename is now README.md, update the docker builds