### PR TITLE
cask - fix image pull

### DIFF
--- a/tools/cask/main.go
+++ b/tools/cask/main.go
@@ -100,6 +100,8 @@ func update(ctx context.Context, image string, dockerClient *client.Client) {
 		_ = jsonmessage.DisplayJSONMessagesStream(out, os.Stdout, 1, true, nil)
 	}
 
+	defer out.Close()
+
 	// Touch the marker file
 	if _, err := os.Stat(updateMarker); err == nil {
 		if err := os.Chtimes(updateMarker, now, now); err != nil {


### PR DESCRIPTION
Best I can tell cask isn't actually ever updating the custodian docker image, despite downloading the new ones all the time.  

Seems we have to block on the pull and wait for it to finish for it to successfully commit the update, otherwise we launch a container and it interrupts the pull.