### PR TITLE
aws -  lambda fix tag values to those supported in lambda

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -490,7 +490,7 @@ class LambdaMode(ServerlessExecutionMode):
         # auto tag lambda policies with mode and version, we use the
         # version in mugc to effect cleanups.
         tags = self.policy.data['mode'].setdefault('tags', {})
-        tags['custodian-info'] = "mode=%s;version=%s" % (
+        tags['custodian-info'] = "mode=%s:version=%s" % (
             self.policy.data['mode']['type'], version)
 
         from c7n import mu

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -964,7 +964,7 @@ class LambdaModeTest(BaseTest):
         p.provision()
         self.assertEqual(
             policy_lambda[0].tags['custodian-info'],
-            'mode=config-rule;version=%s' % version)
+            'mode=config-rule:version=%s' % version)
 
 
 class PullModeTest(BaseTest):


### PR DESCRIPTION
the #4388 added some default tags to lambda, unfortunately not all those values were allowed by the lambda service, which wasn't caught by tests since its a server side validation, effectively rendering trunk failing.