### PR TITLE
aws - universal augment arn type check

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -722,7 +722,7 @@ class TypeInfo(object):
     # arn resource attribute, when describe format has arn
     arn = None
 
-    # type, used for arn construction
+    # type, used for arn construction, also required for universal tag augment
     arn_type = None
 
     # how arn type is separated from rest of arn

--- a/c7n/resources/acm.py
+++ b/c7n/resources/acm.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from c7n.actions import BaseAction
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, DescribeSource, ConfigSource, TypeInfo
-from c7n.tags import universal_augment, register_universal_tags
+from c7n.tags import universal_augment
 from c7n.utils import type_schema, local_session
 
 
@@ -51,10 +51,6 @@ class DescribeCertificate(DescribeSource):
         return universal_augment(
             self.manager,
             super(DescribeCertificate, self).augment(resources))
-
-
-register_universal_tags(
-    Certificate.filter_registry, Certificate.action_registry, compatibility=False)
 
 
 @Certificate.action_registry.register('delete')

--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -22,7 +22,6 @@ from c7n.filters import FilterRegistry, ValueFilter
 from c7n.filters.iamaccess import CrossAccountAccessFilter
 from c7n.manager import resources, ResourceManager
 from c7n import query, utils
-from c7n.tags import universal_augment
 from c7n.utils import generate_arn, type_schema
 
 
@@ -151,7 +150,7 @@ class RestApi(query.QueryResourceManager):
     def get_source(self, source_type):
         if source_type == 'describe':
             return ApiDescribeSource(self)
-        return super(RestStage, self).get_source(source_type)
+        return super(RestApi, self).get_source(source_type)
 
 
 class ApiDescribeSource(query.DescribeSource):

--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -22,7 +22,7 @@ from c7n.filters import FilterRegistry, ValueFilter
 from c7n.filters.iamaccess import CrossAccountAccessFilter
 from c7n.manager import resources, ResourceManager
 from c7n import query, utils
-from c7n.tags import register_universal_tags
+from c7n.tags import universal_augment
 from c7n.utils import generate_arn, type_schema
 
 
@@ -131,6 +131,7 @@ class RestApi(query.QueryResourceManager):
         date = 'createdDate'
         dimension = 'GatewayName'
         config_type = "AWS::ApiGateway::RestApi"
+        universal_taggable = object()
 
     @property
     def generate_arn(self):
@@ -146,6 +147,23 @@ class RestApi(query.QueryResourceManager):
                 region=self.config.region,
                 resource_type=self.resource_type.arn_type)
         return self._generate_arn
+
+    def get_source(self, source_type):
+        if source_type == 'describe':
+            return ApiDescribeSource(self)
+        return super(RestStage, self).get_source(source_type)
+
+
+class ApiDescribeSource(query.DescribeSource):
+
+    def augment(self, resources):
+        for r in resources:
+            tags = r.setdefault('Tags', [])
+            for k, v in r.pop('tags', {}).items():
+                tags.append({
+                    'Key': k,
+                    'Value': v})
+        return resources
 
 
 @RestApi.filter_registry.register('cross-account')
@@ -193,9 +211,6 @@ class UpdateApi(BaseAction):
             client.update_rest_api(
                 restApiId=r['id'],
                 patchOperations=self.data['patch'])
-
-
-register_universal_tags(RestApi.filter_registry, RestApi.action_registry, compatibility=False)
 
 
 @RestApi.action_registry.register('delete')

--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -23,7 +23,7 @@ from c7n.filters.iamaccess import CrossAccountAccessFilter
 from c7n.query import QueryResourceManager, ChildResourceManager, TypeInfo
 from c7n.manager import resources
 from c7n.resolver import ValuesFrom
-from c7n.tags import universal_augment, register_universal_tags
+from c7n.tags import universal_augment
 from c7n.utils import type_schema, local_session, chunks, get_retry
 
 
@@ -159,6 +159,7 @@ class LogGroup(QueryResourceManager):
         filter_type = 'scalar'
         dimension = 'LogGroupName'
         date = 'creationTime'
+        universal_taggable = True
 
     def augment(self, resources):
         resources = universal_augment(self, resources)
@@ -170,9 +171,6 @@ class LogGroup(QueryResourceManager):
         # log group arn in resource describe has ':*' suffix, not all
         # apis can use that form, so normalize to standard arn.
         return [r['arn'][:-2] for r in resources]
