### PR TITLE
gcp - incorrect resource param for set(get)IamPolicy

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/actions/iampolicy.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/iampolicy.py
@@ -133,7 +133,7 @@ class SetIamPolicy(MethodAction):
 
         :param resource: the same as in `get_resource_params`
         """
-        return {'resource': resource['name']}
+        return {'resource': resource[self.manager.resource_type.id]}
 
     def _add_bindings(self, existing_bindings, bindings_to_add):
         """


### PR DESCRIPTION
Some resources like `gcp.project` store identifiers in fields other than `name` (`projectId`). In case we [implement](https://github.com/mediapills/cloud-custodian/pull/136) iam for the project resource, it will fail in those cases where name of a project differs from its id.