### PR TITLE
Use describe_regions method instead of get_available_regions in c7n-org

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -197,7 +197,7 @@ def init(config, use, debug, verbose, accounts, tags, policies, resource=None, p
     return accounts_config, custodian_config, executor
 
 
-def resolve_regions(regions, partition='aws'):
+def resolve_regions(regions):
     if 'all' in regions:
         client = boto3.client('ec2')
         return [region['RegionName'] for region in client.describe_regions()['Regions']]

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -199,7 +199,8 @@ def init(config, use, debug, verbose, accounts, tags, policies, resource=None, p
 
 def resolve_regions(regions, partition='aws'):
     if 'all' in regions:
-        return boto3.Session().get_available_regions('ec2', partition)
+        client = boto3.client('ec2')
+        return [region['RegionName'] for region in client.describe_regions()['Regions']]
     if not regions:
         return ('us-east-1', 'us-west-2')
     return regions


### PR DESCRIPTION
With the release of `ap-east-1` (Hong Kong), AWS has changed the way new regions get rolled out and requires users to _opt-in_. This has caused a lot of stuff breaking around, and c7n-org seems to suffer from the same issue, as we've got plenty of 
```
botocore.exceptions.ClientError: An error occurred (AuthFailure) when calling the DescribeVolumes operation: AWS was not able to validate the provided access credentials
```
in our logs when scanning `ap-east-1`, which we haven't enabled.


Calling ```boto3.Session().get_available_regions('ec2', partition)``` returns all the regions that are available to the user, while ``` boto3.client('ec2').describe_regions()``` only returns the enabled regions. 

I've dropped `partition` from the `resolve_region` signature as:
- it always defaulted to `aws`
- is not supported directly by `describe_regions()`

From my understanding of the [docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html?highlight=describe_regions#EC2.Client.describe_regions) `describe_regions` will return all the regions available to the user, which should include regions from all partitions by default. Can't test it as I don't have access to `-cn` or Gov. 