-
-
-register_universal_tags(LogGroup.filter_registry, LogGroup.action_registry)
 
 
 @LogGroup.action_registry.register('retention')

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -22,8 +22,7 @@ from c7n.filters.kms import KmsRelatedFilter
 from c7n import query
 from c7n.manager import resources
 from c7n.tags import (
-    TagDelayedAction, RemoveTag, TagActionFilter, Tag, universal_augment,
-    register_universal_tags)
+    TagDelayedAction, RemoveTag, TagActionFilter, Tag, universal_augment)
 from c7n.utils import (
     local_session, chunks, type_schema, snapshot_identifier)
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter
@@ -42,6 +41,7 @@ class Table(query.QueryResourceManager):
         date = 'CreationDateTime'
         dimension = 'TableName'
         config_type = 'AWS::DynamoDB::Table'
+        universal_taggable = object()
 
     permissions = ('dynamodb:ListTagsOfResource',)
 
@@ -51,9 +51,6 @@ class Table(query.QueryResourceManager):
         elif source_type == 'config':
             return ConfigTable(self)
         raise ValueError('invalid source %s' % source_type)
-
-
-register_universal_tags(Table.filter_registry, Table.action_registry, False)
 
 
 class ConfigTable(query.ConfigSource):

--- a/c7n/resources/efs.py
+++ b/c7n/resources/efs.py
@@ -18,7 +18,7 @@ from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter
 from c7n.query import QueryResourceManager, ChildResourceManager, TypeInfo
-from c7n.tags import universal_augment, register_universal_tags
+from c7n.tags import universal_augment
 from c7n.utils import local_session, type_schema, get_retry
 
 
@@ -36,15 +36,9 @@ class ElasticFileSystem(QueryResourceManager):
         arn_service = 'elasticfilesystem'
         filter_name = 'FileSystemId'
         filter_type = 'scalar'
+        universal_taggable = True
 
-    def augment(self, resources):
-        return universal_augment(
-            self, super(ElasticFileSystem, self).augment(resources))
-
-
-register_universal_tags(
-    ElasticFileSystem.filter_registry,
-    ElasticFileSystem.action_registry)
+    augment = universal_augment
 
 
 @resources.register('efs-mount-target')

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -21,7 +21,7 @@ from c7n.query import QueryResourceManager, TypeInfo
 from c7n.utils import local_session, chunks, type_schema
 from c7n.actions import BaseAction
 from c7n.filters.vpc import SubnetFilter, SecurityGroupFilter
-from c7n.tags import universal_augment, register_universal_tags
+from c7n.tags import universal_augment
 from c7n.filters import StateTransitionFilter
 from c7n import query
 
@@ -93,12 +93,10 @@ class GlueDevEndpoint(QueryResourceManager):
         id = name = 'EndpointName'
         date = 'CreatedTimestamp'
         arn_type = "devEndpoint"
+        universal_taggable = True
 
     permissions = ('glue:GetDevEndpoints',)
     augment = universal_augment
-
-
-register_universal_tags(GlueDevEndpoint.filter_registry, GlueDevEndpoint.action_registry)
 
 
 @GlueDevEndpoint.action_registry.register('delete')
@@ -149,12 +147,10 @@ class GlueJob(QueryResourceManager):
         id = name = 'Name'
         date = 'CreatedOn'
         arn_type = 'job'
+        universal_taggable = True
 
     permissions = ('glue:GetJobs',)
     augment = universal_augment
-
-
-register_universal_tags(GlueJob.filter_registry, GlueJob.action_registry)
 
 
 @GlueJob.action_registry.register('delete')
@@ -182,12 +178,11 @@ class GlueCrawler(QueryResourceManager):
         date = 'CreatedOn'
         arn_type = 'crawler'
         state_key = 'State'
+        universal_taggable = True
 
     permissions = ('glue:GetCrawlers',)
     augment = universal_augment
 
-
-register_universal_tags(GlueCrawler.filter_registry, GlueCrawler.action_registry)
 
 
 @GlueCrawler.action_registry.register('delete')

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -184,7 +184,6 @@ class GlueCrawler(QueryResourceManager):
     augment = universal_augment
 
 
-
 @GlueCrawler.action_registry.register('delete')
 class DeleteCrawler(BaseAction, StateTransitionFilter):
 

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -97,7 +97,7 @@ class RDS(QueryResourceManager):
         dimension = 'DBInstanceIdentifier'
         config_type = 'AWS::RDS::DBInstance'
         arn = 'DBInstanceArn'
