### PR TITLE
docs - gcp pubsub examples

### DIFF
--- a/docs/source/gcp/examples/pubsub-snapshots.rst
+++ b/docs/source/gcp/examples/pubsub-snapshots.rst
@@ -1,0 +1,28 @@
+Pub/Sub - Find Snapshots Referring to Deleted Topics
+====================================================
+
+In Cloud Pub/Sub, the snapshot feature allows users to capture the message acknowledgment state of a subscription to a topic. Once a snapshot is created, it retains all messages that were unacknowledged in the source subscription (at the time of the snapshot's creation).
+
+Some Pub/Sub snapshots may refer to deleted topics (GCP uses special ``_deleted-topic_`` name for them). Although such snapshots are deleted in a week upon creation, in order to enforce security Custodian can filter them earlier, thus decreasing time-to-live of unused sensitive data.
+
+Note that the ``notify`` action requires a Pub/Sub topic to be configured. To configure Cloud Pub/Sub messaging please take a look at the :ref:`gcp_genericgcpactions` page.
+
+In the example below, the policy reports existing snapshots whose topics have been deleted, therefore snapshots may need deletion as well.
+
+.. code-block:: yaml
+
+    policies:
+      - name: gcp-pub-sub-snapshots-notify-if-topic-deleted
+        resource: gcp.pubsub-snapshot
+        filters:
+          - type: value
+            key: topic
+            value: _deleted-topic_
+        actions:
+         - type: notify
+           to:
+             - email@address
+           format: txt
+           transport:
+             type: pubsub
+             topic: projects/my-gcp-project/topics/my-topic

--- a/docs/source/gcp/examples/pubsub-snapshots.rst
+++ b/docs/source/gcp/examples/pubsub-snapshots.rst
@@ -1,4 +1,4 @@
-Pub/Sub - Find Obsolete Snapshots
+Pub/Sub - Early Detection of Obsolete Snapshots
 ====================================================
 
 In Cloud Pub/Sub, the snapshot feature allows users to capture the message acknowledgment state of a subscription to a topic. Once a snapshot is created, it retains all messages that were unacknowledged in the source subscription (at the time of the snapshot's creation).
@@ -7,7 +7,7 @@ All pubsub snapshots are deleted in a week or less of their creation. For some u
 
 Note that the ``notify`` action requires a Pub/Sub topic to be configured. To configure Cloud Pub/Sub messaging please take a look at the :ref:`gcp_genericgcpactions` page.
 
-In the example below, the policy reports existing snapshots whose topics have been deleted, therefore snapshots may need deletion as well in order to decrease time-to-live of unused sensitive data.
+In the example below, the policy reports existing snapshots whose topics have been deleted, therefore snapshots may need prompt deletion as well.
 
 .. code-block:: yaml
 

--- a/docs/source/gcp/examples/pubsub-snapshots.rst
+++ b/docs/source/gcp/examples/pubsub-snapshots.rst
@@ -1,4 +1,4 @@
-Pub/Sub - Find Snapshots Referring to Deleted Topics
+Pub/Sub - Find Obsolete Snapshots
 ====================================================
 
 In Cloud Pub/Sub, the snapshot feature allows users to capture the message acknowledgment state of a subscription to a topic. Once a snapshot is created, it retains all messages that were unacknowledged in the source subscription (at the time of the snapshot's creation).

--- a/docs/source/gcp/examples/pubsub-snapshots.rst
+++ b/docs/source/gcp/examples/pubsub-snapshots.rst
@@ -3,11 +3,11 @@ Pub/Sub - Find Snapshots Referring to Deleted Topics
 
 In Cloud Pub/Sub, the snapshot feature allows users to capture the message acknowledgment state of a subscription to a topic. Once a snapshot is created, it retains all messages that were unacknowledged in the source subscription (at the time of the snapshot's creation).
 
-Some Pub/Sub snapshots may refer to deleted topics (GCP uses special ``_deleted-topic_`` name for them). Although such snapshots are deleted in a week upon creation, in order to enforce security Custodian can filter them earlier, thus decreasing time-to-live of unused sensitive data.
+All pubsub snapshots are deleted in a week or less of their creation. For some use cases it maybe useful to delete them earlier.
 
 Note that the ``notify`` action requires a Pub/Sub topic to be configured. To configure Cloud Pub/Sub messaging please take a look at the :ref:`gcp_genericgcpactions` page.
 
-In the example below, the policy reports existing snapshots whose topics have been deleted, therefore snapshots may need deletion as well.
+In the example below, the policy reports existing snapshots whose topics have been deleted, therefore snapshots may need deletion as well in order to decrease time-to-live of unused sensitive data.
 
 .. code-block:: yaml
 

--- a/docs/source/gcp/examples/pubsub-subscriptions.rst
+++ b/docs/source/gcp/examples/pubsub-subscriptions.rst
@@ -1,0 +1,31 @@
+Pub/Sub - Audit Subscriptions to Match Requirements
+===================================================
+
+In Cloud Pub/Sub, subscriptions connect a topic to a subscriber application that receives and processes messages published to the topic. Custodian can find Pub/Sub subscriptions whose settings do not match the required ones. 
+
+Note that the ``notify`` action requires a Pub/Sub topic to be configured. To configure Cloud Pub/Sub messaging please take a look at the :ref:`gcp_genericgcpactions` page.
+
+In the example below, users are notified if the resources appearing in the logs with ``CreateSubscription`` or ``UpdateSubscription`` action have expiration policy unset.
+
+.. code-block:: yaml
+
+    policies:
+      - name: gcp-pub-sub-subscription-audit
+        resource: gcp.pubsub-subscription
+        mode:
+          type: gcp-audit
+          methods:
+            - "google.pubsub.v1.Subscriber.CreateSubscription"
+            - "google.pubsub.v1.Subscriber.UpdateSubscription"
+        filters:
+          - type: value
+            key: expirationPolicy.ttl
+            value:
+        actions:
+         - type: notify
+           to:
+             - email@address
+           format: txt
+           transport:
+             type: pubsub
+             topic: projects/my-gcp-project/topics/my-topic


### PR DESCRIPTION
Use cases for Pub/Sub `Topic`, `Subscription`, `Snapshot` resources.