### PR TITLE
core - value filter add a version value type

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -381,6 +381,23 @@ class TestValueTypes(BaseFilterTest):
         self.assertFilter(fdata, i(parse_date('2019/04/01')), True)
         self.assertFilter(fdata, i(datetime.now().isoformat()), False)
 
+    def test_version(self):
+        fdata = {
+            "type": "value",
+            "key": "Version",
+            "op": "less-than",
+            "value_type": "version",
+            "value": "1.9.12",
+        }
+
+        def i(v):
+            return instance(Version=v)
+
+        self.assertFilter(fdata, i("1.32.1"), False)
+        self.assertFilter(fdata, i("1.9.13"), False)
+        self.assertFilter(fdata, i("1.9.11"), True)
+        self.assertFilter(fdata, i("1.1"), True)
+
     def test_expiration(self):
 
         now = datetime.now(tz=tz.tzutc())


### PR DESCRIPTION
Sometimes its useful to be able to compare versioned strings, which aren't as simple
as string comparisons, since they aren't directly lexicographically comparable.

This adds an initial version of doing version compares - I'm open to replacing the `pkg_resources` parse version with another implementation, but I figured this helps avoid dependencies.

A specific example of a use case here is find ECS container instances with old version numbers.