### PR TITLE
Support extracting values using regex

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -371,6 +371,7 @@ class ValueFilter(Filter):
             'key': {'type': 'string'},
             'value_type': {'$ref': '#/definitions/filters_common/value_types'},
             'default': {'type': 'object'},
+            'value_regex': {'type': 'string'},
             'value_from': {'$ref': '#/definitions/filters_common/value_from'},
             'value': {'$ref': '#/definitions/filters_common/value'},
             'op': {'$ref': '#/definitions/filters_common/comparison_operators'}
@@ -404,7 +405,8 @@ class ValueFilter(Filter):
                 "`value` must be an integer in resource_count filter %s" % self.data)
 
         # I don't see how to support regex for this?
-        if self.data['op'] not in OPERATORS or self.data['op'] in {'regex', 'regex-case'}:
+        if (self.data['op'] not in OPERATORS or self.data['op'] in {'regex', 'regex-case'} or
+                'value_regex' in self.data):
             raise PolicyValidationError(
                 "Invalid operator in value filter %s" % self.data)
 
@@ -438,6 +440,35 @@ class ValueFilter(Filter):
                 except re.error as e:
                     raise PolicyValidationError(
                         "Invalid regex: %s %s" % (e, self.data))
+        if 'value_regex' in self.data:
+            return self._validate_value_regex()
+
+        return self
+
+    def _validate_value_regex(self):
+        """ Specific validation for `value_regex` type
+
+        The `value_regex` type works a little differently.
+        In particular it doesn't support OPERATORS that perform operations
+        on a list of values, specifically 'intersect', 'contains', 'difference',
+        'in' and 'not-in'
+        """
+        # Sanity check that we can compile
+        try:
+            pattern = re.compile(self.data['value_regex'])
+            if pattern.groups != 1:
+                raise PolicyValidationError(
+                    "value_regex must have a single capturing group: %s" %
+                    self.data)
+        except re.error as e:
+            raise PolicyValidationError(
+                "Invalid value_regex: %s %s" % (e, self.data))
+
+        if 'op' in self.data:
+            if self.data['op'] in {'intersect', 'in', 'not-in', 'ni', 'contains', 'difference'}:
+                raise PolicyValidationError(
+                    "Operator is incompatible with value_regex: %s" % self.data)
+
         return self
 
     def __call__(self, i):
@@ -483,6 +514,10 @@ class ValueFilter(Filter):
             r = self.expr[k].search(i)
         else:
             r = self.expr[k].search(i)
+
+        if 'value_regex' in self.data:
+            regex = ValueRegex(self.data['value_regex'])
+            r = regex.get_resource_value(r)
         return r
 
     def match(self, i):
@@ -668,3 +703,37 @@ class EventFilter(ValueFilter):
         if self(event):
             return resources
         return []
+
+
+class ValueRegex(object):
+    """Allows filtering based on the output of a regex capture.
+    This is useful for parsing data that has a weird format.
+
+    Instead of comparing the contents of the 'resource value' with the 'value',
+    it will instead apply the regex to contents of the 'resource value', and compare
+    the result of the capture group defined in that regex with the 'value'.
+    Therefore you must have a single capture group defined in the regex.
+
+    Example of getting a datatime object to make an 'expiration' comparison::
+
+    type: value
+    value_regex: ".*delete_after=([0-9]{4}-[0-9]{2}-[0-9]{2}).*"
+    key: "tag:company_mandated_metadata"
+    value_type: expiration
+    op: lte
+    value: 0
+    """
+
+    def __init__(self, expr):
+        self.expr = expr
+
+    def get_resource_value(self, resource):
+        if resource is None:
+            return resource
+        try:
+            capture = re.match(self.expr, resource)
+        except (ValueError, TypeError):
+            return resource
+        if capture is None:  # regex didn't capture anything
+            return resource
+        return capture.group(1)

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -446,12 +446,12 @@ class ValueFilter(Filter):
         return self
 
     def _validate_value_regex(self):
-        """ Specific validation for `value_regex` type
+        """Specific validation for `value_regex` type
 
