### PR TITLE
AWS | ami.py | Feature to modify image launch permission

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -203,7 +203,7 @@ class ModifyImageAttribute(BaseAction):
                       Attribute: LaunchPermissions
                       LaunchPermission:
                         Add: 
-                         - 'UserId': '872247246277'
+                         - 'UserId': 'XXXXXXXXX277'
 
     """
 

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -212,7 +212,7 @@ class ModifyImageAttribute(BaseAction):
         params={'type': 'object'},
         required=('params',))
     
-    permissions = ('ec2:ModifyImageAttribute')
+    permissions = ('ec2:ModifyImageAttribute',)
     shape = 'ModifyImageAttributeRequest'
 
     def validate(self):

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -183,7 +183,7 @@ class RemoveLaunchPermissions(BaseAction):
 class ModifyImageAttribute(BaseAction):
     """Action to modify the image attributes of an AMI
 
-    This action will help share any AMIs to other AWS 
+    This action will help share any AMIs to other AWS
     accounts such that other groups and users can launch instances
     using this.
 
@@ -198,7 +198,12 @@ class ModifyImageAttribute(BaseAction):
                   - type: image-age
                     days: 60
                 actions:
-                  - remove-launch-permissions
+                  - type: modify-image-attribute
+                    params:
+                      Attribute: LaunchPermissions
+                      LaunchPermission:
+                        Add: 
+                         - 'UserId': '872247246277'
 
     """
 

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -202,7 +202,7 @@ class ModifyImageAttribute(BaseAction):
                     params:
                       Attribute: LaunchPermissions
                       LaunchPermission:
-                        Add: 
+                        Add:
                          - 'UserId': 'XXXXXXXXX277'
 
     """
@@ -211,7 +211,7 @@ class ModifyImageAttribute(BaseAction):
         'modify-image-attribute',
         params={'type': 'object'},
         required=('params',))
-    
+
     permissions = ('ec2:ModifyImageAttribute',)
     shape = 'ModifyImageAttributeRequest'
 

--- a/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImageAttribute_1.json
@@ -8,12 +8,12 @@
             }
         ],
         "ResponseMetadata": {
-            "RequestId": "4368f11e-b8be-4b17-ad5d-53957662a15a",
+            "RequestId": "1db98758-6705-4094-85b9-f53d7a8f5969",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
                 "content-type": "text/xml;charset=UTF-8",
                 "content-length": "384",
-                "date": "Tue, 14 May 2019 17:23:33 GMT",
+                "date": "Tue, 14 May 2019 19:29:52 GMT",
                 "server": "AmazonEC2"
             },
             "RetryAttempts": 0

--- a/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImageAttribute_1.json
@@ -4,7 +4,7 @@
         "ImageId": "ami-05eec6d1db8feea7b",
         "LaunchPermissions": [
             {
-                "UserId": "8722XXXXXXXX"
+                "UserId": "872247246277"
             }
         ],
         "ResponseMetadata": {

--- a/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImageAttribute_1.json
@@ -4,7 +4,7 @@
         "ImageId": "ami-05eec6d1db8feea7b",
         "LaunchPermissions": [
             {
-                "UserId": "872247246277"
+                "UserId": "123456789"
             }
         ],
         "ResponseMetadata": {

--- a/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImageAttribute_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "ImageId": "ami-05eec6d1db8feea7b",
+        "LaunchPermissions": [
+            {
+                "UserId": "8722XXXXXXXX"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "4368f11e-b8be-4b17-ad5d-53957662a15a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "384",
+                "date": "Tue, 14 May 2019 17:23:33 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImages_1.json
@@ -34,12 +34,12 @@
             }
         ],
         "ResponseMetadata": {
-            "RequestId": "6fd9a335-0530-43d4-a5ce-deda864e2b70",
+            "RequestId": "934cd636-0d30-4608-aad4-0a98ef9225cd",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
                 "content-type": "text/xml;charset=UTF-8",
                 "content-length": "1686",
-                "date": "Tue, 14 May 2019 17:23:33 GMT",
+                "date": "Tue, 14 May 2019 19:29:50 GMT",
                 "server": "AmazonEC2"
             },
             "RetryAttempts": 0

--- a/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_ami_modify_launch_permissions/ec2.DescribeImages_1.json
@@ -1,0 +1,48 @@
+{
+    "status_code": 200,
+    "data": {
+        "Images": [
+            {
+                "Architecture": "x86_64",
+                "CreationDate": "2019-05-14T16:47:47.000Z",
+                "ImageId": "ami-05eec6d1db8feea7b",
+                "ImageLocation": "644160558196/amzn-ami-hvm-2017.09.1.20180115-x86_64-gp2",
+                "ImageType": "machine",
+                "Public": false,
+                "OwnerId": "644160558196",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-02b7bd98e16c50d31",
+                            "VolumeSize": 8,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    }
+                ],
+                "Description": "amzn-ami-hvm-2017.09.1.20180115-x86_64-gp2",
+                "EnaSupport": true,
+                "Hypervisor": "xen",
+                "Name": "amzn-ami-hvm-2017.09.1.20180115-x86_64-gp2",
+                "RootDeviceName": "/dev/xvda",
+                "RootDeviceType": "ebs",
+                "SriovNetSupport": "simple",
+                "VirtualizationType": "hvm"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "6fd9a335-0530-43d4-a5ce-deda864e2b70",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "1686",
+                "date": "Tue, 14 May 2019 17:23:33 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_ami_modify_launch_permissions/ec2.ModifyImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_modify_launch_permissions/ec2.ModifyImageAttribute_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "84b853b6-a29d-4b08-be5d-7740932fbf0d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "accept-encoding",
+                "date": "Tue, 14 May 2019 17:23:33 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_ami_modify_launch_permissions/ec2.ModifyImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_modify_launch_permissions/ec2.ModifyImageAttribute_1.json
@@ -2,13 +2,13 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RequestId": "84b853b6-a29d-4b08-be5d-7740932fbf0d",
+            "RequestId": "3dd65715-13f0-417f-a340-86ed89c670f8",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
                 "content-type": "text/xml;charset=UTF-8",
                 "transfer-encoding": "chunked",
                 "vary": "accept-encoding",
-                "date": "Tue, 14 May 2019 17:23:33 GMT",
+                "date": "Tue, 14 May 2019 19:29:51 GMT",
                 "server": "AmazonEC2"
             },
             "RetryAttempts": 0

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -181,9 +181,9 @@ class TestAMI(BaseTest):
                 "actions": [{
                     "type": "modify-image-attribute",
                     "params": {
-                      "Attribute": "LaunchPermissions",
-                      "LaunchPermission": {
-                        "Add": [{"UserId": "123456789"}]}}}],
+                        "Attribute": "LaunchPermissions",
+                        "LaunchPermission": {
+                            "Add": [{"UserId": "123456789"}]}}}],
             },
             session_factory=session_factory,
         )

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -183,7 +183,7 @@ class TestAMI(BaseTest):
                     "params": {
                       "Attribute": "LaunchPermissions",
                       "LaunchPermission": {
-                        "Add": [{"UserId": "872247246277"}]}}}],
+                        "Add": [{"UserId": "123456789"}]}}}],
             },
             session_factory=session_factory,
         )
