### PR TITLE
minor fix to address autotagging of federated user

### DIFF
--- a/c7n/actions/autotag.py
+++ b/c7n/actions/autotag.py
@@ -97,14 +97,14 @@ class AutoTagUser(EventAction):
             return
         event = event['detail']
         utype = event['userIdentity']['type']
-        if utype not in self.data.get('user-type', ['AssumedRole', 'IAMUser']):
+        if utype not in self.data.get('user-type', ['AssumedRole', 'IAMUser', 'FederatedUser']):
             return
 
         user = None
         if utype == "IAMUser":
             user = event['userIdentity']['userName']
             principal_id_value = event['userIdentity'].get('principalId', '')
-        elif utype == "AssumedRole":
+        elif utype == "AssumedRole" or utype == "FederatedUser":
             user = event['userIdentity']['arn']
             prefix, user = user.rsplit('/', 1)
             principal_id_value = event['userIdentity'].get('principalId', '').split(':')[0]


### PR DESCRIPTION
While implementing policies in our Federated AWS accounts, I noticed an issue with user auto-tagging.  The minor changes applied to autotag.py have resolved the issues encountered.