### PR TITLE
VPC SG Filtering : take into account ECS Scheduled Tasks

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -782,7 +782,10 @@ class UnusedSecurityGroup(SGUsage):
     lambdas as they may not have extant resources in the vpc at a
     given moment. We also find any security group with references from
     other security group either within the vpc or across peered
-    connections.
+    connections. Also checks cloud watch event targeting ecs.
+
+    Checks - enis, lambda, launch-configs, sg rule refs, and ecs cwe
+    targets.
 
     Note this filter does not support classic security groups atm.
 
@@ -795,6 +798,7 @@ class UnusedSecurityGroup(SGUsage):
                 resource: security-group
                 filters:
                   - unused
+
     """
     schema = type_schema('unused')
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -688,7 +688,7 @@ class SGUsage(Filter):
         return list(itertools.chain(
             *[self.manager.get_resource_manager(m).get_permissions()
              for m in
-             ['lambda', 'eni', 'launch-config', 'security-group']]))
+             ['lambda', 'eni', 'launch-config', 'security-group', 'event-rule-target']]))
 
     def filter_peered_refs(self, resources):
         if not resources:
@@ -739,7 +739,7 @@ class SGUsage(Filter):
 
     def get_lambda_sgs(self):
         sg_ids = set()
-        for func in self.manager.get_resource_manager('lambda').resources():
+        for func in self.manager.get_resource_manager('lambda').resources(augment=False):
             if 'VpcConfig' not in func:
                 continue
             for g in func['VpcConfig']['SecurityGroupIds']:

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -712,6 +712,7 @@ class SGUsage(Filter):
                 ("sg-perm-refs", self.get_sg_refs),
                 ('lambdas', self.get_lambda_sgs),
                 ("launch-configs", self.get_launch_config_sgs),
+                ("ecs", self.get_ecs_sgs),
         ):
             sg_ids = scanner()
             new_refs = sg_ids.difference(used)
@@ -756,6 +757,18 @@ class SGUsage(Filter):
                 for p in sg.get(perm_type, []):
                     for g in p.get('UserIdGroupPairs', ()):
                         sg_ids.add(g['GroupId'])
+        return sg_ids
+
+    def get_ecs_sgs(self):
+        sg_ids = set()
+        for event_rule_target in self.manager.get_resource_manager('event-rule-target').resources():
+            if 'EcsParameters' in event_rule_target:
+                ecs_parameters = event_rule_target.get('EcsParameters', {})
+                network_configuration = ecs_parameters.get('NetworkConfiguration', {})
+                awsvpc_configuration = network_configuration.get('awsvpcConfiguration', {})
+                security_groups = awsvpc_configuration.get('SecurityGroups', [])
+                for g in security_groups:
+                    sg_ids.add(g)
         return sg_ids
 
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -712,7 +712,7 @@ class SGUsage(Filter):
                 ("sg-perm-refs", self.get_sg_refs),
                 ('lambdas', self.get_lambda_sgs),
                 ("launch-configs", self.get_launch_config_sgs),
-                ("ecs", self.get_ecs_sgs),
+                ("ecs-periodic", self.get_ecs_periodic_sgs),
         ):
             sg_ids = scanner()
             new_refs = sg_ids.difference(used)
@@ -759,7 +759,7 @@ class SGUsage(Filter):
                         sg_ids.add(g['GroupId'])
         return sg_ids
 
-    def get_ecs_sgs(self):
+    def get_ecs_periodic_sgs(self):
         sg_ids = set()
         for event_rule_target in self.manager.get_resource_manager('event-rule-target').resources():
             if 'EcsParameters' in event_rule_target:

--- a/tests/data/placebo/test_security_group_ecs_unused/config.SelectResourceConfig_1.json
+++ b/tests/data/placebo/test_security_group_ecs_unused/config.SelectResourceConfig_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Results": [
+            "{\"configuration\":{\"groupName\":\"apichanges-task\",\"groupId\":\"sg-0f026884bba48e350\",\"vpcId\":\"vpc-39831640\",\"ipPermissionsEgress\":[{\"ipRanges\":[\"0.0.0.0/0\"],\"prefixListIds\":[],\"userIdGroupPairs\":[],\"ipProtocol\":\"-1\",\"ipv4Ranges\":[{\"description\":\"Allows task to establish connections to all resources\",\"cidrIp\":\"0.0.0.0/0\"}],\"ipv6Ranges\":[]}],\"description\":\"Limit connections from internal resources while allowing apichanges-task to connect to all external resources\",\"ownerId\":\"644160558196\",\"ipPermissions\":[],\"tags\":[{\"value\":\"AWSAPIChanges\",\"key\":\"App\"}]},\"supplementaryConfiguration\":{}}"
+        ],
+        "QueryInfo": {
+            "SelectFields": [
+                {
+                    "Name": "configuration"
+                },
+                {
+                    "Name": "supplementaryConfiguration"
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_security_group_ecs_unused/events.ListRules_1.json
+++ b/tests/data/placebo/test_security_group_ecs_unused/events.ListRules_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Rules": [
+            {
+                "Name": "apichanges-build",
+                "Arn": "arn:aws:events:us-east-1:644160558196:rule/apichanges-build",
+                "State": "ENABLED",
+                "Description": "Runs fargate task apichanges: rate(6 hours)",
+                "ScheduleExpression": "rate(6 hours)",
+                "EventBusName": "default"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_security_group_ecs_unused/events.ListTargetsByRule_1.json
+++ b/tests/data/placebo/test_security_group_ecs_unused/events.ListTargetsByRule_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "Targets": [
+            {
+                "Id": "apichanges-build-target",
+                "Arn": "arn:aws:ecs:us-east-1:644160558196:cluster/apichanges",
+                "RoleArn": "arn:aws:iam::644160558196:role/apichanges-events",
+                "Input": "{}",
+                "EcsParameters": {
+                    "TaskDefinitionArn": "arn:aws:ecs:us-east-1:644160558196:task-definition/apichanges:6",
+                    "TaskCount": 1,
+                    "LaunchType": "FARGATE",
+                    "NetworkConfiguration": {
+                        "awsvpcConfiguration": {
+                            "Subnets": [
+                                "subnet-8e261cb2"
+                            ],
+                            "SecurityGroups": [
+                                "sg-0f026884bba48e350"
+                            ],
+                            "AssignPublicIp": "ENABLED"
+                        }
+                    },
+                    "PlatformVersion": "LATEST"
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_security_group_unused/events.ListRules_1.json
+++ b/tests/data/placebo/test_security_group_unused/events.ListRules_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Rules": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_security_group_used/events.ListRules_1.json
+++ b/tests/data/placebo/test_security_group_used/events.ListRules_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Rules": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1126,7 +1126,7 @@ class SecurityGroupTest(BaseTest):
         )
 
     def test_unused_ecs(self):
-        factory = self.record_flight_data("test_security_group_ecs_unused")
+        factory = self.replay_flight_data("test_security_group_ecs_unused")
         p = self.load_policy(
             {'name': 'sg-xyz',
              'source': 'config',

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1125,6 +1125,24 @@ class SecurityGroupTest(BaseTest):
             set([r["GroupId"] for r in resources]),
         )
 
+    def test_unused_ecs(self):
+        factory = self.record_flight_data("test_security_group_ecs_unused")
+        p = self.load_policy(
+            {'name': 'sg-xyz',
+             'source': 'config',
+             'query': [
+                 {'clause': "resourceId ='sg-0f026884bba48e350'"}],
+             'resource': 'security-group',
+             'filters': ['unused']},
+            session_factory=factory)
+        unused = p.resource_manager.filters[0]
+        self.patch(
+            unused,
+            'get_scanners',
+            lambda: (('ecs-cwe', unused.get_ecs_cwe_sgs),))
+        resources = p.run()
+        assert resources == []
+
     def test_unused(self):
         factory = self.replay_flight_data("test_security_group_unused")
         p = self.load_policy(


### PR DESCRIPTION
ECS Scheduled Tasks have a network configuration (among which Security Groups) defined in CloudWatch Events.
This PR add the necessary query to take those SGs into account.

Fixes #4845