### PR TITLE
Azure - Validate event grid events against policy resource

### DIFF
--- a/tools/c7n_azure/tests_azure/test_function_package.py
+++ b/tools/c7n_azure/tests_azure/test_function_package.py
@@ -58,7 +58,7 @@ class FunctionPackageTest(BaseTest):
             'resource': 'azure.publicip',
             'mode':
                 {'type': FUNCTION_EVENT_TRIGGER_MODE,
-                 'events': ['VmWrite']},
+                 'events': ['PublicIpWrite']},
         })
 
         packer = FunctionPackage(p.data['name'])
@@ -76,7 +76,7 @@ class FunctionPackageTest(BaseTest):
             'resource': 'azure.publicip',
             'mode':
                 {'type': FUNCTION_EVENT_TRIGGER_MODE,
-                 'events': ['VmWrite']},
+                 'events': ['PublicIpWrite']},
         })
 
         packer = FunctionPackage(p.data['name'])
@@ -87,7 +87,7 @@ class FunctionPackageTest(BaseTest):
                          {u'resource': u'azure.publicip',
                           u'name': u'test-azure-public-ip',
                           u'mode': {u'type': u'azure-event-grid',
-                                    u'events': [u'VmWrite']}})
+                                    u'events': [u'PublicIpWrite']}})
 
     def test_zipped_files_have_modified_timestamp(self):
         t = time.gmtime(1577854800)
@@ -128,7 +128,7 @@ class FunctionPackageTest(BaseTest):
             'resource': 'azure.resourcegroup',
             'mode':
                 {'type': FUNCTION_EVENT_TRIGGER_MODE,
-                 'events': ['VmWrite']},
+                 'events': ['ResourceGroupWrite']},
         })
 
         packer = FunctionPackage(p.data['name'])
@@ -196,7 +196,7 @@ class FunctionPackageTest(BaseTest):
             'resource': 'azure.resourcegroup',
             'mode':
                 {'type': FUNCTION_EVENT_TRIGGER_MODE,
-                 'events': ['VmWrite']},
+                 'events': ['ResourceGroupWrite']},
         })
 
         with patch.dict(os.environ,

--- a/tools/c7n_azure/tests_azure/test_policy_mode.py
+++ b/tools/c7n_azure/tests_azure/test_policy_mode.py
@@ -102,19 +102,19 @@ class AzurePolicyModeTest(BaseTest):
     def test_azure_function_event_mode_child_event_type(self):
         with self.sign_out_patch():
             p = self.load_policy({
-                    'name': 'test-azure-serverless-mode',
-                    'resource': 'azure.networksecuritygroup',
-                    'mode': {
-                        'type': FUNCTION_EVENT_TRIGGER_MODE,
-                        'events': [
-                            {
-                                'resourceProvider':
-                                    'Microsoft.Network/networkSecurityGroups/securityRules',
-                                'event': 'write'
-                            }
-                        ]
-                    }
-                }, validate=True)
+                'name': 'test-azure-serverless-mode',
+                'resource': 'azure.networksecuritygroup',
+                'mode': {
+                    'type': FUNCTION_EVENT_TRIGGER_MODE,
+                    'events': [
+                        {
+                            'resourceProvider':
+                                'Microsoft.Network/networkSecurityGroups/securityRules',
+                            'event': 'write'
+                        }
+                    ]
+                }
+            }, validate=True)
             self.assertTrue(p)
 
     def test_azure_function_periodic_mode_schema_validation(self):

--- a/tools/c7n_azure/tests_azure/test_policy_mode.py
+++ b/tools/c7n_azure/tests_azure/test_policy_mode.py
@@ -101,8 +101,7 @@ class AzurePolicyModeTest(BaseTest):
 
     def test_azure_function_event_mode_child_event_type(self):
         with self.sign_out_patch():
