### PR TITLE
azure - skiplive warning fix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,3 +68,4 @@ deps =
 addopts= --tb=native --durations 50 --junitxml=junit/test-results.xml
 markers =
   functional
+  skiplive


### PR DESCRIPTION
Registered skiplive marker in tox.ini to get rid of the warning: 

`PytestUnknownMarkWarning: Unknown pytest.mark.skiplive - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html`