### PR TITLE
azure - add storage container support

### DIFF
--- a/tools/c7n_azure/c7n_azure/entry.py
+++ b/tools/c7n_azure/c7n_azure/entry.py
@@ -33,6 +33,7 @@ import c7n_azure.resources.load_balancer
 import c7n_azure.resources.resourcegroup
 import c7n_azure.resources.public_ip
 import c7n_azure.resources.storage
+import c7n_azure.resources.storage_container
 import c7n_azure.resources.sqlserver
 import c7n_azure.resources.sqldatabase
 import c7n_azure.resources.vm

--- a/tools/c7n_azure/c7n_azure/query.py
+++ b/tools/c7n_azure/c7n_azure/query.py
@@ -15,11 +15,14 @@
 import logging
 
 import six
+from collections import Iterable
+
 from c7n_azure import constants
 from c7n_azure.actions.logic_app import LogicAppAction
 from c7n_azure.actions.notify import Notify
 from c7n_azure.filters import ParentFilter
 from c7n_azure.provider import resources
+
 
 from c7n.actions import ActionRegistry
 from c7n.filters import FilterRegistry
@@ -317,7 +320,15 @@ class ChildResourceManager(QueryResourceManager):
         else:
             op = getattr(client, list_op)
 
-        return [r.serialize(True) for r in op(**params)]
+        result = op(**params)
+
+        if isinstance(result, Iterable):
+            return [r.serialize(True) for r in result]
+        elif hasattr(result, 'value'):
+            return [r.serialize(True) for r in result.value]
+
+        raise TypeError("Enumerating resources resulted in a return"
+                        "value which could not be iterated.")
 
     @staticmethod
     def register_child_specific(registry, _):

--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -1,0 +1,59 @@
+# Copyright 2019 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ChildArmResourceManager
+
+
+@resources.register('storage-container')
+class StorageContainer(ChildArmResourceManager):
+    """Storage Container Resource
+
+    :example:
+
+    Finds all containers with public access enabled
+
+    .. code-block:: yaml
+
+        policies:
+          - name: storage-container-public
+            description: |
+              Find all containers with public access enabled
+            resource: azure.storage-container
+            filters:
+              - type: value
+                key: properties.publicAccess
+                op: not-equal
+                value: None   # Possible values: Blob, Container, None
+    """
+
+    class resource_type(ChildArmResourceManager.resource_type):
+        doc_groups = ['Storage']
+
+        service = 'azure.mgmt.storage'
+        client = 'StorageManagementClient'
+        enum_spec = ('blob_containers', 'list', None)
+        parent_manager_name = 'storage'
+        diagnostic_settings_enabled = False
+        resource_type = 'Microsoft.Storage/storageAccounts/blobServices/containers'
+        enable_tag_operations = False
+
+    def enumerate_resources(self, parent_resource, type_info, **params):
+        client = self.get_client()
+
+        params.update({'resource_group_name': parent_resource['resourceGroup'],
+                       'account_name': parent_resource['name']})
+
+        # Storage SDK is non-standard and returns `dict` from `list`
+        return [r.serialize(True) for r in client.blob_containers.list(**params).value]

--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from c7n_azure.provider import resources
-from c7n_azure.resources.arm import ChildArmResourceManager
+from c7n_azure.query import ChildTypeInfo, ChildResourceManager
 
 
 @resources.register('storage-container')
-class StorageContainer(ChildArmResourceManager):
+class StorageContainer(ChildResourceManager):
     """Storage Container Resource
 
     :example:
@@ -38,7 +38,7 @@ class StorageContainer(ChildArmResourceManager):
                 value: None   # Possible values: Blob, Container, None
     """
 
-    class resource_type(ChildArmResourceManager.resource_type):
+    class resource_type(ChildTypeInfo):
         doc_groups = ['Storage']
         service = 'azure.mgmt.storage'
         client = 'StorageManagementClient'
@@ -48,11 +48,7 @@ class StorageContainer(ChildArmResourceManager):
         resource_type = 'Microsoft.Storage/storageAccounts/blobServices/containers'
         enable_tag_operations = False
 
