### PR TITLE
azure - test fix- locked filter

### DIFF
--- a/tools/c7n_azure/tests/cassettes/ResourceLockFilter.test_find_by_lock.json
+++ b/tools/c7n_azure/tests/cassettes/ResourceLockFilter.test_find_by_lock.json
@@ -4,7 +4,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/disks?api-version=2018-09-30",
                 "body": null,
                 "headers": {}
             },
@@ -14,35 +14,66 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
                     "date": [
-                        "Fri, 21 Jun 2019 16:35:22 GMT"
+                        "Fri, 13 Sep 2019 22:10:37 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-resource": [
+                        "Microsoft.Compute/HighCostGet3Min;239,Microsoft.Compute/HighCostGet30Min;1919"
                     ],
                     "content-length": [
-                        "467"
-                    ],
-                    "cache-control": [
-                        "no-cache"
+                        "1501"
                     ]
                 },
                 "body": {
                     "data": {
                         "value": [
                             {
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/erwelch-test/providers/Microsoft.KeyVault/vaults/erwelchtest",
-                                "name": "erwelchtest",
-                                "type": "Microsoft.KeyVault/vaults",
-                                "location": "westus2",
-                                "tags": {}
+                                "name": "cctestlockfilterdiskkj6zteiu22tsy",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_DISK-LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskkj6zteiu22tsy",
+                                "type": "Microsoft.Compute/disks",
+                                "location": "southcentralus",
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 32,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "timeCreated": "2019-09-13T21:47:53.1644108+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached"
+                                }
                             },
                             {
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1",
-                                "name": "cckeyvault1",
-                                "type": "Microsoft.KeyVault/vaults",
+                                "name": "cctestlockfilterdiskgt4ngt4wopgzq",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskgt4ngt4wopgzq",
+                                "type": "Microsoft.Compute/disks",
                                 "location": "southcentralus",
-                                "tags": {}
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 32,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "timeCreated": "2019-09-13T22:07:01.3460633+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached"
+                                }
                             }
                         ]
                     }
@@ -52,7 +83,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/erwelch-test/providers/Microsoft.KeyVault/vaults/erwelchtest/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/TEST_DISK-LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskkj6zteiu22tsy/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
                 "body": null,
                 "headers": {}
             },
@@ -62,14 +93,14 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
                     "date": [
-                        "Fri, 21 Jun 2019 16:35:22 GMT"
-                    ],
-                    "cache-control": [
-                        "no-cache"
+                        "Fri, 13 Sep 2019 22:10:38 GMT"
                     ],
                     "content-length": [
                         "12"
@@ -85,7 +116,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/TEST_LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskgt4ngt4wopgzq/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
                 "body": null,
                 "headers": {}
             },
@@ -95,17 +126,17 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
                     "date": [
-                        "Fri, 21 Jun 2019 16:35:23 GMT"
-                    ],
-                    "cache-control": [
-                        "no-cache"
+                        "Fri, 13 Sep 2019 22:10:38 GMT"
                     ],
                     "content-length": [
-                        "327"
+                        "324"
                     ]
                 },
                 "body": {
@@ -114,11 +145,11 @@
                             {
                                 "properties": {
                                     "level": "CanNotDelete",
-                                    "notes": "Keyvault should not be deleted."
+                                    "notes": "This lock is for the cc test_filter_resource_lock test"
                                 },
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1/providers/Microsoft.Authorization/locks/lock",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_locked/providers/Microsoft.Authorization/locks/cctestlockfilter",
                                 "type": "Microsoft.Authorization/locks",
-                                "name": "lock"
+                                "name": "cctestlockfilter"
                             }
                         ]
                     }
@@ -128,7 +159,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/disks?api-version=2018-09-30",
                 "body": null,
                 "headers": {}
             },
