### PR TITLE
Azure - Fix Function support for Mailer

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,10 +15,10 @@ jobs:
 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '2.7'
+        versionSpec: '3.7'
         architecture: 'x64'
 
-    - script: python -m pip install --upgrade pip && pip install flake8==3.5.0
+    - script: python -m pip install --upgrade pip && pip install flake8
       displayName: "Install Dependencies"
 
     - script: make lint

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -73,8 +73,10 @@ class FunctionPackage(object):
 
                 self.pkg.add_contents(dest=name + '/config.json',
                                       contents=policy_contents)
-
-        self._add_host_config(policy.get('mode', {}).get('type', None))
+                self._add_host_config(policy['mode']['type'])
+            
+            else:
+                self._add_host_config(None)
 
     def _add_host_config(self, mode):
         config = copy.deepcopy(FUNCTION_HOST_CONFIG)

--- a/tools/c7n_azure/tests/test_function_package.py
+++ b/tools/c7n_azure/tests/test_function_package.py
@@ -111,6 +111,18 @@ class FunctionPackageTest(BaseTest):
         self.assertTrue(FunctionPackageTest._file_exists(files, 'test-azure-package/config.json'))
         self.assertTrue(FunctionPackageTest._file_exists(files, 'host.json'))
 
+    @patch("c7n_azure.session.Session.get_functions_auth_string", return_value="")
+    def test_no_policy_add_required_files(self, session_mock):
+        """ Tools such as mailer will package with no policy """
+
+        packer = FunctionPackage('name')
+        packer.pkg = PythonPackageArchive()
+
+        packer._add_functions_required_files(None)
+        files = packer.pkg._zip_file.filelist
+
+        self.assertTrue(FunctionPackageTest._file_exists(files, 'host.json'))
+
     def test_add_host_config(self):
         packer = FunctionPackage('test')
         packer.pkg = PythonPackageArchive()


### PR DESCRIPTION
There was a regression here during some recent updates.  Added a test variant to cover this aspect of building function without a policy (e.g. like mailer).

