### PR TITLE
aws - fix AWS ClientError (#3778)

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1303,7 +1303,7 @@ class ModifyableVolume(Filter):
         # Filter volumes that are currently under modification
         client = local_session(self.manager.session_factory).client('ec2')
         modifying = set()
-        for vol_set in chunks(list(results), 200):
+        for vol_set in chunks(list(results), 197):
             vol_ids = [v['VolumeId'] for v in vol_set]
             mutating = client.describe_volumes_modifications(
                 Filters=[

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1303,8 +1303,10 @@ class ModifyableVolume(Filter):
         # Filter volumes that are currently under modification
         client = local_session(self.manager.session_factory).client('ec2')
         modifying = set()
+
+        # Re 197 - Max number of filters is 200, and we have to use
+        # three additional attribute filters.
         for vol_set in chunks(list(results), 197):
-            #must use chunk size 197 over 200, because we adding 3 more to each chunk (line 1315)
             vol_ids = [v['VolumeId'] for v in vol_set]
             mutating = client.describe_volumes_modifications(
                 Filters=[

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1304,7 +1304,7 @@ class ModifyableVolume(Filter):
         client = local_session(self.manager.session_factory).client('ec2')
         modifying = set()
         for vol_set in chunks(list(results), 197):
-            # we have to use chunk size 197, not 200, because we adding 3 more to each chunk (line 1315)
+            #must use chunk size 197 over 200, because we adding 3 more to each chunk (line 1315)
             vol_ids = [v['VolumeId'] for v in vol_set]
             mutating = client.describe_volumes_modifications(
                 Filters=[

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1304,6 +1304,7 @@ class ModifyableVolume(Filter):
         client = local_session(self.manager.session_factory).client('ec2')
         modifying = set()
         for vol_set in chunks(list(results), 197):
+            # we have to use chunk size 197, not 200, because we adding 3 more to each chunk (line 1315)
             vol_ids = [v['VolumeId'] for v in vol_set]
             mutating = client.describe_volumes_modifications(
                 Filters=[


### PR DESCRIPTION
This PR is fixes AWS API call error, mentioned in #3778:

>     ClientError: An error occurred (InvalidParameterValue) when calling the DescribeVolumesModifications operation: The maximum number of filter values specified on a single call is 200

The reason of that error: if you have 200 or more volumes, and then add 3 more filters in line 1313 - you out of  AWS API limit of 200 values. Thats why the chunk size should be 197.