### PR TITLE
aws - copy related tag more explicit handling of missing related ids

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -1017,11 +1017,12 @@ class CopyRelatedResourceTag(Tag):
         return self
 
     def process(self, resources):
-        related_resources = list(
-            zip(jmespath.search('[].[%s || "c7n:NotFound"]|[]' % self.data['key'], resources),
-                resources))
+        related_resources = []
+        for rrid, r in zip(jmespath.search('[].[%s]' % self.data['key'], resources),
+                           resources):
+            related_resources.append((rrid[0], r))
         related_ids = set([r[0] for r in related_resources])
-        related_ids.discard('c7n:NotFound')
+        related_ids.discard(None)
         related_tag_map = self.get_resource_tag_map(self.data['resource'], related_ids)
 
         missing_related_tags = related_ids.difference(related_tag_map.keys())


### PR DESCRIPTION
closes #4754

todo add another test, or rearrange existing partial test data, this was succeeding previously mostly due to ordering of returned resources.