### PR TITLE
azure - aliasing for key vault keys

### DIFF
--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -996,7 +996,7 @@ class ParentFilter(Filter):
 
         policies:
           - name: kv-keys-from-tagged-keyvaults
-            resource: azure.keyvault-keys
+            resource: azure.keyvault-key
             filters:
               - type: parent
                 filter:

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
@@ -28,9 +28,9 @@ from c7n_azure.utils import ThreadHelper, ResourceIdParser, generate_key_vault_u
 log = logging.getLogger('custodian.azure.keyvault.keys')
 
 
-@resources.register('keyvault-keys', aliases=['keyvault-key'])
+@resources.register('keyvault-key', aliases=['keyvault-keys'])
 class KeyVaultKeys(ChildResourceManager):
-    """Key Vault Keys Resource
+    """Key Vault Key Resource
 
     :example:
 
@@ -42,7 +42,7 @@ class KeyVaultKeys(ChildResourceManager):
           - name: keyvault-keys
             description:
               List all keys from 'keyvault_test' and 'keyvault_prod' vaults
-            resource: azure.keyvault-keys
+            resource: azure.keyvault-key
             filters:
               - type: keyvault
                 vaults:
@@ -59,7 +59,7 @@ class KeyVaultKeys(ChildResourceManager):
           - name: keyvault-keys
             description:
               List all keys that are older than 30 days
-            resource: azure.keyvault-keys
+            resource: azure.keyvault-key
             filters:
               - type: value
                 key: attributes.created
@@ -78,7 +78,7 @@ class KeyVaultKeys(ChildResourceManager):
           - name: keyvault-keys
             description:
               List all non-HSM keys
-            resource: azure.keyvault-keys
+            resource: azure.keyvault-key
             filters:
               - not:
                  - type: key-type

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
@@ -28,7 +28,7 @@ from c7n_azure.utils import ThreadHelper, ResourceIdParser, generate_key_vault_u
 log = logging.getLogger('custodian.azure.keyvault.keys')
 
 
-@resources.register('keyvault-keys')
+@resources.register('keyvault-keys', aliases=['keyvault-key'])
 class KeyVaultKeys(ChildResourceManager):
     """Key Vault Keys Resource
 

--- a/tools/c7n_azure/tests_azure/test_filters_parent.py
+++ b/tools/c7n_azure/tests_azure/test_filters_parent.py
@@ -28,7 +28,7 @@ class ParentFilterTest(BaseTest):
     def test_schema(self):
         self.assertTrue(self.load_policy({
             'name': 'test-policy',
-            'resource': 'azure.keyvault-keys',
+            'resource': 'azure.keyvault-key',
             'filters': [
                 {'type': 'parent',
                  'filter': {
@@ -61,7 +61,7 @@ class ParentFilterTest(BaseTest):
             ),
             {
                 'name': 'test-policy',
-                'resource': 'azure.keyvault-keys',
+                'resource': 'azure.keyvault-key',
                 'filters': [
                     {'type': 'parent',
                      'filter': {

--- a/tools/c7n_azure/tests_azure/test_functional_filters_parent.py
+++ b/tools/c7n_azure/tests_azure/test_functional_filters_parent.py
@@ -28,7 +28,7 @@ class ParentFilterFunctionalTest(BaseTest):
     def test_kv_has_keys(self):
         p = self.load_policy({
             'name': 'test-policy',
-            'resource': 'azure.keyvault-keys',
+            'resource': 'azure.keyvault-key',
             'filters': [
                 {'type': 'parent',
                  'filter': {
@@ -47,7 +47,7 @@ class ParentFilterFunctionalTest(BaseTest):
     def test_kv_has_0_keys(self):
         p = self.load_policy({
             'name': 'test-policy',
-            'resource': 'azure.keyvault-keys',
+            'resource': 'azure.keyvault-key',
             'filters': [
                 {'type': 'parent',
                  'filter': {

--- a/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py
@@ -48,7 +48,7 @@ class KeyVaultKeyTest(BaseTest):
     def test_key_vault_keys_keyvault(self):
         p = self.load_policy({
             'name': 'test-key-vault',
-            'resource': 'azure.keyvault-keys',
+            'resource': 'azure.keyvault-key',
             'filters': [
                 {
                     'type': 'parent',
@@ -68,7 +68,7 @@ class KeyVaultKeyTest(BaseTest):
     def test_key_vault_keys_type(self):
         p = self.load_policy({
             'name': 'test-key-vault',
-            'resource': 'azure.keyvault-keys',
+            'resource': 'azure.keyvault-key',
             'filters': [
                 {
                     'type': 'key-type',

--- a/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py
@@ -34,6 +34,16 @@ class KeyVaultKeyTest(BaseTest):
         }, validate=True)
         self.assertTrue(p)
 
+        p = self.load_policy({
+            'name': 'test-key-vault',
+            'resource': 'azure.keyvault-key',
+            'filters': [
+                {'type': 'keyvault', 'vaults': ['kv1', 'kv2']},
+                {'type': 'key-type', 'key-types': ['RSA', 'RSA-HSM', 'EC', 'EC-HSM']}
+            ]
+        }, validate=True)
+        self.assertTrue(p)
+
     @arm_template('keyvault.json')
     def test_key_vault_keys_keyvault(self):
         p = self.load_policy({


### PR DESCRIPTION
Utilizes aliasing to allow keyvault-key to be used as a resource name

Closes #4631 