### PR TITLE
aws - S3 logging improvements

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -2857,7 +2857,7 @@ class Logging(Filter):
                          bucket={'type': 'string'},
                          prefix={'type': 'string'})
 
-    permissions = ('s3:GetBucketLogging')
+    permissions = ('s3:GetBucketLogging', 'iam:ListAccountAliases')
 
     def process(self, buckets, event=None):
 

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.CreateBucket_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-log-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "3V5bsQjQfdNDD8sGT0r7uI2wofIoEy0j3DMcb+fpAXY7bxIIUmb2R6LXGYgTPgdEpg8Ca/A9WJY=", 
+            "RequestId": "5B4FFBA8A8ADF507"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.DeleteBucket_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "NAe1SHCifK4a+frsS71EtsEjMz8YJBPH7QfQmjiDUY2lvZaF/zinCytv1DE0/ABN/WqsJNtOSWs=", 
+            "RequestId": "80CB2B2126355E79"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.GetBucketLogging_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.GetBucketLogging_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "SwOYDo7On0/dMYTP73U8f2S3x4xvGyGdKV6AkhGdB+SVxGSxHgXoKZevjawrM5kc4qejH3nW3zs=", 
+            "RequestId": "35AD2006D72E55A1"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.GetBucketLogging_2.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.GetBucketLogging_2.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "54LwnO6jbrkrXLkRoAtebTcJhWkqBzJgbxCRNSrIkWaGoHw0LhiHInLQeN2NQmBy86zjZoZQ2aE=", 
+            "RequestId": "24473ABB8F85D407"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.GetBucketLogging_3.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.GetBucketLogging_3.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "uDsgMeNIzx7FUfKaxOwIfxy4fGE8riClmv1jWSgbl33wCtfRR6Kw92XSyYcDVf7Ru+FgLfcoPH0=", 
+            "RequestId": "3BB964B7EC9F5E96"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.GetBucketLogging_4.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.GetBucketLogging_4.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "06Go+wigQxuJqdhkdPYm+VDmwbZaJzYSvJ3/kvlpFMvQfO2J3bzywZXxA6+o0JXkMOn9ARryGqI=", 
+            "RequestId": "4214287EE7A56BF9"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.ListBuckets_1.json
@@ -1,0 +1,68 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "k_vertigo", 
+            "ID": "904fc4c4790937100e9eb293a15e6a0a1f265a064888055b43d030034f8881ee"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 35
+                }, 
+                "Name": "cf-templates-nyrabrca5x2n-us-east-1"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 23, 
+                    "minute": 54
+                }, 
+                "Name": "config-bucket-619193117841"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 1
+                }, 
+                "Name": "custodian-log-test"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 3, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2013, 
+                    "day": 21, 
+                    "minute": 12
+                }, 
+                "Name": "hazmat-audit-logs"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "cvHTJjvNKpQicbs3pIYXyejsvdyzwGBcq+GNQjq9y4sS2BUk6F8uWJCCFb3S4coQ/FnOU8seodc=", 
+            "RequestId": "7552201E742B2AB3"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.PutBucketAcl_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.PutBucketAcl_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "DO27dddAHfDtguYPtdRDKsXRrXQ5XIYUSfZhKMni5EyqKbSStTKT9TgJ8i7ixFu2gD4/4kd/BcU=", 
+            "RequestId": "2C2471191CDBDA82"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging/s3.PutBucketLogging_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging/s3.PutBucketLogging_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "1wFwVO/c57CYvhullP6oc0/XbHTq5hebtjuMknZlv3rEAW/SnX1Vd1BhEViesWxwoXUPH8XYDWM=", 
+            "RequestId": "AEC02CB9644B394D"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/iam.ListAccountAliases_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6f92ccac-fc34-11e7-8667-d3eca4ef75b7", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6f92ccac-fc34-11e7-8667-d3eca4ef75b7", 
+                "date": "Thu, 18 Jan 2018 09:46:19 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/iam.ListAccountAliases_2.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/iam.ListAccountAliases_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "7313ddc9-fc34-11e7-9792-1f5758a32676", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "7313ddc9-fc34-11e7-9792-1f5758a32676", 
+                "date": "Thu, 18 Jan 2018 09:46:25 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.CreateBucket_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-log-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "3V5bsQjQfdNDD8sGT0r7uI2wofIoEy0j3DMcb+fpAXY7bxIIUmb2R6LXGYgTPgdEpg8Ca/A9WJY=", 
+            "RequestId": "5B4FFBA8A8ADF507"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.DeleteBucket_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "NAe1SHCifK4a+frsS71EtsEjMz8YJBPH7QfQmjiDUY2lvZaF/zinCytv1DE0/ABN/WqsJNtOSWs=", 
+            "RequestId": "80CB2B2126355E79"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.GetBucketLogging_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.GetBucketLogging_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "SwOYDo7On0/dMYTP73U8f2S3x4xvGyGdKV6AkhGdB+SVxGSxHgXoKZevjawrM5kc4qejH3nW3zs=", 
+            "RequestId": "35AD2006D72E55A1"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.GetBucketLogging_2.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.GetBucketLogging_2.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "54LwnO6jbrkrXLkRoAtebTcJhWkqBzJgbxCRNSrIkWaGoHw0LhiHInLQeN2NQmBy86zjZoZQ2aE=", 
+            "RequestId": "24473ABB8F85D407"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.GetBucketLogging_3.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.GetBucketLogging_3.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200, 
+    "data": {
+        "LoggingEnabled": {
+            "TargetPrefix": "s3-logs/", 
+            "TargetBucket": "custodian-log-test"
+        },         
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "uDsgMeNIzx7FUfKaxOwIfxy4fGE8riClmv1jWSgbl33wCtfRR6Kw92XSyYcDVf7Ru+FgLfcoPH0=", 
+            "RequestId": "3BB964B7EC9F5E96"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.GetBucketLogging_4.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.GetBucketLogging_4.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "06Go+wigQxuJqdhkdPYm+VDmwbZaJzYSvJ3/kvlpFMvQfO2J3bzywZXxA6+o0JXkMOn9ARryGqI=", 
+            "RequestId": "4214287EE7A56BF9"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.ListBuckets_1.json
@@ -1,0 +1,68 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "k_vertigo", 
+            "ID": "904fc4c4790937100e9eb293a15e6a0a1f265a064888055b43d030034f8881ee"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 35
+                }, 
+                "Name": "cf-templates-nyrabrca5x2n-us-east-1"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 23, 
+                    "minute": 54
+                }, 
+                "Name": "config-bucket-619193117841"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 1
+                }, 
+                "Name": "custodian-log-test"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 3, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2013, 
+                    "day": 21, 
+                    "minute": 12
+                }, 
+                "Name": "hazmat-audit-logs"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "cvHTJjvNKpQicbs3pIYXyejsvdyzwGBcq+GNQjq9y4sS2BUk6F8uWJCCFb3S4coQ/FnOU8seodc=", 
+            "RequestId": "7552201E742B2AB3"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.PutBucketAcl_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.PutBucketAcl_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "DO27dddAHfDtguYPtdRDKsXRrXQ5XIYUSfZhKMni5EyqKbSStTKT9TgJ8i7ixFu2gD4/4kd/BcU=", 
+            "RequestId": "2C2471191CDBDA82"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.PutBucketLogging_1.json
+++ b/tests/data/placebo/test_s3_filter_not_logging_to_correct_bucket_or_prefix/s3.PutBucketLogging_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "1wFwVO/c57CYvhullP6oc0/XbHTq5hebtjuMknZlv3rEAW/SnX1Vd1BhEViesWxwoXUPH8XYDWM=", 
+            "RequestId": "AEC02CB9644B394D"
+        }
+    }
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1393,6 +1393,126 @@ class S3Test(BaseTest):
         self.assertEqual(names[0], bname)
         self.assertEqual(len(names), 1)
 