-    def enumerate_resources(self, parent_resource, type_info, **params):
-        client = self.get_client()
-
-        params.update({'resource_group_name': parent_resource['resourceGroup'],
-                       'account_name': parent_resource['name']})
-
-        # Storage SDK is non-standard and returns `dict` from `list`
-        return [r.serialize(True) for r in client.blob_containers.list(**params).value]
+        @classmethod
+        def extra_args(cls, parent_resource):
+            return {'resource_group_name': parent_resource['resourceGroup'],
+                    'account_name': parent_resource['name']}

--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -40,7 +40,6 @@ class StorageContainer(ChildArmResourceManager):
 
     class resource_type(ChildArmResourceManager.resource_type):
         doc_groups = ['Storage']
-
         service = 'azure.mgmt.storage'
         client = 'StorageManagementClient'
         enum_spec = ('blob_containers', 'list', None)

--- a/tools/c7n_azure/tests/cassettes/StorageContainerTest.containers.json
+++ b/tools/c7n_azure/tests/cassettes/StorageContainerTest.containers.json
@@ -1,0 +1,495 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2019-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-length": [
+                        "9066"
+                    ],
+                    "date": [
+                        "Thu, 29 Aug 2019 20:30:04 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "f4bcda96-c4c8-4216-91fb-e0143ebcf33b",
+                        "0d4d03aa-3697-4ac9-8e5c-7d19cfd8ff8c",
+                        "cc83267e-dee7-47f2-bd9e-8f84c8743aaa",
+                        "d6a18abe-74b1-4151-a790-d07a77672ab3"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "kind": "Storage",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o",
+                                "name": "cctstoragey6akyqpagdt3o",
+                                "type": "Microsoft.Storage/storageAccounts",
+                                "location": "southcentralus",
+                                "tags": {},
+                                "properties": {
+                                    "networkAcls": {
+                                        "bypass": "AzureServices",
+                                        "virtualNetworkRules": [],
+                                        "ipRules": [],
+                                        "defaultAction": "Allow"
+                                    },
+                                    "supportsHttpsTrafficOnly": false,
+                                    "encryption": {
+                                        "services": {
+                                            "file": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.3582290Z"
+                                            },
+                                            "blob": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.3582290Z"
+                                            }
+                                        },
+                                        "keySource": "Microsoft.Storage"
+                                    },
+                                    "provisioningState": "Succeeded",
+                                    "creationTime": "2019-08-29T20:28:56.2956738Z",
+                                    "primaryEndpoints": {
+                                        "blob": "https://cctstoragey6akyqpagdt3o.blob.core.windows.net/",
+                                        "queue": "https://cctstoragey6akyqpagdt3o.queue.core.windows.net/",
+                                        "table": "https://cctstoragey6akyqpagdt3o.table.core.windows.net/",
+                                        "file": "https://cctstoragey6akyqpagdt3o.file.core.windows.net/"
+                                    },
+                                    "primaryLocation": "southcentralus",
+                                    "statusOfPrimary": "available"
+                                }
+                            },
+                            {
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "kind": "Storage",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cclgstoragey6akyqpagdt3o",
+                                "name": "cclgstoragey6akyqpagdt3o",
+                                "type": "Microsoft.Storage/storageAccounts",
+                                "location": "southcentralus",
+                                "tags": {},
+                                "properties": {
+                                    "networkAcls": {
+                                        "bypass": "AzureServices",
+                                        "virtualNetworkRules": [],
+                                        "ipRules": [],
+                                        "defaultAction": "Allow"
+                                    },
+                                    "supportsHttpsTrafficOnly": false,
+                                    "encryption": {
+                                        "services": {
+                                            "file": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.4676057Z"
+                                            },
+                                            "blob": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.4676057Z"
+                                            }
+                                        },
+                                        "keySource": "Microsoft.Storage"
+                                    },
+                                    "provisioningState": "Succeeded",
+                                    "creationTime": "2019-08-29T20:28:56.4363025Z",
+                                    "primaryEndpoints": {
+                                        "blob": "https://cclgstoragey6akyqpagdt3o.blob.core.windows.net/",
+                                        "queue": "https://cclgstoragey6akyqpagdt3o.queue.core.windows.net/",
+                                        "table": "https://cclgstoragey6akyqpagdt3o.table.core.windows.net/",
+                                        "file": "https://cclgstoragey6akyqpagdt3o.file.core.windows.net/"
+                                    },
+                                    "primaryLocation": "southcentralus",
+                                    "statusOfPrimary": "available"
+                                }
+                            },
+                            {
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "kind": "Storage",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/ccipstoragey6akyqpagdt3o",
+                                "name": "ccipstoragey6akyqpagdt3o",
+                                "type": "Microsoft.Storage/storageAccounts",
+                                "location": "southcentralus",
+                                "tags": {},
+                                "properties": {
+                                    "networkAcls": {
+                                        "bypass": "AzureServices",
+                                        "virtualNetworkRules": [],
+                                        "ipRules": [
+                                            {
+                                                "value": "3.1.1.1",
+                                                "action": "Allow"
+                                            },
+                                            {
+                                                "value": "1.2.2.128/25",
+                                                "action": "Allow"
+                                            }
+                                        ],
+                                        "defaultAction": "Deny"
+                                    },
+                                    "supportsHttpsTrafficOnly": false,
+                                    "encryption": {
+                                        "services": {
+                                            "file": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.5613163Z"
+                                            },
+                                            "blob": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.5613163Z"
+                                            }
+                                        },
+                                        "keySource": "Microsoft.Storage"
+                                    },
+                                    "provisioningState": "Succeeded",
+                                    "creationTime": "2019-08-29T20:28:56.4988547Z",
+                                    "primaryEndpoints": {
+                                        "blob": "https://ccipstoragey6akyqpagdt3o.blob.core.windows.net/",
+                                        "queue": "https://ccipstoragey6akyqpagdt3o.queue.core.windows.net/",
+                                        "table": "https://ccipstoragey6akyqpagdt3o.table.core.windows.net/",
+                                        "file": "https://ccipstoragey6akyqpagdt3o.file.core.windows.net/"
+                                    },
+                                    "primaryLocation": "southcentralus",
+                                    "statusOfPrimary": "available"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o/blobServices/default/containers?api-version=2019-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Thu, 29 Aug 2019 20:30:06 GMT"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "1036"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o/blobServices/default/containers/containerone",
+                                "name": "containerone",
+                                "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+                                "etag": "\"0x8D72CBF8FFFAAD3\"",
+                                "properties": {
+                                    "publicAccess": "Container",
+                                    "leaseStatus": "Unlocked",
+                                    "leaseState": "Available",
+                                    "lastModifiedTime": "2019-08-29T20:29:16.0000000Z",
+                                    "hasImmutabilityPolicy": false,
+                                    "hasLegalHold": false
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o/blobServices/default/containers/containertwo",
+                                "name": "containertwo",
+                                "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+                                "etag": "\"0x8D72CBF900EC8C6\"",
+                                "properties": {
+                                    "publicAccess": "None",
+                                    "leaseStatus": "Unlocked",
+                                    "leaseState": "Available",
+                                    "lastModifiedTime": "2019-08-29T20:29:16.0000000Z",
+                                    "hasImmutabilityPolicy": false,
+                                    "hasLegalHold": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cclgstoragey6akyqpagdt3o/blobServices/default/containers?api-version=2019-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Thu, 29 Aug 2019 20:30:06 GMT"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "12"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": []
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/ccipstoragey6akyqpagdt3o/blobServices/default/containers?api-version=2019-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Thu, 29 Aug 2019 20:30:07 GMT"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "12"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": []
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2019-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-length": [
+                        "9066"
+                    ],
+                    "date": [
+                        "Thu, 29 Aug 2019 20:30:08 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "daa615a0-3805-4595-9004-095ae8242a5c",
+                        "f92a36e2-68bf-4030-820a-c23a7dc85ac4",
+                        "e1d97f66-bd17-4b73-873f-ba3bc279fc85",
+                        "a0f70544-2fde-402d-814e-8c358f7dcb84"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "kind": "Storage",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o",
+                                "name": "cctstoragey6akyqpagdt3o",
+                                "type": "Microsoft.Storage/storageAccounts",
+                                "location": "southcentralus",
+                                "tags": {},
+                                "properties": {
+                                    "networkAcls": {
+                                        "bypass": "AzureServices",
+                                        "virtualNetworkRules": [],
+                                        "ipRules": [],
+                                        "defaultAction": "Allow"
+                                    },
+                                    "supportsHttpsTrafficOnly": false,
+                                    "encryption": {
+                                        "services": {
+                                            "file": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.3582290Z"
+                                            },
+                                            "blob": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.3582290Z"
+                                            }
+                                        },
+                                        "keySource": "Microsoft.Storage"
+                                    },
+                                    "provisioningState": "Succeeded",
+                                    "creationTime": "2019-08-29T20:28:56.2956738Z",
+                                    "primaryEndpoints": {
+                                        "blob": "https://cctstoragey6akyqpagdt3o.blob.core.windows.net/",
+                                        "queue": "https://cctstoragey6akyqpagdt3o.queue.core.windows.net/",
+                                        "table": "https://cctstoragey6akyqpagdt3o.table.core.windows.net/",
+                                        "file": "https://cctstoragey6akyqpagdt3o.file.core.windows.net/"
+                                    },
+                                    "primaryLocation": "southcentralus",
+                                    "statusOfPrimary": "available"
+                                }
+                            },
+                            {
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "kind": "Storage",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cclgstoragey6akyqpagdt3o",
+                                "name": "cclgstoragey6akyqpagdt3o",
+                                "type": "Microsoft.Storage/storageAccounts",
+                                "location": "southcentralus",
+                                "tags": {},
+                                "properties": {
+                                    "networkAcls": {
+                                        "bypass": "AzureServices",
+                                        "virtualNetworkRules": [],
+                                        "ipRules": [],
+                                        "defaultAction": "Allow"
+                                    },
+                                    "supportsHttpsTrafficOnly": false,
+                                    "encryption": {
+                                        "services": {
+                                            "file": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.4676057Z"
+                                            },
+                                            "blob": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.4676057Z"
+                                            }
+                                        },
+                                        "keySource": "Microsoft.Storage"
+                                    },
+                                    "provisioningState": "Succeeded",
+                                    "creationTime": "2019-08-29T20:28:56.4363025Z",
+                                    "primaryEndpoints": {
+                                        "blob": "https://cclgstoragey6akyqpagdt3o.blob.core.windows.net/",
+                                        "queue": "https://cclgstoragey6akyqpagdt3o.queue.core.windows.net/",
+                                        "table": "https://cclgstoragey6akyqpagdt3o.table.core.windows.net/",
+                                        "file": "https://cclgstoragey6akyqpagdt3o.file.core.windows.net/"
+                                    },
+                                    "primaryLocation": "southcentralus",
+                                    "statusOfPrimary": "available"
+                                }
+                            },
+                            {
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "kind": "Storage",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/ccipstoragey6akyqpagdt3o",
+                                "name": "ccipstoragey6akyqpagdt3o",
+                                "type": "Microsoft.Storage/storageAccounts",
+                                "location": "southcentralus",
+                                "tags": {},
+                                "properties": {
+                                    "networkAcls": {
+                                        "bypass": "AzureServices",
+                                        "virtualNetworkRules": [],
+                                        "ipRules": [
+                                            {
+                                                "value": "3.1.1.1",
+                                                "action": "Allow"
+                                            },
+                                            {
+                                                "value": "1.2.2.128/25",
+                                                "action": "Allow"
+                                            }
+                                        ],
+                                        "defaultAction": "Deny"
+                                    },
+                                    "supportsHttpsTrafficOnly": false,
+                                    "encryption": {
+                                        "services": {
+                                            "file": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.5613163Z"
+                                            },
+                                            "blob": {
+                                                "enabled": true,
+                                                "lastEnabledTime": "2019-08-29T20:28:56.5613163Z"
+                                            }
+                                        },
+                                        "keySource": "Microsoft.Storage"
+                                    },
+                                    "provisioningState": "Succeeded",
+                                    "creationTime": "2019-08-29T20:28:56.4988547Z",
+                                    "primaryEndpoints": {
+                                        "blob": "https://ccipstoragey6akyqpagdt3o.blob.core.windows.net/",
+                                        "queue": "https://ccipstoragey6akyqpagdt3o.queue.core.windows.net/",
+                                        "table": "https://ccipstoragey6akyqpagdt3o.table.core.windows.net/",
+                                        "file": "https://ccipstoragey6akyqpagdt3o.file.core.windows.net/"
+                                    },
+                                    "primaryLocation": "southcentralus",
+                                    "statusOfPrimary": "available"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests/templates/storage.json
+++ b/tools/c7n_azure/tests/templates/storage.json
@@ -1,13 +1,17 @@
 {
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "parameters": {
+  "parameters":  {
+        "storageAccountName": {
+          "type": "string",
+          "defaultValue": "[concat('cctstorage', uniqueString(resourceGroup().id))]"
+        }
   },
   "variables": {
   },
   "resources": [
     {
-      "name": "[concat('cctstorage', uniqueString(resourceGroup().id))]",
+      "name": "[parameters('storageAccountName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2016-01-01",
       "sku": {
@@ -16,7 +20,31 @@
       "kind": "Storage",
       "location": "South Central US",
       "tags": {},
-      "properties": {}
+      "properties": {},
+      "resources": [
+        {
+            "type": "blobServices/containers",
+            "apiVersion": "2018-07-01",
+            "name": "default/containerone",
+            "dependsOn": [
+                "[parameters('StorageAccountName')]"
+            ],
+            "properties": {
+                "publicAccess": "Container"
+            }
+        },
+        {
+            "type": "blobServices/containers",
+            "apiVersion": "2018-07-01",
+            "name": "default/containertwo",
+            "dependsOn": [
+                "[parameters('StorageAccountName')]"
+            ],
+            "properties": {
+                "publicAccess": "None"
+            }
+        }
+    ]
     },
     {
       "name": "[concat('cclgstorage', uniqueString(resourceGroup().id))]",

--- a/tools/c7n_azure/tests/test_storage_container.py
+++ b/tools/c7n_azure/tests/test_storage_container.py
@@ -1,0 +1,49 @@
+# Copyright 2019 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from azure_common import BaseTest, arm_template, cassette_name
+from c7n_azure.storage_utils import StorageUtilities
+
+
+class StorageContainerTest(BaseTest):
+    def setUp(self):
+        super(StorageContainerTest, self).setUp()
+        StorageUtilities.get_storage_primary_key.cache_clear()
+
+    def test_storage_schema_validate(self):
+        p = self.load_policy({
+            'name': 'test-storage-container',
+            'resource': 'azure.storage-container'
+        }, validate=True)
+        self.assertTrue(p)
+
+    @arm_template('storage.json')
+    @cassette_name('containers')
+    def test_value_filter(self):
+        p = self.load_policy({
+            'name': 'test-azure-storage-container-enum',
+            'resource': 'azure.storage-container',
+            'filters': [
+                {'type': 'parent',
+                 'filter':
+                    {'type': 'value',
+                     'key': 'name',
+                     'op': 'glob',
+                     'value_type': 'normalize',
+                     'value': 'cctstorage*'}}],
+        })
+        resources = p.run()
+        self.assertEqual(2, len(resources))
+        self.assertEqual({'containerone', 'containertwo'}, set([c['name'] for c in resources]))


### PR DESCRIPTION
```
policies:
          - name: storage-container-public
            description: |
              Find all containers with public access enabled
            resource: azure.storage-container
            filters:
              - type: value
                key: properties.publicAccess
                op: not-equal
                value: None   # Possible values: Blob, Container, None
```

The useful values on containers are:
```
      "publicAccess": "Blob",  # <-- mostly this one
      "lastModifiedTime": "2019-06-18T05:23:44.000Z",
      "hasLegalHold": false,
      "hasImmutabilityPolicy": false
```

While not as numerous as blobs, there is no limit on containers in a subscription, so this could end up running very slow or even failing at large numbers.  The Azure portal makes the same calls in the UI though, so I think it is fair game. 