### PR TITLE
azure - remove timeout in azure tests pipeline

### DIFF
--- a/.azure-pipelines/azure-nightly-tests.yml
+++ b/.azure-pipelines/azure-nightly-tests.yml
@@ -25,9 +25,6 @@ jobs:
     - script: az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} && az account set -s ${AZURE_SUBSCRIPTION_ID}
       displayName: "Login to Azure"
 
-    - script: sleep 60m
-      displayName: "Emulate long deployment..."
-
     - script: tools/c7n_azure/tests/templates/provision.sh
       displayName: "Provision Azure Resources"
     

--- a/.azure-pipelines/azure-nightly-tests.yml
+++ b/.azure-pipelines/azure-nightly-tests.yml
@@ -4,6 +4,9 @@ variables:
 jobs:
 - job: 'azure_nightly_test_run'
   displayName: 'Azure Nightly Test Run'
+  timeoutInMinutes: 0
+  cancelTimeoutInMinutes: 0
+
   pool:
     vmImage: 'Ubuntu-16.04'
 
@@ -21,6 +24,9 @@ jobs:
 
     - script: az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} && az account set -s ${AZURE_SUBSCRIPTION_ID}
       displayName: "Login to Azure"
+
+    - script: sleep 60m
+      displayName: "Emulate long deployment..."
 
     - script: tools/c7n_azure/tests/templates/provision.sh
       displayName: "Provision Azure Resources"


### PR DESCRIPTION
Default timeout is 60 minutes for the job and 5 for the cleanup