### PR TITLE
core - structural parser for more better top level error messages

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -50,10 +50,6 @@ def load(options, path, format=None, validate=True, vars=None):
         log.warning('yaml in invalid format. The "policies:" line is probably missing.')
         return None
 
-    # Test for empty policy file
-    if not data or data.get('policies') is None:
-        return None
-
     if validate:
         from c7n.schema import validate, StructureParser
         StructureParser().validate(data)
@@ -62,6 +58,10 @@ def load(options, path, format=None, validate=True, vars=None):
             raise PolicyValidationError(
                 "Failed to validate policy %s \n %s" % (
                     errors[1], errors[0]))
+
+    # Test for empty policy file
+    if not data or data.get('policies') is None:
+        return None
 
     collection = PolicyCollection.from_data(data, options)
     if validate:

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -55,7 +55,8 @@ def load(options, path, format=None, validate=True, vars=None):
         return None
 
     if validate:
-        from c7n.schema import validate
+        from c7n.schema import validate, StructureParser
+        StructureParser().validate(data)
         errors = validate(data)
         if errors:
             raise PolicyValidationError(

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -465,6 +465,9 @@ class StructureParser(object):
                     ', '.join(self.allowed_keys),
                     ', '.join(extra))))
 
+        if 'policies' not in data:
+            raise PolicyValidationError("`policies` list missing")
+
         pdata = data.get('policies', [])
         if not isinstance(pdata, list):
             raise PolicyValidationError((

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -35,6 +35,7 @@ import logging
 from jsonschema import Draft4Validator as Validator
 from jsonschema.exceptions import best_match
 
+from c7n.exceptions import PolicyValidationError
 from c7n.policy import execution
 from c7n.provider import clouds
 from c7n.resources import load_resources
@@ -439,6 +440,50 @@ def resource_vocabulary(cloud_name=None, qualify_name=True):
         vocabulary["mode"][mode_name] = cls
 
     return vocabulary
+
+
+class StructureParser(object):
+    """Provide fast validation and inspection of a policy file.
+
+    Intent is to provide more humane validation for top level errors
+    instead of printing full schema as error message.
+    """
+    allowed_keys = set(('vars', 'policies'))
+
+    def validate(self, data):
+        if not isinstance(data, dict):
+            raise PolicyValidationError((
+                "Policy file top level data structure "
+                "should be a mapping/dict, instead found:%s""") % (
+                    type(data).__name__))
+        dkeys = set(data.keys())
+
+        extra = dkeys.difference(self.allowed_keys)
+        if extra:
+            raise PolicyValidationError((
+                'Policy files top level keys are %s, found extra: %s' % (
+                    ', '.join(self.allowed_keys),
+                    ', '.join(extra))))
+
+        pdata = data.get('policies', [])
+        if not isinstance(pdata, list):
+            raise PolicyValidationError((
+                '`policies` key should be an array/list found: %s' % (
+                    type(pdata).__name__)))
+        for p in pdata:
+            if not isinstance(p, dict):
+                raise PolicyValidationError((
+                    'policy must be a dictionary/mapping found:%s policy:\n %s' % (
+                        type(p).__name__, json.dumps(p, indent=2))))
+
+    def get_resource_types(self, data):
+        resources = set()
+        for p in data.get('policies', []):
+            rtype = p['resource']
+            if '.' not in rtype:
+                rtype = 'aws.%s' % rtype
+            resources.add(rtype)
+        return resources
 
 
 class ElementSchema(object):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -682,7 +682,8 @@ class MiscTest(CliTest):
         # Doesn't do anything, but should exit 0
         temp_dir = self.get_temp_dir()
         yaml_file = self.write_policy_file({})
-        self.run_and_expect_success(["custodian", "run", "-s", temp_dir, yaml_file])
+        self.run_and_expect_failure(
+            ["custodian", "run", "-s", temp_dir, yaml_file], 1)
 
     def test_nonexistent_policy_file(self):
         temp_dir = self.get_temp_dir()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,12 +18,50 @@ import sys
 from json import dumps
 from jsonschema.exceptions import best_match
 
+from c7n.exceptions import PolicyValidationError
 from c7n.filters import ValueFilter
 from c7n.manager import resources
 from c7n.schema import (
-    ElementSchema, resource_vocabulary, Validator, validate,
+    StructureParser, ElementSchema, resource_vocabulary, Validator, validate,
     generate, specific_error, policy_error_scope)
 from .common import BaseTest
+
+
+class StructureParserTest(BaseTest):
+
+    def test_extra_keys(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'accounts': []})
+        self.assertTrue(str(ecm.exception).startswith('Policy files top level keys'))
+
+    def test_bad_top_level_datastruct(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate([])
+        self.assertTrue(str(ecm.exception).startswith(
+            'Policy file top level data structure'))
+
+    def test_policies_not_list(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': {}})
+        self.assertTrue(str(ecm.exception).startswith(
+            "`policies` key should be an array/list"))
+
+    def test_policy_not_mapping(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [[]]})
+        self.assertTrue(str(ecm.exception).startswith(
+            'policy must be a dictionary/mapping found:list'))
+
+    def test_get_resource_types(self):
+        p = StructureParser()
+        self.assertEqual(
+            p.get_resource_types({'policies': [
+                {'resource': 'ec2'}, {'resource': 'gcp.instance'}]}),
+            set(('aws.ec2', 'gcp.instance')))
 
 
 class SchemaTest(BaseTest):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -42,6 +42,13 @@ class StructureParserTest(BaseTest):
         self.assertTrue(str(ecm.exception).startswith(
             'Policy file top level data structure'))
 
+    def test_policies_missing(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({})
+        self.assertTrue(str(ecm.exception).startswith(
+            "`policies` list missing"))
+
     def test_policies_not_list(self):
         p = StructureParser()
         with self.assertRaises(PolicyValidationError) as ecm:

--- a/tools/c7n_mailer/c7n_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/deploy.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
+import logging
 import json
 import os
 
@@ -23,6 +24,8 @@ from c7n.mu import (
     LambdaManager,
     PythonPackageArchive)
 
+
+log = logging.getLogger('custodian-mailer')
 
 entry_source = """\
 import logging
@@ -91,5 +94,6 @@ def provision(config, session_factory):
 
     archive = get_archive(config)
     func = LambdaFunction(func_config, archive)
+    log.info("Provisioning mailer lambda %s" % (session_factory().region_name))
     manager = LambdaManager(session_factory)
     manager.publish(func)


### PR DESCRIPTION
    Intent is to satisfy on two different use cases:

    One is more humane validation for a top level error on schema. At
    the moment that results in dumping the full schema out as an error
    message. Instead with a top level sanity check we can ensure that
    we give users a simple user message. This seems to affect new
    users predominantly.

    Second use case is to get a quick assessment of which resources
    are being used in a policy file.  This is to enable better lazy
    loading of resource code.
