### PR TITLE
Fix incorrect iterator chaining in get_permissions calls

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -276,7 +276,7 @@ class ImageUnusedFilter(Filter):
     schema = type_schema('unused', value={'type': 'boolean'})
 
     def get_permissions(self):
-        return list(itertools.chain([
+        return list(itertools.chain(*[
             self.manager.get_resource_manager(m).get_permissions()
             for m in ('asg', 'launch-config', 'ec2')]))
 

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -243,7 +243,7 @@ class LaunchConfigFilter(ValueFilter):
 class ConfigValidFilter(Filter):
 
     def get_permissions(self):
-        return list(itertools.chain([
+        return list(itertools.chain(*[
             self.manager.get_resource_manager(m).get_permissions()
             for m in ('subnet', 'security-group', 'key-pair', 'elb',
                       'app-elb-target-group', 'ebs-snapshot', 'ami')]))

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -268,7 +268,7 @@ class SnapshotUnusedFilter(Filter):
     schema = type_schema('unused', value={'type': 'boolean'})
 
     def get_permissions(self):
-        return list(itertools.chain([
+        return list(itertools.chain(*[
             self.manager.get_resource_manager(m).get_permissions()
             for m in ('asg', 'launch-config', 'ami')]))
 

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -504,7 +504,7 @@ class CheckPermissions(Filter):
 class IamRoleUsage(Filter):
 
     def get_permissions(self):
-        perms = list(itertools.chain([
+        perms = list(itertools.chain(*[
             self.manager.get_resource_manager(m).get_permissions()
             for m in ['lambda', 'launch-config', 'ec2']]))
         perms.extend(['ecs:DescribeClusters', 'ecs:DescribeServices'])

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -666,7 +666,7 @@ class SGUsage(Filter):
 
     def get_permissions(self):
         return list(itertools.chain(
-            [self.manager.get_resource_manager(m).get_permissions()
+            *[self.manager.get_resource_manager(m).get_permissions()
              for m in
              ['lambda', 'eni', 'launch-config', 'security-group']]))
 


### PR DESCRIPTION
Primarily in get_permissions, this usage of itertools.chain actually creates
an array of arrays.

This makes sure we're creating a flat list.