### PR TITLE
azure - subscription ID override works for CLI auth

### DIFF
--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -180,17 +180,18 @@ class Session(object):
                 'access_token': os.environ.get(constants.ENV_ACCESS_TOKEN),
                 'tenant_id': os.environ.get(constants.ENV_TENANT_ID),
                 'use_msi': bool(os.environ.get(constants.ENV_USE_MSI)),
-                'subscription_id': os.environ.get(constants.ENV_SUB_ID),
+                'subscription_id':
+                    self.subscription_id_override or os.environ.get(constants.ENV_SUB_ID),
                 'keyvault_client_id': os.environ.get(constants.ENV_KEYVAULT_CLIENT_ID),
                 'keyvault_secret_id': os.environ.get(constants.ENV_KEYVAULT_SECRET_ID),
                 'enable_cli_auth': True
             }
 
+        self._authenticate()
+
         # Let provided id parameter override everything else
         if self.subscription_id_override is not None:
-            self._auth_params['subscription_id'] = self.subscription_id_override
-
-        self._authenticate()
+            self.subscription_id = self.subscription_id_override
 
         if self.credentials is None:
             log.error('Unable to authenticate with Azure.')

--- a/tools/c7n_azure/tests/test_provider.py
+++ b/tools/c7n_azure/tests/test_provider.py
@@ -5,21 +5,19 @@ from c7n.config import Config
 
 
 class ProviderTest(BaseTest):
+    def test_initialize_default_account_id(self):
+        # Patch get_subscription_id during provider initialization
+        with patch('c7n_azure.session.Session.get_subscription_id',
+                   return_value=DEFAULT_SUBSCRIPTION_ID):
+            options = Config.empty()
+            azure = Azure()
+            azure.initialize(options)
+            self.assertEqual(options['account_id'], DEFAULT_SUBSCRIPTION_ID)
+            session = azure.get_session_factory(options)()
 
-    @patch('c7n_azure.session.Session.get_subscription_id', return_value=DEFAULT_SUBSCRIPTION_ID)
-    def test_initialize_default_account_id(self, get_subscription_id_mock):
-        options = Config.empty()
-        azure = Azure()
-        azure.initialize(options)
+        self.assertEqual(DEFAULT_SUBSCRIPTION_ID, session.get_subscription_id())
 
-        self.assertEqual(options['account_id'], DEFAULT_SUBSCRIPTION_ID)
-
-        session = azure.get_session_factory(options)()
-        session._initialize_session()
-        self.assertEqual(session.subscription_id, DEFAULT_SUBSCRIPTION_ID)
-
-    @patch('c7n_azure.session.Session.get_subscription_id', return_value=DEFAULT_SUBSCRIPTION_ID)
-    def test_initialize_custom_account_id(self, get_subscription_id_mock):
+    def test_initialize_custom_account_id(self):
         sample_account_id = "00000000-5106-4743-99b0-c129bfa71a47"
         options = Config.empty()
         options['account_id'] = sample_account_id
@@ -28,5 +26,4 @@ class ProviderTest(BaseTest):
         self.assertEqual(options['account_id'], sample_account_id)
 
         session = azure.get_session_factory(options)()
-        session._initialize_session()
-        self.assertEqual(session.subscription_id, sample_account_id)
+        self.assertEqual(sample_account_id, session.get_subscription_id())


### PR DESCRIPTION
plus test refactor/cleanup 