### PR TITLE
azure - fix sas generation for Functions package

### DIFF
--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -179,7 +179,7 @@ class FunctionPackage(object):
 
         exclude = os.path.normpath('/cache/') + os.path.sep
         self.pkg.add_modules(lambda f: (exclude in f),
-                             *[m.replace('-', '_') for m in modules])
+                             [m.replace('-', '_') for m in modules])
 
         # add config and policy
         self._add_functions_required_files(policy, queue_name)

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -160,8 +160,8 @@ class FunctionAppUtilities(object):
             sas = blob_client.generate_blob_shared_access_signature(
                 FUNCTION_CONSUMPTION_BLOB_CONTAINER,
                 blob_name,
-                BlobPermissions.READ,
-                datetime.datetime.utcnow() +
+                permission=BlobPermissions.READ,
+                expiry=datetime.datetime.utcnow() +
                 datetime.timedelta(days=FUNCTION_PACKAGE_SAS_EXPIRY_DAYS)
                 # expire in 10 years
             )


### PR DESCRIPTION
- Recent package release of [azure-storage-blob](https://pypi.org/project/azure-storage-blob/) changed the signature of blob sas generation
- When adding modules we were passing them as arguments oppose to a list.