### PR TITLE
Azure - Function Events - limit to 5 events

### DIFF
--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -317,15 +317,16 @@ class AzureEventGridMode(AzureFunctionMode):
     azure event."""
 
     schema = utils.type_schema(FUNCTION_EVENT_TRIGGER_MODE,
-                               events={'type': 'array', 'items': {
-                                   'oneOf': [
-                                       {'type': 'string'},
-                                       {'type': 'object',
-                                        'required': ['resourceProvider', 'event'],
-                                        'properties': {
-                                            'resourceProvider': {'type': 'string'},
-                                            'event': {'type': 'string'}}}]
-                               }},
+                               events={'type': 'array',
+                                    'maxItems': 5,
+                                    'items': {
+                                        'oneOf': [
+                                            {'type': 'string'},
+                                            {'type': 'object',
+                                                'required': ['resourceProvider', 'event'],
+                                                'properties': {
+                                                    'resourceProvider': {'type': 'string'},
+                                                    'event': {'type': 'string'}}}]}},
                                required=['events'],
                                rinherit=AzureFunctionMode.schema)
 

--- a/tools/c7n_azure/tests/test_policy.py
+++ b/tools/c7n_azure/tests/test_policy.py
@@ -18,6 +18,7 @@ from azure_common import BaseTest, DEFAULT_SUBSCRIPTION_ID, arm_template, casset
 from c7n_azure.constants import FUNCTION_EVENT_TRIGGER_MODE, FUNCTION_TIME_TRIGGER_MODE, \
     CONTAINER_EVENT_TRIGGER_MODE, CONTAINER_TIME_TRIGGER_MODE
 from c7n_azure.policy import AzureEventGridMode, AzureFunctionMode, AzureModeCommon
+from jsonschema import ValidationError
 from mock import mock, patch, Mock
 
 
@@ -47,6 +48,25 @@ class AzurePolicyModeTest(BaseTest):
                      }}
             })
             self.assertTrue(p)
+
+    def test_azure_function_event_mode_too_many_events_throws(self):
+        with self.sign_out_patch():
+            with self.assertRaises(ValidationError):
+                self.load_policy({
+                    'name': 'test-azure-serverless-mode',
+                    'resource': 'azure.vm',
+                    'mode': {
+                        'type': FUNCTION_EVENT_TRIGGER_MODE,
+                        'events': [
+                            'VmWrite',
+                            'AppServicePlanWrite',
+                            'CognitiveServiceWrite',
+                            'CosmosDbWrite',
+                            'DataFactoryWrite',
+                            'DataLakeWrite'
+                        ]
+                    }
+                }, validate=True)
 
     def test_azure_function_periodic_mode_schema_validation(self):
         with self.sign_out_patch():

--- a/tools/c7n_azure/tests/test_policy_mode.py
+++ b/tools/c7n_azure/tests/test_policy_mode.py
@@ -46,7 +46,7 @@ class AzurePolicyModeTest(BaseTest):
                              'name': 'testschemaname'
                          }
                      }}
-            })
+            }, validate=True)
             self.assertTrue(p)
 
     def test_azure_function_event_mode_too_many_events_throws(self):
@@ -88,7 +88,7 @@ class AzurePolicyModeTest(BaseTest):
                              'name': 'testschemaname'
                          }
                      }}
-            })
+            }, validate=True)
             self.assertTrue(p)
 
     def test_azure_function_periodic_schema_schedule_valid(self):
@@ -192,7 +192,7 @@ class AzurePolicyModeTest(BaseTest):
                 'mode':
                     {'type': CONTAINER_EVENT_TRIGGER_MODE,
                      'events': ['VmWrite']}
-            })
+            }, validate=True)
             self.assertTrue(p)
 
     def test_container_periodic_mode_schema_validation(self):
@@ -203,7 +203,7 @@ class AzurePolicyModeTest(BaseTest):
                 'mode':
                     {'type': CONTAINER_TIME_TRIGGER_MODE,
                      'schedule': '*/5 * * * *'}
-            })
+            }, validate=True)
             self.assertTrue(p)
 
     def test_init_azure_function_mode_with_service_plan(self):


### PR DESCRIPTION
Adds json schema check for a maximum of 5 events on an Azure Function event grid trigger.

Adds unit test for the case and fixes other unit tests for policy.py so that they validate the schema being passed in

Closes #4669 