### PR TITLE
CI - Cache pip downloads

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -45,6 +45,9 @@ jobs:
     maxParallel: 3
 
   steps:
+  - script: python -c "from pip._internal.utils.appdirs import user_cache_dir; print(user_cache_dir('pip'))"
+    displayName: 'WHERE IS LINUX CACHE'
+
   - task: CacheBeta@0
     inputs:
       key: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,10 +3,8 @@ trigger:
 
 variables:
 - group: CustodianCoreCI
-- name: WINDOWS_CACHE_DIR
-  value: $(LOCALAPPDATA)\pip\cache
-- name: LINUX_CACHE_DIR
-  value: ~/.cache/pip
+- name: PIP_DOWNLOAD_CACHE
+  value: $(Pipeline.Workspace)/.pip
 
 jobs:
 - job: 'Lint'
@@ -51,7 +49,7 @@ jobs:
         c7n-tox
         $(python.version)
         $(Agent.OS)
-      path: $(LINUX_CACHE_DIR)
+      path: $(PIP_DOWNLOAD_CACHE)
 
   - checkout: self
     fetchDepth: 2
@@ -113,7 +111,7 @@ jobs:
         c7n-tox
         $(python.version)
         $(Agent.OS)
-      path: $(WINDOWS_CACHE_DIR)
+      path: $(PIP_DOWNLOAD_CACHE)
 
   - checkout: self
     fetchDepth: 2

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
 - group: CustodianCoreCI
-- WINDOWS_CACHE_DIR: %LOCALAPPDATA%\pip\cache
+- WINDOWS_CACHE_DIR: $(LOCALAPPDATA)\pip\cache
 - LINUX_CACHE_DIR: ~/.cache/pip
 
 jobs:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -45,9 +45,6 @@ jobs:
     maxParallel: 3
 
   steps:
-  - script: python -c "from pip._internal.utils.appdirs import user_cache_dir; print(user_cache_dir('pip'))"
-    displayName: 'WHERE IS LINUX CACHE'
-
   - task: CacheBeta@0
     inputs:
       key: |
@@ -70,6 +67,9 @@ jobs:
 
   - script: tox --notest
     displayName: 'Install Dependencies'
+
+  - script: python -c "from pip._internal.utils.appdirs import user_cache_dir; print(user_cache_dir('pip'))"
+    displayName: 'WHERE IS LINUX CACHE'
 
   - script: tox
     displayName: 'Tox'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
 - name: WINDOWS_CACHE_DIR
   value: $(LOCALAPPDATA)\pip\cache
 - name: LINUX_CACHE_DIR
-  value: ~/.cache/pip
+  value: /home/vsts/.cache/pip
 
 jobs:
 - job: 'Lint'
@@ -67,9 +67,6 @@ jobs:
 
   - script: tox --notest
     displayName: 'Install Dependencies'
-
-  - script: python -c "from pip._internal.utils.appdirs import user_cache_dir; print(user_cache_dir('pip'))"
-    displayName: 'WHERE IS LINUX CACHE'
 
   - script: tox
     displayName: 'Tox'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,10 +3,10 @@ trigger:
 
 variables:
 - group: CustodianCoreCI
-- name: TOX_TESTENV_PASSENV
-  value: PIP_DOWNLOAD_CACHE
-- name: PIP_DOWNLOAD_CACHE
-  value: $(Pipeline.Workspace)/.pip
+- name: WINDOWS_CACHE_DIR
+  value: $(LOCALAPPDATA)\pip\cache
+- name: LINUX_CACHE_DIR
+  value: ~/.cache/pip
 
 jobs:
 - job: 'Lint'
@@ -51,7 +51,7 @@ jobs:
         c7n-tox
         $(python.version)
         $(Agent.OS)
-      path: $(PIP_DOWNLOAD_CACHE)
+      path: $(LINUX_CACHE_DIR)
 
   - checkout: self
     fetchDepth: 2
@@ -113,7 +113,7 @@ jobs:
         c7n-tox
         $(python.version)
         $(Agent.OS)
-      path: $(PIP_DOWNLOAD_CACHE)
+      path: $(WINDOWS_CACHE_DIR)
 
   - checkout: self
     fetchDepth: 2

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,8 +3,10 @@ trigger:
 
 variables:
 - group: CustodianCoreCI
-- WINDOWS_CACHE_DIR: $(LOCALAPPDATA)\pip\cache
-- LINUX_CACHE_DIR: ~/.cache/pip
+- name: WINDOWS_CACHE_DIR
+  value: $(LOCALAPPDATA)\pip\cache
+- name: LINUX_CACHE_DIR
+  value: ~/.cache/pip
 
 jobs:
 - job: 'Lint'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,6 +3,8 @@ trigger:
 
 variables:
 - group: CustodianCoreCI
+- WINDOWS_CACHE_DIR: %LOCALAPPDATA%\pip\cache
+- LINUX_CACHE_DIR: ~/.cache/pip
 
 jobs:
 - job: 'Lint'
@@ -41,6 +43,14 @@ jobs:
     maxParallel: 3
 
   steps:
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        c7n-tox
+        $(python.version)
+        $(Agent.OS)
+      path: $(LINUX_CACHE_DIR)
+
   - checkout: self
     fetchDepth: 2
 
@@ -95,6 +105,14 @@ jobs:
     maxParallel: 3
 
   steps:
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        c7n-tox
+        $(python.version)
+        $(Agent.OS)
+      path: $(WINDOWS_CACHE_DIR)
+
   - checkout: self
     fetchDepth: 2
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,6 +3,8 @@ trigger:
 
 variables:
 - group: CustodianCoreCI
+- name: TOX_TESTENV_PASSENV
+  value: PIP_DOWNLOAD_CACHE
 - name: PIP_DOWNLOAD_CACHE
   value: $(Pipeline.Workspace)/.pip
 


### PR DESCRIPTION
This won't ever build in a PR CI because the Cache Task has some security controls that prevent caches from being created in pull requests. This will have to go straight to master, I have another fork executing it here https://dev.azure.com/cloud-custodian/cloud-custodian/_build/results?buildId=3419