### PR TITLE
azure - update provision\cleanup scripts to support --skip option

### DIFF
--- a/.azure-pipelines/azure-nightly-tests.yml
+++ b/.azure-pipelines/azure-nightly-tests.yml
@@ -49,7 +49,9 @@ jobs:
         AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
         AZURE_TENANT_ID: $(azure-tenant-id)
 
-    - script: tools/c7n_azure/tests/templates/provision.sh
+    # Skip some resources due to some restrictions with their provisioning using Service Principal account
+    # We maintain those resources in the test subscription available for the tests
+    - script: tools/c7n_azure/tests/templates/provision.sh --skip keyvault cost-management-export containerservice
       displayName: "Provision Azure Resources"
       env:
         AZURE_CLIENT_ID: $(azure-client-id)
@@ -58,6 +60,6 @@ jobs:
     - script: C7N_TEST_RUN=true C7N_FUNCTIONAL=yes pytest tools/c7n_azure/tests
       displayName: "Run Azure tests without cassettes"
 
-    - script: tools/c7n_azure/tests/templates/cleanup.sh
+    - script: tools/c7n_azure/tests/templates/cleanup.sh --skip keyvault cost-management-export containerservice
       displayName: "Cleanup Azure Resources"
       condition: always()

--- a/tools/c7n_azure/tests/templates/cleanup.sh
+++ b/tools/c7n_azure/tests/templates/cleanup.sh
@@ -6,6 +6,22 @@ IFS=$'\n\t'
 resourceLocation="South Central US"
 templateDirectory="$( cd "$( dirname "$0" )" && pwd )"
 
