### PR TITLE
aws.rds-snapshot | Exclude rds if create time not present

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1037,14 +1037,10 @@ class RDSSnapshotAge(AgeFilter):
         'age', days={'type': 'number'},
         op={'$ref': '#/definitions/filters_common/comparison_operators'})
 
-    date_attribute = 'dummy'
+    date_attribute = 'SnapshotCreateTime'
 
     def get_resource_date(self, i):
-        v = i.get('SnapshotCreateTime')
-        if v:
-            return v
-        else:
-            return None
+        return i.get('SnapshotCreateTime')
 
 
 @RDSSnapshot.action_registry.register('restore')

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1037,7 +1037,14 @@ class RDSSnapshotAge(AgeFilter):
         'age', days={'type': 'number'},
         op={'$ref': '#/definitions/filters_common/comparison_operators'})
 
-    date_attribute = 'SnapshotCreateTime'
+    date_attribute = 'dummy'
+
+    def get_resource_date(self, i):
+        v = i.get('SnapshotCreateTime')
+        if v:
+            return v
+        else:
+            return None
 
 
 @RDSSnapshot.action_registry.register('restore')


### PR DESCRIPTION
Closes #4970 

Overriding get_resource_date and not returning anything if `SnapshotCreateTime` is not present.