### PR TITLE
gcp - docs for Pub/Sub use cases

### DIFF
--- a/docs/source/gcp/examples/pubsub-snapshots.rst
+++ b/docs/source/gcp/examples/pubsub-snapshots.rst
@@ -1,0 +1,25 @@
+Pub/Sub - Check if there are expiring Snapshots
+===============================================
+Custodian can check if a Pub/Sub Snapshot expires in a set number of days. Note that the ``notify`` action requires a Pub/Sub topic to be configured.
+
+In the example below, the policy notifies users if there are Snapshots expiring in 2 days.
+
+.. code-block:: yaml
+
+    policies:
+      - name: gcp-pub-sub-snapshots-notify-if-expiring
+        resource: gcp.pubsub-snapshot
+        filters:
+          - type: value
+            key: expireTime
+            op: less-than
+            value_type: expiration
+            value: 2
+        actions:
+         - type: notify
+           to:
+             - email@address
+           format: txt
+           transport:
+             type: pubsub
+             topic: projects/my-gcp-project/topics/my-topic

--- a/docs/source/gcp/examples/pubsub-subscriptions.rst
+++ b/docs/source/gcp/examples/pubsub-subscriptions.rst
@@ -1,0 +1,23 @@
+Pub/Sub - Audit Subscriptions updates
+=====================================
+Custodian can audit if a Pub/Sub Subscription has been updated. Note that the ``notify`` action requires a Pub/Sub topic to be configured.
+
+In the example below, the policy notifies users if the ``UpdateSubscription`` action appears in the logs.
+
+.. code-block:: yaml
+
+    policies:
+      - name: gcp-pub-sub-subscription-audit-update
+        resource: gcp.pubsub-subscription
+        mode:
+          type: gcp-audit
+          methods:
+            - "google.pubsub.v1.Subscriber.UpdateSubscription"
+        actions:
+         - type: notify
+           to:
+             - email@address
+           format: txt
+           transport:
+             type: pubsub
+             topic: projects/my-gcp-project/topics/my-topic

--- a/docs/source/gcp/examples/pubsub-topics.rst
+++ b/docs/source/gcp/examples/pubsub-topics.rst
@@ -1,0 +1,23 @@
+Pub/Sub - Audit Topics creation
+===============================
+Custodian can audit if a Pub/Sub Topic has been created. Note that the ``notify`` action requires a Pub/Sub topic to be configured.
+
+In the example below, the policy notifies users if the ``CreateTopic`` action appears in the logs.
+
+.. code-block:: yaml
+
+    policies:
+      - name: gcp-pub-sub-topic-audit-creation
+        resource: gcp.pubsub-topic
+        mode:
+          type: gcp-audit
+          methods:
+            - "google.pubsub.v1.Publisher.CreateTopic"
+        actions:
+         - type: notify
+           to:
+             - email@address
+           format: txt
+           transport:
+             type: pubsub
+             topic: projects/my-gcp-project/topics/my-topic


### PR DESCRIPTION
The use cases that extend Pub/Sub [basic documentation](https://github.com/mediapills/cloud-custodian/pull/56).