### PR TITLE
azure - function cache bug

### DIFF
--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -147,7 +147,9 @@ class FunctionPackage(object):
 
         self.pkg = AzurePythonPackageArchive(cache_file=cache_zip_file)
 
-        self.pkg.add_modules(None, [m.replace('-', '_') for m in modules])
+        exclude = os.path.normpath('/cache/') + os.path.sep
+        self.pkg.add_modules(lambda f: (exclude in f),
+                             [m.replace('-', '_') for m in modules])
 
         # add config and policy
         self._add_functions_required_files(policy, queue_name)

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License. 
+# limitations under the License.
 import copy
 import distutils.util
 import json

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License. 
 import copy
 import distutils.util
 import json

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -40,7 +40,7 @@ class AzurePythonPackageArchive(PythonPackageArchive):
     def create_zinfo(self, file):
         """
         In Dedicated App Service Plans - Functions are updated via KuduSync
-        The KuduSync uses the modified time and file size to determine if a file has changed
+        KuduSync uses the modified time and file size to determine if a file has changed
         """
         info = super(AzurePythonPackageArchive, self).create_zinfo(file)
         info.date_time = self.package_time[0:6]


### PR DESCRIPTION
I accidentally let our function package include the cache zip file in a previous PR, bloating the packages and the dockerfile by ~20mb.

This fixes that, and should shrink our image too.