+    @functional
+    def test_s3_filter_not_logging(self):
+        self.patch(s3.S3, "executor_factory", MainThreadExecutor)
+        self.patch(
+            s3,
+            "S3_AUGMENT_TABLE",
+            [("get_bucket_logging", "Logging", None, "LoggingEnabled")],
+        )
+        session_factory = self.replay_flight_data("test_s3_filter_not_logging")
+        session = session_factory()
+        client = session.client("s3")
+        bname = "custodian-log-test"
+        client.create_bucket(Bucket="custodian-log-test")
+        self.addCleanup(client.delete_bucket, Bucket=bname)
+        client.put_bucket_acl(
+            Bucket=bname,
+            AccessControlPolicy={
+                "Owner": {
+                    "DisplayName": "k_vertigo",
+                    "ID": "904fc4c4790937100e9eb293a15e6a0a1f265a064888055b43d030034f8881ee",
+                },
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "Type": "Group",
+                            "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                        },
+                        "Permission": "WRITE",
+                    },
+                    {
+                        "Grantee": {
+                            "Type": "Group",
+                            "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                        },
+                        "Permission": "READ_ACP",
+                    },
+                ],
+            },
+        )
+        p = self.load_policy(
+            {
+                "name": "s3-no-logging",
+                "resource": "s3",
+                "filters": [
+                    {"Name": bname},
+                    {
+                        "type": "is-not-logging",
+                    },
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        names = [b["Name"] for b in resources]
+        self.assertTrue(bname in names)
+
+    @functional
+    def test_s3_filter_not_logging_to_correct_bucket_or_prefix(self):
+        self.patch(s3.S3, "executor_factory", MainThreadExecutor)
+        self.patch(
+            s3,
+            "S3_AUGMENT_TABLE",
+            [("get_bucket_logging", "Logging", None, "LoggingEnabled")],
+        )
+        session_factory = self.replay_flight_data("test_s3_filter_not_logging_to_correct_bucket_or_prefix")
+        session = session_factory()
+        client = session.client("s3")
+        bname = "custodian-log-test"
+        client.create_bucket(Bucket="custodian-log-test")
+        self.addCleanup(client.delete_bucket, Bucket=bname)
+        client.put_bucket_acl(
+            Bucket=bname,
+            AccessControlPolicy={
+                "Owner": {
+                    "DisplayName": "k_vertigo",
+                    "ID": "904fc4c4790937100e9eb293a15e6a0a1f265a064888055b43d030034f8881ee",
+                },
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "Type": "Group",
+                            "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                        },
+                        "Permission": "WRITE",
+                    },
+                    {
+                        "Grantee": {
+                            "Type": "Group",
+                            "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                        },
+                        "Permission": "READ_ACP",
+                    },
+                ],
+            },
+        )
+        client.put_bucket_logging(
+            Bucket=bname,
+            BucketLoggingStatus={
+                "LoggingEnabled": {"TargetBucket": bname, "TargetPrefix": "s3-logs/"}
+            },
+        )
+        p = self.load_policy(
+            {
+                "name": "s3-no-logging",
+                "resource": "s3",
+                "filters": [
+                    {"Name": bname},
+                    {
+                        "type": "is-not-logging",
+                        "bucket": "foo",
+                        "prefix": "bar/"
+                    },
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        names = [b["Name"] for b in resources]
+        self.assertTrue(bname in names)
+
     def test_log_target(self):
         self.patch(s3.S3, "executor_factory", MainThreadExecutor)
         self.patch(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1457,7 +1457,9 @@ class S3Test(BaseTest):
             "S3_AUGMENT_TABLE",
             [("get_bucket_logging", "Logging", None, "LoggingEnabled")],
         )
-        session_factory = self.replay_flight_data("test_s3_filter_not_logging_to_correct_bucket_or_prefix")
+        session_factory = self.replay_flight_data(
+            "test_s3_filter_not_logging_to_correct_bucket_or_prefix"
+        )
         session = session_factory()
         client = session.client("s3")
         bname = "custodian-log-test"


### PR DESCRIPTION
I added a new filter ```is-not-logging``` to the S3 resource type that allows to filter for non existent or non compliant S3 access log destinations.

To simplify the bucket/prefix definition in the policy, I also added the new variable ```source_bucket_region``` to ```toggle-logging``` action and made all variables available in the new ```is-not-logging``` filter. 

```source_bucket_region``` contains the location information of the bucket.

```
policies:
- name: s3-enable-logging
  resource: s3
  description: |
    Ensure that S3 bucket logging is enabled and configured correctly
  region: us-east-1
  filters:
    - type: is-not-logging
      bucket: "{account_id}-{source_bucket_region}-logs"
      prefix: "AWSLogs/{account_id}/s3/{source_bucket_region}/{source_bucket_name}/"
  actions:
    - type: toggle-logging
      enabled: true
      target_bucket: "{account_id}-{source_bucket_region}-logs"
      target_prefix: "AWSLogs/{account_id}/s3/{source_bucket_region}/{source_bucket_name}/"
