### PR TITLE
ci - mailer build context

### DIFF
--- a/.azure-pipelines/live-functional.yml
+++ b/.azure-pipelines/live-functional.yml
@@ -124,6 +124,7 @@ stages:
             inputs:
               command: buildAndPush
               Dockerfile: tools/c7n_mailer/Dockerfile
+              buildContext: $(Build.Repository.LocalPath)
               containerRegistry: dockerServiceConnection
               repository: cloudcustodian/mailer
               tags: |

--- a/.azure-pipelines/live-functional.yml
+++ b/.azure-pipelines/live-functional.yml
@@ -46,16 +46,16 @@ stages:
 
         # Skip some resources due to some restrictions with their provisioning using Service Principal account
         # We maintain those resources in the test subscription available for the tests
-        - script: tools/c7n_azure/tests/templates/provision.sh --skip keyvault cost-management-export containerservice databricks
+        - script: /bin/bash tools/c7n_azure/tests_azure/templates/provision.sh --skip keyvault cost-management-export containerservice databricks
           displayName: "Provision Azure Resources"
           env:
             AZURE_CLIENT_ID: $(azure-client-id)
             AZURE_CLIENT_SECRET: $(azure-client-secret)
 
-        - script: C7N_TEST_RUN=true C7N_FUNCTIONAL=yes pytest -v -m "not skiplive" tools/c7n_azure/tests
+        - script: C7N_TEST_RUN=true C7N_FUNCTIONAL=yes pytest -v -m "not skiplive" tools/c7n_azure/tests_azure
           displayName: "Run Azure tests without cassettes"
 
-        - script: tools/c7n_azure/tests/templates/cleanup.sh --skip keyvault cost-management-export containerservice databricks
+        - script: /bin/bash tools/c7n_azure/tests_azure/templates/cleanup.sh --skip keyvault cost-management-export containerservice databricks
           displayName: "Cleanup Azure Resources"
           condition: always()
 
@@ -79,8 +79,8 @@ stages:
         - script: python -m pip install --upgrade pip && pip install . && pip install -r requirements-dev.txt
           displayName: "Install Dependencies"
 
-        - script: ./test_functions.sh
-          workingDirectory: tools/c7n_azure/tests/azure-functions
+        - script: /bin/bash test_functions.sh
+          workingDirectory: tools/c7n_azure/tests_azure/azure-functions
           displayName: "Run Azure Functions Test"
           env:
             AZURE_CLIENT_ID: $(azure-client-id)


### PR DESCRIPTION
The mailer dockerfile expects that your working directory is in the repository root.  I believe this change will fix that part of the build task.