### PR TITLE
azure - fix dedicated function deployments not updating consistently

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -100,6 +100,9 @@ class PythonPackageArchive(object):
             raise ValueError("Archive not closed, size not accurate")
         return os.stat(self._temp_archive_file.name).st_size
 
+    def create_zinfo(self, fname):
+        return zinfo(fname)
+
     def add_modules(self, ignore, modules):
         """Add the named Python modules to the archive. For consistency's sake
         we only add ``*.py`` files, not ``*.pyc``. We also don't add other
@@ -203,7 +206,7 @@ class PythonPackageArchive(object):
         """
         assert not self._closed, "Archive closed"
         if not isinstance(dest, zipfile.ZipInfo):
-            dest = zinfo(dest)  # see for some caveats
+            dest = self.create_zinfo(dest)  # see for some caveats
         # Ensure we apply the compression
         dest.compress_type = self.zip_compression
         # Mark host OS as Linux for all archives

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -39,7 +39,6 @@ from c7n.cwe import CloudWatchEvents
 from c7n.logs_support import _timestamp_from_string
 from c7n.utils import parse_s3, local_session
 
-
 log = logging.getLogger('custodian.serverless')
 
 
@@ -100,8 +99,16 @@ class PythonPackageArchive(object):
             raise ValueError("Archive not closed, size not accurate")
         return os.stat(self._temp_archive_file.name).st_size
 
-    def create_zinfo(self, fname):
-        return zinfo(fname)
+    def create_zinfo(self, file):
+        if not isinstance(file, zipfile.ZipInfo):
+            file = zinfo(file)
+
+        # Ensure we apply the compression
+        file.compress_type = self.zip_compression
+        # Mark host OS as Linux for all archives
+        file.create_system = 3
+
+        return file
 
     def add_modules(self, ignore, modules):
         """Add the named Python modules to the archive. For consistency's sake
@@ -205,12 +212,7 @@ class PythonPackageArchive(object):
 
         """
         assert not self._closed, "Archive closed"
-        if not isinstance(dest, zipfile.ZipInfo):
-            dest = self.create_zinfo(dest)  # see for some caveats
-        # Ensure we apply the compression
-        dest.compress_type = self.zip_compression
-        # Mark host OS as Linux for all archives
-        dest.create_system = 3
+        dest = self.create_zinfo(dest)
         self._zip_file.writestr(dest, contents)
 
     def close(self):
@@ -222,8 +224,7 @@ class PythonPackageArchive(object):
         self._zip_file.close()
         log.debug(
             "Created custodian serverless archive size: %0.2fmb",
-            (os.path.getsize(self._temp_archive_file.name) / (
-                1024.0 * 1024.0)))
+            (os.path.getsize(self._temp_archive_file.name) / (1024.0 * 1024.0)))
         return self
 
     def remove(self):
@@ -350,7 +351,7 @@ class LambdaManager(object):
                     Dimensions=[{
                         'Name': 'FunctionName',
                         'Value': (
-                            isinstance(f, dict) and f['FunctionName'] or f.name)}],
+                                isinstance(f, dict) and f['FunctionName'] or f.name)}],
                     Statistics=["Sum"],
                     StartTime=start,
                     EndTime=end,
@@ -399,8 +400,7 @@ class LambdaManager(object):
         for k in new_config:
             # Layers need special handling as they have extra info on describe.
             if k == 'Layers' and k in old_config and new_config[k]:
-                if sorted(new_config[k]) != sorted([
-                        l['Arn'] for l in old_config[k]]):
+                if sorted(new_config[k]) != sorted([l['Arn'] for l in old_config[k]]):
                     changed.append(k)
             # Vpc needs special handling as a dict with lists
             elif k == 'VpcConfig' and k in old_config and new_config[k]:
