### PR TITLE
Fix bug preventing storage gateways from working

### DIFF
--- a/c7n/resources/storagegw.py
+++ b/c7n/resources/storagegw.py
@@ -27,7 +27,7 @@ class StorageGateway(QueryResourceManager):
         arn = id = 'GatewayARN'
         name = 'GatewayName'
 
-    augment = staticmethod(universal_augment)
+    augment = universal_augment
 
 
 register_universal_tags(


### PR DESCRIPTION
The universal_augment function was incorrectly wrapped, breaking it's useage
with an incorrect number of arguments error.

This just removes the unneeded staticmethod decoration, which matches other places
in the code base.