### PR TITLE
Mailer: Implement org_domain logic for non-events based policies

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -167,7 +167,8 @@ class EmailDelivery(object):
                                                     (uid) for uid in non_email_ids]))
 
         elif self.config.get('org_domain', False):
-            self.logger.debug("Using org_domain to reconstruct email addresses from contact_tags values")
+            self.logger.debug(
+                "Using org_domain to reconstruct email addresses from contact_tags values")
             org_domain = self.config.get('org_domain')
             org_emails = [uid + '@' + org_domain for uid in non_email_ids]
 

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -167,7 +167,8 @@ class EmailDelivery(object):
                                                     (uid) for uid in non_email_ids]))
 
         elif self.config.get('org_domain', False):
-            org_domain = self.config.get('org_domain', False)
+            self.logger.debug("Using org_domain to reconstruct email addresses from contact_tags values")
+            org_domain = self.config.get('org_domain')
             org_emails = [uid + '@' + org_domain for uid in non_email_ids]
 
         return list(chain(explicit_emails, ldap_emails, org_emails))

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -112,6 +112,7 @@ class EmailDelivery(object):
                 # if the LDAP config is set, lookup in ldap
                 elif self.config.get('ldap_uri', False):
                     return self.ldap_lookup.get_email_to_addrs_from_uid(aws_username)
+
                 # the org_domain setting is configured, append the org_domain
                 # to the username from AWS
                 elif self.config.get('org_domain', False):
@@ -158,11 +159,18 @@ class EmailDelivery(object):
         explicit_emails = self.get_valid_emails_from_list(resource_owner_tag_values)
 
         # resolve the contact info from ldap
+        ldap_emails = []
+        org_emails = []
         non_email_ids = list(set(resource_owner_tag_values).difference(explicit_emails))
-        ldap_emails = list(chain.from_iterable([self.ldap_lookup.get_email_to_addrs_from_uid
-                                              (uid) for uid in non_email_ids]))
+        if self.config.get('ldap_uri', False):
+            ldap_emails = list(chain.from_iterable([self.ldap_lookup.get_email_to_addrs_from_uid
+                                                    (uid) for uid in non_email_ids]))
 
-        return list(chain(explicit_emails, ldap_emails))
+        elif self.config.get('org_domain', False):
+            org_domain = self.config.get('org_domain', False)
+            org_emails = [uid + '@' + org_domain for uid in non_email_ids]
+
+        return list(chain(explicit_emails, ldap_emails, org_emails))
 
     def get_account_emails(self, sqs_message):
         email_list = []

