### PR TITLE
Add aws.eni delete action

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1367,6 +1367,56 @@ class InterfaceModifyVpcSecurityGroups(ModifyVpcSecurityGroupsAction):
                 Groups=groups[idx])
 
 
+@NetworkInterface.action_registry.register('delete')
+class DeleteNetworkInterface(BaseAction):
+    """Delete a network interface.
+
+    :example:
+
+    .. code-block: yaml
+
+        policies:
+          - name: mark-orphaned-enis
+            comment: Flag abandoned Lambda VPC ENIs for deletion
+            resource: eni
+            filters:
+              - Status: available
+              - type: value
+                op: glob
+                key: Description
+                value: "AWS Lambda VPC ENI*"
+              - "tag:custodian_status": absent
+            actions:
+              - type: mark-for-op
+                tag: custodian_status
+                msg: "Orphaned Lambda VPC ENI: {op}@{action_date}"
+                op: delete
+                days: 1
+
+          - name: delete-marked-enis
+            comment: Delete flagged ENIs that have not been cleaned up naturally
+            resource: eni
+            filters:
+              - type: marked-for-op
+                tag: custodian_status
+                op: delete
+            actions:
+              - type: delete
+    """
+    permissions = ('ec2:DeleteNetworkInterface',)
+    schema = type_schema('delete')
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('ec2')
+        for r in resources:
+            try:
+                self.manager.retry(
+                    client.delete_network_interface,
+                    NetworkInterfaceId=r['NetworkInterfaceId'])
+            except client.exceptions.NotFoundException:
+                pass
+
+
 @resources.register('route-table')
 class RouteTable(query.QueryResourceManager):
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1413,8 +1413,9 @@ class DeleteNetworkInterface(BaseAction):
                 self.manager.retry(
                     client.delete_network_interface,
                     NetworkInterfaceId=r['NetworkInterfaceId'])
-            except client.exceptions.NotFoundException:
-                pass
+            except ClientError as err:
+                if not err.response['Error']['Code'] == 'InvalidNetworkInterfaceID.NotFound':
+                    raise
 
 
 @resources.register('route-table')

--- a/tests/data/placebo/test_network_interface_delete/ec2.DeleteNetworkInterface_1.json
+++ b/tests/data/placebo/test_network_interface_delete/ec2.DeleteNetworkInterface_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "2474bcad-f77c-4e32-81cc-ca3ea75132b0", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Tue, 27 Jun 2017 15:38:08 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_network_interface_delete/ec2.DeleteNetworkInterface_2.json
+++ b/tests/data/placebo/test_network_interface_delete/ec2.DeleteNetworkInterface_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 400, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 400, 
+            "RequestId": "5c44ef13-e769-4e25-8681-b4f39ce17197", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "date": "Tue, 27 Jun 2017 15:44:28 GMT", 
+                "connection": "close", 
+                "server": "AmazonEC2"
+            }
+        }, 
+        "Error": {
+            "Message": "The networkInterface ID 'eni-d834cdcf' does not exist", 
+            "Code": "InvalidNetworkInterfaceID.NotFound"
+        }
+    }
+}

