### PR TITLE
azure - Nightly pipeline pass secrets to tasks + fix AppServicePlan resource_type

### DIFF
--- a/.azure-pipelines/azure-nightly-tests.yml
+++ b/.azure-pipelines/azure-nightly-tests.yml
@@ -43,10 +43,18 @@ jobs:
 
     - script: az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} && az account set -s ${AZURE_SUBSCRIPTION_ID}
       displayName: "Login to Azure"
+      env:
+        AZURE_CLIENT_ID: $(azure-client-id)
+        AZURE_CLIENT_SECRET: $(azure-client-secret)
+        AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
+        AZURE_TENANT_ID: $(azure-tenant-id)
 
     - script: tools/c7n_azure/tests/templates/provision.sh
       displayName: "Provision Azure Resources"
-    
+      env:
+        AZURE_CLIENT_ID: $(azure-client-id)
+        AZURE_CLIENT_SECRET: $(azure-client-secret)
+
     - script: C7N_TEST_RUN=true C7N_FUNCTIONAL=yes pytest tools/c7n_azure/tests
       displayName: "Run Azure tests without cassettes"
 

--- a/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
+++ b/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
@@ -54,7 +54,7 @@ class AppServicePlan(ArmResourceManager):
             'resourceGroup',
             'kind'
         )
-        resource_type = 'Microsoft.Web/sites'
+        resource_type = 'Microsoft.Web/serverfarms'
 
 
 @AppServicePlan.action_registry.register('resize-plan')

--- a/tools/c7n_azure/c7n_azure/resources/web_app.py
+++ b/tools/c7n_azure/c7n_azure/resources/web_app.py
@@ -73,4 +73,4 @@ class WebApp(ArmResourceManager):
             'kind',
             'properties.hostNames[0]'
         )
-        resource_type = 'Microsoft.Web/serverFarms'
+        resource_type = 'Microsoft.Web/sites'


### PR DESCRIPTION
Seems like the recommended approach is to pass envs to tasks individually

https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables