### PR TITLE
azure - tests fixes for KeyVault, Storage permissions, deployment units

### DIFF
--- a/.azure-pipelines/azure-nightly-tests.yml
+++ b/.azure-pipelines/azure-nightly-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Skip some resources due to some restrictions with their provisioning using Service Principal account
     # We maintain those resources in the test subscription available for the tests
-    - script: tools/c7n_azure/tests/templates/provision.sh --skip keyvault cost-management-export containerservice
+    - script: tools/c7n_azure/tests/templates/provision.sh --skip keyvault cost-management-export containerservice databricks
       displayName: "Provision Azure Resources"
       env:
         AZURE_CLIENT_ID: $(azure-client-id)
@@ -51,7 +51,7 @@ jobs:
     - script: C7N_TEST_RUN=true C7N_FUNCTIONAL=yes pytest -v -m "not skiplive" tools/c7n_azure/tests
       displayName: "Run Azure tests without cassettes"
 
-    - script: tools/c7n_azure/tests/templates/cleanup.sh --skip keyvault cost-management-export containerservice
+    - script: tools/c7n_azure/tests/templates/cleanup.sh --skip keyvault cost-management-export containerservice databricks
       displayName: "Cleanup Azure Resources"
       condition: always()
 
@@ -75,7 +75,8 @@ jobs:
     - script: python -m pip install --upgrade pip && pip install . && pip install -r requirements-dev.txt
       displayName: "Install Dependencies"
 
-    - script: tools/c7n_azure/tests/azure-functions/test_functions.sh
+    - script: ./test_functions.sh
+      workingDirectory: tools/c7n_azure/tests/azure-functions
       displayName: "Run Azure Functions Test"
       env:
         AZURE_CLIENT_ID: $(azure-client-id)

--- a/tools/c7n_azure/tests/test_databricks.py
+++ b/tools/c7n_azure/tests/test_databricks.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import pytest
+
 from azure_common import BaseTest, arm_template
 
 
@@ -25,7 +27,9 @@ class DatabricksTest(BaseTest):
             }, validate=True)
             self.assertTrue(p)
 
+    # Skip due to Azure Storage RBAC issues when databricks resource is deployed
     @arm_template('databricks.json')
