### PR TITLE
gcp - fix exception caused by retrieval of children whose parents are not running

### DIFF
--- a/tools/c7n_gcp/tests/data/flights/sqldatabase-stopped-instance-query/get-sql-v1beta4-projects-mitrop-custodian-instances-test-instance-databases_1.json
+++ b/tools/c7n_gcp/tests/data/flights/sqldatabase-stopped-instance-query/get-sql-v1beta4-projects-mitrop-custodian-instances-test-instance-databases_1.json
@@ -1,0 +1,30 @@
+{
+  "body": {
+    "error": {
+      "message": "Invalid request: Invalid request since instance is not running.", 
+      "code": 400, 
+      "errors": [
+        {
+          "reason": "invalid", 
+          "message": "Invalid request: Invalid request since instance is not running.", 
+          "domain": "global"
+        }
+      ]
+    }
+  }, 
+  "headers": {
+    "status": "400", 
+    "content-length": "300", 
+    "x-xss-protection": "0", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "vary": "Origin, X-Origin, Referer", 
+    "server": "ESF", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private", 
+    "date": "Wed, 19 Jun 2019 09:55:58 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/sqldatabase-stopped-instance-query/get-sql-v1beta4-projects-mitrop-custodian-instances_1.json
+++ b/tools/c7n_gcp/tests/data/flights/sqldatabase-stopped-instance-query/get-sql-v1beta4-projects-mitrop-custodian-instances_1.json
@@ -1,0 +1,87 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "sql#instance", 
+        "name": "test-instance", 
+        "settings": {
+          "kind": "sql#settings", 
+          "dataDiskType": "PD_SSD", 
+          "maintenanceWindow": {
+            "kind": "sql#maintenanceWindow", 
+            "day": 0, 
+            "hour": 0
+          }, 
+          "authorizedGaeApplications": [], 
+          "activationPolicy": "NEVER", 
+          "backupConfiguration": {
+            "kind": "sql#backupConfiguration", 
+            "enabled": true, 
+            "binaryLogEnabled": true, 
+            "startTime": "10:00"
+          }, 
+          "ipConfiguration": {
+            "ipv4Enabled": true, 
+            "authorizedNetworks": []
+          }, 
+          "pricingPlan": "PER_USE", 
+          "replicationType": "SYNCHRONOUS", 
+          "storageAutoResizeLimit": "0", 
+          "tier": "db-n1-standard-1", 
+          "settingsVersion": "3", 
+          "storageAutoResize": true, 
+          "locationPreference": {
+            "kind": "sql#locationPreference", 
+            "zone": "us-central1-a"
+          }, 
+          "dataDiskSizeGb": "10"
+        }, 
+        "region": "us-central1", 
+        "backendType": "SECOND_GEN", 
+        "gceZone": "us-central1-a", 
+        "project": "mitrop-custodian", 
+        "state": "RUNNABLE", 
+        "etag": "a3a6d4b63282437eb48383df36c0e936b1d136d4ec76c1b90f3152935f2bfb93", 
+        "serviceAccountEmailAddress": "p468975819404-9puagn@gcp-sa-cloud-sql.iam.gserviceaccount.com", 
+        "serverCaCert": {
+          "certSerialNumber": "0", 
+          "kind": "sql#sslCert", 
+          "sha1Fingerprint": "44e5658aa75cc5d47268b4045e5a892516036537", 
+          "commonName": "C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=969e5b11-0c82-4270-b4a8-86c8798f9ace", 
+          "instance": "test-instance", 
+          "cert": "-----BEGIN CERTIFICATE-----\nMIIDfzCCAmegAwIBAgIBADANBgkqhkiG9w0BAQsFADB3MS0wKwYDVQQuEyQ5Njll\nNWIxMS0wYzgyLTQyNzAtYjRhOC04NmM4Nzk4ZjlhY2UxIzAhBgNVBAMTGkdvb2ds\nZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUsIEluYzELMAkG\nA1UEBhMCVVMwHhcNMTkwNjE5MDk0MTA1WhcNMjkwNjE2MDk0MjA1WjB3MS0wKwYD\nVQQuEyQ5NjllNWIxMS0wYzgyLTQyNzAtYjRhOC04NmM4Nzk4ZjlhY2UxIzAhBgNV\nBAMTGkdvb2dsZSBDbG91ZCBTUUwgU2VydmVyIENBMRQwEgYDVQQKEwtHb29nbGUs\nIEluYzELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\nAQCOLHmW2xMyhQ9g4Wg7wKPtwpOsiUPsYjgt3PUjFEE7PinUxWpjc2LbIpMzI1bO\nwOhqWea+iGtfpGd6pM4j5gwryJkbfC2GziFi7H445oPyO4HJmXjTKeLP7aZ7Auwv\nxfAEXw6J+OGwoMJ4akHuITiwFZdRAd2HV06I8OvRY02LrDySjR1CwyVnISQoXZvG\nnEBq74ilJ6JAco9sCWNV2tg2HeSahZ26HtD+Di3YoGwPXPpHzSSuzXT+GCcJP1mq\n99Xc+sgbsz34CGpyUsa7a1k2RD7OO6uqplRAaF2CEX2fQYaUqM62smEDxI0gsLv/\n2fxiIazE5wpyuiE7rohUJUMRAgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw\nDQYJKoZIhvcNAQELBQADggEBACqfXOfpBbvPJ6vdu0NaWOwLaTk17v2nji987zl8\nyNZL++fYMgKwHRZLI4oXKm0iMyuBSxRSU96NE0h4O84LtQDOZ9uOfEzk16Ts7hac\nqbfVBRLGrnzVbFAIS+rdV+RoXX6pQaHmCa+l0CsmXVQXRpSK93bAkyW+1XGh7BXP\nBD4jgT0sNpEAORSjtwpj+EwqyBi9+VhwKIjh4jKz3VLdkmNhuxb1PPMM+WuN90s0\nRpILHp34YkPL2BT5g7811Ybb/ovBQmxWjpEYM93smBE3Kygfg8StEgp9LVb61dme\nGkBczsAe3fBmZeJi04PK1jJpAvhagCMR/3I8xZa3SoLgYEI=\n-----END CERTIFICATE-----", 
+          "expirationTime": "2029-06-16T09:42:05.773Z", 
+          "createTime": "2019-06-19T09:41:05.773Z"
+        }, 
+        "ipAddresses": [
+          {
+            "type": "PRIMARY", 
+            "ipAddress": "35.202.145.202"
+          }
+        ], 
+        "connectionName": "mitrop-custodian:us-central1:test-instance", 
+        "databaseVersion": "MYSQL_5_7", 
+        "instanceType": "CLOUD_SQL_INSTANCE", 
+        "selfLink": "https://www.googleapis.com/sql/v1beta4/projects/mitrop-custodian/instances/test-instance"
+      }
+    ], 
+    "kind": "sql#instancesList"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "3311", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/sql/v1beta4/projects/mitrop-custodian/instances?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 19 Jun 2019 09:55:57 GMT", 
+    "vary": "Origin, X-Origin", 
+    "server": "GSE", 
+    "-content-encoding": "gzip", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "date": "Wed, 19 Jun 2019 09:55:57 GMT", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/test_sql.py
+++ b/tools/c7n_gcp/tests/test_sql.py
@@ -102,6 +102,20 @@ class SqlDatabaseTest(BaseTest):
         databases = policy.run()
         self.assertEqual(databases[0]['name'], database_name)
 
+    def test_sqldatabase_stopped_instance_query(self):
+        project_id = 'mitrop-custodian'
+        session_factory = self.replay_flight_data(
+            'sqldatabase-stopped-instance-query',
+            project_id=project_id)
+
+        policy = self.load_policy(
+            {'name': 'all-sql-databases',
+             'resource': 'gcp.sql-database'},
+            session_factory=session_factory)
+
+        databases = policy.run()
+        self.assertEqual(len(databases), 0)
+
     def test_sqldatabase_get(self):
         project_id = 'mitropject'
         session_factory = self.replay_flight_data('sqldatabase-get', project_id=project_id)


### PR DESCRIPTION
Steps to reproduce:
1. Make sure you have a stopped SQL instance in a GCP project
2. Run the following policy:
```yaml
policies:
  - name: gcp-sql-database-list
    resource: gcp.sql-database
```
As remainder: there is parent-child relationship between SQL instance and SQL database. Firstly all instances are fetched (even those that are stopped) and then children (databases) for each one of them.