@@ -192,4 +192,4 @@ class TestAMI(BaseTest):
         client = session_factory().client("ec2")
         res = client.describe_image_attribute(Attribute='launchPermission',
             ImageId='ami-05eec6d1db8feea7b')
-        self.assertEqual(res['LaunchPermissions'], [{'UserId': '872247246277'}])
+        self.assertEqual(res['LaunchPermissions'], [{'UserId': '123456789'}])

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -190,7 +190,6 @@ class TestAMI(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         client = session_factory().client("ec2")
-        res = client.describe_image_attribute(
-           Attribute='launchPermission',
-           ImageId='ami-05eec6d1db8feea7b')
+        res = client.describe_image_attribute(Attribute='launchPermission',
+            ImageId='ami-05eec6d1db8feea7b')
         self.assertEqual(res['LaunchPermissions'], [{'UserId': '872247246277'}])

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -191,5 +191,5 @@ class TestAMI(BaseTest):
         self.assertEqual(len(resources), 1)
         client = session_factory().client("ec2")
         res = client.describe_image_attribute(Attribute='launchPermission',
-            ImageId='ami-05eec6d1db8feea7b')
+            ImageId=resources[0]['ImageId'])
         self.assertEqual(res['LaunchPermissions'], [{'UserId': '123456789'}])

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -170,3 +170,27 @@ class TestAMI(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_ami_modify_launch_permissions(self):
+        session_factory = self.replay_flight_data("test_ami_modify_launch_permissions")
+        p = self.load_policy(
+            {
+                "name": "cross-account-ami",
+                "resource": "ami",
+                "filters": [{"type": "image-age", "days": 0}],
+                "actions": [{
+                    "type": "modify-image-attribute",
+                    "params": {
+                      "Attribute": "LaunchPermissions",
+                      "LaunchPermission": {
+                        "Add": [{"UserId": "872247246277"}]}}}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = session_factory().client("ec2")
+        res = client.describe_image_attribute(
+           Attribute='launchPermission',
+           ImageId='ami-05eec6d1db8feea7b')
+        self.assertEqual(res['LaunchPermissions'], [{'UserId': '872247246277'}])


### PR DESCRIPTION
AWS added functionality to share encrypted AMIs cross account: https://aws.amazon.com/about-aws/whats-new/2019/05/share-encrypted-amis-across-accounts-to-launch-instances-in-a-single-step/

Adding action to modify image launch permission.
```
Use-case: 
1. Share new images to cross accounts
2. Unshare images older than X number of days
```
Sample policy:
```
policies:
  - name: share-ami-cross-account
    resource: ami
    filters:
      - type: image-age
        days: 0
    actions:
      - type: modify-image-attribute
        params:
          Attribute: LaunchPermissions
          LaunchPermission:
            Add: 
              - 'UserId': '123456789'
```