### PR TITLE
Fix value from filter in sg cidr check

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1000,7 +1000,7 @@ class SGPermission(Filter):
                 fv['key'] = f
             else:
                 fv = {f: fv}
-            vf = ValueFilter(fv)
+            vf = ValueFilter(fv, self.manager)
             vf.annotate = False
             self.vfilters.append(vf)
         return super(SGPermission, self).process(resources, event)
@@ -1032,7 +1032,11 @@ class SGPermission(Filter):
         match_range = self.data[cidr_key]
         match_range['key'] = cidr_type
 
+<<<<<<< HEAD
+        vf = ValueFilter(match_range, self.manager)
+=======
         vf = ValueFilter(match_range)
+>>>>>>> 898ebe5984b694e16fad051300d4f664db9fda6d
         vf.annotate = False
 
         for ip_range in ip_perms:
@@ -1062,7 +1066,11 @@ class SGPermission(Filter):
         d = dict(self.data['Description'])
         d['key'] = 'Description'
 
+<<<<<<< HEAD
+        vf = ValueFilter(d, self.manager)
+=======
         vf = ValueFilter(d)
+>>>>>>> 898ebe5984b694e16fad051300d4f664db9fda6d
         vf.annotate = False
 
         for k in ('Ipv6Ranges', 'IpRanges', 'UserIdGroupPairs', 'PrefixListIds'):

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1032,11 +1032,7 @@ class SGPermission(Filter):
         match_range = self.data[cidr_key]
         match_range['key'] = cidr_type
 
-<<<<<<< HEAD
         vf = ValueFilter(match_range, self.manager)
-=======
-        vf = ValueFilter(match_range)
->>>>>>> 898ebe5984b694e16fad051300d4f664db9fda6d
         vf.annotate = False
 
         for ip_range in ip_perms:
@@ -1066,11 +1062,7 @@ class SGPermission(Filter):
         d = dict(self.data['Description'])
         d['key'] = 'Description'
 
-<<<<<<< HEAD
         vf = ValueFilter(d, self.manager)
-=======
-        vf = ValueFilter(d)
->>>>>>> 898ebe5984b694e16fad051300d4f664db9fda6d
         vf.annotate = False
 
         for k in ('Ipv6Ranges', 'IpRanges', 'UserIdGroupPairs', 'PrefixListIds'):


### PR DESCRIPTION
security-group filter for vpc resource is erroring out when used in config mode with ValueFrom attribute. The ValueFilter call from vpc resource is missing the manager object for the resource and causing the ValueFilter to error when looking up manager attributes.

example policy:
``` 
   resource: security-group
   mode:
      type: config-rule
      role: *******


   filters:
     - type: ingress
       Cidr:
         op: not-in
         value_from:
           url: s3://my_cidr_list.csv
           format: csv2dict ```

Error:
``` [ERROR] AttributeError: 'NoneType' object has no attribute 'config'
Traceback (most recent call last):
  File "/var/task/custodian_policy.py", line 4, in run
    return handler.dispatch_event(event, context)
  File "/var/task/c7n/handler.py", line 106, in dispatch_event
    p.push(event, context)
  File "/var/task/c7n/policy.py", line 905, in push
    return mode.run(event, lambda_ctx)
  File "/var/task/c7n/policy.py", line 708, in run
    resources = super(ConfigRuleMode, self).run(event, lambda_context)
  File "/var/task/c7n/policy.py", line 449, in run
    resources, event)
  File "/var/task/c7n/manager.py", line 105, in filter_resources
    resources = f.process(resources, event)
  File "/var/task/c7n/resources/vpc.py", line 908, in process
    return super(SGPermission, self).process(resources, event)
  File "/var/task/c7n/filters/core.py", line 181, in process
    return list(filter(self, resources))
  File "/var/task/c7n/resources/vpc.py", line 1024, in __call__
    perm_matches['cidrs'] = self.process_cidrs(perm)
  File "/var/task/c7n/resources/vpc.py", line 953, in process_cidrs
    found_v4 = self._process_cidr('Cidr', 'CidrIp', 'IpRanges', perm)
  File "/var/task/c7n/resources/vpc.py", line 941, in _process_cidr
    found = vf(ip_range)
  File "/var/task/c7n/filters/core.py", line 438, in __call__
    matched = self.match(i)
  File "/var/task/c7n/filters/core.py", line 486, in match
    values = ValuesFrom(self.data['value_from'], self.manager)
  File "/var/task/c7n/resolver.py", line 116, in __init__
    'account_id': manager.config.account_id, ```