### PR TITLE
tools/mailer - remove enum, which isn't part of 2.7

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import base64
 from datetime import datetime, timedelta
-from enum import Enum
 import functools
 import json
 import os
@@ -29,7 +28,7 @@ from dateutil.tz import gettz, tzutc
 from ruamel import yaml
 
 
-class Providers(Enum):
+class Providers(object):
     AWS = 0
     Azure = 1
 

--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -49,7 +49,7 @@ if path.exists(readme):
 
 setup(
     name="c7n_mailer",
-    version='0.5.1',
+    version='0.5.2',
     description="Cloud Custodian - Reference Mailer",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
cause it breaks lambda 2.7 deployments which was the default for the mailer, also the use of it here was incidental

closes #4201