### PR TITLE
Bug/4619 report cosmos

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
+++ b/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
@@ -88,6 +88,9 @@ class CosmosDBChildResource(ChildResourceManager):
         raise_on_exception = False
         annotate_parent = True
 
+        id = '_rid'
+        name = 'id'
+
     @staticmethod
     @lru_cache()
     def get_cosmos_key(resource_group, resource_name, client, readonly=True):

--- a/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
+++ b/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
@@ -91,6 +91,12 @@ class CosmosDBChildResource(ChildResourceManager):
         id = '_rid'
         name = 'id'
 
+        default_report_fields = (
+            'id',
+            '_ts',
+            '_self'
+        )
+
     @staticmethod
     @lru_cache()
     def get_cosmos_key(resource_group, resource_name, client, readonly=True):

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
@@ -98,6 +98,9 @@ class KeyVaultKeys(ChildResourceManager):
         parent_manager_name = 'keyvault'
         raise_on_exception = False
 
+        id = 'kid'
+        name = 'kid'
+
         @classmethod
         def extra_args(cls, parent_resource):
             return {'vault_base_url': generate_key_vault_url(parent_resource['name'])}

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
@@ -101,6 +101,13 @@ class KeyVaultKeys(ChildResourceManager):
         id = 'kid'
         name = 'kid'
 
+        default_report_fields = (
+            'kid',
+            'attributes.enabled',
+            'attributes.exp',
+            'attributes.recoveryLevel'
+        )
+
         @classmethod
         def extra_args(cls, parent_resource):
             return {'vault_base_url': generate_key_vault_url(parent_resource['name'])}


### PR DESCRIPTION
Adds `id`, `name` and `default_report_field` to objects that derive their resource_type from `ChildTypeInfo`. This is collections and databases for CosmosDb and keys for KeyVault.

Closes #4619 