### PR TITLE
tests - pytest support fixture for unit tests

### DIFF
--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 import functools
 import io
+import jmespath
 import json
 import logging
 import os
@@ -214,7 +215,6 @@ class PyTestUtils(CustodianTestCore):
         self.request.addfinalizer(functools.partial(func, *args, **kw))
 
 
-
 class TestUtils(unittest.TestCase, CustodianTestCore):
 
     def tearDown(self):
@@ -223,7 +223,6 @@ class TestUtils(unittest.TestCase, CustodianTestCore):
     def cleanUp(self):
         # Clear out thread local session cache
         reset_session_cache()
-
 
 
 class TextTestIO(io.StringIO):

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -200,13 +200,19 @@ class CustodianTestCore(object):
         self.assertEqual(value, expected)
 
 
+class _TestUtils(unittest.TestCase):
+    # used to expose unittest feature set as a pytest fixture
+    def test_utils(self):
+        """dummy method for py2.7 unittest"""
+
+
 class PyTestUtils(CustodianTestCore):
     """Pytest compatibile testing utils intended for use as fixture."""
     def __init__(self, request):
         self.request = request
 
         # Copy over asserts from unit test
-        t = unittest.TestCase()
+        t = _TestUtils('test_utils')
         for n in dir(t):
             if n.startswith('assert'):
                 setattr(self, n, getattr(t, n))

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import json
 import datetime
+import functools
 import io
+import json
 import logging
 import os
 import re
@@ -23,7 +24,7 @@ import shutil
 import tempfile
 import unittest
 
-
+import pytest
 import mock
 import six
 import yaml
@@ -34,31 +35,19 @@ from c7n.ctx import ExecutionContext
 from c7n.utils import reset_session_cache
 from c7n.config import Bag, Config
 
+
 C7N_VALIDATE = bool(os.environ.get("C7N_VALIDATE", ""))
-
 skip_if_not_validating = unittest.skipIf(
-    not C7N_VALIDATE, reason="We are not validating schemas."
-)
+    not C7N_VALIDATE, reason="We are not validating schemas.")
+functional = pytest.mark.functional
 
 
-try:
-    import pytest
-
-    functional = pytest.mark.functional
-except ImportError:
-    functional = lambda func: func  # noqa E731
-
-
-class TestUtils(unittest.TestCase):
+class CustodianTestCore(object):
 
     custodian_schema = None
 