@@ -1411,7 +1411,7 @@ class SNSSubscription(object):
                             response = sns_client.unsubscribe(
                                 SubscriptionArn=subscription['SubscriptionArn'])
                             log.debug("Unsubscribed %s from %s" %
-                                (func.name, topic_name))
+                                      (func.name, topic_name))
                         except sns_client.exceptions.NotFoundException:
                             pass
                         raise Done  # break out of both for loops
@@ -1457,7 +1457,7 @@ class BucketSNSNotification(SNSSubscription):
                 'TopicArn': topic_arn,
                 'Events': ['s3:ObjectCreated:*']})
             s3.put_bucket_notification_configuration(Bucket=bucket['Name'],
-                NotificationConfiguration=notifies)
+                                                     NotificationConfiguration=notifies)
             topic_arns = [topic_arn]
         return topic_arns
 
@@ -1500,10 +1500,10 @@ class ConfigRule(object):
                 config_type = manager.get_model().config_type
             else:
                 raise Exception("You may have attempted to deploy a config "
-                        "based lambda function with an unsupported config type. "
-                        "The most recent AWS config types are here: http://docs.aws"
-                        ".amazon.com/config/latest/developerguide/resource"
-                        "-config-reference.html.")
+                                "based lambda function with an unsupported config type. "
+                                "The most recent AWS config types are here: http://docs.aws"
+                                ".amazon.com/config/latest/developerguide/resource"
+                                "-config-reference.html.")
             params['Scope'] = {
                 'ComplianceResourceTypes': [config_type]}
         else:

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -20,9 +20,6 @@ import shutil
 import time
 
 import requests