-        The `value_regex` type works a little differently.
-        In particular it doesn't support OPERATORS that perform operations
-        on a list of values, specifically 'intersect', 'contains', 'difference',
-        'in' and 'not-in'
+        The `value_regex` type works a little differently.  In
+        particular it doesn't support OPERATORS that perform
+        operations on a list of values, specifically 'intersect',
+        'contains', 'difference', 'in' and 'not-in'
         """
         # Sanity check that we can compile
         try:
@@ -463,12 +463,6 @@ class ValueFilter(Filter):
         except re.error as e:
             raise PolicyValidationError(
                 "Invalid value_regex: %s %s" % (e, self.data))
-
-        if 'op' in self.data:
-            if self.data['op'] in {'intersect', 'in', 'not-in', 'ni', 'contains', 'difference'}:
-                raise PolicyValidationError(
-                    "Operator is incompatible with value_regex: %s" % self.data)
-
         return self
 
     def __call__(self, i):

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -714,7 +714,9 @@ class ValueRegex(object):
     the result of the capture group defined in that regex with the 'value'.
     Therefore you must have a single capture group defined in the regex.
 
-    Example of getting a datatime object to make an 'expiration' comparison::
+    If the regex doesn't find a match it will return 'None'
+
+    Example of getting a datetime object to make an 'expiration' comparison::
 
     type: value
     value_regex: ".*delete_after=([0-9]{4}-[0-9]{2}-[0-9]{2}).*"
@@ -733,7 +735,7 @@ class ValueRegex(object):
         try:
             capture = re.match(self.expr, resource)
         except (ValueError, TypeError):
-            return resource
+            return None
         if capture is None:  # regex didn't capture anything
-            return resource
+            return None
         return capture.group(1)

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -232,19 +232,19 @@ There are several ways to get a list of possible keys for each resource.
                  - subnet-2d2736444
 
 - Value Regex:
+
   When using a Value Filter, a ``value_regex`` can be
-  specified. This will mean that the value is evaluated against the
-  result of running the regex that was provided on the ``key``,
-  instead of the full contents of the ``key`` itself.
+  specified. This will mean that the value used for comparison is the output
+  from evaluating a regex on the value found on a resource using `key`.
 
   The filter expects that there will be exactly one capturing group, however
   non-capturing groups can be specified as well, e.g. ``(?:newkey|oldkey)``.
 
   Note that if the value regex does not find a match, it will just
-  pass-through the full contents of the ``key`` itself, i.e. essentially act as
-  if the ``value_regex`` had not been specified at all.
-  This could possibly have unintended consequences depending on how the
-  filter is configured.
+  pass-through the full contents of the original ``key`` value,
+  i.e. essentially act as if the ``value_regex`` had not been
+  specified at all.  This could possibly have unintended consequences
+  depending on how the filter is configured.
 
   In this example there is an ``expiration`` comparison,
   which needs a datetime, however the tag containing this information

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -51,7 +51,7 @@ There are several ways to get a list of possible keys for each resource.
 - Via Cloud Provider Documentation
 
     Go to the relevant cloud provider sdk documentation and search for the describe api call for the resource
-    your interested in. The available fields will be listed under the results of that api call.
+    you're interested in. The available fields will be listed under the results of that api call.
 
 
 
@@ -231,6 +231,36 @@ There are several ways to get a list of possible keys for each resource.
                  - subnet-1b8474522
                  - subnet-2d2736444
 
+- Value Regex:
+  When using a Value Filter, a ``value_regex`` can be
+  specified. This will mean that the value is evaluated against the
+  result of running the regex that was provided on the ``key``,
+  instead of the full contents of the ``key`` itself.
+
+  The filter expects that there will be exactly one capturing group, however
+  non-capturing groups can be specified as well, e.g. ``(?:newkey|oldkey)``.
+
+  Note that if the value regex does not find a match, it will just
+  pass-through the full contents of the ``key`` itself, i.e. essentially act as
+  if the ``value_regex`` had not been specified at all.
+  This could possibly have unintended consequences depending on how the
+  filter is configured.
+
+  In this example there is an ``expiration`` comparison,
+  which needs a datetime, however the tag containing this information
+  also has other data in it. By setting the ``value_regex``
+  to capture just the datetime part of the tag, the filter can be evaluated
+  as normal.
+
+  .. code-block:: yaml
+
+    # Find expiry from tag contents
+    - type: value
+      key: "tag:metadata"
+      value_type: expiration
+      value_regex: ".*delete_after=([0-9]{4}-[0-9]{2}-[0-9]{2}).*"
+      op: less-than
+      value: 0
 
 Age Filter
 -------------

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -240,11 +240,8 @@ There are several ways to get a list of possible keys for each resource.
   The filter expects that there will be exactly one capturing group, however
   non-capturing groups can be specified as well, e.g. ``(?:newkey|oldkey)``.
 
-  Note that if the value regex does not find a match, it will just
-  pass-through the full contents of the original ``key`` value,
-  i.e. essentially act as if the ``value_regex`` had not been
-  specified at all.  This could possibly have unintended consequences
-  depending on how the filter is configured.
+  Note that if the value regex does not find a match, it will return a ``None``
+  value.
 
   In this example there is an ``expiration`` comparison,
   which needs a datetime, however the tag containing this information

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -23,6 +23,7 @@ from c7n import filters as base_filters
 from c7n.resources.ec2 import filters
 from c7n.utils import annotation
 from .common import instance, event_data, Bag
+from c7n.filters.core import ValueRegex
 
 
 class BaseFilterTest(unittest.TestCase):
@@ -289,6 +290,33 @@ class TestValueTypes(BaseFilterTest):
         fdata["op"] = "equal"
         self.assertFilter(fdata, i("abc"), True)
 
+    def test_integer_with_value_regex(self):
+        fdata = {
+            "type": "value",
+            "key": "tag:Count",
+            "op": "greater-than",
+            "value_regex": r".*data=([0-9]+)",
+            "value_type": "integer",
+            "value": 0,
+        }
+
+        def i(d):
+            value = "mode=5;data={}".format(d)
+            return instance(Tags=[{"Key": "Count", "Value": value}])
+
+        self.assertFilter(fdata, i("42"), True)
+        self.assertFilter(fdata, i("0"), False)
+        self.assertFilter(fdata, i("abc"), False)
+
+        fdata["op"] = "equal"
+        self.assertFilter(fdata, i("42"), False)
+        self.assertFilter(fdata, i("0"), True)
+        # This passes because the 'integer' value_type
+        # returns '0' when it fails to parse an int.
+        # Making abc == 0 evaluate to True seems dangerous,
+        # but it's existing behaviour.
+        self.assertFilter(fdata, i("abc"), True)
+
     def test_swap(self):
         fdata = {
             "type": "value",
@@ -347,6 +375,147 @@ class TestValueTypes(BaseFilterTest):
         self.assertFilter(fdata, i(now), True)
         self.assertFilter(fdata, i(now.isoformat()), True)
 
+    def test_expiration_with_value_regex(self):
+
+        now = datetime.now(tz=tz.tzutc())
+        three_months = now + timedelta(90)
+        two_months = now + timedelta(60)
+
+        def i(c, e):
+            value = "creation={};expiry={}".format(c, e)
+            return instance(Tags=[{"Key": "metadata", "Value": value}])
+
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "less-than",
+            "value_regex": r".*expiry=([0-9-:\s\+\.T]+Z?)",
+            "value_type": "expiration",
+            "value": 61,
+        }
+
+        self.assertFilter(fdata, i((three_months - timedelta(100)), three_months), False)
+        self.assertFilter(fdata, i((two_months - timedelta(100)), two_months), True)
+        self.assertFilter(fdata, i((now - timedelta(100)), now), True)
+        self.assertFilter(fdata, i((now - timedelta(100)).isoformat(), now.isoformat()), True)
+
+    def test_regex_capture_matches_first_occurrence(self):
+
+        def i(first, second):
+            value = "{}text{}".format(first, second)
+            return instance(Tags=[{"Key": "metadata", "Value": value}])
+
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "equal",
+            "value_regex": r"([0-9])",
+            "value_type": "integer",
+            "value": 3,
+        }
+
+        self.assertFilter(fdata, i(2, 3), False)
+        self.assertFilter(fdata, i(3, 2), True)
+
+        fdata['value_regex'] = r".*([0-9])"
+        self.assertFilter(fdata, i(2, 3), True)
+        self.assertFilter(fdata, i(3, 2), False)
+
+    def test_regex_capture_with_non_capturing_groups(self):
+
+        def i(d):
+            return instance(Tags=[{"Key": "metadata", "Value": d}])
+
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "equal",
+            "value_regex": r"(?:oldformat|newformat)=(expected\s\w+)",
+            "value_type": "string",
+            "value": "expected value",
+        }
+
+        self.assertFilter(fdata, i("newformat=expected value"), True)
+        self.assertFilter(fdata, i("oldformat=expected value"), True)
+        self.assertFilter(fdata, i("otherformat=expected value"), False)
+
+    def test_value_regex_validation(self):
+        # Regex won't compile
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "less-than",
+            "value_regex": r".*expiry=?????[([0-9)",
+            "value_type": "expiration",
+            "value": 61,
+        }
+        self.assertRaises(PolicyValidationError, filters.factory(fdata, {}).validate)
+
+        # More than one capture group
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "less-than",
+            "value_regex": r".*(expiry)=([0-9-:\s\+\.T]+Z?)",
+            "value_type": "expiration",
+            "value": 61,
+        }
+        self.assertRaises(PolicyValidationError, filters.factory(fdata, {}).validate)
+
+        # No capture group
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "less-than",
+            "value_regex": r".*expiry=[0-9-:\s\+\.T]+Z?",
+            "value_type": "expiration",
+            "value": 61,
+        }
+        self.assertRaises(PolicyValidationError, filters.factory(fdata, {}).validate)
+
+        # One capture group and non-capturing groups (should not error)
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "less-than",
+            "value_regex": r"pet=(?:cat|dog);number=([0-9]{1,4})",
+            "value_type": "integer",
+            "value": 12,
+        }
+        filters.factory(fdata, {}).validate
+
+        # Invalid `op`
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "contains",
+            "value_regex": r"pet=(?:cat|dog);number=([0-9]{1,4})",
+            "value_type": "integer",
+            "value": [12, 13, 14, 15],
+        }
+        self.assertRaises(PolicyValidationError, filters.factory(fdata, {}).validate)
+
+    def test_value_regex_match(self):
+        fdata = {
+            "type": "value",
+            "key": "tag:metadata",
+            "op": "less-than",
+            "value_regex": r"pet=(?:cat|dog);number=([0-9]{1,4})",
+            "value_type": "integer",
+            "value": 12,
+        }
+        capture = ValueRegex(fdata['value_regex'])
+
+        # No match returns original value (pass-through)
+        retValue = capture.get_resource_value("pet=elephant;number=3")
+        self.assertEqual("pet=elephant;number=3", retValue)
+        # TypeError returns original value (pass-through)
+        retValue = capture.get_resource_value(True)
+        self.assertEqual(True, retValue)
+        # Match returns matched value
+        retValue = capture.get_resource_value("pet=dog;number=44")
+        self.assertEqual("44", retValue)
+
     def test_resource_count_filter(self):
         fdata = {
             "type": "value", "value_type": "resource_count", "op": "lt", "value": 2
@@ -376,6 +545,15 @@ class TestValueTypes(BaseFilterTest):
 
         # Missing `op`
         f = {"type": "value", "value_type": "resource_count", "value": 1}
+        self.assertRaises(
+            PolicyValidationError, filters.factory(f, {}).validate
+        )
+
+        # Unexpected `value_regex`
+        f = {
+            "type": "value", "value_type": "resource_count", "op": "eq", "value": "foo",
+            "value_regex": "([0-7]{3,7})"
+        }
         self.assertRaises(
             PolicyValidationError, filters.factory(f, {}).validate
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -399,7 +399,7 @@ class TestValueTypes(BaseFilterTest):
         self.assertFilter(fdata, i((now - timedelta(100)), now), True)
         self.assertFilter(fdata, i((now - timedelta(100)).isoformat(), now.isoformat()), True)
 
-    def test_regex_capture_matches_first_occurrence(self):
+    def test_value_regex_matches_first_occurrence(self):
 
         def i(first, second):
             value = "{}text{}".format(first, second)
@@ -421,7 +421,7 @@ class TestValueTypes(BaseFilterTest):
         self.assertFilter(fdata, i(2, 3), True)
         self.assertFilter(fdata, i(3, 2), False)
 
-    def test_regex_capture_with_non_capturing_groups(self):
+    def test_value_regex_with_non_capturing_groups(self):
 
         def i(d):
             return instance(Tags=[{"Key": "metadata", "Value": d}])
@@ -506,12 +506,12 @@ class TestValueTypes(BaseFilterTest):
         }
         capture = ValueRegex(fdata['value_regex'])
 
-        # No match returns original value (pass-through)
+        # No match returns None
         retValue = capture.get_resource_value("pet=elephant;number=3")
-        self.assertEqual("pet=elephant;number=3", retValue)
-        # TypeError returns original value (pass-through)
+        self.assertIsNone(retValue)
+        # TypeError returns None
         retValue = capture.get_resource_value(True)
-        self.assertEqual(True, retValue)
+        self.assertIsNone(retValue)
         # Match returns matched value
         retValue = capture.get_resource_value("pet=dog;number=44")
         self.assertEqual("44", retValue)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -484,17 +484,6 @@ class TestValueTypes(BaseFilterTest):
         }
         filters.factory(fdata, {}).validate
 
-        # Invalid `op`
-        fdata = {
-            "type": "value",
-            "key": "tag:metadata",
-            "op": "contains",
-            "value_regex": r"pet=(?:cat|dog);number=([0-9]{1,4})",
-            "value_type": "integer",
-            "value": [12, 13, 14, 15],
-        }
-        self.assertRaises(PolicyValidationError, filters.factory(fdata, {}).validate)
-
     def test_value_regex_match(self):
         fdata = {
             "type": "value",


### PR DESCRIPTION
Currently it's only possible to perform a filter operation on the value contained in a
given tag on the resource. 

We'd like to be able to optionally use a regex to capture
just a part of the value contained in the tag and perform the filter operation using
that captured value instead. 

This would be useful for extracting dates to do expiry filtering, and various other uses-cases
we have to support where there are multiple metadatas contained in a single tag.

An example of what we need to do is we have resources tagged with 
`"OurCustomKey": "expiry=2019-03-04;otherdata=..."`, and would like to use the date 
from `"expiry="` as an expiration date. With this feature, we could do this with a filter like:

````
    - type: value
      key: "tag:OurCustomKey"
      value_type: expiration
      regex_capture_expression: ".*expiry=([0-9]{4}-[0-9]{2}-[0-9]{2}).*"
      op: less-than
      value: 0
````