-    def tearDown(self):
-        self.cleanUp()
-
-    def cleanUp(self):
-        # Clear out thread local session cache
-        reset_session_cache()
+    def addCleanup(self, func, *args, **kw):
+        raise NotImplementedError("subclass required")
 
     def write_policy_file(self, policy, format="yaml"):
         """ Write a policy file to disk in the specified format.
@@ -204,6 +193,37 @@ class TestUtils(unittest.TestCase):
             # _formatMessage ensures the longMessage option is respected
             msg = self._formatMessage(msg, standardMsg)
             raise self.failureException(msg)
+
+    def assertJmes(self, expr, instance, expected):
+        value = jmespath.search(expr, instance)
+        self.assertEqual(value, expected)
+
+
+class PyTestUtils(CustodianTestCore):
+    """Pytest compatibile testing utils intended for use as fixture."""
+    def __init__(self, request):
+        self.request = request
+
+        # Copy over asserts from unit test
+        t = unittest.TestCase()
+        for n in dir(t):
+            if n.startswith('assert'):
+                setattr(self, n, getattr(t, n))
+
+    def addCleanup(self, func, *args, **kw):
+        self.request.addfinalizer(functools.partial(func, *args, **kw))
+
+
+
+class TestUtils(unittest.TestCase, CustodianTestCore):
+
+    def tearDown(self):
+        self.cleanUp()
+
+    def cleanUp(self):
+        # Clear out thread local session cache
+        reset_session_cache()
+
 
 
 class TextTestIO(io.StringIO):

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,6 +25,7 @@ from c7n.resources import load_resources
 from c7n.config import Bag, Config
 
 from c7n.testing import TestUtils, TextTestIO, functional # NOQA
+
 from .zpill import PillTest
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from .common import C7N_SCHEMA
+from .zpill import PillTest
+from c7n.testing import PyTestUtils, reset_session_cache
+
+
+class CustodianAWSTesting(PyTestUtils, PillTest):
+
+    custodian_schema = C7N_SCHEMA
+
+    @property
+    def account_id(self):
+        return ACCOUNT_ID
+
+
+@pytest.fixture(scope='function')
+def test(request):
+    test_utils = CustodianAWSTesting(request)
+    test_utils.addCleanup(reset_session_cache)
+    return test_utils

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .common import C7N_SCHEMA
+from .common import C7N_SCHEMA, ACCOUNT_ID
 from .zpill import PillTest
 from c7n.testing import PyTestUtils, reset_session_cache
 

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -20,16 +20,16 @@ import json
 import time
 
 
-class TestSqsAction(BaseTest):
+class TestSqs(object):
 
     @functional
-    def test_sqs_delete(self):
-        session_factory = self.replay_flight_data("test_sqs_delete")
+    def test_sqs_delete(self, test):
+        session_factory = test.replay_flight_data("test_sqs_delete")
         client = session_factory().client("sqs")
         client.create_queue(QueueName="test-sqs")
         queue_url = client.get_queue_url(QueueName="test-sqs")["QueueUrl"]
 
-        p = self.load_policy(
+        p = test.load_policy(
             {
                 "name": "sqs-delete",
                 "resource": "sqs",
@@ -39,14 +39,14 @@ class TestSqsAction(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertEqual(len(resources), 1)
-        self.assertRaises(ClientError, client.purge_queue, QueueUrl=queue_url)
-        if self.recording:
+        test.assertEqual(len(resources), 1)
+        test.assertRaises(ClientError, client.purge_queue, QueueUrl=queue_url)
+        if test.recording:
             time.sleep(60)
 
     @functional
-    def test_sqs_set_encryption(self):
-        session_factory = self.replay_flight_data("test_sqs_set_encryption")
+    def test_sqs_set_encryption(self, test):
+        session_factory = test.replay_flight_data("test_sqs_set_encryption")
 
         client_sqs = session_factory().client("sqs")
         client_sqs.create_queue(QueueName="sqs-test")
@@ -54,10 +54,10 @@ class TestSqsAction(BaseTest):
 
         def cleanup():
             client_sqs.delete_queue(QueueUrl=queue_url)
-            if self.recording:
+            if test.recording:
                 time.sleep(60)
 
-        self.addCleanup(cleanup)
+        test.addCleanup(cleanup)
 
         client_kms = session_factory().client("kms")
         key_id = client_kms.create_key(Description="West SQS encryption key")[
@@ -65,16 +65,16 @@ class TestSqsAction(BaseTest):
         ][
             "KeyId"
         ]
-        self.addCleanup(client_kms.disable_key, KeyId=key_id)
+        test.addCleanup(client_kms.disable_key, KeyId=key_id)
 
         alias_name = "alias/new-key-test-sqs"
-        self.addCleanup(client_kms.delete_alias, AliasName=alias_name)
+        test.addCleanup(client_kms.delete_alias, AliasName=alias_name)
         client_kms.create_alias(AliasName=alias_name, TargetKeyId=key_id)
 
-        if self.recording:
+        if test.recording:
             time.sleep(30)
 
-        p = self.load_policy(
+        p = test.load_policy(
             {
                 "name": "sqs-delete",
                 "resource": "sqs",
@@ -92,7 +92,11 @@ class TestSqsAction(BaseTest):
         ][
             "KmsMasterKeyId"
         ]
-        self.assertEqual(check_master_key, key_id)
+        test.assertEqual(check_master_key, key_id)
+
+
+
+class TestSqsAction(BaseTest):
 
     @functional
     def test_sqs_remove_matched(self):

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -95,7 +95,6 @@ class TestSqs(object):
         test.assertEqual(check_master_key, key_id)
 
 
-
 class TestSqsAction(BaseTest):
 
     @functional

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -29,6 +29,7 @@ from botocore.response import StreamingBody
 from placebo import pill
 from six import StringIO
 
+from c7n.testing import CustodianTestCore
 
 ###########################################################################
 # BEGIN PLACEBO MONKEY PATCH
@@ -255,7 +256,7 @@ def attach(session, data_path, prefix=None, debug=False):
     return pill
 
 
-class PillTest(unittest.TestCase):
+class PillTest(CustodianTestCore):
 
     archive_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "placebo_data.zip"
@@ -271,9 +272,6 @@ class PillTest(unittest.TestCase):
 
     recording = False
 
-    def assertJmes(self, expr, instance, expected):
-        value = jmespath.search(expr, instance)
-        self.assertEqual(value, expected)
 
     def cleanUp(self):
         self.pill = None

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -17,13 +17,11 @@ import fnmatch
 import json
 import os
 import shutil
-import unittest
 import zipfile
 from datetime import datetime, timedelta, tzinfo
 from distutils.util import strtobool
 
 import boto3
-import jmespath
 import placebo
 from botocore.response import StreamingBody
 from placebo import pill
@@ -271,7 +269,6 @@ class PillTest(CustodianTestCore):
     )
 
     recording = False
-
 
     def cleanUp(self):
         self.pill = None


### PR DESCRIPTION
addresses #4912 

this provides for custodian unit testing without using a unittest derived test class, instead it supports using a normal python class with a pytest fixture providing the core testing infrastructure, and allows use of other pytest features and features by removing some of the restrictions per
https://docs.pytest.org/en/latest/unittest.html#pytest-features-in-unittest-testcase-subclasses