+if [[ $# -eq 0 ]]; then
+    # If there is no arguments -- deploy everything
+    cleanup_all=1
+else
+    if [[ $1 == "--skip" ]]; then
+        # If we see option '--skip' -- deploy everything except for specific templates
+        cleanup_all=1
+        skip_list="${@:2}"
+        echo $skip_list
+    else
+        # If there is no '--skip', deploy specific templates
+        cleanup_all=0
+        cleanup_list="${@:1}"
+    fi
+fi
+
 delete_resource() {
     echo "Delete for $filenameNoExtension started"
     fileName=${1##*/}
@@ -36,23 +52,40 @@ delete_policy_assignment() {
     echo "Delete for policy assignment complete"
 }
 
+
+function should_cleanup() {
+    if [[ ${cleanup_all} -eq 1 ]]; then
+        if ! [[ "${skip_list[@]}" =~ $1 ]]; then
+            return 1
+        fi
+    else
+        if [[ "${cleanup_list[@]}" =~ $1 ]]; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
 # Delete RG's for each template file
 for file in "$templateDirectory"/*.json; do
     fileName=${file##*/}
     filenameNoExtension=${fileName%.*}
 
-    if [ $# -eq 0 ] || [[ "$@" =~ "$filenameNoExtension" ]]; then
+    should_cleanup "$filenameNoExtension"
+    if [[ $? -eq 1 ]]; then
         delete_resource ${file} &
     fi
 done
 
 # Destroy ACS resource
-if [ $# -eq 0 ] || [[ "$@" =~ "containerservice" ]]; then
+should_cleanup "containerservice"
+if [[ $? -eq 1 ]]; then
     delete_acs &
 fi
 
+should_cleanup "policy"
 # Destroy Azure Policy Assignment
-if [ $# -eq 0 ] || [[ "$@" =~ "policyassignment" ]]; then
+if [[ $? -eq 1 ]]; then
     delete_policy_assignment &
 fi
 

--- a/tools/c7n_azure/tests/templates/cost-management-export-body.template
+++ b/tools/c7n_azure/tests/templates/cost-management-export-body.template
@@ -3,7 +3,7 @@
         \"schedule\": {
             \"recurrence\": \"Daily\",
             \"recurrencePeriod\": {
-                \"from\": \"2019-08-28T02:38:12.680Z\",
+                \"from\": \"$(date --iso-8601=minutes)\",
                 \"to\": \"2050-02-01T08:00:00.000Z\"
             },
             \"status\": \"Active\"

--- a/tools/c7n_azure/tests/templates/provision.sh
+++ b/tools/c7n_azure/tests/templates/provision.sh
@@ -5,13 +5,33 @@ IFS=$'\n\t'
 
 # If `az ad signed-in-user show` fails then update your Azure CLI version
 
+# If you can't provisiong keyvault or cost-management-export resources please ensure you use
+# your user account and not a Service Principals.
+# cost-management-export: requires SP to have valid email claim
+# keyvault: Managed Storage can't be provisioned with SP
+
 resourceLocation="South Central US"
 templateDirectory="$( cd "$( dirname "$0" )" && pwd )"
 
-if [ $# -eq 0 ] || [[ "$@" =~ "aks" ]]; then
-    if [[ -z "$AZURE_CLIENT_ID" ]] || [[ -z "$AZURE_CLIENT_SECRET" ]]; then
-        echo "AZURE_CLIENT_ID AND AZURE_CLIENT_SECRET environment variables are required to deploy AKS"
-        exit 1
+if [[ $(az account show --query user.type --out tsv) == "user" ]]; then
+    is_user=1
+else
+    is_user=0
+fi
+
+if [[ $# -eq 0 ]]; then
+    # If there is no arguments -- deploy everything
+    deploy_all=1
+else
+    if [[ $1 == "--skip" ]]; then
+        # If we see option '--skip' -- deploy everything except for specific templates
+        deploy_all=1
+        skip_list="${@:2}"
+        echo $skip_list
+    else
+        # If there is no '--skip', deploy specific templates
+        deploy_all=0
+        deploy_list="${@:1}"
     fi
 fi
 
@@ -26,12 +46,12 @@ deploy_resource() {
 
     if [[ "$fileName" == "keyvault.json" ]]; then
 
-        if [[ $(az account show --query user.type --out tsv) == "user" ]]; then
-            azureAdUserObjectId=$(az ad signed-in-user show --query objectId --output tsv)
-        else
-            azureAdUserObjectId=$(az ad sp  show --id ${AZURE_CLIENT_ID} --query objectId --out tsv)
+        if [[ ${is_user} -ne 1 ]]; then
+            echo "KeyVault can't be provisioned with Service Principal due to Keyvault Managed Storage Account restrictions"
+            exit 1
         fi
 
+        azureAdUserObjectId=$(az ad signed-in-user show --query objectId --output tsv)
         az group deployment create --resource-group $rgName --template-file $file \
             --parameters "userObjectId=$azureAdUserObjectId" --output None
 
@@ -54,6 +74,11 @@ deploy_resource() {
         az group deployment create --resource-group $rgName --template-file $file --parameters client_id=$AZURE_CLIENT_ID client_secret=$AZURE_CLIENT_SECRET --mode Complete --output None
 
     elif [[ "$fileName" == "cost-management-export.json" ]]; then
+
+        if [[ ${is_user} -ne 1 ]]; then
+            echo "Cost Management Export can't be provisioned with Service Principal due to Keyvault Managed Storage Account restrictions"
+            exit 1
+        fi
 
         # Deploy storage account required for the export
         az group deployment create --resource-group $rgName --template-file $file --mode Complete --output None
@@ -91,21 +116,46 @@ deploy_policy_assignment() {
     echo "Deployment for policy assignment complete"
 }
 
+function should_deploy() {
+    if [[ ${deploy_all} -eq 1 ]]; then
+        if ! [[ "${skip_list[@]}" =~ $1 ]]; then
+            return 1
+        fi
+    else
+        if [[ "${deploy_list[@]}" =~ $1 ]]; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# Ensure AZURE_CLIENT_ID and AZURE_CLIENT_SECRET are available for AKS deployment
+should_deploy "aks"
+if [[ $? -eq 1 ]]; then
+    if [[ -z "$AZURE_CLIENT_ID" ]] || [[ -z "$AZURE_CLIENT_SECRET" ]]; then
+        echo "AZURE_CLIENT_ID AND AZURE_CLIENT_SECRET environment variables are required to deploy AKS"
+        exit 1
+    fi
+fi
+
 # Create resource groups and deploy for each template file
 for file in "$templateDirectory"/*.json; do
     fileName=${file##*/}
     filenameNoExtension=${fileName%.*}
-
-    if [ $# -eq 0 ] || [[ "$@" =~ "$filenameNoExtension" ]]; then
+    should_deploy "$filenameNoExtension"
+    if [[ $? -eq 1 ]]; then
         deploy_resource ${file} &
     fi
 done
 
-if [ $# -eq 0 ] || [[ "$@" =~ "containerservice" ]]; then
+# Provision non-arm resources
+should_deploy "containerservice"
+if [[ $? -eq 1 ]]; then
     deploy_acs &
 fi
 
-if [ $# -eq 0 ] || [[ "$@" =~ "policyassignment" ]]; then
+should_deploy "policy"
+if [[ $? -eq 1 ]]; then
     deploy_policy_assignment &
 fi
 

--- a/tools/c7n_azure/tests/templates/provision.sh
+++ b/tools/c7n_azure/tests/templates/provision.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 
 # If `az ad signed-in-user show` fails then update your Azure CLI version
 
-# If you can't provisiong keyvault or cost-management-export resources please ensure you use
+# If you can't provision keyvault or cost-management-export resources please ensure you use
 # your user account and not a Service Principals.
 # cost-management-export: requires SP to have valid email claim
 # keyvault: Managed Storage can't be provisioned with SP


### PR DESCRIPTION
Some resources can't be currently provisioned using Service Principal auth.

Keyvault: managed storage can't be provisioned using SP (https://github.com/MicrosoftDocs/azure-docs/issues/26079)

cost-management-export: requires SP to have valid email claim