### PR TITLE
azure - metric filter - support for child resources

### DIFF
--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -185,19 +185,12 @@ class MetricFilter(Filter):
             processed = list(w.map(self.process_resource, resources))
             return [item for item in processed if item is not None]
 
-    def get_metric_data(self, resource):
+    def append_metric_data(self, resource):
         cached_metric_data = self._get_cached_metric_data(resource)
         if cached_metric_data:
             return cached_metric_data['measurement']
         try:
-            metrics_data = self.client.metrics.list(
-                resource['id'],
-                timespan=self.timespan,
-                interval=self.interval,
-                metricnames=self.metric,
-                aggregation=self.aggregation,
-                filter=self.filter
-            )
+            metrics_data = self.get_metric_data(resource)
         except HttpOperationError as e:
             self.log.error("could not get metric:%s on %s. Full error: %s" % (
                 self.metric, resource['id'], str(e)))
@@ -212,6 +205,16 @@ class MetricFilter(Filter):
         self._write_metric_to_resource(resource, metrics_data, m)
 
         return m
+    
+    def get_metric_data(self, resource):
+        return self.client.metrics.list(
+                resource['id'],
+                timespan=self.timespan,
+                interval=self.interval,
+                metricnames=self.metric,
+                aggregation=self.aggregation,
+                filter=self.filter
+            )
 
     def _write_metric_to_resource(self, resource, metrics_data, m):
         resource_metrics = resource.setdefault(get_annotation_prefix('metrics'), {})
@@ -236,7 +239,7 @@ class MetricFilter(Filter):
         return metrics.get(self._get_metrics_cache_key())
 
     def passes_op_filter(self, resource):
-        m_data = self.get_metric_data(resource)
+        m_data = self.append_metric_data(resource)
         if m_data is None:
             return self.no_data_action == 'include'
         aggregate_value = self.func(m_data)

--- a/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
+++ b/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
@@ -22,7 +22,7 @@ from azure.mgmt.cosmosdb.models import VirtualNetworkRule
 from c7n_azure import constants
 from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.actions.firewall import SetFirewallAction
-from c7n_azure.filters import FirewallRulesFilter
+from c7n_azure.filters import (FirewallRulesFilter, MetricFilter)
 from c7n_azure.provider import resources
 from c7n_azure.query import ChildResourceManager, ChildTypeInfo
 from c7n_azure.resources.arm import ArmResourceManager
@@ -172,6 +172,26 @@ class CosmosDBDatabase(CosmosDBChildResource):
 
         return databases
 
+@CosmosDBDatabase.filter_registry.register('metric')
+class CosmosDBDatabaseMetricFilter(MetricFilter):
+    """CosmosDB Database Metric Filter
+    """
+    def __init__(self, data, manager=None):
+        super().__init__(data, manager)
+    
+    def get_metric_data(self, resource):
+        if self.filter is None:
+            parent_filter = "DatabaseName eq '%s'" % resource['id']
+        else:
+            parent_filter = "%s and DatabaseName eq '%s'" % (self.filter, resource['id'])
+        return self.client.metrics.list(
+                resource['c7n:parent-id'],
+                timespan=self.timespan,
+                interval=self.interval,
+                metricnames=self.metric,
+                aggregation=self.aggregation,
+                filter=parent_filter
+            )
 
 @resources.register('cosmosdb-collection')
 class CosmosDBCollection(CosmosDBChildResource):


### PR DESCRIPTION
The following is a proposal for how we can extend the current MetricFilter to make it easy to support child resources. It also includes an example of a metric filter for cosmosdb-databases. This can be tested with the following yaml policy:
```yaml
policies:
  - name: cosmosdb-database-metric
    resource: azure.cosmosdb-database
    filters:
      - type: metric
        metric: TotalRequestUnits
        op: le
        aggregation: total
        threshold: 1000
        timeframe: 24
```

The core of the proposed change is refactoring the portion of `MetricFilter.get_metric_data` that changes between child and parent resources into a function. This way child resources can implement their own metric filter by inheriting from MetricFilter and overriding the method (get_metric_data) needed to implement their custom logic. An example of this is included for CosmosDb.Database

Please comment and ask further questions. I have raw notes going over the different solutions to this problem that I am happy to share, but the proposed solution here seems to be the best. Once everyone has agreed on an implementation I will extend the methodology for other child resources, include tests and new example documentation.