### PR TITLE
webhook action - use schema alias to reduce schema size

### DIFF
--- a/c7n/actions/webhook.py
+++ b/c7n/actions/webhook.py
@@ -42,6 +42,7 @@ class Webhook(EventAction):
                     policy_name: policy.name
     """
 
+    schema_alias = True
     schema = utils.type_schema(
         'webhook',
         required=['url'],


### PR DESCRIPTION
reduces schema size 300kb on aws provider alone.