### PR TITLE
azure - add support for aci container groups

### DIFF
--- a/tools/c7n_azure/c7n_azure/entry.py
+++ b/tools/c7n_azure/c7n_azure/entry.py
@@ -22,6 +22,7 @@ import c7n_azure.filters
 import c7n_azure.output
 import c7n_azure.policy
 import c7n_azure.container_host.modes
+import c7n_azure.resources.aci
 import c7n_azure.resources.generic_arm_resource
 import c7n_azure.resources.cosmos_db
 import c7n_azure.resources.key_vault

--- a/tools/c7n_azure/c7n_azure/resources/aci.py
+++ b/tools/c7n_azure/c7n_azure/resources/aci.py
@@ -1,0 +1,108 @@
+# Copyright 2019 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from c7n_azure.actions.base import AzureBaseAction
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ArmResourceManager
+from azure.mgmt.resource.resources.models import GenericResource
+
+from c7n.utils import type_schema
+
+
+@resources.register('api-management')
+class ApiManagement(ArmResourceManager):
+    """API Management Resource
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: api-management-no-vnet
+            resource: azure.api-management
+            filters:
+              - type: value
+                key: properties.virtualNetworkType
+                op: eq
+                value: None
+    """
+
+    class resource_type(ArmResourceManager.resource_type):
+        doc_groups = ['Integration']
+
+        service = 'azure.mgmt.apimanagement'
+        client = 'ApiManagementClient'
+        enum_spec = ('api_management_service', 'list', None)
+        default_report_fields = (
+            'name',
+            'location',
+            'resourceGroup'
+        )
+        resource_type = 'Microsoft.ApiManagement/service'
+
+
+@ApiManagement.action_registry.register('resize')
+class Resize(AzureBaseAction):
+    """
+    Action to scale api management resource.
+    Required arguments: capacity in units and tier (Developer, Basic, Standard or Premium).
+
+    :example:
+
+    This policy will resize api management to Premium tier with 8 units.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: resize-api
+            resource: azure.api-management
+            filters:
+              - type: value
+                key: name
+                value: test-api
+            actions:
+              - type: resize
+                tier: Premium
+                capacity: 8
+
+    """
+
+    schema = type_schema(
+        'resize',
+        required=['capacity', 'tier'],
+        **{
+            'capacity': {'type': 'number'},
+            'tier': {'enum': ['Developer', 'Basic', 'Standard', 'Premium']}
+        })
+
+    def __init__(self, data, manager=None):
+        super(Resize, self).__init__(data, manager)
+        self.capacity = self.data['capacity']
+        self.tier = self.data['tier']
+
+    def _prepare_processing(self):
+        self.client = self.session.client('azure.mgmt.resource.ResourceManagementClient')
+
+    def _process_resource(self, resource):
+        resource['sku']['capacity'] = self.capacity
+        resource['sku']['tier'] = self.tier
+        resource['sku']['name'] = self.tier
+
+        az_resource = GenericResource.deserialize(resource)
+
+        api_version = self.session.resource_api_version(resource['id'])
+
+        # create a GenericResource object with the required parameters
+        generic_resource = GenericResource(sku=az_resource.sku)
+
+        self.client.resources.update_by_id(resource['id'], api_version, generic_resource)

