### PR TITLE
core - extend structure validation to policy verification

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -31,6 +31,7 @@ from collections import Counter
 import json
 import inspect
 import logging
+import six
 
 from jsonschema import Draft4Validator as Validator
 from jsonschema.exceptions import best_match
@@ -502,8 +503,9 @@ class StructureParser(object):
             raise PolicyValidationError((
                 'policy:%s must use a list for filters found:%s' % (
                     p['name'], type(p['filters']).__name__)))
+        element_types = (dict,) + six.string_types
         for f in p.get('filters', ()):
-            if not isinstance(f, dict):
+            if not isinstance(f, element_types):
                 raise PolicyValidationError((
                     'policy:%s filter must be a mapping/dict found:%s' % (
                         p.get('name', 'unknown'), type(f).__name__)))
@@ -512,7 +514,7 @@ class StructureParser(object):
                 'policy:%s must use a list for actions found:%s' % (
                     p.get('name', 'unknown'), type(p['actions']).__name__)))
         for a in p.get('actions', ()):
-            if not isinstance(a, dict):
+            if not isinstance(a, element_types):
                 raise PolicyValidationError((
                     'policy:%s action must be a mapping/dict found:%s' % (
                         p.get('name', 'unknown'), type(a).__name__)))

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -448,7 +448,14 @@ class StructureParser(object):
     Intent is to provide more humane validation for top level errors
     instead of printing full schema as error message.
     """
-    allowed_keys = set(('vars', 'policies'))
+    allowed_file_keys = set(('vars', 'policies'))
+    required_policy_keys = set(('name', 'resource'))
+    allowed_policy_keys = set(
+        ('name', 'resource', 'title', 'description', 'mode', 'tags', 'max-resources',
+         'filters', 'actions', 'source', 'tags',
+         # legacy keys subject to deprecation.
+         'region', 'start', 'end', 'max-resources-percent', 'comments', 'comment'
+    ))
 
     def validate(self, data):
         if not isinstance(data, dict):
@@ -458,11 +465,11 @@ class StructureParser(object):
                     type(data).__name__))
         dkeys = set(data.keys())
 
-        extra = dkeys.difference(self.allowed_keys)
+        extra = dkeys.difference(self.allowed_file_keys)
         if extra:
             raise PolicyValidationError((
                 'Policy files top level keys are %s, found extra: %s' % (
-                    ', '.join(self.allowed_keys),
+                    ', '.join(self.allowed_file_keys),
                     ', '.join(extra))))
 
         if 'policies' not in data:
@@ -474,10 +481,40 @@ class StructureParser(object):
                 '`policies` key should be an array/list found: %s' % (
                     type(pdata).__name__)))
         for p in pdata:
-            if not isinstance(p, dict):
+            self.validate_policy(p)
+
+    def validate_policy(self, p):
+        if not isinstance(p, dict):
+            raise PolicyValidationError((
+                'policy must be a dictionary/mapping found:%s policy:\n %s' % (
+                    type(p).__name__, json.dumps(p, indent=2))))
+        pkeys = set(p)
+        if self.required_policy_keys.difference(pkeys):
+            raise PolicyValidationError(
+                'policy missing required keys (name, resource) data:\n %s' %  (
+                    json.dumps(p, indent=2)))
+        if pkeys.difference(self.allowed_policy_keys):
+            raise PolicyValidationError(
+                'policy:%s has unknown keys: %s' % (
+                    p['name'], ','.join(pkeys.difference(self.allowed_policy_keys))))
+        if not isinstance(p.get('filters', []), (list, type(None))):
+            raise PolicyValidationError((
+                'policy:%s must use a list for filters found:%s' % (
+                    p['name'], type(p['filters']).__name__)))
+        for f in p.get('filters', ()):
+            if not isinstance(f, dict):
                 raise PolicyValidationError((
-                    'policy must be a dictionary/mapping found:%s policy:\n %s' % (
-                        type(p).__name__, json.dumps(p, indent=2))))
+                    'policy:%s filter must be a mapping/dict found:%s' % (
+                        p.get('name', 'unknown'), type(f).__name__)))
+        if not isinstance(p.get('actions', []), (list, type(None))):
+            raise PolicyValidationError((
+                'policy:%s must use a list for actions found:%s' % (
+                    p.get('name', 'unknown'), type(p['actions']).__name__)))
+        for a in p.get('actions', ()):
+            if not isinstance(a, dict):
+                raise PolicyValidationError((
+                    'policy:%s action must be a mapping/dict found:%s' % (
+                        p.get('name', 'unknown'), type(a).__name__)))
 
     def get_resource_types(self, data):
         resources = set()

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -451,7 +451,8 @@ class StructureParser(object):
     allowed_file_keys = set(('vars', 'policies'))
     required_policy_keys = set(('name', 'resource'))
     allowed_policy_keys = set(
-        ('name', 'resource', 'title', 'description', 'mode', 'tags', 'max-resources',
+        ('name', 'resource', 'title', 'description', 'mode',
+         'tags', 'max-resources', 'source', 'query',
          'filters', 'actions', 'source', 'tags',
          # legacy keys subject to deprecation.
          'region', 'start', 'end', 'max-resources-percent', 'comments', 'comment'

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -456,8 +456,8 @@ class StructureParser(object):
          'tags', 'max-resources', 'source', 'query',
          'filters', 'actions', 'source', 'tags',
          # legacy keys subject to deprecation.
-         'region', 'start', 'end', 'max-resources-percent', 'comments', 'comment'
-    ))
+         'region', 'start', 'end', 'max-resources-percent',
+         'comments', 'comment'))
 
     def validate(self, data):
         if not isinstance(data, dict):
@@ -493,7 +493,7 @@ class StructureParser(object):
         pkeys = set(p)
         if self.required_policy_keys.difference(pkeys):
             raise PolicyValidationError(
-                'policy missing required keys (name, resource) data:\n %s' %  (
+                'policy missing required keys (name, resource) data:\n %s' % (
                     json.dumps(p, indent=2)))
         if pkeys.difference(self.allowed_policy_keys):
             raise PolicyValidationError(

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -81,7 +81,6 @@ def register_universal_tags(filters, actions, compatibility=True):
 def universal_augment(self, resources):
     # Resource Tagging API Support
     # https://docs.aws.amazon.com/awsconsolehelpdocs/latest/gsg/supported-resources.html
-
     # Bail on empty set
     if not resources:
         return resources

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -56,6 +56,48 @@ class StructureParserTest(BaseTest):
         self.assertTrue(str(ecm.exception).startswith(
             "`policies` key should be an array/list"))
 
+    def test_policy_missing_required(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [{'resource': 'aws.ec2'}]})
+        self.assertTrue(str(ecm.exception).startswith(
+            "policy missing required keys"))
+
+    def test_policy_extra_key(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [{
+                'name': 'foo', 'extra': 1, 'resource': 'aws.ec2'}]})
+        self.assertEqual(str(ecm.exception),
+            "policy:foo has unknown keys: extra")
+
+    def test_invalid_action(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [{
+                'name': 'foo', 'resource': 'ec2', 'actions': {}}]})
+        self.assertTrue(str(ecm.exception).startswith(
+            'policy:foo must use a list for actions found:dict'))
+
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [{
+                'name': 'foo', 'resource': 'ec2', 'actions': [[]]}]})
+        self.assertTrue(str(ecm.exception).startswith(
+            'policy:foo action must be a mapping/dict found:list'))
+
+    def test_invalid_filter(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [{
+                'name': 'foo', 'resource': 'ec2', 'filters': {}}]})
+        self.assertTrue(str(ecm.exception).startswith(
+            'policy:foo must use a list for filters found:dict'))
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [{
+                'name': 'foo', 'resource': 'ec2', 'filters': [[]]}]})
+        self.assertTrue(str(ecm.exception).startswith(
+            'policy:foo filter must be a mapping/dict found:list'))
+
     def test_policy_not_mapping(self):
         p = StructureParser()
         with self.assertRaises(PolicyValidationError) as ecm:


### PR DESCRIPTION

structure verification was primarily examining top level data structures previously, this extends it to also sanity check the policy data structure as well, as in the absence of this the user could also potentially get a full schema dump error message.