### PR TITLE
Custom finding type classifier securityhub

### DIFF
--- a/c7n/actions/securityhub.py
+++ b/c7n/actions/securityhub.py
@@ -35,8 +35,6 @@ FindingTypes = {
     "Sensitive Data Identifications"
 }
 
-
-
 # Mostly undocumented value size limit
 SECHUB_VALUE_SIZE_LIMIT = 1024
 

--- a/c7n/actions/securityhub.py
+++ b/c7n/actions/securityhub.py
@@ -106,14 +106,6 @@ FindingTypes = {
 SECHUB_VALUE_SIZE_LIMIT = 1024
 
 
-def build_vocabulary():
-    vocab = []
-    for ns, quals in FindingTypes.items():
-        for q in quals:
-            vocab.append("{}/{}".format(ns, q))
-    return vocab
-
-
 class PostFinding(BaseAction):
     """Report a finding to AWS Security Hub.
 

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -29,7 +29,7 @@ class SecurityHubTest(BaseTest):
             'name': 's3',
             'resource': 's3',
             'actions': [{'type': 'post-finding',
-                         'types':  ['Effects/CustomB/CustomA']}]}
+                         'types': ['Effects/CustomB/CustomA']}]}
         self.load_policy(templ)
         templ['actions'][0]['types'] = ['CustomA/CustomB/CustomC']
         self.assertRaises(PolicyValidationError, self.load_policy, templ)

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from jsonschema.exceptions import ValidationError
+from c7n.exceptions import PolicyValidationError
 from .common import BaseTest
 
 import time
@@ -20,6 +22,21 @@ LambdaFindingId = "us-east-2/644160558196/81cc9d38b8f8ebfd260ecc81585b4bc9/9f593
 
 
 class SecurityHubTest(BaseTest):
+
+    def test_custom_classifier(self):
+
+        templ = {
+            'name': 's3',
+            'resource': 's3',
+            'actions': [{'type': 'post-finding',
+                         'types':  ['Effects/CustomB/CustomA']}]}
+        self.load_policy(templ)
+        templ['actions'][0]['types'] = ['CustomA/CustomB/CustomC']
+        self.assertRaises(PolicyValidationError, self.load_policy, templ)
+        templ['actions'][0]['types'] = ['Effects/CustomB/CustomA/CustomD']
+        self.assertRaises(PolicyValidationError, self.load_policy, templ)
+        templ['actions'][0]['types'] = []
+        self.assertRaises(ValidationError, self.load_policy, templ, validate=True)
 
     def test_s3_bucket_arn(self):
         policy = self.load_policy({


### PR DESCRIPTION
add type_classifier key for security hub which will be appended to all finding types that both have a namespace and a category already set. 

Note that this is an 'all or nothing' approach for type classifiers (either all types get the classifier appended or none), but IMO this is not a bad thing. 


Original issue #4115:

> In security hub, finding types are formatted as: namespace/category/classifier, where the category and classifier are optional. (https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html)
> 
> Currently in CloudCustodian, only predefined namespaces and categories are supported (e.g. "Effects/Data Exposure", but not a custom classier (e.g. "Effects/Data Exposure/Public Bucket"). This does not allow for granular filtering of Findings in Security Hub's 'Insights' tab.
> 
> One of the problems is that Security Hub's default findings have a trailing slash (e.g. for public buckets, the filter is: "TYPE PREFIX Effects/Data Exposure/". The trailing slash filter out Cloud Custodian's "Effects/Data Exposure" Type, and is therefore not visible as an insight.
