### PR TITLE
fix value_type: expr to lookup value instead of resolved key

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -573,7 +573,7 @@ class ValueFilter(Filter):
             return sentinel, value.strip().lower()
 
         elif self.vtype == 'expr':
-            return sentinel, self.get_resource_value(value, resource)
+            return self.get_resource_value(sentinel, resource), value
 
         elif self.vtype == 'integer':
             try:


### PR DESCRIPTION
I'm almost certain the `value_type: expr` was intended to allow the `value:` part of an event or value filter to be used to compare different attributes in an event or resource.

However, the current implementation actually tries to search the event for the value of the resolved key instead of the value provided by the user.

Example:
```
filters:
 - type: event
   key: "detail.some.path.here"
   op: eq
   value: "detail.some.other.path.here"
   value_type: expr
```
Lets say the `key` resolves in the event to a value 'some-value' and the `value` would resolve to 'some-other-value'.

First, the `key` is resolved and stored in the variable `r (='some-value')`. Also, the `value` is stored in the variable `v (='detail.some.other.path.here')`. The event itself is stored in `i`.  Then the following code is executed:

```python
v, r = self.process_value_type('detail.some.other.path.here', 'some-value', i) . # line 547
def process_value_type(self, sentinel, value, resource):  # line 571
    return sentinel, self.get_resource_value(value, resource) . # this breaks, since 'value' equals 'some-value', which is definitely not a key in the cloudwatch event.

```
This obviously breaks, since 'some-value' does not correspond to a valid key in the original event. 