### PR TITLE
azure - update lock action prefixing

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions/lock.py
+++ b/tools/c7n_azure/c7n_azure/actions/lock.py
@@ -107,10 +107,7 @@ class LockAction(AzureBaseAction):
             )
 
     def _get_lock_name(self, resource):
-        return self.data.get('lock-name',
-                             "custodian_lock_{}_{}".format(resource['name'], self.lock_type))
+        return self.data.get('lock-name', "c7n-policy-{}".format(self.manager.data['name']))
 
     def _get_lock_notes(self, resource):
-        return self.data.get('lock-notes',
-                             "Custodian lock created by policy: {}"
-                             .format(self.manager.data['name']))
+        return self.data.get('lock-notes')


### PR DESCRIPTION
Mimicked NSG adding "c7n-policy-" as prefix for lock name. Difference is NSG has a UUID following the prefix and lock has the policy name.  Removed lock type and scope as this is redundant and can be found in the lock metadata. 

Default notes is now empty as policy name was moved to the default lock name. Possible thoughts would be adding a datetime to show when the lock was created or reiterating the policy name in Notes as users may overwrite lock name and leave notes as default. 