### PR TITLE
core - load only known cloud providers by default

### DIFF
--- a/c7n/resources/__init__.py
+++ b/c7n/resources/__init__.py
@@ -109,17 +109,20 @@ def load_resources():
         resources.load_plugins()
     else:
         try:
-            import c7n_azure.entry  # NOQA
+            from c7n_azure.entry import initialize_azure
+            initialize_azure()
         except ImportError:
             pass
 
         try:
-            import c7n_gcp.entry  # NOQA
+            from c7n_gcp.entry import initialize_gcp
+            initialize_gcp()
         except ImportError:
             pass
 
         try:
-            import c7n_kube.entry  # NOQA
+            from c7n_kube.entry import initialize_kube
+            initialize_kube()
         except ImportError:
             pass
 

--- a/c7n/resources/__init__.py
+++ b/c7n/resources/__init__.py
@@ -17,7 +17,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import time
-
+import os
 
 LOADED = False
 
@@ -96,11 +96,33 @@ def load_resources():
     import c7n.resources.vpc
     import c7n.resources.waf
     import c7n.resources.fsx
-    import c7n.resources.workspaces
+    import c7n.resources.workspaces  # NOQA
 
     # Load external plugins (private sdks etc)
+    #
+    # We default to loading known cloud providers
+    # to avoid the runtime costs in serverless
+    # environments of scanning the entire python
+    # path for entry points.
     from c7n.manager import resources
-    resources.load_plugins()
+    if 'C7N_EXTPLUGINS' in os.environ:
+        resources.load_plugins()
+    else:
+        try:
+            import c7n_azure.entry  # NOQA
+        except ImportError:
+            pass
+
+        try:
+            import c7n_gcp.entry  # NOQA
+        except ImportError:
+            pass
+
+        try:
+            import c7n_kube.entry  # NOQA
+        except ImportError:
+            pass
+
     resources.notify(resources.EVENT_FINAL)
 
     LOADED = True


### PR DESCRIPTION
this minimizes cold start times in Serverless environments by avoiding an expensive disk/path scan for entry points via setup tools.