### PR TITLE
Azure - Make mailer work

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,10 +15,10 @@ jobs:
 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '2.7'
+        versionSpec: '3.7'
         architecture: 'x64'
 
-    - script: python -m pip install --upgrade pip && pip install flake8==3.5.0
+    - script: python -m pip install --upgrade pip && pip install flake8
       displayName: "Install Dependencies"
 
     - script: make lint

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -74,7 +74,6 @@ class FunctionPackage(object):
                 self.pkg.add_contents(dest=name + '/config.json',
                                       contents=policy_contents)
                 self._add_host_config(policy['mode']['type'])
-            
             else:
                 self._add_host_config(None)
 

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -73,8 +73,10 @@ class FunctionPackage(object):
 
                 self.pkg.add_contents(dest=name + '/config.json',
                                       contents=policy_contents)
-
-        self._add_host_config(policy.get('mode', {}).get('type', None))
+                self._add_host_config(policy['mode']['type'])
+            
+            else:
+                self._add_host_config(None)
 
     def _add_host_config(self, mode):
         config = copy.deepcopy(FUNCTION_HOST_CONFIG)

--- a/tools/c7n_azure/tests/test_function_package.py
+++ b/tools/c7n_azure/tests/test_function_package.py
@@ -111,6 +111,18 @@ class FunctionPackageTest(BaseTest):
         self.assertTrue(FunctionPackageTest._file_exists(files, 'test-azure-package/config.json'))
         self.assertTrue(FunctionPackageTest._file_exists(files, 'host.json'))
 
+    @patch("c7n_azure.session.Session.get_functions_auth_string", return_value="")
+    def test_no_policy_add_required_files(self, session_mock):
+        """ Tools such as mailer will package with no policy """
+
+        packer = FunctionPackage('name')
+        packer.pkg = PythonPackageArchive()
+
+        packer._add_functions_required_files(None)
+        files = packer.pkg._zip_file.filelist
+
+        self.assertTrue(FunctionPackageTest._file_exists(files, 'host.json'))
+
     def test_add_host_config(self):
         packer = FunctionPackage('test')
         packer.pkg = PythonPackageArchive()

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -408,7 +408,7 @@ to an Azure Storage Queue.  For example:
 policies:
   - name: azure-notify
     resource: azure.resourcegroup
-    description: example policy
+    description: send a message to a mailer instance
     actions:
       - type: notify
         template: default
@@ -441,7 +441,7 @@ mailer configuration.
 
 `c7n-mailer --config mailer.yml --update-lambda`
 
-where `mailer.yml` may look like:
+where a simple `mailer.yml` using Consumption functions may look like:
 
 ```yaml
 queue_url: asq://storage.queue.core.windows.net/custodian
@@ -450,10 +450,6 @@ sendgrid_api_key: <key>
 function_properties:
   servicePlan:
     name: 'testmailer1'
-    resourceGroupName: custodianmailer1
-    skuTier: Basic
-    skuName: B1
-    location: WestUS2
 ```
 
 ## Writing an email template

--- a/tools/c7n_mailer/c7n_mailer/azure/sendgrid_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/sendgrid_delivery.py
@@ -17,7 +17,7 @@ import six
 from c7n_mailer.utils import (get_message_subject, get_rendered_jinja)
 from c7n_mailer.utils_email import is_email
 from python_http_client import exceptions
-from sendgrid.helpers.mail import Email, Content, Mail
+from sendgrid.helpers.mail import Mail
 
 
 class SendGridDelivery(object):

--- a/tools/c7n_mailer/c7n_mailer/azure/sendgrid_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/sendgrid_delivery.py
@@ -86,7 +86,7 @@ class SendGridDelivery(object):
             queue_message['action'].get('template', 'default'),
             to_addrs_to_email_messages_map))
 
-        from_email = Email(self.config.get('from_address', ''))
+        from_address = self.config.get('from_address', '')
         subject = get_message_subject(queue_message)
         email_format = queue_message['action'].get('template_format', None)
         if not email_format:
@@ -95,11 +95,20 @@ class SendGridDelivery(object):
 
         for email_to_addrs, email_content in six.iteritems(to_addrs_to_email_messages_map):
             for to_address in email_to_addrs:
-                to_email = Email(to_address)
-                content = Content("text/" + email_format, email_content)
-                mail = Mail(from_email, subject, to_email, content)
+                if email_format == "html":
+                    mail = Mail(
+                        from_email=from_address,
+                        to_emails=to_address,
+                        subject=subject,
+                        html_content=email_content)
+                else:
+                    mail = Mail(
+                        from_email=from_address,
+                        to_emails=to_address,
+                        subject=subject,
+                        plain_text_content=email_content)
                 try:
