### PR TITLE
gcp - fix cloudbilling-account get method

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/cloudbilling.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/cloudbilling.py
@@ -14,6 +14,8 @@
 from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo
 
+import jmespath
+
 
 @resources.register('cloudbilling-account')
 class CloudBillingAccount(QueryResourceManager):
@@ -23,10 +25,12 @@ class CloudBillingAccount(QueryResourceManager):
         version = 'v1'
         component = 'billingAccounts'
         enum_spec = ('list', 'billingAccounts[]', None)
+        get_requires_event = True
         scope = None
         id = 'name'
 
         @staticmethod
-        def get(client, resource_info):
+        def get(client, event):
             return client.execute_query(
-                'get', {'name': resource_info['name']})
+                'get', {'name': jmespath.search(
+                    'protoPayload.response.billingAccountInfo.billingAccountName', event)})

--- a/tools/c7n_gcp/tests/data/events/cloudbilling-account-assign.json
+++ b/tools/c7n_gcp/tests/data/events/cloudbilling-account-assign.json
@@ -1,0 +1,82 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "alex.karpitski@gmail.com"
+    },
+    "requestMetadata": {
+      "callerIp": "86.57.255.94",
+      "requestAttributes": {},
+      "destinationAttributes": {}
+    },
+    "serviceName": "cloudbilling.googleapis.com",
+    "methodName": "AssignResourceToBillingAccount",
+    "authorizationInfo": [
+      {
+        "resource": "billingAccounts/CU570D-1A4CU5-70D1A4",
+        "permission": "billing.resourceAssociations.create",
+        "granted": true,
+        "resourceAttributes": {}
+      },
+      {
+        "resource": "projects/cloud-custodian",
+        "permission": "resourcemanager.projects.createBillingAssignment",
+        "granted": true,
+        "resourceAttributes": {}
+      },
+      {
+        "resource": "billingAccounts/CU570D-1A4CU5-70D1A4",
+        "permission": "billing.resourceAssociations.create",
+        "granted": true,
+        "resourceAttributes": {}
+      },
+      {
+        "resource": "projects/cloud-custodian",
+        "permission": "resourcemanager.projects.deleteBillingAssignment",
+        "granted": true,
+        "resourceAttributes": {}
+      }
+    ],
+    "resourceName": "projects/cloud-custodian",
+    "request": {
+      "billingAccountName": "billingAccounts/CU570D-1A4CU5-70D1A4",
+      "@type": "type.googleapis.com/google.internal.cloudbilling.billingaccount.v1.AssignResourceToBillingAccountRequest",
+      "resourceName": "projects/2030697917"
+    },
+    "response": {
+      "permissionInfo": {},
+      "@type": "type.googleapis.com/google.internal.cloudbilling.billingaccount.v1.ResourceBillingInfo",
+      "billingAccountAssignmentType": "EXPLICIT",
+      "resourceIdentifier": {
+        "resourceName": "projects/2030697917",
+        "projectId": "cloud-custodian"
+      },
+      "billingAccountInfo": {
+        "billingAccountName": "billingAccounts/CU570D-1A4CU5-70D1A4",
+        "billingAccountDisplayName": "Custodian Billing Account",
+        "billingAccountState": {
+          "auditEntry": {
+            "time": "2019-05-20T09:59:23.191Z"
+          }
+        },
+        "supportedBusinessEntities": [
+          "businessEntity/CLOUD_PLATFORM",
+          "businessEntity/SEARCH",
+          "businessEntity/GEO"
+        ]
+      }
+    }
+  },
+  "insertId": "pjl00dd96nm",
+  "resource": {
+    "type": "project",
+    "labels": {
+      "project_id": "cloud-custodian"
+    }
+  },
+  "timestamp": "2019-05-20T12:06:27.208Z",
+  "severity": "NOTICE",
+  "logName": "projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity",
+  "receiveTimestamp": "2019-05-20T12:06:29.023807450Z"
+}

--- a/tools/c7n_gcp/tests/test_cloudbilling.py
+++ b/tools/c7n_gcp/tests/test_cloudbilling.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gcp_common import BaseTest
+from gcp_common import BaseTest, event_data
 
 
 class CloudBillingAccountTest(BaseTest):
@@ -36,10 +36,16 @@ class CloudBillingAccountTest(BaseTest):
             'cloudbilling-account-get')
 
         policy = self.load_policy(
-            {'name': 'billing-cloudbilling-account-dryrun',
-             'resource': 'gcp.cloudbilling-account'},
+            {'name': 'billing-cloudbilling-account-audit',
+             'resource': 'gcp.cloudbilling-account',
+             'mode': {
+                 'type': 'gcp-audit',
+                 'methods': ['AssignProjectToBillingAccount']
+             }},
             session_factory=session_factory)
 
-        billingaccount_resource = policy.resource_manager.get_resource(
-            {'name': billingaccount_resource_name})
-        self.assertEqual(billingaccount_resource['name'], billingaccount_resource_name)
+        exec_mode = policy.get_execution_mode()
+        event = event_data('cloudbilling-account-assign.json')
+
+        resources = exec_mode.run(event, None)
+        self.assertEqual(resources[0]['name'], billingaccount_resource_name)


### PR DESCRIPTION
Instead of referring to the parameters based on assumptions, use the real log export.