### PR TITLE
docs - Update inline comments to get rid of docs warnings

### DIFF
--- a/docs/source/azure/advanced/azurepolicy.rst
+++ b/docs/source/azure/advanced/azurepolicy.rst
@@ -42,7 +42,8 @@ during resource creation.
 
 Here is what that Azure Policy might look like:
 
-.. code-block:: yaml
+.. code-block:: json
+
     {
        "properties": {
           "displayName": "Enforce tag and its value on resource groups",
@@ -84,6 +85,7 @@ events and automatically finds the identity of the creator and writes the tag wi
 required user action.
 
 .. code-block:: yaml
+
     policies:
       - name: azure-auto-tag-creator
         mode:
@@ -103,6 +105,7 @@ With Cloud Custodian a policy to find and delete unused Network Interfaces would
 like this:
 
 .. code-block:: yaml
+
     policies:
       - name: orphaned-nic
         resource: azure.networkinterface

--- a/tools/c7n_azure/c7n_azure/actions/delete.py
+++ b/tools/c7n_azure/c7n_azure/actions/delete.py
@@ -9,24 +9,27 @@ class DeleteAction(AzureBaseAction):
     ARM resource type supported by Cloud Custodian.
 
     :example:
+
     This policy will delete any ARM resource with 'test' in the name
 
     .. code-block:: yaml
 
-            policies:
-              - name: delete-test-resources
-                resource: azure.armresource
-                description: |
-                  Deletes any ARM resource with 'test' in the name
-                filters:
-                  - type: value
-                    key: name
-                    value: test
-                    op: contains
-                actions:
-                 - type: delete
+        policies:
+          - name: delete-test-resources
+            resource: azure.armresource
+            description: |
+              Deletes any ARM resource with 'test' in the name
+            filters:
+              - type: value
+                key: name
+                value: test
+                op: contains
+            actions:
+              - type: delete
+
 
     :example:
+
     This policy will delete any Network Security Group  with 'test' in the name
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/actions/lock.py
+++ b/tools/c7n_azure/c7n_azure/actions/lock.py
@@ -32,7 +32,9 @@ class LockAction(AzureBaseAction):
     See `Who can create or delete locks <https://docs.microsoft.com/en-us/azure/
     azure-resource-manager/resource-group-lock-resources#who-can-create-or-delete-locks>`_
 
-    :example: Add ReadOnly lock to all keyvaults:
+    :example:
+
+    Add ReadOnly lock to all keyvaults:
 
     .. code-block:: yaml
 

--- a/tools/c7n_azure/c7n_azure/actions/logic_app.py
+++ b/tools/c7n_azure/c7n_azure/actions/logic_app.py
@@ -26,7 +26,9 @@ class LogicAppAction(Webhook):
 
     This action is based on the ``webhook`` action and supports the same options.
 
-    :example: This policy will call logic app with list of VM's
+    :example:
+
+    This policy will call logic app with list of VM's
 
         .. code-block:: yaml
 

--- a/tools/c7n_azure/c7n_azure/actions/notify.py
+++ b/tools/c7n_azure/c7n_azure/actions/notify.py
@@ -10,7 +10,7 @@ class Notify(BaseNotify):
     Action to queue email.
 
     See `c7n_mailer readme.md <https://github.com/cloud-custodian/cloud-custodian/blob/
-    master/tools/c7n_mailer/README.md#using-on-azure>`_for more information.
+    master/tools/c7n_mailer/README.md#using-on-azure>`_ for more information.
 
     :example:
 

--- a/tools/c7n_azure/c7n_azure/actions/tagging.py
+++ b/tools/c7n_azure/c7n_azure/actions/tagging.py
@@ -18,19 +18,21 @@ from c7n.filters.offhours import Time
 class Tag(AzureBaseAction):
     """Adds tags to Azure resources
 
-    :example: This policy will tag all existing resource groups with a value such as Environment
+    :example:
 
-        .. code-block:: yaml
+    This policy will tag all existing resource groups with a value such as Environment
 
-          policies:
-            - name: azure-tag-resourcegroups
-              resource: azure.resourcegroup
-              description: |
-                Tag all existing resource groups with a value such as Environment
-              actions:
-               - type: tag
-                 tag: Environment
-                 value: Test
+    .. code-block:: yaml
+
+      policies:
+        - name: azure-tag-resourcegroups
+          resource: azure.resourcegroup
+          description: |
+            Tag all existing resource groups with a value such as Environment
+          actions:
+           - type: tag
+             tag: Environment
+             value: Test
     """
 
     schema = utils.type_schema(
@@ -68,6 +70,7 @@ class RemoveTag(AzureBaseAction):
     """Removes tags from Azure resources
 
     :example:
+
     This policy will remove tag for all existing resource groups with a key such as Environment
 
         .. code-block:: yaml
@@ -105,6 +108,7 @@ class AutoTagUser(AzureEventAction):
     """Attempts to tag a resource with the first user who created/modified it.
 
     :example:
+
     This policy will tag all existing resource groups with the 'CreatorEmail' tag
 
     .. code-block:: yaml
@@ -276,6 +280,7 @@ class TagTrim(AzureBaseAction):
     listed to preserve.
 
     :example:
+
     .. code-block :: yaml
 
        policies:
@@ -305,6 +310,7 @@ class TagTrim(AzureBaseAction):
                  - Environment
                  - downtime
                  - custodian_status
+
     """
     max_tag_count = 15
 
@@ -363,18 +369,19 @@ class TagDelayedAction(AzureBaseAction):
 
     :example:
 
-        .. code-block :: yaml
+    .. code-block :: yaml
 
-           policies:
-            - name: vm-mark-for-stop
-              resource: azure.vm
-              filters:
-                - type: value
-                  key: Name
-                  value: instance-to-stop-in-four-days
-              actions:
-                - type: mark-for-op
-                  op: stop
+       policies:
+        - name: vm-mark-for-stop
+          resource: azure.vm
+          filters:
+            - type: value
+              key: Name
+              value: instance-to-stop-in-four-days
+          actions:
+            - type: mark-for-op
+              op: stop
+
     """
 
     schema = utils.type_schema(

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -54,22 +54,26 @@ class MetricFilter(Filter):
 
     Filters Azure resources based on live metrics from the Azure monitor
 
-    :example: Find all VMs with an average Percentage CPU greater than 75% over last 2 hours
+    :example:
+
+    Find all VMs with an average Percentage CPU greater than 75% over last 2 hours
 
     .. code-block:: yaml
 
-            policies:
-              - name: vm-percentage-cpu
-                resource: azure.vm
-                filters:
-                  - type: metric
-                    metric: Percentage CPU
-                    aggregation: average
-                    op: gt
-                    threshold: 75
-                    timeframe: 2
+        policies:
+          - name: vm-percentage-cpu
+            resource: azure.vm
+            filters:
+              - type: metric
+                metric: Percentage CPU
+                aggregation: average
+                op: gt
+                threshold: 75
+                timeframe: 2
 
-    :example: Find KeyVaults with more than 1000 API hits in the last hour
+    :example:
+
+    Find KeyVaults with more than 1000 API hits in the last hour
 
     .. code-block:: yaml
 
@@ -85,6 +89,7 @@ class MetricFilter(Filter):
                 timeframe: 1
 
     :example:
+
     Find SQL servers with less than 10% average DTU consumption
     across all databases over last 24 hours
 
@@ -222,6 +227,7 @@ class TagActionFilter(Filter):
     in which to interpret the clock (default value is 'utc')
 
     :example:
+
     .. code-block :: yaml
 
        policies:
@@ -307,6 +313,7 @@ class DiagnosticSettingsFilter(ValueFilter):
     on the diagnostic settings for an azure resource.
 
     :example:
+
     Find Load Balancers that have logs for both LoadBalancerProbeHealthStatus category and
     LoadBalancerAlertEvent category enabled.
     The use of value_type: swap is important for these examples because it swaps the value
@@ -330,6 +337,7 @@ class DiagnosticSettingsFilter(ValueFilter):
                 value_type: swap
 
     :example:
+
     Find KeyVaults that have logs enabled for the AuditEvent category.
 
     .. code-block:: yaml
@@ -562,7 +570,9 @@ class ResourceLockFilter(Filter):
     Lock type is optional, by default any lock will be applied to the filter.
     To get unlocked resources, use "Absent" type.
 
-    :example: Get all keyvaults with ReadOnly lock:
+    :example:
+
+    Get all keyvaults with ReadOnly lock:
 
     .. code-block :: yaml
 
@@ -573,7 +583,9 @@ class ResourceLockFilter(Filter):
             - type: resource-lock
               lock-type: ReadOnly
 
-    :example: Get all locked sqldatabases (any type of lock):
+    :example:
+
+    Get all locked sqldatabases (any type of lock):
 
     .. code-block :: yaml
 
@@ -583,7 +595,9 @@ class ResourceLockFilter(Filter):
           filters:
             - type: resource-lock
 
-    :example: Get all unlocked resource groups:
+    :example:
+
+    Get all unlocked resource groups:
 
     .. code-block :: yaml
 

--- a/tools/c7n_azure/c7n_azure/resources/access_control.py
+++ b/tools/c7n_azure/c7n_azure/resources/access_control.py
@@ -51,6 +51,7 @@ class RoleAssignment(QueryResourceManager):
     :example:
 
     .. code-block:: yaml
+
         policies:
             - name: role-assignment-owner
               resource: azure.roleassignment

--- a/tools/c7n_azure/c7n_azure/resources/arm.py
+++ b/tools/c7n_azure/c7n_azure/resources/arm.py
@@ -48,7 +48,9 @@ class ArmTypeInfo(TypeInfo):
 class ArmResourceManager(QueryResourceManager):
     """Azure Arm Resource
 
-    :example: This policy will find all ARM resources with the tag 'Tag1' present
+    :example:
+
+    This policy will find all ARM resources with the tag 'Tag1' present
 
     .. code-block:: yaml
 

--- a/tools/c7n_azure/c7n_azure/resources/batch.py
+++ b/tools/c7n_azure/c7n_azure/resources/batch.py
@@ -21,6 +21,7 @@ class Batch(ArmResourceManager):
     """Batch Resource
 
     :example:
+
     This set of policies will find all Azure Batch services that have more than 100 cores
     as the limit for the dedicated core quota.
 
@@ -29,12 +30,12 @@ class Batch(ArmResourceManager):
         policies:
           - name: find-batch-with-high-dedicated-cores
             resource: azure.batch
-          resource: azure.batch
-          filters:
-            - type: value
-              key: properties.dedicatedCoreQuota
-              op: gt
-              value: 100
+            filters:
+              - type: value
+                key: properties.dedicatedCoreQuota
+                op: gt
+                value: 100
+
     """
 
     class resource_type(ArmResourceManager.resource_type):

--- a/tools/c7n_azure/c7n_azure/resources/cdn.py
+++ b/tools/c7n_azure/c7n_azure/resources/cdn.py
@@ -21,6 +21,7 @@ class CdnProfile(ArmResourceManager):
     """CDN Resource
 
     :example:
+
     Returns all CDNs with Standard_Verizon sku
 
     .. code-block:: yaml
@@ -34,6 +35,7 @@ class CdnProfile(ArmResourceManager):
                 op: in
                 value_type: normalize
                 value: Standard_Verizon
+
     """
 
     class resource_type(ArmResourceManager.resource_type):

--- a/tools/c7n_azure/c7n_azure/resources/cognitive_service.py
+++ b/tools/c7n_azure/c7n_azure/resources/cognitive_service.py
@@ -21,6 +21,7 @@ class CognitiveService(ArmResourceManager):
     """Cognitive Services Resource
 
     :example:
+
     This policy will find all Cognitive Service accounts with 1000 or more
     total errors over the 72 hours
 

--- a/tools/c7n_azure/c7n_azure/resources/container_registry.py
+++ b/tools/c7n_azure/c7n_azure/resources/container_registry.py
@@ -21,6 +21,7 @@ class ContainerRegistry(ArmResourceManager):
     """Container Registry Resource
 
     :example:
+
     Returns all container registry named my-test-container-registry
 
     .. code-block:: yaml
@@ -33,6 +34,7 @@ class ContainerRegistry(ArmResourceManager):
               key: name
               op: eq
               value: my-test-container-registry
+
     """
 
     class resource_type(ArmResourceManager.resource_type):

--- a/tools/c7n_azure/c7n_azure/resources/container_service.py
+++ b/tools/c7n_azure/c7n_azure/resources/container_service.py
@@ -21,6 +21,7 @@ class ContainerService(ArmResourceManager):
     """Container Service Resource
 
     :example:
+
     Returns all container services that did not provision successfully
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
+++ b/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
@@ -45,6 +45,7 @@ class CosmosDB(ArmResourceManager):
     """CosmosDB Account Resource
 
     :example:
+
     This policy will find all CosmosDB with 1000 or less total requests over the last 72 hou
 
     .. code-block:: yaml
@@ -107,6 +108,7 @@ class CosmosDBDatabase(CosmosDBChildResource):
     """CosmosDB Database Resource
 
     :example:
+
     This policy will enumerate all cosmos databases
 
     .. code-block:: yaml
@@ -141,6 +143,7 @@ class CosmosDBCollection(CosmosDBChildResource):
     """CosmosDB Collection Resource
 
     :example:
+
     This policy will find all collections with Offer Throughput > 100
 
     .. code-block:: yaml
@@ -188,6 +191,7 @@ class CosmosDBOfferFilter(ValueFilter):
     Allows access to the offer on a collection or database.
 
     :example:
+
     This policy will find all collections with a V2 offer which indicates
     throughput is provisioned at the collection scope.
 

--- a/tools/c7n_azure/c7n_azure/resources/data_factory.py
+++ b/tools/c7n_azure/c7n_azure/resources/data_factory.py
@@ -21,6 +21,7 @@ class DataFactory(ArmResourceManager):
     """Data Factory Resource
 
     :example:
+
     This policy will find all Data Factories with 10 or more failures in pipeline
     runs over the last 72 hours
 

--- a/tools/c7n_azure/c7n_azure/resources/databricks.py
+++ b/tools/c7n_azure/c7n_azure/resources/databricks.py
@@ -21,6 +21,7 @@ class Databricks(ArmResourceManager):
     """Databricks Resource
 
     :example:
+
     Returns all databricks named my-test-databricks
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/datalake_store.py
+++ b/tools/c7n_azure/c7n_azure/resources/datalake_store.py
@@ -21,6 +21,7 @@ class DataLakeStore(ArmResourceManager):
     """Data Lake Resource
 
     :example:
+
     This policy will find all Datalake Stores with one million or more
     write requests in the last 72 hours
 

--- a/tools/c7n_azure/c7n_azure/resources/disk.py
+++ b/tools/c7n_azure/c7n_azure/resources/disk.py
@@ -21,6 +21,7 @@ class Disk(ArmResourceManager):
     """Disk Resource
 
     :example:
+
     This policy will disks that are not being managed by a VM
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/image.py
+++ b/tools/c7n_azure/c7n_azure/resources/image.py
@@ -21,6 +21,7 @@ class Image(ArmResourceManager):
     """Virtual Machine Image
 
     :example:
+
     Returns all virtual machine images named my-test-vm-image
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/iot_hub.py
+++ b/tools/c7n_azure/c7n_azure/resources/iot_hub.py
@@ -21,6 +21,7 @@ class IoTHub(ArmResourceManager):
     """IoT Hub Resource
 
     :example:
+
     This policy will find all IoT Hubs with 1000 or more dropped messages over the last 72 hours
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/k8s_service.py
+++ b/tools/c7n_azure/c7n_azure/resources/k8s_service.py
@@ -21,6 +21,7 @@ class KubernetesService(ArmResourceManager):
     """Azure Kubernetes Service Resource
 
     :example:
+
     Returns all aks clusters that did not provision successfully
 
     .. code-block:: yaml
@@ -34,7 +35,6 @@ class KubernetesService(ArmResourceManager):
                 op: not-equal
                 value_type: normalize
                 value: succeeded
-
 
     """
 

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -37,6 +37,7 @@ class KeyVault(ArmResourceManager):
     """Key Vault Resource
 
     :example:
+
     This policy will find all KeyVaults with 10 or less API Hits over the last 72 hours
 
     .. code-block:: yaml
@@ -53,6 +54,7 @@ class KeyVault(ArmResourceManager):
                 timeframe: 72
 
     :example:
+
     This policy will find all KeyVaults with an access of Service Principals not in the white list
     that exceed read-only access
 
@@ -79,6 +81,7 @@ class KeyVault(ArmResourceManager):
                         - get
 
     :example:
+
     This policy will find all KeyVaults and add get and list permissions for keys.
 
     .. code-block:: yaml
@@ -249,6 +252,7 @@ class KeyVaultUpdateAccessPolicyAction(AzureBaseAction):
                           keys:
                             - Get
                             - List
+
     """
 
     schema = type_schema('update-access-policy',

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
@@ -33,6 +33,7 @@ class KeyVaultKeys(ChildResourceManager):
     """Key Vault Keys Resource
 
     :example:
+
     This policy will find all Keys in `keyvault_test` and `keyvault_prod` KeyVaults
 
     .. code-block:: yaml
@@ -49,6 +50,7 @@ class KeyVaultKeys(ChildResourceManager):
                   - keyvault_prod
 
     :example:
+
     This policy will find all Keys in all KeyVaults that are older than 30 days
 
     .. code-block:: yaml
@@ -66,6 +68,7 @@ class KeyVaultKeys(ChildResourceManager):
                 value: 30
 
     :example:
+
     If your company wants to enforce usage of HSM-backed keys in the KeyVaults,
     you can use this policy to find all Keys in all KeyVaults not backed by an HSM module.
 

--- a/tools/c7n_azure/c7n_azure/resources/load_balancer.py
+++ b/tools/c7n_azure/c7n_azure/resources/load_balancer.py
@@ -24,6 +24,7 @@ class LoadBalancer(ArmResourceManager):
     """Load Balancer Resource
 
     :example:
+
     This policy will filter load balancers with an ipv6 frontend public IP
 
     .. code-block:: yaml
@@ -39,6 +40,7 @@ class LoadBalancer(ArmResourceManager):
                   value: "ipv6"
 
     :example:
+
     This policy will find all load balancers with 1000 or less transmitted packets
     over the last 72 hours
 
@@ -69,7 +71,7 @@ class LoadBalancer(ArmResourceManager):
 class FrontEndIp(RelatedResourceFilter):
     """Filters load balancers by frontend public ip.
 
-    :Example:
+    :example:
 
         .. code-block:: yaml
 

--- a/tools/c7n_azure/c7n_azure/resources/network_interface.py
+++ b/tools/c7n_azure/c7n_azure/resources/network_interface.py
@@ -30,6 +30,7 @@ class NetworkInterface(ArmResourceManager):
     """Network Interface Resource
 
     :example:
+
     This policy will get Network Interfaces that have User added routes.
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/network_security_group.py
+++ b/tools/c7n_azure/c7n_azure/resources/network_security_group.py
@@ -31,6 +31,7 @@ class NetworkSecurityGroup(ArmResourceManager):
     """Network Security Group Resource
 
     :example:
+
     This policy will deny access to all ports that are NOT 22, 23 or 24
     for all Network Security Groups
 
@@ -50,6 +51,7 @@ class NetworkSecurityGroup(ArmResourceManager):
                 direction: 'Inbound'
 
     :example:
+
     This policy will find all NSGs with port 80 opened and port 443 closed,
     then it will open port 443
 

--- a/tools/c7n_azure/c7n_azure/resources/policy_assignments.py
+++ b/tools/c7n_azure/c7n_azure/resources/policy_assignments.py
@@ -21,6 +21,7 @@ class PolicyAssignments(ArmResourceManager):
     """Policy Assignment Resource
 
     :example:
+
     This policy will find all policy assignments named 'test-assignment' and delete them.
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
@@ -190,7 +190,9 @@ class ShortTermBackupRetentionPolicyFilter(BackupRetentionPolicyBaseFilter):
     If the database has no backup retention policies, the database is treated as if
     it has a backup retention of zero days.
 
-    :example: Find all SQL Databases with a short term retention policy shorter than 2 weeks.
+    :example:
+
+    Find all SQL Databases with a short term retention policy shorter than 2 weeks.
 
     .. code-block:: yaml
 
@@ -234,7 +236,9 @@ class LongTermBackupRetentionPolicyFilter(BackupRetentionPolicyBaseFilter):
     of these backups has a retention period that can specified in units of days, weeks,
     months, or years.
 
-    :example: Find all SQL Databases with weekly backup retentions longer than 1 month.
+    :example:
+
+    Find all SQL Databases with weekly backup retentions longer than 1 month.
 
     .. code-block:: yaml
 
@@ -326,7 +330,9 @@ class ShortTermBackupRetentionPolicyAction(BackupRetentionPolicyBaseAction):
 
     Update the short term backup retention policy for a SQL Database.
 
-    :example: Update any SQL Database short term retentions to at least 7 days.
+    :example:
+
+    Update any SQL Database short term retentions to at least 7 days.
 
     .. code-block:: yaml
 
@@ -383,7 +389,9 @@ class LongTermBackupRetentionPolicyAction(BackupRetentionPolicyBaseAction):
     of these backups has a retention period that can specified in units of days, weeks,
     months, or years.
 
-    :example: Enforce a 1 month maximum retention for weekly backups on all SQL Databases
+    :example:
+
+    Enforce a 1 month maximum retention for weekly backups on all SQL Databases
 
     .. code-block:: yaml
 

--- a/tools/c7n_azure/c7n_azure/resources/subscription.py
+++ b/tools/c7n_azure/c7n_azure/resources/subscription.py
@@ -35,6 +35,7 @@ class Subscription(ResourceManager):
     """Subscription Resource
 
     :example:
+
     This policy creates Azure Policy scoped to the current subscription if doesn't exist.
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/vm.py
+++ b/tools/c7n_azure/c7n_azure/resources/vm.py
@@ -25,6 +25,7 @@ class VirtualMachine(ArmResourceManager):
     """Virtual Machine Resource
 
     :example:
+
     Stop all running VMs
 
     .. code-block:: yaml
@@ -42,6 +43,7 @@ class VirtualMachine(ArmResourceManager):
               - type: stop
 
     :example:
+
     Start all VMs
 
     .. code-block:: yaml
@@ -53,6 +55,7 @@ class VirtualMachine(ArmResourceManager):
               - type: start
 
     :example:
+
     Restart all VMs
 
     .. code-block:: yaml
@@ -64,6 +67,7 @@ class VirtualMachine(ArmResourceManager):
               - type: restart
 
     :example:
+
     Delete specific VM by name
 
     .. code-block:: yaml
@@ -81,6 +85,7 @@ class VirtualMachine(ArmResourceManager):
               - type: delete
 
     :example:
+
     Find all VMs with a Public IP address
 
     .. code-block:: yaml
@@ -94,6 +99,7 @@ class VirtualMachine(ArmResourceManager):
                 value: not-null
 
     :example:
+
     This policy will find all VMs that have Percentage CPU usage >= 75% over the last 72 hours
 
     .. code-block:: yaml
@@ -110,6 +116,7 @@ class VirtualMachine(ArmResourceManager):
                 timeframe: 72
 
     :example:
+
     This policy will find all VMs that have Percentage CPU usage <= 1% over the last 72 hours,
     mark for deletion in 7 days
 
@@ -129,6 +136,7 @@ class VirtualMachine(ArmResourceManager):
               - type: mark-for-op
                 op: delete
                 days: 7
+
     """
 
     class resource_type(ArmResourceManager.resource_type):

--- a/tools/c7n_azure/c7n_azure/resources/vmss.py
+++ b/tools/c7n_azure/c7n_azure/resources/vmss.py
@@ -21,6 +21,7 @@ class VMScaleSet(ArmResourceManager):
     """Virtual Machine Scale Set Resource
 
     :example:
+
     This policy will find all VM Scale Sets that are set to overprovision
 
     .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/resources/vnet.py
+++ b/tools/c7n_azure/c7n_azure/resources/vnet.py
@@ -21,6 +21,7 @@ class Vnet(ArmResourceManager):
     """Virtual Networks Resource
 
     :example:
+
     This set of policies will find all Virtual Networks that do not have DDOS protection enabled.
 
     .. code-block:: yaml
@@ -33,6 +34,7 @@ class Vnet(ArmResourceManager):
                 key: properties.enableDdosProtection
                 op: equal
                 value: False
+
     """
 
     class resource_type(ArmResourceManager.resource_type):

--- a/tools/c7n_azure/c7n_azure/resources/web_app.py
+++ b/tools/c7n_azure/c7n_azure/resources/web_app.py
@@ -21,6 +21,7 @@ class WebApp(ArmResourceManager):
     """Web Applications Resource
 
     :example:
+
     This policy will find all web apps with 10 or less requests over the last 72 hours
 
     .. code-block:: yaml
@@ -41,6 +42,7 @@ class WebApp(ArmResourceManager):
                 days: 7
 
     :example:
+
     This policy will find all web apps with 1000 or more server errors over the last 72 hours
 
     .. code-block:: yaml
@@ -55,6 +57,7 @@ class WebApp(ArmResourceManager):
                 aggregation: total
                 threshold: 1000
                 timeframe: 72
+
     """
 
     class resource_type(ArmResourceManager.resource_type):

--- a/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
@@ -45,6 +45,7 @@ class DeleteInstanceGroupManager(MethodAction):
     :Example:
 
     .. code-block:: yaml
+
         policies:
           - name: delete-deployments
             description: Delete all deployments


### PR DESCRIPTION
Fix some missing empty lines, wrong spaces etc issues with inline docs to get rid of doc build warnings