@@ -138,35 +169,66 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
                     "date": [
-                        "Fri, 21 Jun 2019 16:35:23 GMT"
+                        "Fri, 13 Sep 2019 22:10:38 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-resource": [
+                        "Microsoft.Compute/HighCostGet3Min;238,Microsoft.Compute/HighCostGet30Min;1918"
                     ],
                     "content-length": [
-                        "467"
-                    ],
-                    "cache-control": [
-                        "no-cache"
+                        "1501"
                     ]
                 },
                 "body": {
                     "data": {
                         "value": [
                             {
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/erwelch-test/providers/Microsoft.KeyVault/vaults/erwelchtest",
-                                "name": "erwelchtest",
-                                "type": "Microsoft.KeyVault/vaults",
-                                "location": "westus2",
-                                "tags": {}
+                                "name": "cctestlockfilterdiskkj6zteiu22tsy",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_DISK-LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskkj6zteiu22tsy",
+                                "type": "Microsoft.Compute/disks",
+                                "location": "southcentralus",
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 32,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "timeCreated": "2019-09-13T21:47:53.1644108+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached"
+                                }
                             },
                             {
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1",
-                                "name": "cckeyvault1",
-                                "type": "Microsoft.KeyVault/vaults",
+                                "name": "cctestlockfilterdiskgt4ngt4wopgzq",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskgt4ngt4wopgzq",
+                                "type": "Microsoft.Compute/disks",
                                 "location": "southcentralus",
-                                "tags": {}
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 32,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "timeCreated": "2019-09-13T22:07:01.3460633+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached"
+                                }
                             }
                         ]
                     }
@@ -176,7 +238,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/erwelch-test/providers/Microsoft.KeyVault/vaults/erwelchtest/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/TEST_DISK-LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskkj6zteiu22tsy/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
                 "body": null,
                 "headers": {}
             },
@@ -186,14 +248,14 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
                     "date": [
-                        "Fri, 21 Jun 2019 16:35:23 GMT"
-                    ],
-                    "cache-control": [
-                        "no-cache"
+                        "Fri, 13 Sep 2019 22:10:38 GMT"
                     ],
                     "content-length": [
                         "12"
@@ -209,7 +271,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/TEST_LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskgt4ngt4wopgzq/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
                 "body": null,
                 "headers": {}
             },
@@ -219,17 +281,17 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
                     "date": [
-                        "Fri, 21 Jun 2019 16:35:23 GMT"
-                    ],
-                    "cache-control": [
-                        "no-cache"
+                        "Fri, 13 Sep 2019 22:10:39 GMT"
                     ],
                     "content-length": [
-                        "327"
+                        "324"
                     ]
                 },
                 "body": {
@@ -238,11 +300,11 @@
                             {
                                 "properties": {
                                     "level": "CanNotDelete",
-                                    "notes": "Keyvault should not be deleted."
+                                    "notes": "This lock is for the cc test_filter_resource_lock test"
                                 },
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1/providers/Microsoft.Authorization/locks/lock",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_locked/providers/Microsoft.Authorization/locks/cctestlockfilter",
                                 "type": "Microsoft.Authorization/locks",
-                                "name": "lock"
+                                "name": "cctestlockfilter"
                             }
                         ]
                     }

--- a/tools/c7n_azure/tests/cassettes/ResourceLockFilter.test_find_by_lock_type_any.json
+++ b/tools/c7n_azure/tests/cassettes/ResourceLockFilter.test_find_by_lock_type_any.json
@@ -4,7 +4,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/disks?api-version=2018-09-30",
                 "body": null,
                 "headers": {}
             },
@@ -17,32 +17,63 @@
                     "cache-control": [
                         "no-cache"
                     ],
-                    "date": [
-                        "Fri, 21 Jun 2019 00:18:16 GMT"
-                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
+                    "date": [
+                        "Fri, 13 Sep 2019 22:10:40 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-resource": [
+                        "Microsoft.Compute/HighCostGet3Min;237,Microsoft.Compute/HighCostGet30Min;1917"
+                    ],
                     "content-length": [
-                        "467"
+                        "1501"
                     ]
                 },
                 "body": {
                     "data": {
                         "value": [
                             {
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/erwelch-test/providers/Microsoft.KeyVault/vaults/erwelchtest",
-                                "name": "erwelchtest",
-                                "type": "Microsoft.KeyVault/vaults",
-                                "location": "westus2",
-                                "tags": {}
+                                "name": "cctestlockfilterdiskkj6zteiu22tsy",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_DISK-LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskkj6zteiu22tsy",
+                                "type": "Microsoft.Compute/disks",
+                                "location": "southcentralus",
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 32,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "timeCreated": "2019-09-13T21:47:53.1644108+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached"
+                                }
                             },
                             {
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1",
-                                "name": "cckeyvault1",
-                                "type": "Microsoft.KeyVault/vaults",
+                                "name": "cctestlockfilterdiskgt4ngt4wopgzq",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskgt4ngt4wopgzq",
+                                "type": "Microsoft.Compute/disks",
                                 "location": "southcentralus",
-                                "tags": {}
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 32,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "timeCreated": "2019-09-13T22:07:01.3460633+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached"
+                                }
                             }
                         ]
                     }