-                    self.sendgrid_client.client.mail.send.post(request_body=mail.get())
+                    self.sendgrid_client.send(mail)
                 except (exceptions.UnauthorizedError, exceptions.BadRequestsError) as e:
                     self.logger.warning(
                         "\n**Error \nPolicy:%s \nAccount:%s \nSending to:%s \n\nRequest body:"

--- a/tools/c7n_mailer/c7n_mailer/azure/sendgrid_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/sendgrid_delivery.py
@@ -17,7 +17,7 @@ import six
 from c7n_mailer.utils import (get_message_subject, get_rendered_jinja)
 from c7n_mailer.utils_email import is_email
 from python_http_client import exceptions
-from sendgrid.helpers.mail import Mail
+from sendgrid.helpers.mail import Mail, To, From
 
 
 class SendGridDelivery(object):
@@ -97,14 +97,14 @@ class SendGridDelivery(object):
             for to_address in email_to_addrs:
                 if email_format == "html":
                     mail = Mail(
-                        from_email=from_address,
-                        to_emails=to_address,
+                        from_email=From(from_address),
+                        to_emails=To(to_address),
                         subject=subject,
                         html_content=email_content)
                 else:
                     mail = Mail(
-                        from_email=from_address,
-                        to_emails=to_address,
+                        from_email=From(from_address),
+                        to_emails=To(to_address),
                         subject=subject,
                         plain_text_content=email_content)
                 try:

--- a/tools/c7n_mailer/requirements.txt
+++ b/tools/c7n_mailer/requirements.txt
@@ -8,6 +8,6 @@ jsonschema>=2.5.1
 ruamel.yaml>=0.15.93
 six>=1.12.0
 datadog==0.28.0
-sendgrid==5.6.0
+sendgrid==6.0.5
 redis==3.2.1
 ldap3==2.6

--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -26,7 +26,7 @@ requires = [
     "python-dateutil>=2.8",
     "ruamel.yaml==0.15.88",
     "datadog",
-    "sendgrid",
+    "sendgrid==6.0.5",
     "ldap3",
     "c7n",
     "redis"]

--- a/tools/c7n_mailer/tests/test_azure.py
+++ b/tools/c7n_mailer/tests/test_azure.py
@@ -83,7 +83,8 @@ class AzureTest(unittest.TestCase):
     @patch('sendgrid.SendGridAPIClient.send')
     def test_sendgrid_handler(self, mock_send):
         sendgrid_delivery = SendGridDelivery(MAILER_CONFIG_AZURE, logger)
-        sendgrid_messages = sendgrid_delivery.get_to_addrs_sendgrid_messages_map(self.loaded_message)
+        sendgrid_messages = \
+            sendgrid_delivery.get_to_addrs_sendgrid_messages_map(self.loaded_message)
         result = sendgrid_delivery.sendgrid_handler(self.loaded_message, sendgrid_messages)
         self.assertTrue(result)
         mock_send.assert_called()

--- a/tools/c7n_mailer/tests/test_azure.py
+++ b/tools/c7n_mailer/tests/test_azure.py
@@ -19,6 +19,7 @@ import zlib
 
 from c7n_azure.storage_utils import StorageUtilities
 from c7n_mailer.azure.azure_queue_processor import MailerAzureQueueProcessor
+from c7n_mailer.azure.sendgrid_delivery import SendGridDelivery
 from common import MAILER_CONFIG_AZURE, ASQ_MESSAGE, ASQ_MESSAGE_TAG, logger
 
 from mock import MagicMock, patch
@@ -78,3 +79,11 @@ class AzureTest(unittest.TestCase):
         self.assertEqual(2, mock_get_messages.call_count)
         self.assertEqual(1, mock_process.call_count)
         mock_delete.assert_called()
+
+    @patch('sendgrid.SendGridAPIClient.send')
+    def test_sendgrid_handler(self, mock_send):
+        sendgrid_delivery = SendGridDelivery(MAILER_CONFIG_AZURE, logger)
+        sendgrid_messages = sendgrid_delivery.get_to_addrs_sendgrid_messages_map(self.loaded_message)
+        result = sendgrid_delivery.sendgrid_handler(self.loaded_message, sendgrid_messages)
+        self.assertTrue(result)
+        mock_send.assert_called()


### PR DESCRIPTION
Fixes

- Regressions in function packaging
- Mailer requirements.txt had pinned version but setup.py did not, and they were not compatible
- Make mailer compatible with latest sendgrid SDK
- Minor doc improvement
- Added test