### PR TITLE
c7n - resource aliases

### DIFF
--- a/c7n/registry.py
+++ b/c7n/registry.py
@@ -60,12 +60,14 @@ class PluginRegistry(object):
         self._subscribers[event].append(func)
 
     def register(self, name, klass=None, condition=True,
-                 condition_message="Missing dependency for {}"):
+                 condition_message="Missing dependency for {}",
+                 aliases=None):
         if not condition and klass:
             return klass
         # invoked as function
         if klass:
             klass.type = name
+            klass.aliases = aliases
             self._factories[name] = klass
             self.notify(self.EVENT_REGISTER, klass)
             return klass
@@ -76,6 +78,7 @@ class PluginRegistry(object):
                 return klass
             self._factories[name] = klass
             klass.type = name
+            klass.aliases = aliases
             self.notify(self.EVENT_REGISTER, klass)
             return klass
         return _register_class
@@ -95,7 +98,12 @@ class PluginRegistry(object):
         return self.get(name)
 
     def get(self, name):
-        return self._factories.get(name)
+        factory = self._factories.get(name)
+
+        if factory:
+            return factory
+
+        return next((v for k, v in self._factories.items() if v.aliases and name in v.aliases), None)
 
     def keys(self):
         return self._factories.keys()

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -266,16 +266,26 @@ def generate(resource_types=()):
         for type_name, resource_type in cloud_type.resources.items():
             if resource_types and type_name not in resource_types:
                 continue
-            alias_name = None
+
             r_type_name = "%s.%s" % (cloud_name, type_name)
+
+            aliases = []
+            if resource_type.aliases:
+                aliases.extend(["%s.%s" % (cloud_name, a) for a in resource_type.aliases])
+                # aws gets legacy aliases with no cloud prefix
+                if cloud_name == 'aws':
+                    aliases.extend(resource_type.aliases)
+
+            # aws gets additional alias for default name
             if cloud_name == 'aws':
-                alias_name = type_name
+                aliases.append(type_name)
+
             resource_refs.append(
                 process_resource(
                     r_type_name,
                     resource_type,
                     resource_defs,
-                    alias_name,
+                    aliases,
                     definitions,
                     cloud_name
                 ))
@@ -301,7 +311,7 @@ def generate(resource_types=()):
 
 
 def process_resource(
-        type_name, resource_type, resource_defs, alias_name=None,
+        type_name, resource_type, resource_defs, aliases=None,
         definitions=None, provider_name=None):
 
     r = resource_defs.setdefault(type_name, {'actions': {}, 'filters': {}})
@@ -380,9 +390,9 @@ def process_resource(
         ]
     }
 
-    if alias_name:
+    if aliases:
         resource_policy['allOf'][1]['properties'][
-            'resource']['enum'].append(alias_name)
+            'resource']['enum'].extend(aliases)
 
     if type_name == 'ec2':
         resource_policy['allOf'][1]['properties']['query'] = {}

--- a/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
@@ -33,7 +33,7 @@ from c7n_azure.utils import ResourceIdParser, RetentionPeriod, ThreadHelper
 log = logging.getLogger('custodian.azure.sqldatabase')
 
 
-@resources.register('sqldatabase')
+@resources.register('sql-database', aliases=['sqldatabase'])
 class SqlDatabase(ChildArmResourceManager):
     """SQL Server Database Resource
 

--- a/tools/c7n_azure/c7n_azure/resources/sqlserver.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqlserver.py
@@ -20,7 +20,7 @@ from c7n_azure.resources.arm import ArmResourceManager
 from netaddr import IPRange, IPSet
 
 
-@resources.register('sqlserver')
+@resources.register('sql-server', aliases=['sqlserver'])
 class SqlServer(ArmResourceManager):
     """SQL Server Resource
 


### PR DESCRIPTION
Quick implementation of resource aliases.  Thoughts?  How can we do it better? 

Allows you to do this:
```
@resources.register('sql-database', aliases=['sqldatabase'])
```


Use cases:

- We have been bad about naming consistency and would like to ensure it is corrected 
- Azure has a habit of renaming things (docdb/cosmosdb, app service/webapp, etc)

