### PR TITLE
tools/c7n_mailer - fix tests, update doc build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,6 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Cloud Custodian'
-copyright = u'2017, Capital One Services, LLC'
 author = u'Kapil Thangavelu'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/tools/c7n_mailer/tests/test_splunk.py
+++ b/tools/c7n_mailer/tests/test_splunk.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-import botocore.vendored.requests as requests
+import requests
 from logging import Logger
 from mock import Mock, call, patch
 import pytest


### PR DESCRIPTION
latest botocore drops vendors requests, the Splunk mailer tests were using it.

note this is an urgent fix as currently all pull requests are failing status checks due to the failing mailer Splunk tests.