### PR TITLE
azure - tag sql database

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions/lock.py
+++ b/tools/c7n_azure/c7n_azure/actions/lock.py
@@ -96,10 +96,13 @@ class LockAction(AzureBaseAction):
                 ManagementLockObject(level=self.lock_type, notes=lock_notes)
             )
         else:
+            parent = resource.get('c7n:parent-id')
+            parent_resource_path = ResourceIdParser.get_resource_path(parent) if parent else ''
+
             self.client.management_locks.create_or_update_at_resource_level(
                 resource['resourceGroup'],
                 ResourceIdParser.get_namespace(resource['id']),
-                ResourceIdParser.get_resource_name(resource.get('c7n:parent-id')) or '',
+                parent_resource_path,
                 ResourceIdParser.get_resource_type(resource['id']),
                 resource['name'],
                 lock_name,

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -792,10 +792,13 @@ class ResourceLockFilter(Filter):
                          client.management_locks.list_at_resource_group_level(
                     resource['name'])]
             else:
+                parent = resource.get('c7n:parent-id')
+                parent_resource_path = ResourceIdParser.get_resource_path(parent) if parent else ''
+
                 locks = [r.serialize(True) for r in client.management_locks.list_at_resource_level(
                     resource['resourceGroup'],
                     ResourceIdParser.get_namespace(resource['id']),
-                    ResourceIdParser.get_resource_name(resource.get('c7n:parent-id')) or '',
+                    parent_resource_path,
                     ResourceIdParser.get_resource_type(resource['id']),
                     resource['name'])]
 

--- a/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
@@ -59,7 +59,6 @@ class SqlDatabase(ChildArmResourceManager):
         enum_spec = ('databases', 'list_by_server', None)
         parent_manager_name = 'sqlserver'
         resource_type = 'Microsoft.Sql/servers/databases'
-        enable_tag_operations = False  # GH Issue #4543
         default_report_fields = (
             'name',
             'location',

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -217,7 +217,7 @@ class Session(object):
         """ latest non-preview api version for resource """
 
         namespace = ResourceIdParser.get_namespace(resource_id)
-        resource_type = ResourceIdParser.get_resource_type(resource_id)
+        resource_type = ResourceIdParser.get_full_type(resource_id)
 
         cache_id = namespace + resource_type
 

--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -51,10 +51,7 @@ class ResourceIdParser(object):
 
     @staticmethod
     def get_namespace(resource_id):
-        parsed = parse_resource_id(resource_id)
-        if parsed.get('children'):
-            return '/'.join([parsed.get('namespace'), parsed.get('type')])
-        return parsed.get('namespace')
+        return parse_resource_id(resource_id).get('namespace')
 
     @staticmethod
     def get_subscription_id(resource_id):
@@ -70,14 +67,7 @@ class ResourceIdParser(object):
 
     @staticmethod
     def get_resource_type(resource_id):
-        parsed = parse_resource_id(resource_id)
-        # parse_resource_id returns dictionary with "child_type_#" to represent
-        # types sequence. "type" stores root type.
-        child_type_keys = [k for k in parsed.keys() if k.find("child_type_") != -1]
-        types = [parsed.get(k) for k in sorted(child_type_keys)]
-        if not types:
-            types.insert(0, parsed.get('type'))
-        return '/'.join(types)
+        return parse_resource_id(resource_id).get('resource_type')
 
     @staticmethod
     def get_resource_name(resource_id):
@@ -85,8 +75,19 @@ class ResourceIdParser(object):
 
     @staticmethod
     def get_full_type(resource_id):
-        return '/'.join([ResourceIdParser.get_namespace(resource_id),
-                         ResourceIdParser.get_resource_type(resource_id)])
+        parsed = parse_resource_id(resource_id)
+        # parse_resource_id returns dictionary with "child_type_#" to represent
+        # types sequence. "type" stores root type.
+        child_type_keys = [k for k in parsed.keys() if k.find("child_type_") != -1]
+        types = [parsed.get(k) for k in sorted(child_type_keys)]
+        types.insert(0, parsed.get('type'))
+
+        return '/'.join(types)
+
+    @staticmethod
+    def get_resource_path(resource_id):
+        return '/'.join([ResourceIdParser.get_resource_type(resource_id),
+                         ResourceIdParser.get_resource_name(resource_id)])
 
 
 def is_resource_group_id(rid):


### PR DESCRIPTION
The `get_resource_type` and `get_namespace` functions were accounting for child resources in addition to standalone resources. The functions were modified to have single responsibilities, and a `get_full_type` function was added to account for child resources. 

The `get_resource_type` function was being used in two different ways:

1. In `session.py` to find the correct API for tagging. What was actually needed was the full resource type (`servers/databases`) while 

2. In `lock.py` to find the resource type. What was needed was just (`databases`)

The parameters for the [management lock SDK](https://github.com/Azure/azure-sdk-for-python/blob/15dc31f9e835ebd48a1e5b48b0563bb9c46a5227/sdk/resources/azure-mgmt-resource/azure/mgmt/resource/locks/v2016_09_01/operations/_management_locks_operations.py#L431) were updated to reflect these changes. For example, using the `parent_resource_path` instead of just the `parent_name`

Closes Issue #4543 
 