+    @pytest.mark.skiplive
     def test_find_by_name(self):
         p = self.load_policy({
             'name': 'test-azure-databricks',

--- a/tools/c7n_azure/tests/test_deployment_units.py
+++ b/tools/c7n_azure/tests/test_deployment_units.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import uuid
+
 from azure_common import BaseTest, requires_arm_polling
 from c7n_azure import constants
 from c7n_azure.constants import FUNCTION_DOCKER_VERSION
@@ -30,7 +32,8 @@ from c7n.utils import local_session
 @requires_arm_polling
 class DeploymentUnitsTest(BaseTest):
 
-    rg_name = 'cloud-custodian-test-deployment-units'
+    suffix = str(uuid.uuid1())[:8]
+    rg_name = 'cloud-custodian-test-deployment-units' + suffix
     rg_location = 'westus'
 
     @classmethod
@@ -64,7 +67,7 @@ class DeploymentUnitsTest(BaseTest):
         self._validate(unit, params)
 
     def test_storage_account(self):
-        params = {'name': 'custodianaccount47182745',
+        params = {'name': 'custodianaccount{0}'.format(self.suffix),
                   'location': self.rg_location,
                   'resource_group_name': self.rg_name}
         unit = StorageAccountUnit()
@@ -105,7 +108,7 @@ class DeploymentUnitsTest(BaseTest):
     def test_function_app_consumption(self):
         # provision storage account
         sa_params = {
-            'name': 'custodianaccount47182748',
+            'name': 'custodianaccount{0}'.format(self.suffix),
             'location': self.rg_location,
             'resource_group_name': self.rg_name}
         storage_unit = StorageAccountUnit()
@@ -114,7 +117,7 @@ class DeploymentUnitsTest(BaseTest):
 
         # provision function app
         func_params = {
-            'name': 'cc-consumption-47182748',
+            'name': 'cc-consumption-{0}'.format(self.suffix),
             'location': self.rg_location,
             'resource_group_name': self.rg_name,
             'app_service_plan_id': None,  # auto-provision a dynamic app plan
@@ -132,7 +135,7 @@ class DeploymentUnitsTest(BaseTest):
     def test_function_app_dedicated(self):
         # provision storage account
         sa_params = {
-            'name': 'custodianaccount47182741',
+            'name': 'custodianaccount{0}'.format(self.suffix),
             'location': self.rg_location,
             'resource_group_name': self.rg_name}
         storage_unit = StorageAccountUnit()
@@ -150,7 +153,7 @@ class DeploymentUnitsTest(BaseTest):
         app_plan = app_plan_unit.provision(app_plan_params)
 
         # provision function app
-        func_app_name = 'cc-dedicated-47182748'
+        func_app_name = 'cc-dedicated-{0}'.format(self.suffix)
         func_params = {
             'name': func_app_name,
             'location': self.rg_location,

--- a/tools/c7n_azure/tests/test_deployment_units.py
+++ b/tools/c7n_azure/tests/test_deployment_units.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import uuid
-
 from azure_common import BaseTest, requires_arm_polling
 from c7n_azure import constants
 from c7n_azure.constants import FUNCTION_DOCKER_VERSION
@@ -32,8 +30,7 @@ from c7n.utils import local_session
 @requires_arm_polling
 class DeploymentUnitsTest(BaseTest):
 
-    suffix = str(uuid.uuid1())[:8]
-    rg_name = 'cloud-custodian-test-deployment-units' + suffix
+    rg_name = 'cloud-custodian-test-deployment-units'
     rg_location = 'westus'
 
     @classmethod
@@ -67,7 +64,7 @@ class DeploymentUnitsTest(BaseTest):
         self._validate(unit, params)
 
     def test_storage_account(self):
-        params = {'name': 'custodianaccount{0}'.format(self.suffix),
+        params = {'name': 'custodianaccount47182745',
                   'location': self.rg_location,
                   'resource_group_name': self.rg_name}
         unit = StorageAccountUnit()
@@ -108,7 +105,7 @@ class DeploymentUnitsTest(BaseTest):
     def test_function_app_consumption(self):
         # provision storage account
         sa_params = {
-            'name': 'custodianaccount{0}'.format(self.suffix),
+            'name': 'custodianaccount47182748',
             'location': self.rg_location,
             'resource_group_name': self.rg_name}
         storage_unit = StorageAccountUnit()
@@ -117,7 +114,7 @@ class DeploymentUnitsTest(BaseTest):
 
         # provision function app
         func_params = {
-            'name': 'cc-consumption-{0}'.format(self.suffix),
+            'name': 'cc-consumption-47182748',
             'location': self.rg_location,
             'resource_group_name': self.rg_name,
             'app_service_plan_id': None,  # auto-provision a dynamic app plan
@@ -135,7 +132,7 @@ class DeploymentUnitsTest(BaseTest):
     def test_function_app_dedicated(self):
         # provision storage account
         sa_params = {
-            'name': 'custodianaccount{0}'.format(self.suffix),
+            'name': 'custodianaccount47182741',
             'location': self.rg_location,
             'resource_group_name': self.rg_name}
         storage_unit = StorageAccountUnit()
@@ -153,7 +150,7 @@ class DeploymentUnitsTest(BaseTest):
         app_plan = app_plan_unit.provision(app_plan_params)
 
         # provision function app
-        func_app_name = 'cc-dedicated-{0}'.format(self.suffix)
+        func_app_name = 'cc-dedicated-47182748'
         func_params = {
             'name': func_app_name,
             'location': self.rg_location,

--- a/tools/c7n_azure/tests/test_keyvault.py
+++ b/tools/c7n_azure/tests/test_keyvault.py
@@ -89,6 +89,7 @@ class KeyVaultTest(BaseTest):
         p2 = {}
         self.assertFalse(WhiteListFilter.compare_permissions(p1, p2))
 
+    # Requires Graph access
     @arm_template('keyvault.json')
     @pytest.mark.skiplive
     def test_whitelist(self):

--- a/tools/c7n_azure/tests/test_keyvault.py
+++ b/tools/c7n_azure/tests/test_keyvault.py
@@ -21,6 +21,7 @@ from c7n_azure.utils import GraphHelper
 from mock import patch, Mock
 from msrestazure.azure_exceptions import CloudError
 from netaddr import IPSet
+import pytest
 from requests import Response
 
 from c7n.utils import local_session
@@ -89,6 +90,7 @@ class KeyVaultTest(BaseTest):
         self.assertFalse(WhiteListFilter.compare_permissions(p1, p2))
 
     @arm_template('keyvault.json')
+    @pytest.mark.skiplive
     def test_whitelist(self):
         """Tests basic whitelist functionality"""
         p = self.load_policy({
@@ -217,6 +219,10 @@ class KeyVaultTest(BaseTest):
             'name': 'test-azure-keyvault',
             'resource': 'azure.keyvault',
             'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'glob',
+                 'value': 'cckeyvault1*'},
                 {'type': 'firewall-rules',
                  'include': ['1.0.0.0']}],
         })
@@ -230,6 +236,10 @@ class KeyVaultTest(BaseTest):
             'name': 'test-azure-keyvault',
             'resource': 'azure.keyvault',
             'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'glob',
+                 'value': 'cckeyvault1*'},
                 {'type': 'firewall-rules',
                  'include': ['1.0.0.0', '127.0.0.1']}],
         }, validate=True)
@@ -243,6 +253,10 @@ class KeyVaultTest(BaseTest):
             'name': 'test-azure-keyvault',
             'resource': 'azure.keyvault',
             'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'glob',
+                 'value': 'cckeyvault1*'},
                 {'type': 'firewall-rules',
                  'include': ['128.0.0.0/1']}],
         }, validate=True)
@@ -256,6 +270,10 @@ class KeyVaultTest(BaseTest):
             'name': 'test-azure-keyvault',
             'resource': 'azure.keyvault',
             'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'glob',
+                 'value': 'cckeyvault1*'},
                 {'type': 'firewall-rules',
                  'include': ['127.0.0.0/8']}],
         }, validate=True)
@@ -269,6 +287,10 @@ class KeyVaultTest(BaseTest):
             'name': 'test-azure-keyvault',
             'resource': 'azure.keyvault',
             'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'glob',
+                 'value': 'cckeyvault1*'},
                 {'type': 'firewall-rules',
                  'equal': ['0.0.0.0-126.255.255.255', '128.0.0.0-255.255.255.255']}],
         }, validate=True)
@@ -282,6 +304,10 @@ class KeyVaultTest(BaseTest):
             'name': 'test-azure-keyvault',
             'resource': 'azure.keyvault',
             'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'glob',
+                 'value': 'cckeyvault1*'},
                 {'type': 'firewall-rules',
                  'equal': ['0.0.0.0-126.255.255.255', '128.0.0.0-255.255.255.254']}],
         }, validate=True)


### PR DESCRIPTION
- KeyVault tests: scope down to a specific resource
- Storage permissions: don't deploy databricks resource until RBAC for Storage permissions is fixed
- Fix Azure Functions nightly (script relies on working directory)
- Deployment units: add random suffix to the resource names