### PR TITLE
aws.rest-api | Delete action for rest-api

### DIFF
--- a/tests/data/placebo/test_rest_api_delete/apigateway.DeleteRestApi_1.json
+++ b/tests/data/placebo/test_rest_api_delete/apigateway.DeleteRestApi_1.json
@@ -2,15 +2,15 @@
     "status_code": 202,
     "data": {
         "ResponseMetadata": {
-            "RequestId": "42dd392c-3141-4ba5-911b-00af8d0e9b36",
+            "RequestId": "579b0dd7-ec2b-4fe5-b96c-2775b3271649",
             "HTTPStatusCode": 202,
             "HTTPHeaders": {
-                "date": "Thu, 17 Oct 2019 17:50:32 GMT",
+                "date": "Fri, 18 Oct 2019 15:39:06 GMT",
                 "content-type": "application/json",
                 "content-length": "0",
                 "connection": "keep-alive",
-                "x-amzn-requestid": "42dd392c-3141-4ba5-911b-00af8d0e9b36",
-                "x-amz-apigw-id": "Bt98YKWwoAMEdVA="
+                "x-amzn-requestid": "579b0dd7-ec2b-4fe5-b96c-2775b3271649",
+                "x-amz-apigw-id": "Bw9oHKh2IAMEdZw="
             },
             "RetryAttempts": 0
         }

--- a/tests/data/placebo/test_rest_api_delete/apigateway.DeleteRestApi_1.json
+++ b/tests/data/placebo/test_rest_api_delete/apigateway.DeleteRestApi_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 202,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "42dd392c-3141-4ba5-911b-00af8d0e9b36",
+            "HTTPStatusCode": 202,
+            "HTTPHeaders": {
+                "date": "Thu, 17 Oct 2019 17:50:32 GMT",
+                "content-type": "application/json",
+                "content-length": "0",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "42dd392c-3141-4ba5-911b-00af8d0e9b36",
+                "x-amz-apigw-id": "Bt98YKWwoAMEdVA="
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_rest_api_delete/apigateway.DeleteRestApi_2.json
+++ b/tests/data/placebo/test_rest_api_delete/apigateway.DeleteRestApi_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Invalid API identifier specified 644160558196:am0c2fyskg",
+            "Code": "NotFoundException"
+        },
+        "ResponseMetadata": {
+            "RequestId": "4128996d-0a75-427c-b659-0ccbda4ed8ed",
+            "HTTPStatusCode": 404,
+            "HTTPHeaders": {
+                "date": "Fri, 18 Oct 2019 15:39:06 GMT",
+                "content-type": "application/json",
+                "content-length": "71",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "4128996d-0a75-427c-b659-0ccbda4ed8ed",
+                "x-amzn-errortype": "NotFoundException",
+                "x-amz-apigw-id": "Bw9oMIRSoAMEd3Q="
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_rest_api_delete/apigateway.GetRestApis_1.json
+++ b/tests/data/placebo/test_rest_api_delete/apigateway.GetRestApis_1.json
@@ -1,0 +1,82 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "9da286e1-2e9d-4f74-83a1-82c07a01507a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "date": "Thu, 17 Oct 2019 17:50:32 GMT",
+                "content-type": "application/json",
+                "content-length": "1005",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "9da286e1-2e9d-4f74-83a1-82c07a01507a",
+                "x-amz-apigw-id": "Bt98UKAwIAMEctw="
+            },
+            "RetryAttempts": 0
+        },
+        "items": [
+            {
+                "id": "6b1g7ewn9g",
+                "name": "demoauth1",
+                "createdDate": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 8,
+                    "day": 5,
+                    "hour": 6,
+                    "minute": 38,
+                    "second": 29,
+                    "microsecond": 0
+                },
+                "version": "1.0",
+                "binaryMediaTypes": [
+                    "application/octet-stream",
+                    "application/x-tar",
+                    "application/zip",
+                    "audio/basic",
+                    "audio/ogg",
+                    "audio/mp4",
+                    "audio/mpeg",
+                    "audio/wav",
+                    "audio/webm",
+                    "image/png",
+                    "image/jpg",
+                    "image/jpeg",
+                    "image/gif",
+                    "video/ogg",
+                    "video/mpeg",
+                    "video/webm"
+                ],
+                "apiKeySource": "HEADER",
+                "endpointConfiguration": {
+                    "types": [
+                        "EDGE"
+                    ]
+                }
+            },
+            {
+                "id": "7keylcvgkk",
+                "name": "c7n-test-2",
+                "createdDate": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 5,
+                    "day": 9,
+                    "hour": 19,
+                    "minute": 29,
+                    "second": 22,
+                    "microsecond": 0
+                },
+                "apiKeySource": "HEADER",
+                "endpointConfiguration": {
+                    "types": [
+                        "PRIVATE"
+                    ]
+                },
+                "tags": {
+                    "target-tag": "pratyush"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rest_api_delete/apigateway.GetRestApis_1.json
+++ b/tests/data/placebo/test_rest_api_delete/apigateway.GetRestApis_1.json
@@ -2,15 +2,15 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RequestId": "9da286e1-2e9d-4f74-83a1-82c07a01507a",
+            "RequestId": "ec070591-8160-4e22-a536-aa94c69629fa",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
-                "date": "Thu, 17 Oct 2019 17:50:32 GMT",
+                "date": "Fri, 18 Oct 2019 15:39:06 GMT",
                 "content-type": "application/json",
-                "content-length": "1005",
+                "content-length": "1022",
                 "connection": "keep-alive",
-                "x-amzn-requestid": "9da286e1-2e9d-4f74-83a1-82c07a01507a",
-                "x-amz-apigw-id": "Bt98UKAwIAMEctw="
+                "x-amzn-requestid": "ec070591-8160-4e22-a536-aa94c69629fa",
+                "x-amz-apigw-id": "Bw9oEJ-bIAMEb-A="
             },
             "RetryAttempts": 0
         },
