### PR TITLE
azure - fix PATCH updates for tags

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
+++ b/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
@@ -53,7 +53,6 @@ class AppServicePlan(ArmResourceManager):
             'kind'
         )
         resource_type = 'Microsoft.Web/sites'
-        enable_tag_operations = False
 
 
 @AppServicePlan.action_registry.register('resize-plan')

--- a/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
@@ -59,6 +59,7 @@ class SqlDatabase(ChildArmResourceManager):
         enum_spec = ('databases', 'list_by_server', None)
         parent_manager_name = 'sqlserver'
         resource_type = 'Microsoft.Sql/servers/databases'
+        enable_tag_operations = False  # GH Issue #4543
 
         @classmethod
         def extra_args(cls, parent_resource):

--- a/tools/c7n_azure/c7n_azure/tags.py
+++ b/tools/c7n_azure/c7n_azure/tags.py
@@ -43,15 +43,10 @@ class TagHelper:
                                           .format(az_resource.type))
             api_version = tag_action.session.resource_api_version(resource['id'])
 
-            # create a GenericResource object with the required parameters
-            generic_resource = GenericResource(location=az_resource.location,
-                                               tags=tags,
-                                               properties=az_resource.properties,
-                                               kind=az_resource.kind,
-                                               managed_by=az_resource.managed_by,
-                                               identity=az_resource.identity)
+            # create a PATCH object with only updates to tags
+            tags_patch = GenericResource(tags=tags)
 
-            client.resources.update_by_id(resource['id'], api_version, generic_resource)
+            client.resources.update_by_id(resource['id'], api_version, tags_patch)
 
     @staticmethod
     def remove_tags(tag_action, resource, tags_to_delete):

--- a/tools/c7n_azure/tests/templates/cleanup.sh
+++ b/tools/c7n_azure/tests/templates/cleanup.sh
@@ -14,7 +14,7 @@ for file in "$templateDirectory"/*.json; do
 
   if [ $# -eq 0 ] || [[ "$@" =~ "$filenameNoExtension" ]]; then
     echo "Deleting $rgName"
-    az group delete --name $rgName --yes
+    az group delete --name $rgName --yes --no-wait
   else
     echo "Skipping $rgName"
   fi
@@ -24,14 +24,14 @@ done
 # Destroy ACS resource
 rgName=test_containerservice
 if [ $# -eq 0 ] || [[ "$@" =~ "containerservice" ]]; then
-  az group delete --name $rgName --yes
+  az group delete --name $rgName --yes --no-wait
 else
   echo "Skipping $rgName"
 fi
 
 # Destroy Azure Policy Assignment
 if [ $# -eq 0 ] || [[ "$@" =~ "policyassignment" ]]; then
-  az policy assignment delete --name cctestpolicy
+  az policy assignment delete --name cctestpolicy --no-wait
 else
   echo "Skipping policyassignment"
 fi

--- a/tools/c7n_azure/tests/templates/provision.sh
+++ b/tools/c7n_azure/tests/templates/provision.sh
@@ -35,9 +35,9 @@ for file in "$templateDirectory"/*.json; do
         az keyvault key create --vault-name $vault_name --name cctestrsa --kty RSA
         az keyvault key create --vault-name $vault_name --name cctestec --kty EC
       elif [[ "$filenameNoExtension" =~ "aks" ]]; then
-        az group deployment create --resource-group $rgName --template-file $file --parameters client_id=$AZURE_CLIENT_ID client_secret=$AZURE_CLIENT_SECRET
+        az group deployment create --resource-group $rgName --template-file $file --parameters client_id=$AZURE_CLIENT_ID client_secret=$AZURE_CLIENT_SECRET --no-wait
       else
-        az group deployment create --resource-group $rgName --template-file $file
+        az group deployment create --resource-group $rgName --template-file $file --no-wait
       fi
   else
     echo "Skipping $rgName"

--- a/tools/c7n_azure/tests/test_tags.py
+++ b/tools/c7n_azure/tests/test_tags.py
@@ -72,6 +72,8 @@ class TagsTest(BaseTest):
         args = client_mock.resource_groups.update.call_args[0]
         self.assertEqual(args[0], resource_group['name'])
         self.assertEqual(args[1].tags, self.existing_tags)
+        # Only PATCH tags
+        self.assertListEqual(['tags'], [x for x in args[1].as_dict() if x is not None])
 
         action.manager.type = 'vm'
         TagHelper.update_resource_tags(action, resource, self.existing_tags)
@@ -79,3 +81,5 @@ class TagsTest(BaseTest):
         args = client_mock.resources.update_by_id.call_args[0]
         self.assertEqual(args[0], resource['id'])
         self.assertEqual(args[2].tags, self.existing_tags)
+        # Only PATCH tags
+        self.assertListEqual(['tags'], [x for x in args[2].as_dict() if x is not None])


### PR DESCRIPTION
- Updated PATCH to only send the updated tags oppose to attempting to reconstruct the `GenericResource`
- enabled **App Service Plan**, Fix #4494 
- disabled tagging of **SQL Databases**, opened bug #4543 
- I both **cleanup.sh** and **provision.sh** async oppose to blocking 