@@ -52,7 +83,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/erwelch-test/providers/Microsoft.KeyVault/vaults/erwelchtest/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/TEST_DISK-LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskkj6zteiu22tsy/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
                 "body": null,
                 "headers": {}
             },
@@ -65,11 +96,11 @@
                     "cache-control": [
                         "no-cache"
                     ],
-                    "date": [
-                        "Fri, 21 Jun 2019 00:18:17 GMT"
-                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Fri, 13 Sep 2019 22:10:39 GMT"
                     ],
                     "content-length": [
                         "12"
@@ -85,7 +116,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/TEST_LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskgt4ngt4wopgzq/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
                 "body": null,
                 "headers": {}
             },
@@ -98,14 +129,14 @@
                     "cache-control": [
                         "no-cache"
                     ],
-                    "date": [
-                        "Fri, 21 Jun 2019 00:18:17 GMT"
-                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
+                    "date": [
+                        "Fri, 13 Sep 2019 22:10:39 GMT"
+                    ],
                     "content-length": [
-                        "327"
+                        "324"
                     ]
                 },
                 "body": {
@@ -114,11 +145,11 @@
                             {
                                 "properties": {
                                     "level": "CanNotDelete",
-                                    "notes": "Keyvault should not be deleted."
+                                    "notes": "This lock is for the cc test_filter_resource_lock test"
                                 },
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1/providers/Microsoft.Authorization/locks/lock",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_locked/providers/Microsoft.Authorization/locks/cctestlockfilter",
                                 "type": "Microsoft.Authorization/locks",
-                                "name": "lock"
+                                "name": "cctestlockfilter"
                             }
                         ]
                     }
@@ -128,7 +159,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/disks?api-version=2018-09-30",
                 "body": null,
                 "headers": {}
             },
@@ -141,32 +172,63 @@
                     "cache-control": [
                         "no-cache"
                     ],
-                    "date": [
-                        "Fri, 21 Jun 2019 00:18:17 GMT"
-                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
+                    "date": [
+                        "Fri, 13 Sep 2019 22:10:40 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-resource": [
+                        "Microsoft.Compute/HighCostGet3Min;236,Microsoft.Compute/HighCostGet30Min;1916"
+                    ],
                     "content-length": [
-                        "467"
+                        "1501"
                     ]
                 },
                 "body": {
                     "data": {
                         "value": [
                             {
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/erwelch-test/providers/Microsoft.KeyVault/vaults/erwelchtest",
-                                "name": "erwelchtest",
-                                "type": "Microsoft.KeyVault/vaults",
-                                "location": "westus2",
-                                "tags": {}
+                                "name": "cctestlockfilterdiskkj6zteiu22tsy",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_DISK-LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskkj6zteiu22tsy",
+                                "type": "Microsoft.Compute/disks",
+                                "location": "southcentralus",
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 32,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "timeCreated": "2019-09-13T21:47:53.1644108+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached"
+                                }
                             },
                             {
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1",
-                                "name": "cckeyvault1",
-                                "type": "Microsoft.KeyVault/vaults",
+                                "name": "cctestlockfilterdiskgt4ngt4wopgzq",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskgt4ngt4wopgzq",
+                                "type": "Microsoft.Compute/disks",
                                 "location": "southcentralus",
-                                "tags": {}
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 32,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "timeCreated": "2019-09-13T22:07:01.3460633+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached"
+                                }
                             }
                         ]
                     }
@@ -176,7 +238,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/erwelch-test/providers/Microsoft.KeyVault/vaults/erwelchtest/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/TEST_DISK-LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskkj6zteiu22tsy/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
                 "body": null,
                 "headers": {}
             },
@@ -189,11 +251,11 @@
                     "cache-control": [
                         "no-cache"
                     ],
-                    "date": [
-                        "Fri, 21 Jun 2019 00:18:17 GMT"
-                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Fri, 13 Sep 2019 22:10:40 GMT"
                     ],
                     "content-length": [
                         "12"
@@ -209,7 +271,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/TEST_LOCKED/providers/Microsoft.Compute/disks/cctestlockfilterdiskgt4ngt4wopgzq/providers/Microsoft.Authorization/locks?api-version=2016-09-01",
                 "body": null,
                 "headers": {}
             },
@@ -222,14 +284,14 @@
                     "cache-control": [
                         "no-cache"
                     ],
-                    "date": [
-                        "Fri, 21 Jun 2019 00:18:17 GMT"
-                    ],
                     "content-type": [
                         "application/json; charset=utf-8"
                     ],
