### PR TITLE
aws - Route 53 Query Logging fix for multiple hosted zones

### DIFF
--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -332,7 +332,7 @@ class SetQueryLogging(BaseAction):
             if log_manager.get_resources(list(group_names), augment=False):
                 groups = [{'logGroupName': g} for g in group_names]
         else:
-            common_prefix = os.path.commonprefix(group_names)
+            common_prefix = os.path.commonprefix(list(group_names))
             if common_prefix not in ('', '/'):
                 groups = log_manager.get_resources(
                     [common_prefix], augment=False)


### PR DESCRIPTION
Python 3.7.4
Cloud Custodian: 0.8.45.0
Using this policy:

```
policies:
  - name: route53-enable-query-logging
    resource: aws.hostedzone
    comments: |
      Enable Route 53 Query Logging for all Public DNS Zones
    region: us-east-1
    filters:
      - type: query-logging-enabled
        state: false
    actions:
      - type: set-query-logging
        state: true
        set-permissions: true
```

Python raised the following error
```
2019-09-27 13:12:55,825: custodian.policy:INFO policy:route53-enable-query-logging resource:aws.hostedzone region:us-east-1 count:3 time:2.96
2019-09-27 13:12:55,832: custodian.output:ERROR Error while executing policy
Traceback (most recent call last):
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\site-packages\c7n\policy.py", line 261, in run
    results = a.process(resources)
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\site-packages\c7n\resources\route53.py", line 302, in process
    self.ensure_log_groups(set(zone_log_names.values()))
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\site-packages\c7n\resources\route53.py", line 335, in ensure_log_groups
    common_prefix = os.path.commonprefix(group_names)
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\genericpath.py", line 76, in commonprefix
    if not isinstance(m[0], (list, tuple)):
TypeError: 'set' object is not subscriptable
2019-09-27 13:12:55,834: custodian.commands:ERROR Error while executing policy route53-enable-query-logging, continuing
Traceback (most recent call last):
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\site-packages\c7n\commands.py", line 269, in run
    policy()
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\site-packages\c7n\policy.py", line 970, in __call__
    resources = mode.run()
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\site-packages\c7n\policy.py", line 261, in run
    results = a.process(resources)
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\site-packages\c7n\resources\route53.py", line 302, in process
    self.ensure_log_groups(set(zone_log_names.values()))
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\site-packages\c7n\resources\route53.py", line 335, in ensure_log_groups
    common_prefix = os.path.commonprefix(group_names)
  File "c:\users\removed\.virtualenvs\cc-z7ykjtw5\lib\genericpath.py", line 76, in commonprefix
    if not isinstance(m[0], (list, tuple)):
TypeError: 'set' object is not subscriptable
```

