### PR TITLE
add wildcard to statement id enum

### DIFF
--- a/c7n/actions/policy.py
+++ b/c7n/actions/policy.py
@@ -22,7 +22,7 @@ class RemovePolicyBase(BaseAction):
         'remove-statements',
         required=['statement_ids'],
         statement_ids={'oneOf': [
-            {'enum': ['matched']},
+            {'enum': ['matched', "*"]},
             {'type': 'array', 'items': {'type': 'string'}}]})
 
     def process_policy(self, policy, resource, matched_key):


### PR DESCRIPTION
I want to remove all statements in a policy, which your code seems to support. However, the schema doesn't (compare remove_statements with the schema for "*"). I don't know if this is by design or not, but I need it for removing public s3 bucket statements.
