### PR TITLE
azure - fix test regressions

### DIFF
--- a/tools/c7n_azure/tests_azure/azure_common.py
+++ b/tools/c7n_azure/tests_azure/azure_common.py
@@ -398,11 +398,11 @@ class BaseTest(TestUtils, AzureVCRBaseTest):
 
         # We always patch the date for recordings so URLs that involve dates match up
         if self.vcr_enabled:
-            self._utc_patch = patch.object(utils, 'utcnow', self.get_test_date)
+            self._utc_patch = patch.object(utils, 'utcnow', self._get_test_date)
             self._utc_patch.start()
             self.addCleanup(self._utc_patch.stop)
 
-            self._now_patch = patch.object(utils, 'now', self.get_test_date)
+            self._now_patch = patch.object(utils, 'now', self._get_test_date)
             self._now_patch.start()
             self.addCleanup(self._now_patch.stop)
 
@@ -432,7 +432,7 @@ class BaseTest(TestUtils, AzureVCRBaseTest):
             self._subscription_patch.start()
             self.addCleanup(self._subscription_patch.stop)
 
-    def get_test_date(self, tz=None):
+    def _get_test_date(self, tz=None):
         header_date = self.cassette.responses[0]['headers'].get('date') \
             if self.cassette.responses else None
 

--- a/tools/c7n_azure/tests_azure/test_actions_autotag-user.py
+++ b/tools/c7n_azure/tests_azure/test_actions_autotag-user.py
@@ -23,7 +23,7 @@ from c7n.exceptions import PolicyValidationError
 from c7n.filters import FilterValidationError
 
 
-class TagsTest(BaseTest):
+class ActionsAutotagUserTest(BaseTest):
 
     existing_tags = {'pre-existing-1': 'unmodified', 'pre-existing-2': 'unmodified'}
 

--- a/tools/c7n_azure/tests_azure/test_actions_mark-for-op.py
+++ b/tools/c7n_azure/tests_azure/test_actions_mark-for-op.py
@@ -15,13 +15,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import datetime
 
-from . import tools_tags as tools
-from .azure_common import BaseTest
+from c7n_azure import utils
 from c7n_azure.actions.tagging import TagDelayedAction
 from mock import patch, Mock
 
+from . import tools_tags as tools
+from .azure_common import BaseTest
 
-class TagsTest(BaseTest):
+
+class ActionsMarkForOpTest(BaseTest):
 
     existing_tags = {'pre-existing-1': 'unmodified', 'pre-existing-2': 'unmodified'}
     DAYS = 10
@@ -48,7 +50,7 @@ class TagsTest(BaseTest):
 
         tags = tools.get_tags_parameter(update_resource_tags)
 
-        date = (self.get_test_date() + datetime.timedelta(days=self.DAYS)).strftime('%Y/%m/%d')
+        date = (utils.now() + datetime.timedelta(days=self.DAYS)).strftime('%Y/%m/%d')
         expected_value = TagDelayedAction.default_template.format(op='stop', action_date=date)
         expected_tags = self.existing_tags.copy()
         expected_tags.update({'custodian_status': expected_value})

--- a/tools/c7n_azure/tests_azure/test_functional_actions_tags.py
+++ b/tools/c7n_azure/tests_azure/test_functional_actions_tags.py
@@ -17,7 +17,7 @@ import datetime
 
 from .azure_common import BaseTest, arm_template
 from c7n_azure.session import Session
-from mock import patch
+from c7n_azure import utils
 
 from . import tools_tags as tools
 
@@ -70,17 +70,15 @@ class FunctionalActionsTagsTest(BaseTest):
 
     @arm_template('vm.json')
     def test_mark_for_op(self):
-        with patch('c7n_azure.utils.now') as utc_patch:
-            utc_patch.return_value = self.get_test_date()
-            self._run_policy([{'type': 'mark-for-op',
-                               'tag': 'cctest_mark',
-                               'op': 'delete',
-                               'msg': '{op}, {action_date}',
-                               'days': self.DAYS}])
+        self._run_policy([{'type': 'mark-for-op',
+                           'tag': 'cctest_mark',
+                           'op': 'delete',
+                           'msg': '{op}, {action_date}',
+                           'days': self.DAYS}])
 