-        univeral_taggable = True
+        universal_taggable = True
         default_report_fields = (
             'DBInstanceIdentifier',
             'DBName',
@@ -953,7 +953,7 @@ class RDSSnapshot(QueryResourceManager):
         date = 'SnapshotCreateTime'
         config_type = "AWS::RDS::DBSnapshot"
         filter_name = "DBSnapshotIdentifier"
-        univeral_taggable = True
+        universal_taggable = True
 
     def get_source(self, source_type):
         if source_type == 'describe':

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -66,7 +66,7 @@ import c7n.filters.vpc as net_filters
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, DescribeSource, ConfigSource, TypeInfo
 from c7n import tags
-from c7n.tags import universal_augment, register_universal_tags
+from c7n.tags import universal_augment
 
 from c7n.utils import (
     local_session, type_schema, get_retry, chunks, snapshot_identifier)
@@ -97,7 +97,7 @@ class RDS(QueryResourceManager):
         dimension = 'DBInstanceIdentifier'
         config_type = 'AWS::RDS::DBInstance'
         arn = 'DBInstanceArn'
-
+        univeral_taggable = True
         default_report_fields = (
             'DBInstanceIdentifier',
             'DBName',
@@ -136,11 +136,6 @@ class ConfigRDS(ConfigSource):
         resource['Tags'] = [{u'Key': t['key'], u'Value': t['value']}
           for t in item['supplementaryConfiguration']['Tags']]
         return resource
-
-
-register_universal_tags(
-    RDS.filter_registry,
-    RDS.action_registry)
 
 
 def _db_instance_eligible_for_backup(resource):
@@ -958,6 +953,7 @@ class RDSSnapshot(QueryResourceManager):
         date = 'SnapshotCreateTime'
         config_type = "AWS::RDS::DBSnapshot"
         filter_name = "DBSnapshotIdentifier"
+        univeral_taggable = True
 
     def get_source(self, source_type):
         if source_type == 'describe':
@@ -983,11 +979,6 @@ class ConfigRDSSnapshot(ConfigSource):
           for t in item['supplementaryConfiguration']['Tags']]
         # TODO: Load DBSnapshotAttributes into annotation
         return resource
-
-
-register_universal_tags(
-    RDSSnapshot.filter_registry,
-    RDSSnapshot.action_registry)
 
 
 @RDSSnapshot.filter_registry.register('onhour')

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -42,6 +42,8 @@ class RDSCluster(QueryResourceManager):
 
         service = 'rds'
         arn = 'DBClusterArn'
+        arn_type = 'cluster'
+        arn_separator = ":"
         enum_spec = ('describe_db_clusters', 'DBClusters', None)
         name = id = 'DBClusterIdentifier'
         dimension = 'DBClusterIdentifier'
@@ -344,6 +346,8 @@ class RDSClusterSnapshot(QueryResourceManager):
     class resource_type(TypeInfo):
 
         service = 'rds'
+        arn_type = 'cluster-snapshot'
+        arn_separator = ':'
         arn = 'DBClusterSnapshotArn'
         enum_spec = (
             'describe_db_cluster_snapshots', 'DBClusterSnapshots', None)

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -25,7 +25,7 @@ from c7n.utils import local_session
 from c7n.query import QueryResourceManager, TypeInfo
 from c7n.actions import BaseAction
 from c7n.utils import type_schema
-from c7n.tags import universal_augment, register_universal_tags
+from c7n.tags import universal_augment
 
 
 @resources.register('sqs')
@@ -43,7 +43,7 @@ class SQS(QueryResourceManager):
         name = 'QueueUrl'
         date = 'CreatedTimestamp'
         dimension = 'QueueName'
-
+        universal_taggable = object()
         default_report_fields = (
             'QueueArn',
             'CreatedTimestamp',
@@ -86,10 +86,6 @@ class SQS(QueryResourceManager):
         with self.executor_factory(max_workers=2) as w:
             return universal_augment(
                 self, list(filter(None, w.map(_augment, resources))))
-
-
-register_universal_tags(
-    SQS.filter_registry, SQS.action_registry, compatibility=False)
 
 
 @SQS.filter_registry.register('metrics')

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -22,6 +22,7 @@ from c7n.exceptions import PolicyValidationError
 from c7n.filters import Filter
 from c7n.query import QueryResourceManager, TypeInfo
 from c7n.manager import resources
+from c7n.tags import universal_augment
 from c7n.utils import chunks, get_retry, local_session, type_schema, filter_empty
 from c7n.version import version
 
@@ -43,6 +44,8 @@ class SSMParameter(QueryResourceManager):
     retry = staticmethod(get_retry(('Throttled',)))
     permissions = ('ssm:GetParameters',
                    'ssm:DescribeParameters')
+
+    augment = universal_augment
 
 
 @resources.register('ssm-managed-instance')

--- a/c7n/resources/storagegw.py
+++ b/c7n/resources/storagegw.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
-from c7n.tags import register_universal_tags, universal_augment
+from c7n.tags import universal_augment
 
 
 @resources.register('storage-gateway')
@@ -25,11 +25,8 @@ class StorageGateway(QueryResourceManager):
         service = 'storagegateway'
         enum_spec = ('list_gateways', 'Gateways', None)
         arn = id = 'GatewayARN'
+        arn_type = 'gateway'
         name = 'GatewayName'
+        universal_taggble = object()
 
     augment = universal_augment
-
-
-register_universal_tags(
-    StorageGateway.filter_registry, StorageGateway.action_registry,
-    compatibility=False)

--- a/c7n/resources/workspaces.py
+++ b/c7n/resources/workspaces.py
@@ -20,7 +20,7 @@ import itertools
 from c7n.filters import ValueFilter
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
-from c7n.tags import universal_augment, register_universal_tags
+from c7n.tags import universal_augment
 from c7n.utils import local_session, type_schema, chunks
 
 
@@ -32,12 +32,10 @@ class Workspace(QueryResourceManager):
         enum_spec = ('describe_workspaces', 'Workspaces', None)
         arn_type = 'workspace'
         name = id = dimension = 'WorkspaceId'
+        universal_taggable = True
 
     def augment(self, resources):
         return universal_augment(self, resources)
-
-
-register_universal_tags(Workspace.filter_registry, Workspace.action_registry)
 
 
 @Workspace.filter_registry.register('connection-status')

--- a/tests/data/placebo/test_ssm_parameter_not_secure/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_ssm_parameter_not_secure/tagging.GetResources_1.json
@@ -1,0 +1,4 @@
+{
+    "status_code": 200, 
+    "data": {"ResourceTagMappingList": []}
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -109,6 +109,7 @@ class PolicyMeta(BaseTest):
     def test_resource_augment_universal_mask(self):
         # universal tag had a potential bad patterm of masking
         # resource augmentation, scan resources to ensure
+        missing = []
         for k, v in manager.resources.items():
             if not getattr(v.resource_type, "universal_taggable", None):
                 continue
@@ -116,19 +117,29 @@ class PolicyMeta(BaseTest):
                 v.augment.__name__ == "universal_augment" and
                 getattr(v.resource_type, "detail_spec", None)
             ):
-                self.fail(
-                    "%s resource has universal augment masking resource augment" % k
-                )
+                missing.append(k)
+
+        if missing:
+            self.fail(
+                "%s resource has universal augment masking resource augment" % (
+                    ', '.join(missing))
+            )
 
     def test_resource_universal_taggable_arn_type(self):
+        missing = []
         for k, v in manager.resources.items():
             if not getattr(v, 'augment', None):
                 continue
             if (
-                v.augment.__name__ == "universal_augment" and not v.arn_type
+                v.augment.__name__ == "universal_augment" and
+                    v.resource_type.arn_type is None
             ):
-                self.fail(
-                    "%s universal taggable resource missing arn_type" % k)
+                missing.append(k)
+
+        if missing:
+            self.fail("%s universal taggable resource missing arn_type" % (
+                ', '.join(missing)))
+
     def test_resource_shadow_source_augment(self):
         shadowed = []
         bad = []

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -120,6 +120,15 @@ class PolicyMeta(BaseTest):
                     "%s resource has universal augment masking resource augment" % k
                 )
 
+    def test_resource_universal_taggable_arn_type(self):
+        for k, v in manager.resources.items():
+            if not getattr(v, 'augment', None):
+                continue
+            if (
+                v.augment.__name__ == "universal_augment" and not v.arn_type
+            ):
+                self.fail(
+                    "%s universal taggable resource missing arn_type" % k)
     def test_resource_shadow_source_augment(self):
         shadowed = []
         bad = []


### PR DESCRIPTION
fixed an issue with rds cluster tags on trunk, note that arn_type is required for universal tagging, switch uses of register_universal_tags to using type metadata, add a meta test that verifies arn_type on resources.