### PR TITLE
azure - validate event resource is ARM resource

### DIFF
--- a/tools/c7n_azure/c7n_azure/azure_events.py
+++ b/tools/c7n_azure/c7n_azure/azure_events.py
@@ -24,13 +24,6 @@ class AzureEvents(object):
     """A mapping of resource types to events."""
 
     azure_events = {
-        'RoleAssignmentWrite': {
-            'resource_provider': 'Microsoft.Authorization/roleAssignments',
-            'event': 'write'},
-
-        'RoleDefinitionW': {
-            'resource_provider': 'Microsoft.Authorization/roleDefinitions',
-            'event': 'write'},
 
         'AppServicePlanWrite': {
             'resource_provider': 'Microsoft.Web/serverFarms',

--- a/tools/c7n_azure/tests_azure/test_policy_mode.py
+++ b/tools/c7n_azure/tests_azure/test_policy_mode.py
@@ -117,6 +117,36 @@ class AzurePolicyModeTest(BaseTest):
             }, validate=True)
             self.assertTrue(p)
 
+    def test_azure_function_event_mode_generic_resource_type(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-azure-serverless-mode',
+                'resource': 'azure.armresource',
+                'mode': {
+                    'type': FUNCTION_EVENT_TRIGGER_MODE,
+                    'events': [
+                            'KeyVaultWrite',
+                            'ResourceGroupWrite',
+                            'VmWrite'
+                    ]
+                }
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_azure_function_event_mode_unsupported_resource_type(self):
+        with self.sign_out_patch():
+            with self.assertRaises(PolicyValidationError):
+                self.load_policy({
+                    'name': 'test-azure-serverless-mode',
+                    'resource': 'azure.keyvault-key',
+                    'mode': {
+                        'type': FUNCTION_EVENT_TRIGGER_MODE,
+                        'events': [
+                            'KeyVaultWrite',
+                        ]
+                    }
+                }, validate=True)
+
     def test_azure_function_periodic_mode_schema_validation(self):
         with self.sign_out_patch():
             p = self.load_policy({


### PR DESCRIPTION
This PR:
- validates the resource provided in an event-mode policy is an ARM resource since non-ARM resources is not supported by event grid
- fixes regression for generic ARM resource

closes #4617