### PR TITLE
cask - docs, install script, pipeline

### DIFF
--- a/.azure-pipelines/cask-release.yml
+++ b/.azure-pipelines/cask-release.yml
@@ -4,7 +4,7 @@ trigger:
     - master
   paths:
     include:
-    - tools/custodian-cask/*
+    - tools/cask/*
 
 variables:
 - group: CustodianCoreCI

--- a/tools/cask/readme.md
+++ b/tools/cask/readme.md
@@ -17,10 +17,10 @@ Linux
 sudo sh -c 'wget -q https://cloudcustodian.io/downloads/custodian-cask/linux-latest/custodian-cask -P /usr/local/bin && chmod +x /usr/local/bin/custodian-cask'
 ```
 
-Darwin
+MacOS (Darwin)
 
 ```shell
-sudo sh -c 'wget -q https://cloudcustodian.io/downloads/custodian-cask/darwin-latest/custodian-cask -P /usr/local/bin && chmod +x /usr/local/bin/custodian-cask'
+sudo sh -c '(cd /usr/local/bin && curl -fsSLO https://cloudcustodian.io/downloads/custodian-cask/darwin-latest/custodian-cask && chmod +x /usr/local/bin/custodian-cask)'
 ```
 
 Windows (cmd.exe)

--- a/tools/cask/scripts/install.ps1
+++ b/tools/cask/scripts/install.ps1
@@ -20,6 +20,9 @@ $base = "$env:LOCALAPPDATA\custodian"
 
 try
 {
+    # Ensure folder
+    md -Force $base | Out-Null
+
     # Download
     Invoke-WebRequest -OutFile "$base\custodian-cask.exe" "$url"
 


### PR DESCRIPTION
Turns out fixing Cask bugs was not very fruitful because our pipeline wasn't publishing releases :) 

Move from wget->curl for Mac as wget is not installed by default. 

And for Windows, ensure folder exists before downloading. 