### PR TITLE
azure - fix azure-mgmt-subscription api and pin azure-cli-core

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/subscription.py
+++ b/tools/c7n_azure/c7n_azure/resources/subscription.py
@@ -49,8 +49,8 @@ class Subscription(ResourceManager):
 
     def _get_subscription(self, session_factory, config):
         session = local_session(session_factory)
-        client = SubscriptionClient(session.get_credentials(), session.subscription_id)
-        details = client.subscriptions.get(subscription_id=session.subscription_id)
+        client = SubscriptionClient(session.get_credentials(), session.get_subscription_id())
+        details = client.subscriptions.get(subscription_id=session.get_subscription_id())
         return details.serialize(True)
 
 

--- a/tools/c7n_azure/c7n_azure/resources/subscription.py
+++ b/tools/c7n_azure/c7n_azure/resources/subscription.py
@@ -49,7 +49,7 @@ class Subscription(ResourceManager):
 
     def _get_subscription(self, session_factory, config):
         session = local_session(session_factory)
-        client = SubscriptionClient(session.get_credentials())
+        client = SubscriptionClient(session.get_credentials(), session.subscription_id)
         details = client.subscriptions.get(subscription_id=session.subscription_id)
         return details.serialize(True)
 

--- a/tools/c7n_azure/c7n_azure/resources/subscription.py
+++ b/tools/c7n_azure/c7n_azure/resources/subscription.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import six
 
 from azure.mgmt.resource.policy.models import PolicyAssignment
-from azure.mgmt.subscription import SubscriptionClient
+from azure.mgmt.resource import SubscriptionClient
 
 from c7n.actions import BaseAction
 from c7n.exceptions import PolicyValidationError
@@ -49,7 +49,7 @@ class Subscription(ResourceManager):
 
     def _get_subscription(self, session_factory, config):
         session = local_session(session_factory)
-        client = SubscriptionClient(session.get_credentials(), session.get_subscription_id())
+        client = SubscriptionClient(session.get_credentials())
         details = client.subscriptions.get(subscription_id=session.get_subscription_id())
         return details.serialize(True)
 

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -57,7 +57,7 @@ setup(
                       "azure-mgmt-managementgroups",
                       "azure-mgmt-network",
                       "azure-mgmt-redis",
-                      "azure-mgmt-resource",
+                      "azure-mgmt-resource==2.1.0",
                       "azure-mgmt-sql",
                       "azure-mgmt-storage",
                       "azure-mgmt-web",

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -63,7 +63,6 @@ setup(
                       "azure-mgmt-web",
                       "azure-mgmt-monitor",
                       "azure-mgmt-policyinsights",
-                      "azure-mgmt-subscription",
                       "azure-mgmt-eventgrid==2.0.0rc2",  # RC2 supports AdvancedFilters
                       "azure-graphrbac",
                       "azure-keyvault",


### PR DESCRIPTION
Fixing build break:

- pin azure-mgmt-resource because it is incompatible with azure-cli-core==2.0.65
- fix breaking api change for azure-mgmt-subscription