--- a/tests/data/placebo/test_network_interface_delete/ec2.DescribeNetworkInterfaces_1.json
+++ b/tests/data/placebo/test_network_interface_delete/ec2.DescribeNetworkInterfaces_1.json
@@ -1,0 +1,47 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "710478fa-6be2-4374-ad96-dd0b55bd04c0", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Tue, 27 Jun 2017 15:38:05 GMT"
+            }
+        }, 
+        "NetworkInterfaces": [
+            {
+                "Status": "available", 
+                "MacAddress": "02:54:b7:8e:05:ac", 
+                "SourceDestCheck": true, 
+                "AvailabilityZone": "us-east-1c", 
+                "Description": "", 
+                "NetworkInterfaceId": "eni-d834cdcf", 
+                "PrivateIpAddresses": [
+                    {
+                        "Primary": true, 
+                        "PrivateIpAddress": "10.4.8.179"
+                    }
+                ], 
+                "RequesterManaged": false, 
+                "SubnetId": "subnet-55061130", 
+                "VpcId": "vpc-c3c27aba", 
+                "RequesterId": "AIDAIYEUEZZQWE5TZHHAE", 
+                "Groups": [
+                    {
+                        "GroupName": "web-tier", 
+                        "GroupId": "sg-d29623a3"
+                    }
+                ], 
+                "Ipv6Addresses": [], 
+                "OwnerId": "644160558196", 
+                "TagSet": [], 
+                "PrivateIpAddress": "10.4.8.179"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_network_interface_delete/ec2.DescribeNetworkInterfaces_2.json
+++ b/tests/data/placebo/test_network_interface_delete/ec2.DescribeNetworkInterfaces_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 400, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 400, 
+            "RequestId": "5c44ef13-e769-4e25-8681-b4f39ce17197", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "date": "Tue, 27 Jun 2017 15:44:28 GMT", 
+                "connection": "close", 
+                "server": "AmazonEC2"
+            }
+        }, 
+        "Error": {
+            "Message": "The networkInterface ID 'eni-d834cdcf' does not exist", 
+            "Code": "InvalidNetworkInterfaceID.NotFound"
+        }
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -645,6 +645,31 @@ class NetworkInterfaceTest(BaseTest):
             [k for k in resources[0] if k.startswith("c7n")], ["c7n:MatchedFilters"]
         )
 
+    def test_interface_delete(self):
+        factory = self.replay_flight_data("test_network_interface_delete")
+        client = factory().client("ec2")
+        eni = "eni-d834cdcf"
+
+        p = self.load_policy(
+            {
+                "name": "eni-delete",
+                "resource": "eni",
+                "filters": [
+                    {
+                        "type": "value",
+                        "key": "NetworkInterfaceId",
+                        "value": eni,
+                    }
+                ]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        with self.assertRaises(client.exceptions.ClientError) as e:
+            client.describe_network_interfaces(NetworkInterfaceIds=[eni])
+        self.assertEqual(e.exception.response['Error']['Code'], 'InvalidNetworkInterfaceID.NotFound')
+
     @functional
     def test_interface_subnet(self):
         factory = self.replay_flight_data("test_network_interface_filter")

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -664,7 +664,11 @@ class NetworkInterfaceTest(BaseTest):
                 "actions": [
                     {
                         "type": "delete",
-                    }
+                    },
+                    {
+                        # ensure graceful handling of multiple delete attempts
+                        "type": "delete",
+                    },
                 ],
             },
             session_factory=factory,

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -668,7 +668,8 @@ class NetworkInterfaceTest(BaseTest):
         self.assertEqual(len(resources), 1)
         with self.assertRaises(client.exceptions.ClientError) as e:
             client.describe_network_interfaces(NetworkInterfaceIds=[eni])
-        self.assertEqual(e.exception.response['Error']['Code'], 'InvalidNetworkInterfaceID.NotFound')
+        self.assertEqual(e.exception.response['Error']['Code'],
+            'InvalidNetworkInterfaceID.NotFound')
 
     @functional
     def test_interface_subnet(self):

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -660,7 +660,12 @@ class NetworkInterfaceTest(BaseTest):
                         "key": "NetworkInterfaceId",
                         "value": eni,
                     }
-                ]
+                ],
+                "actions": [
+                    {
+                        "type": "delete",
+                    }
+                ],
             },
             session_factory=factory,
         )


### PR DESCRIPTION
Add a `delete` action for the AWS `eni` resource. The immediate use case is detection/cleanup of orphaned network interfaces created by VPC-based Lambda functions.

For an example of when this could be useful, see the notes in [this document](https://docs.aws.amazon.com/lambda/latest/dg/vpc.html#vpc-configuring):

>Do not delete this role immediately after your Lambda function execution. There is a delay between the time your Lambda function executes and ENI deletion. If you do delete the role immediately after function execution, you are responsible for deleting the ENIs. 