-
-from c7n.mu import PythonPackageArchive
-from c7n.utils import local_session
 from c7n_azure.constants import (ENV_CUSTODIAN_DISABLE_SSL_CERT_VERIFICATION,
                                  FUNCTION_EVENT_TRIGGER_MODE,
                                  FUNCTION_TIME_TRIGGER_MODE,
@@ -30,6 +27,25 @@ from c7n_azure.constants import (ENV_CUSTODIAN_DISABLE_SSL_CERT_VERIFICATION,
                                  FUNCTION_EXTENSION_BUNDLE_CONFIG)
 from c7n_azure.dependency_manager import DependencyManager
 from c7n_azure.session import Session
+
+from c7n.mu import PythonPackageArchive
+from c7n.utils import local_session
+
+
+class AzurePythonPackageArchive(PythonPackageArchive):
+    def __init__(self, modules=(), cache_file=None):
+        super(AzurePythonPackageArchive, self).__init__(modules, cache_file)
+        self.package_time = time.gmtime()
+
+    def create_zinfo(self, fname):
+        """
+        In Dedicated App Service Plans - Functions are updated via KuduSync
+        The KuduSync uses the modified time and file size to determine if a file has changed
+        """
+        info = super(AzurePythonPackageArchive, self).create_zinfo(fname)
+
+        info.date_time = self.package_time[0:6]
+        return info
 
 
 class FunctionPackage(object):
@@ -130,7 +146,7 @@ class FunctionPackage(object):
     def build(self, policy, modules, non_binary_packages, excluded_packages, queue_name=None):
         cache_zip_file = self.build_cache(modules, excluded_packages, non_binary_packages)
 
-        self.pkg = PythonPackageArchive(cache_file=cache_zip_file)
+        self.pkg = AzurePythonPackageArchive(cache_file=cache_zip_file)
 
         self.pkg.add_modules(None, [m.replace('-', '_') for m in modules])
 
@@ -145,7 +161,7 @@ class FunctionPackage(object):
         packages = DependencyManager.get_dependency_packages_list(modules, excluded_packages)
 
         if not DependencyManager.check_cache(cache_metadata_file, cache_zip_file, packages):
-            cache_pkg = PythonPackageArchive()
+            cache_pkg = AzurePythonPackageArchive()
             self.log.info("Cached packages not found or requirements were changed.")
 
             # If cache check fails, wipe all previous wheels, installations etc
@@ -186,6 +202,7 @@ class FunctionPackage(object):
             DependencyManager.create_cache_metadata(cache_metadata_file,
                                                     cache_zip_file,
                                                     packages)
+
         return cache_zip_file
 
     def wait_for_status(self, deployment_creds, retries=10, delay=15):

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -37,13 +37,12 @@ class AzurePythonPackageArchive(PythonPackageArchive):
         super(AzurePythonPackageArchive, self).__init__(modules, cache_file)
         self.package_time = time.gmtime()
 
-    def create_zinfo(self, fname):
+    def create_zinfo(self, file):
         """
         In Dedicated App Service Plans - Functions are updated via KuduSync
         The KuduSync uses the modified time and file size to determine if a file has changed
         """
-        info = super(AzurePythonPackageArchive, self).create_zinfo(fname)
-
+        info = super(AzurePythonPackageArchive, self).create_zinfo(file)
         info.date_time = self.package_time[0:6]
         return info
 

--- a/tools/c7n_azure/tests/test_function_package.py
+++ b/tools/c7n_azure/tests/test_function_package.py
@@ -198,8 +198,10 @@ class FunctionPackageTest(BaseTest):
             mocks.append(self._create_patch(
                 'c7n_azure.dependency_manager.DependencyManager.' + f[0],
                 return_value=f[1]))
-        add_modules_mock = self._create_patch('c7n_azure.function_package.AzurePythonPackageArchive.add_modules')
-        mocks.append(self._create_patch('c7n_azure.function_package.AzurePythonPackageArchive.add_file'))
+        add_modules_mock = self._create_patch(
+            'c7n_azure.function_package.AzurePythonPackageArchive.add_modules')
+        mocks.append(self._create_patch(
+            'c7n_azure.function_package.AzurePythonPackageArchive.add_file'))
 
         cache_zip = os.path.join(test_files_folder, 'cache.zip')
         self.addCleanup(os.remove, cache_zip)
@@ -236,7 +238,8 @@ class FunctionPackageTest(BaseTest):
             mocks.append(self._create_patch(
                 'c7n_azure.dependency_manager.DependencyManager.' + f[0],
                 return_value=f[1]))
-        add_modules_mock = self._create_patch('c7n_azure.function_package.AzurePythonPackageArchive.add_modules')
+        add_modules_mock = self._create_patch(
+            'c7n_azure.function_package.AzurePythonPackageArchive.add_modules')
         self._create_patch('c7n_azure.function_package.AzurePythonPackageArchive.__init__')
 
         packer = FunctionPackage('test')

--- a/tools/c7n_azure/tests/test_functionapp_utils.py
+++ b/tools/c7n_azure/tests/test_functionapp_utils.py
@@ -14,14 +14,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from azure_common import BaseTest, arm_template
-from c7n_azure.function_package import FunctionPackage
+from c7n_azure.function_package import FunctionPackage, AzurePythonPackageArchive
 from c7n_azure.functionapp_utils import FunctionAppUtilities
 
 from c7n_azure.provisioning.app_insights import AppInsightsUnit
 from mock import patch
 
 from c7n.utils import local_session
-from c7n.mu import PythonPackageArchive
 from c7n_azure.session import Session
 
 CONST_GROUP_NAME = 'test_functionapp-reqs'
@@ -159,7 +158,7 @@ class FunctionAppUtilsTest(BaseTest):
             function_app_name='cloud-custodian-test-consumption')
 
         package = FunctionPackage("TestPolicy")
-        package.pkg = PythonPackageArchive()
+        package.pkg = AzurePythonPackageArchive()
         package.close()
 
         FunctionAppUtilities.publish_functions_package(


### PR DESCRIPTION
Zip Deploy tries to [optimize deployments](https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file-or-url#comparison-with-zip-api) by looking at the timestamp and file size to determine if it needs to copy files over. We were not adding the modified time metadata each file in the zip, consequently updates to files were not being honored.

This should fix #4343.