+                    "date": [
+                        "Fri, 13 Sep 2019 22:10:40 GMT"
+                    ],
                     "content-length": [
-                        "327"
+                        "324"
                     ]
                 },
                 "body": {
@@ -238,11 +300,11 @@
                             {
                                 "properties": {
                                     "level": "CanNotDelete",
-                                    "notes": "Keyvault should not be deleted."
+                                    "notes": "This lock is for the cc test_filter_resource_lock test"
                                 },
-                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1/providers/Microsoft.Authorization/locks/lock",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_locked/providers/Microsoft.Authorization/locks/cctestlockfilter",
                                 "type": "Microsoft.Authorization/locks",
-                                "name": "lock"
+                                "name": "cctestlockfilter"
                             }
                         ]
                     }

--- a/tools/c7n_azure/tests/templates/cleanup.sh
+++ b/tools/c7n_azure/tests/templates/cleanup.sh
@@ -32,6 +32,8 @@ delete_resource() {
         token=$(az account get-access-token --query accessToken --output tsv)
         url=https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.CostManagement/exports/cccostexport?api-version=2019-01-01
         curl -X DELETE -H "Authorization: Bearer ${token}" ${url}
+    elif [[ "$fileName" == "locked.json" ]]; then
+        az lock delete --name cctestlockfilter --resource-group $rgName
     fi
 
     az group delete --name $rgName --yes --output None

--- a/tools/c7n_azure/tests/templates/locked.json
+++ b/tools/c7n_azure/tests/templates/locked.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "diskName": {
+            "defaultValue": "[concat('cctestlockfilterdisk', uniqueString(resourceGroup().id))]",
+            "type": "string"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/disks",
+            "name": "[parameters('diskName')]",
+            "location": "[resourceGroup().location]",
+            "sku": {
+                "name": "Standard_LRS"
+            },
+            "properties": {
+                "creationData": {
+                    "createOption": "Empty"
+                },
+                "diskSizeGB": 32
+            },
+            "dependsOn": []
+        },
+        {	
+            "name": "cctestlockfilter",	
+            "type": "Microsoft.Authorization/locks",	
+            "apiVersion": "2016-09-01",	
+            "dependsOn": [	
+                "[resourceId('Microsoft.Compute/disks', parameters('diskName'))]"	
+            ],	
+            "properties": {	
+                "level": "CanNotDelete",	
+                "notes": "This lock is for the cc test_filter_resource_lock test"	
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests/test_filter_resource_lock.py
+++ b/tools/c7n_azure/tests/test_filter_resource_lock.py
@@ -39,11 +39,11 @@ class ResourceLockFilter(BaseTest):
         }, validate=True)
         self.assertTrue(p)
 
-    @arm_template('keyvault.json')
+    @arm_template('locked.json')
     def test_find_by_lock(self):
         p = self.load_policy({
             'name': 'test-lock-filter',
-            'resource': 'azure.keyvault',
+            'resource': 'azure.disk',
             'filters': [
                 {'type': 'resource-lock',
                  'lock-type': 'ReadOnly'}
@@ -54,7 +54,7 @@ class ResourceLockFilter(BaseTest):
 
         p = self.load_policy({
             'name': 'test-lock-filter',
-            'resource': 'azure.keyvault',
+            'resource': 'azure.disk',
             'filters': [
                 {'type': 'resource-lock',
                  'lock-type': 'CanNotDelete'}
@@ -63,12 +63,12 @@ class ResourceLockFilter(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
-    @arm_template('keyvault.json')
+    @arm_template('locked.json')
     def test_find_by_lock_type_any(self):
 
         p = self.load_policy({
             'name': 'test-lock-filter',
-            'resource': 'azure.keyvault',
+            'resource': 'azure.disk',
             'filters': [
                 {'type': 'resource-lock'}
             ]
@@ -78,7 +78,7 @@ class ResourceLockFilter(BaseTest):
 
         p = self.load_policy({
             'name': 'test-lock-filter',
-            'resource': 'azure.keyvault',
+            'resource': 'azure.disk',
             'filters': [
                 {'type': 'resource-lock',
                  'lock-type': 'Any'}


### PR DESCRIPTION
Bug: `test_find_by_lock` and `test_find_by_lock_type_any` were checking for locked resources in KeyVaults; however, we have infrastructure in KeyVaults that are already locked which was causing different values to return. In addition, we do not deploy the `keyvault.json` ARM template, so this was a dated test. 

Fix: Created a new ARM template that creates a locked disk. The test now checks the locked filter against the disk resource, instead of keyvaults. `cleanup.sh` deletes the lock on the resource before it is cleaned up. 