### PR TITLE
tests - clean up deprecations

### DIFF
--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -195,7 +195,7 @@ class TestUtils(unittest.TestCase):
     # Backport from stdlib for 2.7 compat, drop when 2.7 support is dropped.
     def assertRegex(self, text, expected_regex, msg=None):
         """Fail the test unless the text matches the regular expression."""
-        if isinstance(expected_regex, (str, bytes)):
+        if isinstance(expected_regex, six.string_types):
             assert expected_regex, "expected_regex must not be empty."
             expected_regex = re.compile(expected_regex)
         if not expected_regex.search(text):

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -191,6 +191,19 @@ class TestUtils(unittest.TestCase):
 
         return log_file
 
+    # Backport from stdlib for 2.7 compat, drop when 2.7 support is dropped.
+    def assertRegex(self, text, expected_regex, msg=None):
+        """Fail the test unless the text matches the regular expression."""
+        if isinstance(expected_regex, (str, bytes)):
+            assert expected_regex, "expected_regex must not be empty."
+            expected_regex = re.compile(expected_regex)
+        if not expected_regex.search(text):
+            standardMsg = "Regex didn't match: %r not found in %r" % (
+                expected_regex.pattern, text)
+            # _formatMessage ensures the longMessage option is respected
+            msg = self._formatMessage(msg, standardMsg)
+            raise self.failureException(msg)
+
 
 class TextTestIO(io.StringIO):
 

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -18,6 +18,7 @@ import datetime
 import io
 import logging
 import os
+import re
 import shutil
 import tempfile
 import unittest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,7 +249,7 @@ class SchemaTest(CliTest):
             '$ref': '#/definitions/filters_common/value_from'
         }
         result = ElementSchema.schema(generate()['definitions'], test_schema)
-        self.assertEquals(result, ValuesFrom.schema)
+        self.assertEqual(result, ValuesFrom.schema)
 
     def test_schema_multi_expand(self):
         test_schema = {
@@ -289,14 +289,14 @@ class SchemaTest(CliTest):
         })
 
         result = yaml_dump(ElementSchema.schema(generate()['definitions'], test_schema))
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_schema_expand_not_found(self):
         test_schema = {
             '$ref': '#/definitions/filters_common/invalid_schema'
         }
         result = ElementSchema.schema(generate()['definitions'], test_schema)
-        self.assertEquals(result, None)
+        self.assertEqual(result, None)
 
 
 class ReportTest(CliTest):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,15 @@ from c7n.config import Config
 from .common import BaseTest
 
 
+class TestTesting(BaseTest):
+
+    def test_assert_regex(self):
+        self.assertRaises(
+            AssertionError,
+            self.assertRegex,
+            "^hello", "not hello world")
+
+
 class Backoff(BaseTest):
 
     def test_retry_passthrough(self):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -146,7 +146,7 @@ class WebhookTest(BaseTest):
             "body": "resources[].name",
             "body-size": 10,
             "headers": {
-                "test": "`header`"
+                "test": "'header'"
             },
             "query-params": {
                 "foo": "resources[0].name"

--- a/tools/c7n_azure/requirements.txt
+++ b/tools/c7n_azure/requirements.txt
@@ -1,4 +1,4 @@
-vcrpy==2.0.1
+vcrpy==2.1.0
 vcrpy_unittest==0.1.7
 backports.functools_lru_cache==1.5
 azure-functions; python_version >= '3.6'

--- a/tools/c7n_azure/tests/test_cosmos_db.py
+++ b/tools/c7n_azure/tests/test_cosmos_db.py
@@ -122,7 +122,6 @@ class CosmosDBTest(BaseTest):
                  'include': ['3.1.1.1']}],
         }, validate=True)
         resources = p.run()
-        print(resources)
         self.assertEqual(1, len(resources))
 
     @arm_template('cosmosdb.json')

--- a/tools/c7n_azure/tests/test_policy_mode.py
+++ b/tools/c7n_azure/tests/test_policy_mode.py
@@ -273,7 +273,7 @@ class AzurePolicyModeTest(BaseTest):
 
         function_mode = AzureFunctionMode(p)
         params = function_mode.get_function_app_params()
-        self.assertRegexpMatches(params.function_app_name, "invalid-policy-name1-[a-zA-Z0-9]+")
+        self.assertRegex(params.function_app_name, "invalid-policy-name1-[a-zA-Z0-9]+")
 
     def test_init_azure_function_mode_with_resource_ids(self):
         ai_id = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups' \


### PR DESCRIPTION
a few assorted cleanups on deprecations during test execution. after this the only deprecation warnings are from dependencies.