--- a/tools/c7n_mailer/tests/common.py
+++ b/tools/c7n_mailer/tests/common.py
@@ -47,6 +47,7 @@ MAILER_CONFIG = {
     'contact_tags': ['OwnerEmail', 'SupportEmail'],
     'queue_url': 'https://sqs.us-east-1.amazonaws.com/xxxx/cloudcustodian-mailer',
     'region': 'us-east-1',
+    'ses_region': 'us-east-1',
     'ldap_uri': 'ldap.initech.com',
     'smtp_server': 'smtp.inittech.com',
     'cache_engine': 'sqlite',

--- a/tools/c7n_mailer/tests/test_email.py
+++ b/tools/c7n_mailer/tests/test_email.py
@@ -21,7 +21,7 @@ import six
 from c7n_mailer.email_delivery import EmailDelivery
 from common import logger, get_ldap_lookup
 from common import MAILER_CONFIG, RESOURCE_1, SQS_MESSAGE_1, SQS_MESSAGE_4
-from mock import patch, call
+from mock import patch, call, MagicMock
 
 from c7n_mailer.utils_email import is_email
 
@@ -44,7 +44,6 @@ CLOUDTRAIL_EVENT = {
 class MockEmailDelivery(EmailDelivery):
     def get_ldap_connection(self):
         return get_ldap_lookup(cache_engine='redis')
-
 
 class EmailTest(unittest.TestCase):
 
@@ -292,7 +291,57 @@ class EmailTest(unittest.TestCase):
 
         self.assertEqual(ldap_emails, ['milton@initech.com'])
 
+
+    def test_get_resource_owner_emails_from_resource_org_domain_not_invoked(self):
+        config = copy.deepcopy(MAILER_CONFIG)
+        logger_mock = MagicMock()
+
+        # Enable org_domain
+        config['org_domain'] = "test.com"
+
+        # Add "CreatorName" to contact tags to avoid creating a new
+        # resource.
+        config['contact_tags'].append('CreatorName')
+
+        self.email_delivery = MockEmailDelivery(config, self.aws_session, logger_mock)
+        org_emails = self.email_delivery.get_resource_owner_emails_from_resource(
+            SQS_MESSAGE_1,
+            RESOURCE_1
+        )
+
+        assert org_emails == ['milton@initech.com', 'peter@initech.com']
+        assert call("Using org_domain to reconstruct email addresses from contact_tags values") not in \
+            logger_mock.debug.call_args_list
+
+    def test_get_resource_owner_emails_from_resource_org_domain(self):
+        config = copy.deepcopy(MAILER_CONFIG)
+        logger_mock = MagicMock()
+
+        # Enable org_domain and disable ldap lookups
+        # If ldap lookups are enabled, org_domain logic is not invoked.
+        config['org_domain'] = "test.com"
+        del config['ldap_uri']
+
+        # Add "CreatorName" to contact tags to avoid creating a new
+        # resource.
+        config['contact_tags'].append('CreatorName')
+
+
+        self.email_delivery = MockEmailDelivery(config, self.aws_session, logger_mock)
+        org_emails = self.email_delivery.get_resource_owner_emails_from_resource(
+            SQS_MESSAGE_1,
+            RESOURCE_1
+        )
+
+        assert org_emails == ['milton@initech.com', 'peter@test.com']
+        logger_mock.debug.assert_called_with(
+            "Using org_domain to reconstruct email addresses from contact_tags values")
+
+
+
     def test_cc_email_functionality(self):
         email = self.email_delivery.get_mimetext_message(
             SQS_MESSAGE_4, SQS_MESSAGE_4['resources'], ['hello@example.com'])
         self.assertEqual(email['Cc'], 'hello@example.com, cc@example.com')
+
+

--- a/tools/c7n_mailer/tests/test_email.py
+++ b/tools/c7n_mailer/tests/test_email.py
@@ -45,6 +45,7 @@ class MockEmailDelivery(EmailDelivery):
     def get_ldap_connection(self):
         return get_ldap_lookup(cache_engine='redis')
 
+
 class EmailTest(unittest.TestCase):
 
     def setUp(self):
@@ -291,7 +292,6 @@ class EmailTest(unittest.TestCase):
 
         self.assertEqual(ldap_emails, ['milton@initech.com'])
 
-
     def test_get_resource_owner_emails_from_resource_org_domain_not_invoked(self):
         config = copy.deepcopy(MAILER_CONFIG)
         logger_mock = MagicMock()
@@ -310,8 +310,8 @@ class EmailTest(unittest.TestCase):
         )
 
         assert org_emails == ['milton@initech.com', 'peter@initech.com']
-        assert call("Using org_domain to reconstruct email addresses from contact_tags values") not in \
-            logger_mock.debug.call_args_list
+        assert call("Using org_domain to reconstruct email addresses from contact_tags values") \
+            not in logger_mock.debug.call_args_list
 
     def test_get_resource_owner_emails_from_resource_org_domain(self):
         config = copy.deepcopy(MAILER_CONFIG)
@@ -326,7 +326,6 @@ class EmailTest(unittest.TestCase):
         # resource.
         config['contact_tags'].append('CreatorName')
 
-
         self.email_delivery = MockEmailDelivery(config, self.aws_session, logger_mock)
         org_emails = self.email_delivery.get_resource_owner_emails_from_resource(
             SQS_MESSAGE_1,
@@ -337,11 +336,7 @@ class EmailTest(unittest.TestCase):
         logger_mock.debug.assert_called_with(
             "Using org_domain to reconstruct email addresses from contact_tags values")
 
-
-
     def test_cc_email_functionality(self):
         email = self.email_delivery.get_mimetext_message(
             SQS_MESSAGE_4, SQS_MESSAGE_4['resources'], ['hello@example.com'])
         self.assertEqual(email['Cc'], 'hello@example.com, cc@example.com')
-
-


### PR DESCRIPTION
This pull request implements org_domain logic for dynamically adding a "@something.org" to contacts found in tags. 

This is useful when owner tags contain the username of the owner of the resources and that username is also their email address with a "@domain" added to it.

Needs to go in after #4228. 