### PR TITLE
docs - disable sticky sidebar

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,7 +125,7 @@ html_theme_options = {
   'style_external_links': True,
   # Toc options
   'collapse_navigation': False,
-  'sticky_navigation': True,
+  'sticky_navigation': False,
   'includehidden': True,
   'titles_only': False
 }


### PR DESCRIPTION
Changes a [RTD configuration setting](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html) to set navigation bar still while scrolling on the main docs page. 

**Before**
![Before](https://user-images.githubusercontent.com/19538721/66151821-13dcff80-e5e6-11e9-9d66-4d50006e9350.gif)


**After**
![after](https://user-images.githubusercontent.com/19538721/66151939-530b5080-e5e6-11e9-9028-e439bdb99bcf.gif)

