### PR TITLE
AWS Org script - Get tags on AWS Org accounts into acounts.yaml

### DIFF
--- a/tools/c7n_org/scripts/orgaccounts.py
+++ b/tools/c7n_org/scripts/orgaccounts.py
@@ -57,7 +57,7 @@ def main(role, ou, assume, profile, output, regions, active):
         path_parts = a['Path'].strip('/').split('/')
         for idx, _ in enumerate(path_parts):
             tags.append("path:/%s" % "/".join(path_parts[:idx + 1]))
-        
+
         for tag in list_tags_for_account(client, a['Id']):
             tags.append("{}:{}".format(tag.get('Key'), tag.get('Value')))
 
@@ -137,6 +137,7 @@ def get_accounts_for_ou(client, ou, active, recursive=True):
             else:
                 results.append(a)
     return results
+
 
 def list_tags_for_account(client, id):
     results = []

--- a/tools/c7n_org/scripts/orgaccounts.py
+++ b/tools/c7n_org/scripts/orgaccounts.py
@@ -57,6 +57,9 @@ def main(role, ou, assume, profile, output, regions, active):
         path_parts = a['Path'].strip('/').split('/')
         for idx, _ in enumerate(path_parts):
             tags.append("path:/%s" % "/".join(path_parts[:idx + 1]))
+        
+        for tag in list_tags_for_account(client, a['Id']):
+            tags.append("{}:{}".format(tag.get('Key'), tag.get('Value')))
 
         ainfo = {
             'account_id': a['Id'],
@@ -133,6 +136,16 @@ def get_accounts_for_ou(client, ou, active, recursive=True):
                     results.append(a)
             else:
                 results.append(a)
+    return results
+
+def list_tags_for_account(client, id):
+    results = []
+
+    tags_pager = client.get_paginator('list_tags_for_resource')
+    for tag in tags_pager.paginate(
+        ResourceId=id).build_full_result().get(
+            'Tags', []):
+        results.append(tag)
     return results
 
 


### PR DESCRIPTION
AWS Org now supports tagging accounts. This pull requests updates the `orgaccounts.py` to get the tag values on accounts into the `yaml`