### PR TITLE
core - policy execution conditions

### DIFF
--- a/c7n/filters/__init__.py
+++ b/c7n/filters/__init__.py
@@ -21,6 +21,7 @@ from .core import (
     Filter,
     Or,
     And,
+    Not,
     ValueFilter,
     AgeFilter,
     EventFilter,

--- a/c7n/filters/missing.py
+++ b/c7n/filters/missing.py
@@ -14,11 +14,9 @@
 
 from .core import Filter
 
-from c7n.provider import clouds
 from c7n.exceptions import PolicyValidationError
 from c7n.loader import PolicyLoader
 from c7n.utils import type_schema
-from c7n.policy import PolicyCollection
 
 
 class Missing(Filter):
@@ -29,7 +27,10 @@ class Missing(Filter):
     This works as an effectively an embedded policy thats evaluated.
     """
     schema = type_schema(
-        'missing', policy={'type': 'object'},
+        'missing',
+        policy={'type': 'object',
+                'required': ['resource'],
+                'properties': {'resource': {'type': 'string'}}},
         required=['policy'])
 
     def __init__(self, data, manager):
@@ -61,27 +62,9 @@ class Missing(Filter):
         return self.embedded_policy.get_permissions()
 
     def process(self, resources, event=None):
+        if not self.embedded_policy.is_runnable():
+            return []
 
-        provider = clouds[self.manager.ctx.policy.provider_name]()
-
-        # if the embedded policy only specifies one region, or only
-        # being executed on a single region.
-        if self.embedded_policy.region or len(self.manager.config.regions) <= 1:
-            if (self.embedded_policy.region and
-                    self.embedded_policy.region != self.manager.config.region):
-                return []
-            self.embedded_policy.expand_variables(self.embedded_policy.get_variables())
-            return not self.embedded_policy.poll() and resources or []
-
-        # For regional resources and multi-region execution, the policy matches if
-        # the resource is missing in any region.
-        found = {}
-        for p in provider.initialize_policies(
-                PolicyCollection([self.embedded_policy], self.manager.config),
-                self.manager.config):
-            p.expand_variables(p.get_variables())
-            p.validate()
-            found[p.options.region] = p.poll()
-        if not all(found.values()):
-            return resources
-        return []
+        if self.embedded_policy.poll():
+            return []
+        return resources

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -817,7 +817,6 @@ class ConfigRuleMode(LambdaMode):
         return resources
 
 
-
 def get_session_factory(provider_name, options):
     try:
         return clouds[provider_name]().get_session_factory(options)
@@ -885,8 +884,7 @@ class Policy(object):
         self.options = options
         assert "name" in self.data
         if session_factory is None:
-            session_factory = get_session_factory(
-                self.provider_name, options)
+            session_factory = get_session_factory(self.provider_name, options)
         self.session_factory = session_factory
         self.ctx = ExecutionContext(self.session_factory, self, self.options)
         self.resource_manager = self.load_resource_manager()
@@ -912,7 +910,7 @@ class Policy(object):
             provider_name = 'aws'
         return provider_name
 
-    ## Preexecution Conditions
+    # Preexecution Conditions
     @property
     def region(self):
         return self.data.get('region')

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -834,7 +834,7 @@ class PolicyConditions(object):
     def __init__(self, policy, data):
         self.policy = policy
         self.data = data
-        self.filters = []
+        self.filters = self.data.get('conditions', [])
 
     def validate(self):
         self.filters.extend(self.convert_deprecated())
@@ -850,7 +850,7 @@ class PolicyConditions(object):
             'now': datetime.utcnow().replace(tzinfo=tzutil.tzutc()),
             'policy': self.policy.data
         }
-        state = all([f.process([policy_vars, event]) for f in self.filters])
+        state = all([f.process([policy_vars], event) for f in self.filters])
         if not state:
             self.policy.log.info(
                 'Skipping policy:%s due to execution conditions', self.policy.name)

--- a/c7n/provider.py
+++ b/c7n/provider.py
@@ -121,14 +121,20 @@ def get_resource_class(resource_type):
         provider_name, resource = resource_type.split('.', 1)
     else:
         provider_name, resource = 'aws', resource_type
+        resource_type = '%s.%s' % (provider_name, resource_type)
 
     provider = clouds.get(provider_name)
     if provider is None:
         raise KeyError(
             "Invalid cloud provider: %s" % provider_name)
 
-    factory = provider.resources.get(resource)
-    if factory is None:
+    if resource_type not in provider.resource_map:
         raise KeyError("Invalid resource: %s for provider: %s" % (
             resource, provider_name))
+
+    factory = provider.resources.get(resource)
+    if factory is None:
+        import_resource_classes(provider.resource_map, (resource_type,))
+        factory = provider.resources.get(resource)
+
     return factory

--- a/c7n/provider.py
+++ b/c7n/provider.py
@@ -131,10 +131,6 @@ def get_resource_class(resource_type):
     if resource_type not in provider.resource_map:
         raise KeyError("Invalid resource: %s for provider: %s" % (
             resource, provider_name))
-
     factory = provider.resources.get(resource)
-    if factory is None:
-        import_resource_classes(provider.resource_map, (resource_type,))
-        factory = provider.resources.get(resource)
-
+    assert factory, "Resource:%s not loaded" % resource_type
     return factory

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -217,6 +217,15 @@ def generate(resource_types=()):
                 'conditions': {
                     'type': 'array',
                     'items': {'anyOf': [
+                        {'type': 'object', 'additionalProperties': False,
+                         'properties': {'or': {
+                             '$ref': '#/definitions/policy/properties/conditions'}}},
+                        {'type': 'object', 'additionalProperties': False,
+                         'properties': {'not': {
+                             '$ref': '#/definitions/policy/properties/conditions'}}},
+                        {'type': 'object', 'additionalProperties': False,
+                         'properties': {'and': {
+                             '$ref': '#/definitions/policy/properties/conditions'}}},
                         {'$ref': '#/definitions/filters/value'},
                         {'$ref': '#/definitions/filters/event'},
                         {'$ref': '#/definitions/filters/valuekv'}]}},

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -214,13 +214,12 @@ def generate(resource_types=()):
                 'name': {
                     'type': 'string',
                     'pattern': "^[A-z][A-z0-9]*(-[A-z0-9]+)*$"},
-
                 'conditions': {
                     'type': 'array',
-                    'items': {'oneOf': [
-                        '#/definitions/filters/value',
-                        '#/definitions/filters/event',
-                        '#/definitions/filters/valuekv']}},
+                    'items': {'anyOf': [
+                        {'$ref': '#/definitions/filters/value'},
+                        {'$ref': '#/definitions/filters/event'},
+                        {'$ref': '#/definitions/filters/valuekv'}]}},
                 # these should be deprecated for conditions
                 'region': {'type': 'string'},
                 'tz': {'type': 'string'},

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -214,10 +214,19 @@ def generate(resource_types=()):
                 'name': {
                     'type': 'string',
                     'pattern': "^[A-z][A-z0-9]*(-[A-z0-9]+)*$"},
+
+                'conditions': {
+                    'type': 'array',
+                    'items': {'oneOf': [
+                        '#/definitions/filters/value',
+                        '#/definitions/filters/event',
+                        '#/definitions/filters/valuekv']}},
+                # these should be deprecated for conditions
                 'region': {'type': 'string'},
                 'tz': {'type': 'string'},
                 'start': {'format': 'date-time'},
                 'end': {'format': 'date-time'},
+
                 'resource': {'type': 'string'},
                 'max-resources': {'anyOf': [
                     {'type': 'integer', 'minimum': 1},

--- a/c7n/structure.py
+++ b/c7n/structure.py
@@ -29,7 +29,7 @@ class StructureParser(object):
     allowed_policy_keys = set(
         ('name', 'resource', 'title', 'description', 'mode',
          'tags', 'max-resources', 'source', 'query',
-         'filters', 'actions', 'source', 'tags',
+         'filters', 'actions', 'source', 'tags', 'conditions',
          # legacy keys subject to deprecation.
          'region', 'start', 'end', 'tz', 'max-resources-percent',
          'comments', 'comment'))

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -554,6 +554,10 @@ class FormatDate(object):
     def __init__(self, d=None):
         self._d = d
 
+    @property
+    def datetime(self):
+        return self._d
+
     @classmethod
     def utcnow(cls):
         return cls(datetime.utcnow())

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -185,13 +185,13 @@ Single Node Deployment
 
 Now that your policies are stored and available in source control, you can now
 fill in the next pieces of the puzzle to deploy. The simplest way to operate
-Cloud Custodian is to start with running Cloud Custodian against a single account
-on a virtual machine.
+Cloud Custodian is to start with running Cloud Custodian against a single account (or subscription or project) on a virtual machine.
 
 To start, create a virtual machine on your cloud provider of choice.
 It's recommended to execute Cloud Custodian in the same cloud provider
-that you are operating against to prevent a hard dependency on one cloud
-to another.
+that you are operating against to prevent a hard dependency on one
+cloud to another as well being able to utilize your cloud's best pratices
+for credentials (instance profile, service account, etc).
 
 Then, log into the instance and set up Custodian, following the instructions
 in the  :ref:`install-cc` guide.

--- a/docs/source/quickstart/advanced.rst
+++ b/docs/source/quickstart/advanced.rst
@@ -55,35 +55,37 @@ indicate which region each row is from.
 
 .. _scheduling-policy-execution:
 
-Filtering Policy Execution by Date
-----------------------------------
+
+Conditional Policy Execution
+----------------------------
 
 Cloud Custodian can skip policies that are included in a policy file when running if
-the start and end date/times are before or after the current date-time respectively.
-To utilize this behavior, include the ``start``, ``end``, and ``tz`` attributes
-in the policy.
+the policy specifies conditions that aren't met by the current environment.
 
-If the current date and/or time is after the ``start``  value and there is no ``end``
-value, the policy will execute. Likewise, if the ``end`` value is after the current
-date and/or time and there is no ``start`` value, the policy will execute. Otherwise,
-the current date and/or time must fall between ``start`` and ``end`` values for the
-policy to execute. In order to specify a timezone, a ``tz`` attribute must be
-specified. Otherwise, UTC will be used to perform the comparison.
 
-This allows you to continuously run the same policy file for different time periods,
-without having to update the policy file for specific days or times.
+The available environment keys are
 
-**Note**: Dates and/or times specified in ``start`` or ``end`` must not be offset-aware.
-The policy's ``tz`` attribute will be applied to the ``start`` and ``end`` values.
-If no ``tz`` attribute is specified, UTC is set by default.
 
-``start`` and ``end`` attributes support the following formats:
+==========   ========================================================================
+Key          Description
+==========   ========================================================================
+name         Name of the policy
+region       Region the policy is being evaluated in.
+resource     The resource type of the policy.
+account_id   The account id (subscription, project) the policy is being evaluated in.
+provider     The name of the cloud provider (aws, azure, gcp, etc)
+policy       The policy data as structure
+now          The current time
+event        In serverless, the event that triggered the policy
+==========   ========================================================================
 
-* a date (example: ``1-1-2018``, ``January 1 2018``, ``2018-1-1``)
-* a offset-naive time with up to second precision (example: ``2:03:01 PM`` ``16:03:01``, ``3 AM``)
-* a date and a offset-naive time with up to second precision (example: ``1-1-2018 2 PM``, ``January 1 2018 14:00:00``)
+If a policy is executing in a serverless mode the triggering ``event`` is available.
+
+As an example, one can set up policy conditions to only execute between a given
+set of dates.
 
 .. code-block:: yaml
+
 
   policies:
 
@@ -100,9 +102,17 @@ If no ``tz`` attribute is specified, UTC is set by default.
         to ensure that the environment is fully
         turned off during the break.
       resource: ec2
-      start: "2018-12-15"
-      end: "2018-12-31"
-      tz: UTC
+      conditions:
+         - type: value
+	   key: now
+	   op: greater-than
+	   value_type: date
+	   value: "2018-12-15"
+	 - type: value
+	   key: now
+	   op: less-than
+	   value_type: date
+	   value: "2018-12-31"
       filters:
         - "tag:holiday-off-hours": present
       actions:
@@ -113,9 +123,17 @@ If no ``tz`` attribute is specified, UTC is set by default.
         This policy will start up all EC2 instances
         and only run on 1-1-2019.
       resource: ec2
-      start: "2019-1-1"
-      end: "2019-1-1 23:59:59"
-      tz: UTC
+      conditions:
+        - type: value
+	  key: now
+	  value_type: date
+	  op: greater-than
+	  value: "2009-1-1"
+	- type: value
+	  key: now
+	  value_type: date
+	  op: less-than
+	  value: "2019-1-1 23:59:59"
       filters:
         - "tag:holiday-off-hours": present
       actions:

--- a/docs/source/quickstart/advanced.rst
+++ b/docs/source/quickstart/advanced.rst
@@ -77,6 +77,7 @@ provider     The name of the cloud provider (aws, azure, gcp, etc)
 policy       The policy data as structure
 now          The current time
 event        In serverless, the event that triggered the policy
+account      When running in c7n-org, current account info per account config file
 ==========   ========================================================================
 
 If a policy is executing in a serverless mode the triggering ``event`` is available.

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,6 @@ pyrsistent==0.15.7
 pytest==5.4.1
 pytest-cov==2.8.1
 pytest-forked==1.1.3
-pytest-sugar==0.9.2
 pytest-xdist==1.31.0
 python-dateutil==2.8.1
 pywin32-ctypes==0.2.0; sys_platform == "win32"

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1024,6 +1024,26 @@ class TestPolicy(BaseTest):
         self.assertEqual(result, None)
 
 
+class PolicyConditionsTest(BaseTest):
+
+    def test_event_filter(self):
+        p = self.load_policy({
+            'name': 'profx',
+            'resource': 'aws.ec2',
+            'conditions': [{
+                'type': 'event',
+                'key': 'detail.userIdentity.userName',
+                'value': 'deputy'}]})
+        self.assertTrue(
+            p.conditions.evaluate(
+                {'detail': {'userIdentity': {'userName': 'deputy'}}}))
+        self.assertTrue(p.conditions.evaluate(None))
+        self.assertFalse(p.conditions.evaluate({}))
+        self.assertFalse(
+            p.conditions.evaluate(
+                {'detail': {'userIdentity': {'userName': 'mike'}}}))
+
+
 class PolicyExecutionModeTest(BaseTest):
 
     def test_run_unimplemented(self):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1037,6 +1037,8 @@ class PolicyConditionsTest(BaseTest):
         self.assertTrue(
             p.conditions.evaluate(
                 {'detail': {'userIdentity': {'userName': 'deputy'}}}))
+
+        # event filters pass if we don't have an event.
         self.assertTrue(p.conditions.evaluate(None))
         self.assertFalse(p.conditions.evaluate({}))
         self.assertFalse(

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1101,7 +1101,7 @@ class PullModeTest(BaseTest):
 
         lines = log_file.getvalue().strip().split("\n")
         self.assertIn(
-            "Skipping policy:{} target-region:us-east-1 current-region:us-west-2".format(
+            "Skipping policy:{} due to execution conditions".format(
                 policy_name
             ),
             lines,

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1043,6 +1043,35 @@ class PolicyConditionsTest(BaseTest):
             p.conditions.evaluate(
                 {'detail': {'userIdentity': {'userName': 'mike'}}}))
 
+    def test_boolean_or_blocks(self):
+        p = self.load_policy({
+            'name': 'magenta',
+            'resource': 'aws.codebuild',
+            'conditions': [{
+                'or': [
+                    {'region': 'us-east-1'},
+                    {'region': 'us-west-2'}]}]})
+        self.assertTrue(p.conditions.evaluate(None))
+
+    def test_boolean_and_blocks(self):
+        p = self.load_policy({
+            'name': 'magenta',
+            'resource': 'aws.codebuild',
+            'conditions': [{
+                'and': [
+                    {'region': 'us-east-1'},
+                    {'region': 'us-west-2'}]}]})
+        self.assertFalse(p.conditions.evaluate(None))
+
+    def test_boolean_not_blocks(self):
+        p = self.load_policy({
+            'name': 'magenta',
+            'resource': 'aws.codebuild',
+            'conditions': [{
+                'not': [
+                    {'region': 'us-east-1'}]}]})
+        self.assertFalse(p.conditions.evaluate(None))
+
 
 class PolicyExecutionModeTest(BaseTest):
 

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -549,6 +549,8 @@ def run_account(account, region, policies_config, output_path,
 
     with environ(**env_vars):
         for p in policies:
+            # Extend policy execution conditions with account information
+            p.conditions.env_vars['account'] = account
             # Variable expansion and non schema validation (not optional)
             p.expand_variables(p.get_variables(account.get('vars', {})))
             p.validate()


### PR DESCRIPTION
there are many different notions and conditions for only conditionally executing a policy, only execute it against these accounts, at this time of year, in this region, etc.

we originally started with a region filter, and then added  start/end to policies, but the current implementations of conditions is littering the public policy interface with a half-dozen attributes, and represent very use case specific specialized handling of something we already have generically through the rest of the code base via value type filters.

instead this changes policies to grow a conditions array on policies much like the filters section within a policy that then can be used to control policy execution conditionally based on those values.

todos:

- [x] update docs
- [x] evaluation conditions on policy provision
- [x] for c7n-org bring in account tags/variables if possible.

