### PR TITLE
gcp - fix pubsub-subscription get method to comply with logging updates

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/pubsub.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/pubsub.py
@@ -50,7 +50,7 @@ class PubSubSubscription(QueryResourceManager):
         @staticmethod
         def get(client, resource_info):
             return client.execute_command(
-                'get', {'subscription': resource_info['name']})
+                'get', {'subscription': resource_info['subscription_id']})
 
 
 @resources.register('pubsub-snapshot')

--- a/tools/c7n_gcp/tests/data/events/pubsub-subscription-create.json
+++ b/tools/c7n_gcp/tests/data/events/pubsub-subscription-create.json
@@ -1,0 +1,50 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "alex.karpitski@gmail.com"
+    },
+    "requestMetadata": {
+      "callerIp": "86.57.255.91",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0,gzip(gfe)",
+      "requestAttributes": {},
+      "destinationAttributes": {}
+    },
+    "serviceName": "pubsub.googleapis.com",
+    "methodName": "google.pubsub.v1.Subscriber.CreateSubscription",
+    "authorizationInfo": [
+      {
+        "resource": "projects/cloud-custodian/topics/custodian",
+        "permission": "pubsub.topics.attachSubscription",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/cloud-custodian/subscriptions/custodian",
+    "request": {
+      "@type": "type.googleapis.com/google.pubsub.v1.Subscription",
+      "ackDeadlineSeconds": 10,
+      "name": "projects/cloud-custodian/subscriptions/custodian",
+      "messageRetentionDuration": "604800s"
+    },
+    "response": {
+      "messageRetentionDuration": "604800s",
+      "pushConfig": {},
+      "@type": "type.googleapis.com/google.pubsub.v1.Subscription",
+      "ackDeadlineSeconds": 10,
+      "name": "projects/cloud-custodian/subscriptions/custodian"
+    }
+  },
+  "insertId": "1vzqeatcofk",
+  "resource": {
+    "type": "pubsub_subscription",
+    "labels": {
+      "subscription_id": "projects/cloud-custodian/subscriptions/custodian",
+      "project_id": "cloud-custodian"
+    }
+  },
+  "timestamp": "2019-03-05T14:17:56.721374586Z",
+  "severity": "NOTICE",
+  "logName": "projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity",
+  "receiveTimestamp": "2019-03-05T14:18:01.005189376Z"
+}

--- a/tools/c7n_gcp/tests/data/flights/pubsub-subscription-get/get-v1-projects-cloud-custodian-subscriptions-custodian_1.json
+++ b/tools/c7n_gcp/tests/data/flights/pubsub-subscription-get/get-v1-projects-cloud-custodian-subscriptions-custodian_1.json
@@ -1,26 +1,28 @@
 {
-  "headers": {
-    "content-type": "application/json; charset=UTF-8",
-    "vary": "Origin, X-Origin, Referer",
-    "date": "Tue, 05 Mar 2019 15:07:14 GMT",
-    "server": "ESF",
-    "cache-control": "private",
-    "x-xss-protection": "1; mode=block",
-    "x-frame-options": "SAMEORIGIN",
-    "x-content-type-options": "nosniff",
-    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"",
-    "transfer-encoding": "chunked",
-    "status": "200",
-    "content-length": "250",
-    "-content-encoding": "gzip",
-    "content-location": "https://pubsub.googleapis.com/v1/projects/cloud-custodian/subscriptions/custodian?alt=json"
-  },
   "body": {
-    "name": "projects/cloud-custodian/subscriptions/custodian",
-    "topic": "projects/cloud-custodian/topics/custodian",
-    "pushConfig": {},
-    "ackDeadlineSeconds": 10,
-    "messageRetentionDuration": "604800s",
-    "expirationPolicy": {}
+    "name": "projects/cloud-custodian/subscriptions/custodian", 
+    "ackDeadlineSeconds": 10, 
+    "pushConfig": {}, 
+    "topic": "projects/cloud-custodian/topics/cloud-builds", 
+    "messageRetentionDuration": "604800s", 
+    "expirationPolicy": {
+      "ttl": "2678400s"
+    }
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "278", 
+    "x-xss-protection": "0", 
+    "content-location": "https://pubsub.googleapis.com/v1/projects/cloud-custodian/subscriptions/custodian?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "vary": "Origin, X-Origin, Referer", 
+    "server": "ESF", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private", 
+    "date": "Thu, 30 May 2019 07:48:07 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
   }
 }


### PR DESCRIPTION
Instead of referring to the parameters based on assumptions, use the real log export.