-            expected_date = self.get_test_date() + datetime.timedelta(days=self.DAYS)
-            expected = 'delete, ' + expected_date.strftime('%Y/%m/%d')
-            self.assertEqual(self._get_tags().get('cctest_mark'), expected)
+        expected_date = utils.now() + datetime.timedelta(days=self.DAYS)
+        expected = 'delete, ' + expected_date.strftime('%Y/%m/%d')
+        self.assertEqual(self._get_tags().get('cctest_mark'), expected)
 
     @arm_template('vm.json')
     def test_autotag_user_and_date(self):

--- a/tools/c7n_azure/tests_azure/test_functional_filters_cost.py
+++ b/tools/c7n_azure/tests_azure/test_functional_filters_cost.py
@@ -31,7 +31,7 @@ class CostFilterTest(BaseTest):
                  'value_type': 'normalize',
                  'value': 'cctestvm'},
                 {'type': 'cost',
-                 'timeframe': 1,
+                 'timeframe': 30,
                  'op': 'ge',
                  'value': 0}
             ]
@@ -58,7 +58,7 @@ class CostFilterTest(BaseTest):
                  'value_type': 'normalize',
                  'value': 'test_vm'},
                 {'type': 'cost',
-                 'timeframe': 1,
+                 'timeframe': 30,
                  'op': 'ge',
                  'value': 0}
             ]

--- a/tools/c7n_azure/tests_azure/test_output.py
+++ b/tools/c7n_azure/tests_azure/test_output.py
@@ -23,6 +23,7 @@ from azure.common import AzureHttpError
 from .azure_common import BaseTest
 import re
 from c7n_azure.output import AzureStorageOutput
+from c7n.utils import local_session
 
 from c7n.config import Bag, Config
 from c7n.ctx import ExecutionContext
@@ -132,12 +133,13 @@ class OutputTest(BaseTest):
             [{
                 'Name': 'ResourceCount',
                 'Value': 101,
-                'Dimensions': {'Policy': 'test-rg',
-                                         'ResType': 'azure.resourcegroup',
-                                         'SubscriptionId': 'ea42f556-5106-4743-99b0-c129bfa71a47',
-                                         'ExecutionId': '00000000-0000-0000-0000-000000000000',
-                                         'ExecutionMode': 'pull',
-                                         'Unit': 'Count'}}])
+                'Dimensions':
+                    {'Policy': 'test-rg',
+                     'ResType': 'azure.resourcegroup',
+                     'SubscriptionId': local_session(Session).get_subscription_id(),
+                     'ExecutionId': '00000000-0000-0000-0000-000000000000',
+                     'ExecutionMode': 'pull',
+                     'Unit': 'Count'}}])
 
     @patch('logging.Logger.error')
     def test_access_error(self, logger_mock):

--- a/tools/c7n_azure/tests_azure/tests_resources/test_storage_container.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_storage_container.py
@@ -39,6 +39,10 @@ class StorageContainerTest(BaseTest):
             'name': 'test-azure-storage-container-enum',
             'resource': 'azure.storage-container',
             'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'glob',
+                 'value': 'container*'},
                 {'type': 'parent',
                  'filter':
                     {'type': 'value',


### PR DESCRIPTION
- Make `get_test_data` internal & use `c7n_azure.utils.now` or `c7n_azure.utils.utcnow` instead. They're patched for cassettes run either way, and not changed for real runs

- Increase number of days in cost filter tests. When using 1, it gets costs for the last day (excluding today), so if tests didn't run yesterday, cost filters returns 0.

- Use subscription_id for metrics tests instead of hardcoded value

- Add extra filter for storage containers. `test_storageutils.py` actually create new containers, so because tests order was changed `test_storage_container.py` failed.