@@ -55,22 +55,23 @@
                 }
             },
             {
-                "id": "7keylcvgkk",
+                "id": "am0c2fyskg",
                 "name": "c7n-test-2",
                 "createdDate": {
                     "__class__": "datetime",
                     "year": 2019,
-                    "month": 5,
-                    "day": 9,
-                    "hour": 19,
-                    "minute": 29,
-                    "second": 22,
+                    "month": 10,
+                    "day": 18,
+                    "hour": 11,
+                    "minute": 38,
+                    "second": 30,
                     "microsecond": 0
                 },
+                "version": "1.0",
                 "apiKeySource": "HEADER",
                 "endpointConfiguration": {
                     "types": [
-                        "PRIVATE"
+                        "REGIONAL"
                     ]
                 },
                 "tags": {

--- a/tests/test_apigw.py
+++ b/tests/test_apigw.py
@@ -128,7 +128,7 @@ class TestRestApi(BaseTest):
             session_factory=session_factory)
         resources = p.run()
         self.assertTrue(len(resources), 1)
-        self.assertTrue(resources[0]['name'],'c7n-test-2')
+        self.assertTrue(resources[0]['name'], 'c7n-test-2')
 
 
 class TestRestResource(BaseTest):

--- a/tests/test_apigw.py
+++ b/tests/test_apigw.py
@@ -118,6 +118,18 @@ class TestRestApi(BaseTest):
             {'Env': 'Dev',
             'custodian_cleanup': 'Resource does not meet policy: update@2019/09/11'})
 
+    def test_rest_api_delete(self):
+        session_factory = self.replay_flight_data('test_rest_api_delete')
+        p = self.load_policy({
+            'name': 'tag-rest-api',
+            'resource': 'rest-api',
+            'filters': [{'tag:target-tag': 'pratyush'}],
+            "actions": [{"type": "delete"}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertTrue(len(resources), 1)
+        self.assertTrue(resources[0]['name'],'c7n-test-2')
+
 
 class TestRestResource(BaseTest):
 

--- a/tests/test_apigw.py
+++ b/tests/test_apigw.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from botocore.exceptions import ClientError
+import time
 
 from .common import BaseTest
 
@@ -128,7 +129,11 @@ class TestRestApi(BaseTest):
             session_factory=session_factory)
         resources = p.run()
         self.assertTrue(len(resources), 1)
-        self.assertTrue(resources[0]['name'], 'c7n-test-2')
+        self.assertTrue(resources[0]['id'], 'am0c2fyskg')
+        client = session_factory().client("apigateway")
+        with self.assertRaises(ClientError) as e:
+            client.delete_rest_api(restApiId='am0c2fyskg')
+        self.assertEqual(e.exception.response['Error']['Code'], 'NotFoundException')
 
 
 class TestRestResource(BaseTest):

--- a/tests/test_apigw.py
+++ b/tests/test_apigw.py
@@ -14,7 +14,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from botocore.exceptions import ClientError
-import time
 
 from .common import BaseTest
 


### PR DESCRIPTION
Adding feature to delete rest-api. 
Sample policy:
```
policies:
  - name: apigw-delete
    resource: rest-api
    filters:
      - 'tag:xyz': present
    actions:
      - type: delete
```