-            with self.assertRaises(PolicyValidationError):
-                self.load_policy({
+            p = self.load_policy({
                     'name': 'test-azure-serverless-mode',
                     'resource': 'azure.networksecuritygroup',
                     'mode': {
@@ -116,6 +115,7 @@ class AzurePolicyModeTest(BaseTest):
                         ]
                     }
                 }, validate=True)
+            self.assertTrue(p)
 
     def test_azure_function_periodic_mode_schema_validation(self):
         with self.sign_out_patch():

--- a/tools/c7n_azure/tests_azure/test_policy_mode.py
+++ b/tools/c7n_azure/tests_azure/test_policy_mode.py
@@ -14,12 +14,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from azure.mgmt.storage.models import StorageAccount
-from .azure_common import BaseTest, DEFAULT_SUBSCRIPTION_ID, arm_template, cassette_name
 from c7n_azure.constants import FUNCTION_EVENT_TRIGGER_MODE, FUNCTION_TIME_TRIGGER_MODE, \
     CONTAINER_EVENT_TRIGGER_MODE, CONTAINER_TIME_TRIGGER_MODE
 from c7n_azure.policy import AzureEventGridMode, AzureFunctionMode, AzureModeCommon
 from jsonschema import ValidationError
 from mock import mock, patch, Mock
+
+from c7n.exceptions import PolicyValidationError
+from .azure_common import BaseTest, DEFAULT_SUBSCRIPTION_ID, arm_template, cassette_name
 
 
 class AzurePolicyModeTest(BaseTest):
@@ -59,11 +61,58 @@ class AzurePolicyModeTest(BaseTest):
                         'type': FUNCTION_EVENT_TRIGGER_MODE,
                         'events': [
                             'VmWrite',
-                            'AppServicePlanWrite',
-                            'CognitiveServiceWrite',
+                            {
+                                'resourceProvider': 'Microsoft.Compute/virtualMachines/',
+                                'event': 'delete'
+                            },
+                            {
+                                'resourceProvider': 'Microsoft.Compute/virtualMachines/',
+                                'event': 'powerOff/action'
+                            },
+                            {
+                                'resourceProvider': 'Microsoft.Compute/virtualMachines/',
+                                'event': 'reimage/action'
+                            },
+                            {
+                                'resourceProvider': 'Microsoft.Compute/virtualMachines/',
+                                'event': 'redeploy/action'
+                            },
+                            {
+                                'resourceProvider': 'Microsoft.Compute/virtualMachines/',
+                                'event': 'start/action'
+                            }
+                        ]
+                    }
+                }, validate=True)
+
+    def test_azure_function_event_mode_incorrect_event_type(self):
+        with self.sign_out_patch():
+            with self.assertRaises(PolicyValidationError):
+                self.load_policy({
+                    'name': 'test-azure-serverless-mode',
+                    'resource': 'azure.vm',
+                    'mode': {
+                        'type': FUNCTION_EVENT_TRIGGER_MODE,
+                        'events': [
                             'CosmosDbWrite',
-                            'DataFactoryWrite',
-                            'DataLakeWrite'
+                        ]
+                    }
+                }, validate=True)
+
+    def test_azure_function_event_mode_child_event_type(self):
+        with self.sign_out_patch():
+            with self.assertRaises(PolicyValidationError):
+                self.load_policy({
+                    'name': 'test-azure-serverless-mode',
+                    'resource': 'azure.networksecuritygroup',
+                    'mode': {
+                        'type': FUNCTION_EVENT_TRIGGER_MODE,
+                        'events': [
+                            {
+                                'resourceProvider':
+                                    'Microsoft.Network/networkSecurityGroups/securityRules',
+                                'event': 'write'
+                            }
                         ]
                     }
                 }, validate=True)
@@ -364,10 +413,10 @@ class AzurePolicyModeTest(BaseTest):
                 {'type': FUNCTION_EVENT_TRIGGER_MODE,
                  'events':
                      ['VmWrite',
-                        {
-                            'resourceProvider': 'Microsoft.Resources/subscriptions/resourceGroups',
-                            'event': 'write'
-                        }]},
+                      {
+                          'resourceProvider': 'Microsoft.Compute/virtualMachines',
+                          'event': 'powerOff/action'
+                      }]},
         })
 
         with mock.patch('c7n_azure.azure_events.AzureEventSubscription.create') as mock_create:
@@ -383,7 +432,7 @@ class AzurePolicyModeTest(BaseTest):
             self.assertEqual(event_filter.key, 'Data.OperationName')
             self.assertEqual(event_filter.values,
                              ['Microsoft.Compute/virtualMachines/write',
-                              'Microsoft.Resources/subscriptions/resourceGroups/write'])
+                              'Microsoft.Compute/virtualMachines/powerOff/action'])
             self.assertEqual(event_filter.operator_type, 'StringIn')
 
     def test_extract_properties(self):


### PR DESCRIPTION
This PR addressed the lack of validation for the `azure-event-grid` mode to verify the resource can be triggered by the events. 

closes #4162