### PR TITLE
azure - update firewall-rules filter to use effective rule set

### DIFF
--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -531,9 +531,12 @@ class FirewallRulesFilter(Filter):
     specific notation.
 
     **include**: True if all IP space listed is included in firewall.
+
     **any**: True if any overlap in IP space exists.
+
     **only**: True if firewall IP space only includes IPs from provided space
     (firewall is subset of provided space).
+
     **equal**: the list of IP ranges or CIDR that firewall rules must match exactly.
 
     :example:

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -132,11 +132,14 @@ class KeyVaultFirewallRulesFilter(FirewallRulesFilter):
             resource['properties'] = vault.properties.serialize()
 
         if 'networkAcls' not in resource['properties']:
-            return []
+            return IPSet(['0.0.0.0/0'])
 
-        ip_rules = resource['properties']['networkAcls']['ipRules']
+        if resource['properties']['networkAcls']['defaultAction'] == 'Deny':
+            ip_rules = resource['properties']['networkAcls']['ipRules']
+            resource_rules = IPSet([r['value'] for r in ip_rules])
+        else:
+            resource_rules = IPSet(['0.0.0.0/0'])
 
-        resource_rules = IPSet([r['value'] for r in ip_rules])
         return resource_rules
 
 

--- a/tools/c7n_azure/c7n_azure/resources/storage.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage.py
@@ -194,9 +194,11 @@ class StorageFirewallRulesFilter(FirewallRulesFilter):
 
     def _query_rules(self, resource):
 
-        ip_rules = resource['properties']['networkAcls']['ipRules']
-
-        resource_rules = IPSet([r['value'] for r in ip_rules])
+        if resource['properties']['networkAcls']['defaultAction'] == 'Deny':
+            ip_rules = resource['properties']['networkAcls']['ipRules']
+            resource_rules = IPSet([r['value'] for r in ip_rules])
+        else:
+            resource_rules = IPSet(['0.0.0.0/0'])
 
         return resource_rules
 


### PR DESCRIPTION
We didn't consider Default action previously. That way, if all rules were properly configured, but Firewall was disabled, we won't be able to find resources with violation without extra filters in c7n.

This change updates the behavior to consider Default action by appending 0.0.0.0/0 CIDR if default action is Allow (since Azure resources can't explicitly block certain IPs).

Update tests to verify changed behavior for `_query_rules`