--- a/tools/c7n_azure/c7n_azure/resources/aci.py
+++ b/tools/c7n_azure/c7n_azure/resources/aci.py
@@ -34,7 +34,7 @@ class ContainerGroup(ArmResourceManager):
     """
 
     class resource_type(ArmResourceManager.resource_type):
-        doc_groups = ['Integration']
+        doc_groups = ['Containers']
 
         service = 'azure.mgmt.containerinstance'
         client = 'ContainerInstanceManagementClient'

--- a/tools/c7n_azure/c7n_azure/resources/aci.py
+++ b/tools/c7n_azure/c7n_azure/resources/aci.py
@@ -19,17 +19,17 @@ from azure.mgmt.resource.resources.models import GenericResource
 from c7n.utils import type_schema
 
 
-@resources.register('api-management')
-class ApiManagement(ArmResourceManager):
-    """API Management Resource
+@resources.register('container-group')
+class ContainerGroup(ArmResourceManager):
+    """Container Group Resource
 
     :example:
 
     .. code-block:: yaml
 
         policies:
-          - name: api-management-no-vnet
-            resource: azure.api-management
+          - name: aci
+            resource: azure.container-group
             filters:
               - type: value
                 key: properties.virtualNetworkType
@@ -40,69 +40,12 @@ class ApiManagement(ArmResourceManager):
     class resource_type(ArmResourceManager.resource_type):
         doc_groups = ['Integration']
 
-        service = 'azure.mgmt.apimanagement'
-        client = 'ApiManagementClient'
-        enum_spec = ('api_management_service', 'list', None)
+        service = 'azure.mgmt.containerinstance'
+        client = 'ContainerInstanceManagementClient'
+        enum_spec = ('container_groups', 'list', None)
         default_report_fields = (
             'name',
             'location',
             'resourceGroup'
         )
-        resource_type = 'Microsoft.ApiManagement/service'
-
-
-@ApiManagement.action_registry.register('resize')
-class Resize(AzureBaseAction):
-    """
-    Action to scale api management resource.
-    Required arguments: capacity in units and tier (Developer, Basic, Standard or Premium).
-
-    :example:
-
-    This policy will resize api management to Premium tier with 8 units.
-
-    .. code-block:: yaml
-
-        policies:
-          - name: resize-api
-            resource: azure.api-management
-            filters:
-              - type: value
-                key: name
-                value: test-api
-            actions:
-              - type: resize
-                tier: Premium
-                capacity: 8
-
-    """
-
-    schema = type_schema(
-        'resize',
-        required=['capacity', 'tier'],
-        **{
-            'capacity': {'type': 'number'},
-            'tier': {'enum': ['Developer', 'Basic', 'Standard', 'Premium']}
-        })
-
-    def __init__(self, data, manager=None):
-        super(Resize, self).__init__(data, manager)
-        self.capacity = self.data['capacity']
-        self.tier = self.data['tier']
-
-    def _prepare_processing(self):
-        self.client = self.session.client('azure.mgmt.resource.ResourceManagementClient')
-
-    def _process_resource(self, resource):
-        resource['sku']['capacity'] = self.capacity
-        resource['sku']['tier'] = self.tier
-        resource['sku']['name'] = self.tier
-
-        az_resource = GenericResource.deserialize(resource)
-
-        api_version = self.session.resource_api_version(resource['id'])
-
-        # create a GenericResource object with the required parameters
-        generic_resource = GenericResource(sku=az_resource.sku)
-
-        self.client.resources.update_by_id(resource['id'], api_version, generic_resource)
+        resource_type = 'Microsoft.ContainerInstance/containerGroups'

--- a/tools/c7n_azure/c7n_azure/resources/aci.py
+++ b/tools/c7n_azure/c7n_azure/resources/aci.py
@@ -11,12 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
-from azure.mgmt.resource.resources.models import GenericResource
-
-from c7n.utils import type_schema
 
 
 @resources.register('container-group')

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -53,6 +53,7 @@ setup(
                       "azure-mgmt-cognitiveservices",
                       "azure-mgmt-cosmosdb",
                       "azure-mgmt-costmanagement",
+                      "azure-mgmt-containerinstance",
                       "azure-mgmt-compute",
                       "azure-mgmt-cdn",
                       "azure-mgmt-containerregistry",

--- a/tools/c7n_azure/tests/cassettes/ContainerGroupTest.list.json
+++ b/tools/c7n_azure/tests/cassettes/ContainerGroupTest.list.json
@@ -1,0 +1,70 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerInstance/containerGroups?api-version=2018-10-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-ms-original-request-ids": [
+                        "westus2:439c1101-b957-404b-8ff2-ae03eade7723",
+                        "southcentralus:5611569a-295e-49b2-8d98-10232071c324"
+                    ],
+                    "content-length": [
+                        "2263"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Tue, 06 Aug 2019 18:48:03 GMT"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "containers": [
+                                        {
+                                            "name": "cctest-container",
+                                            "properties": {
+                                                "image": "microsoft/aci-helloworld",
+                                                "ports": [],
+                                                "environmentVariables": [],
+                                                "resources": {
+                                                    "requests": {
+                                                        "memoryInGB": 1.5,
+                                                        "cpu": 1.0
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "restartPolicy": "Always",
+                                    "osType": "Linux"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_aci/providers/Microsoft.ContainerInstance/containerGroups/cctest-containergroup",
+                                "name": "cctest-containergroup",
+                                "type": "Microsoft.ContainerInstance/containerGroups",
+                                "location": "southcentralus"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests/templates/aci.json
+++ b/tools/c7n_azure/tests/templates/aci.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    },
+    "containerGroupName": {
+      "type": "string",
+      "defaultValue": "cctest-containergroup"
+    },
+    "containerName": {
+      "type": "string",
+      "defaultValue": "cctest-container"
+    },
+    "image": {
+      "type": "string",
+      "metadata": {
+        "description": "Container image to deploy. Should be of the form accountName/imagename:tag for images stored in Docker Hub or a fully qualified URI for a private registry like the Azure Container Registry."
+      },
+      "defaultValue": "microsoft/aci-helloworld"
+    },
+    "cpuCores": {
+      "type": "string",
+      "metadata": {
+        "description": "The number of CPU cores to allocate to the container. Must be an integer."
+      },
+      "defaultValue": "1.0"
+    },
+    "memoryInGb": {
+      "type": "string",
+      "metadata": {
+        "description": "The amount of memory to allocate to the container in gigabytes."
+      },
+      "defaultValue": "1.5"
+    }
+  },
+  "resources": [
+    {
+      "name": "[parameters('containerGroupName')]",
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2018-10-01",
+      "location": "[parameters('location')]",
+      "properties": {
+        "containers": [
+          {
+            "name": "[parameters('containerName')]",
+            "properties": {
+              "image": "[parameters('image')]",
+              "ports": [     ],
+              "resources": {
+                "requests": {
+                  "cpu": "[parameters('cpuCores')]",
+                  "memoryInGB": "[parameters('memoryInGb')]"
+                }
+              }
+            }
+          }
+        ],
+        "osType": "Linux",
+        "restartPolicy": "Always"
+      }
+    }
+  ]
+}

--- a/tools/c7n_azure/tests/test_aci.py
+++ b/tools/c7n_azure/tests/test_aci.py
@@ -1,0 +1,73 @@
+# Copyright 2019 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+from c7n_azure.resources.apimanagement import Resize
+from mock import MagicMock
+
+from azure_common import BaseTest, arm_template
+
+from c7n.utils import local_session
+from c7n_azure.session import Session
+
+
+class ApiManagementTest(BaseTest):
+    def setUp(self):
+        super(ApiManagementTest, self).setUp()
+
+    def test_apimanagement_schema_validate(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-azure-apimanagement',
+                'resource': 'azure.api-management'
+            }, validate=True)
+            self.assertTrue(p)
+
+    @arm_template('apimanagement.json')
+    def test_find_apimanagement_by_name(self):
+        p = self.load_policy({
+            'name': 'test-azure-apimanagement',
+            'resource': 'azure.api-management',
+            'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'glob',
+                 'value_type': 'normalize',
+                 'value': 'cctestapimanagement*'}],
+        })
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_resize_action(self):
+        action = Resize(data={'capacity': 8, 'tier': 'Premium'})
+        action.client = MagicMock()
+        action.manager = MagicMock()
+        action.session = local_session(Session)
+
+        resource = {
+            'id': '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/'
+                  'providers/Microsoft.ApiManagement/service/test-apimanagement',
+            'name': 'test-apimanagement',
+            'type': 'Microsoft.ApiManagement/service',
+            'sku': {'name': 'Developer', 'capacity': 1, 'tier': 'Developer'},
+            'resourceGroup': 'test-rg'
+        }
+
+        action.process([resource])
+
+        update_by_id = action.client.resources.update_by_id
+
+        self.assertEqual(len(update_by_id.call_args_list), 1)
+        self.assertEqual(len(update_by_id.call_args_list[0][0]), 3)
+        self.assertEqual(update_by_id.call_args_list[0][0][2].serialize()['sku']['capacity'], 8)
+        self.assertEqual(update_by_id.call_args_list[0][0][2].serialize()['sku']['tier'], 'Premium')

--- a/tools/c7n_azure/tests/test_aci.py
+++ b/tools/c7n_azure/tests/test_aci.py
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
-from mock import MagicMock
 
 from azure_common import BaseTest, arm_template, cassette_name
-
-from c7n.utils import local_session
-from c7n_azure.session import Session
 
 
 class ContainerGroupTest(BaseTest):

--- a/tools/c7n_azure/tests/test_aci.py
+++ b/tools/c7n_azure/tests/test_aci.py
@@ -12,62 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
-from c7n_azure.resources.apimanagement import Resize
 from mock import MagicMock
 
-from azure_common import BaseTest, arm_template
+from azure_common import BaseTest, arm_template, cassette_name
 
 from c7n.utils import local_session
 from c7n_azure.session import Session
 
 
-class ApiManagementTest(BaseTest):
-    def setUp(self):
-        super(ApiManagementTest, self).setUp()
-
-    def test_apimanagement_schema_validate(self):
+class ContainerGroupTest(BaseTest):
+    def test_containergroup_schema_validate(self):
         with self.sign_out_patch():
             p = self.load_policy({
-                'name': 'test-azure-apimanagement',
-                'resource': 'azure.api-management'
+                'name': 'test',
+                'resource': 'azure.container-group'
             }, validate=True)
             self.assertTrue(p)
 
-    @arm_template('apimanagement.json')
-    def test_find_apimanagement_by_name(self):
+    @arm_template('aci.json')
+    @cassette_name('list')
+    def test_find_container_by_name(self):
         p = self.load_policy({
-            'name': 'test-azure-apimanagement',
-            'resource': 'azure.api-management',
+            'name': 'test',
+            'resource': 'azure.container-group',
             'filters': [
                 {'type': 'value',
-                 'key': 'name',
-                 'op': 'glob',
-                 'value_type': 'normalize',
-                 'value': 'cctestapimanagement*'}],
+                 'key': 'properties.containers[].name',
+                 'op': 'in',
+                 'value_type': 'swap',
+                 'value': 'cctest-container'}],
         })
         resources = p.run()
         self.assertEqual(len(resources), 1)
-
-    def test_resize_action(self):
-        action = Resize(data={'capacity': 8, 'tier': 'Premium'})
-        action.client = MagicMock()
-        action.manager = MagicMock()
-        action.session = local_session(Session)
-
-        resource = {
-            'id': '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/'
-                  'providers/Microsoft.ApiManagement/service/test-apimanagement',
-            'name': 'test-apimanagement',
-            'type': 'Microsoft.ApiManagement/service',
-            'sku': {'name': 'Developer', 'capacity': 1, 'tier': 'Developer'},
-            'resourceGroup': 'test-rg'
-        }
-
-        action.process([resource])
-
-        update_by_id = action.client.resources.update_by_id
-
-        self.assertEqual(len(update_by_id.call_args_list), 1)
-        self.assertEqual(len(update_by_id.call_args_list[0][0]), 3)
-        self.assertEqual(update_by_id.call_args_list[0][0][2].serialize()['sku']['capacity'], 8)
-        self.assertEqual(update_by_id.call_args_list[0][0][2].serialize()['sku']['tier'], 'Premium')


### PR DESCRIPTION
Adds support for container groups which return with the full array of containers.

We wanted instance state though, which the docs clearly show in `instanceview` in the response here:
https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups/list#containergroupslist

But I'm not seeing them right now on my resources. Going to go ahead and get this support added and we'll file a bug to figure out why the API isn't returning that data (it is in the portal so we can see how they get it).