### PR TITLE
utils - remove worker decorator

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import csv
 from datetime import datetime, timedelta
-import functools
 import json
 import itertools
 import logging

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -360,6 +360,9 @@ def snapshot_identifier(prefix, db_identifier):
     return '%s-%s-%s' % (prefix, db_identifier, now.strftime('%Y-%m-%d-%H-%M'))
 
 
+retry_log = logging.getLogger('c7n.retry')
+
+
 def get_retry(codes=(), max_attempts=8, min_delay=1, log_retries=False):
     """Decorator for retry boto3 api call on transient errors.
 
@@ -391,7 +394,7 @@ def get_retry(codes=(), max_attempts=8, min_delay=1, log_retries=False):
                 elif idx == max_attempts - 1:
                     raise
                 if log_retries:
-                    worker_log.log(
+                    retry_log.log(
                         log_retries,
                         "retrying %s on error:%s attempt:%d last delay:%0.2f",
                         func, e.response['Error']['Code'], idx, delay)
@@ -432,30 +435,6 @@ class IPv4Network(ipaddress.IPv4Network):
         if isinstance(other, ipaddress._BaseNetwork):
             return self.supernet_of(other)
         return super(IPv4Network, self).__contains__(other)
-
-
-worker_log = logging.getLogger('c7n.worker')
-
-
-def worker(f):
-    """Generic wrapper to log uncaught exceptions in a function.
-
-    When we cross concurrent.futures executor boundaries we lose our
-    traceback information, and when doing bulk operations we may tolerate
-    transient failures on a partial subset. However we still want to have
-    full accounting of the error in the logs, in a format that our error
-    collection (cwl subscription) can still pickup.
-    """
-    def _f(*args, **kw):
-        try:
-            return f(*args, **kw)
-        except Exception:
-            worker_log.exception(
-                'Error invoking %s',
-                "%s.%s" % (f.__module__, f.__name__))
-            raise
-    functools.update_wrapper(_f, f)
-    return _f
 
 
 def reformat_schema(model):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -928,7 +928,7 @@ class RDSSnapshotTest(BaseTest):
         def brooklyn(delay):
             return
 
-        output = self.capture_logging("c7n.worker", level=logging.DEBUG)
+        output = self.capture_logging("c7n.retry", level=logging.DEBUG)
         self.patch(time, "sleep", brooklyn)
         self.change_environment(AWS_DEFAULT_REGION="us-east-1")
         p = self.load_policy(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,51 +78,6 @@ class Backoff(BaseTest):
             self.assertTrue(i < maxv)
 
 
-class WorkerDecorator(BaseTest):
-
-    def test_method_worker(self):
-
-        class foo(object):
-
-            @utils.worker
-            def bar(self, err=False):
-                """abc"""
-                if err:
-                    raise ValueError("foo")
-                return 42
-
-        i = foo()
-        log_output = self.capture_logging("c7n.worker")
-        self.assertEqual(i.bar(), 42)
-        self.assertRaises(ValueError, i.bar, True)
-        self.assertTrue(
-            log_output.getvalue().startswith(
-                "Error invoking tests.test_utils.bar\nTraceback"
-            )
-        )
-
-    def test_function_worker(self):
-
-        @utils.worker
-        def rabbit(err=False):
-            """what's up doc"""
-            if err:
-                raise ValueError("more carrots")
-            return 42
-
-        self.assertEqual(rabbit.__doc__, "what's up doc")
-        log_output = self.capture_logging("c7n.worker")
-        self.assertEqual(rabbit(), 42)
-        self.assertEqual(log_output.getvalue(), "")
-        self.assertRaises(ValueError, rabbit, True)
-        self.assertTrue(
-            log_output.getvalue().startswith(
-                "Error invoking tests.test_utils.rabbit\nTraceback"
-            )
-        )
-        self.assertTrue("more carrots" in log_output.getvalue())
-
-
 class UrlConfTest(BaseTest):
 
     def test_parse_url(self):


### PR DESCRIPTION
the worker decorator wasn't really being used and wasn't needed, go ahead and remove.