### PR TITLE
cask - linux install should overwrite previous binary

### DIFF
--- a/tools/cask/readme.md
+++ b/tools/cask/readme.md
@@ -15,7 +15,6 @@ Linux
 
 ```shell
 sudo sh -c 'wget -q https://cloudcustodian.io/downloads/custodian-cask/linux-latest/custodian-cask -O /usr/local/bin/custodian-cask && chmod +x /usr/local/bin/custodian-cask'
-
 ```
 
 MacOS (Darwin)

--- a/tools/cask/readme.md
+++ b/tools/cask/readme.md
@@ -14,7 +14,8 @@ Install
 Linux
 
 ```shell
-sudo sh -c 'wget -q https://cloudcustodian.io/downloads/custodian-cask/linux-latest/custodian-cask -P /usr/local/bin && chmod +x /usr/local/bin/custodian-cask'
+sudo sh -c 'wget -q https://cloudcustodian.io/downloads/custodian-cask/linux-latest/custodian-cask -O /usr/local/bin/custodian-cask && chmod +x /usr/local/bin/custodian-cask'
+
 ```
 
 MacOS (Darwin)


### PR DESCRIPTION
Pass full output path rather than directory to force `wget` to overwrite when updating. 

Previous behavior would add a `.1` to the end of the new binary when downloading it, so the user never actually got the update. 