### PR TITLE
aws - use sts regional endpoints revisit

### DIFF
--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -26,6 +26,10 @@ from c7n.version import version
 from c7n.utils import get_retry
 
 
+# 0.8.45.1 compatibility with global only sts endpoints, out of caution, remove in 0.8.46.1
+USE_STS_GLOBAL = os.environ.get('C7N_USE_STS_GLOBAL', '').lower() in ('yes', 'true')
+
+
 class SessionFactory(object):
 
     def __init__(self, region, profile=None, assume_role=None, external_id=None):
@@ -98,7 +102,8 @@ def assumed_session(role_arn, session_name, session=None, region=None, external_
             parameters['ExternalId'] = external_id
 
         credentials = retry(
-            session.client('sts').assume_role, **parameters)['Credentials']
+            get_sts_client(
+                session, region).assume_role, **parameters)['Credentials']
         return dict(
             access_key=credentials['AccessKeyId'],
             secret_key=credentials['SecretAccessKey'],
@@ -123,3 +128,20 @@ def assumed_session(role_arn, session_name, session=None, region=None, external_
         region = s.get_config_variable('region') or 'us-east-1'
     s.set_config_variable('region', region)
     return Session(botocore_session=s)
+
+
+def get_sts_client(session, region):
+    """Get the AWS STS endpoint specific for the given region.
+
+    Returns the global endpoint if region is not specified.
+
+    For the list of regional endpoints, see https://amzn.to/2ohJgtR
+    """
+    if region and not USE_STS_GLOBAL:
+        endpoint_url = "https://sts.{}.amazonaws.com".format(region)
+        region_name = region
+    else:
+        endpoint_url = "https://sts.amazonaws.com"
+        region_name = None
+    return session.client(
+        'sts', endpoint_url=endpoint_url, region_name=region_name)

--- a/tests/data/placebo/test_credential_sts/sts.AssumeRole_1.json
+++ b/tests/data/placebo/test_credential_sts/sts.AssumeRole_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "Credentials": {
+            "AccessKeyId": "ASIAZL6XWCR2MIB6XHU7",
+            "SecretAccessKey": "VDpkOc0GkN6P0h7uw7UBCUjDhZyf1nhWTr+QAAAA",
+            "SessionToken": "FQoGZXIvYXdzEOf//////////wEaDIMk7cQ0yRT21yv3qyLxAXuy3hMxv+eno5ZEeNG2h0WulIKmuQFdP/cgTxIOTpcxDagVnMwceRbkDl7ILd8L9RkrWgmAzuZNjDSzYeIq3QGqF3OLpC+O4MQQJ0ToGKCupj9cAUojM2yG8twjgXyQFve6oPURlWqftK+n6BKos5MoJN8J1i3TiD14Lr5wQwxYjrGirINKCwmV6qS5nhLvq4kjFYiD5Q4drhV27FeVicQA98kL/ArJKHmqkCRzRUPRV1NdjIay8F/ApO7pdBMqmYHXCHjIJA8KskvuF368tHEIyG8H78hCm1wQ/KOOPQ2dWpEYR6qsyJ98Q8YRwrcLHJ4oorrE7AU=",
+            "Expiration": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 9,
+                "day": 29,
+                "hour": 22,
+                "minute": 7,
+                "second": 46,
+                "microsecond": 0
+            }
+        },
+        "AssumedRoleUser": {
+            "AssumedRoleId": "AROAIS6DAH72KKDTPRAXA:custodian-dev",
+            "Arn": "arn:aws:sts::644160558196:assumed-role/CustodianGuardDuty/custodian-dev"
+        },
+        "ResponseMetadata": {
+            "RequestId": "2fd19c17-e2fd-11e9-ab45-b3c33c550d67",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "2fd19c17-e2fd-11e9-ab45-b3c33c550d67",
+                "content-type": "text/xml",
+                "content-length": "1091",
+                "date": "Sun, 29 Sep 2019 21:07:46 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_credential_sts/sts.GetCallerIdentity_1.json
+++ b/tests/data/placebo/test_credential_sts/sts.GetCallerIdentity_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserId": "AROAIS6DAH72KKDTPRAXA:custodian-dev",
+        "Account": "644160558196",
+        "Arn": "arn:aws:sts::644160558196:assumed-role/CustodianGuardDuty/custodian-dev",
+        "ResponseMetadata": {
+            "RequestId": "2fe1c83b-e2fd-11e9-a799-d327b1809fe0",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "2fe1c83b-e2fd-11e9-a799-d327b1809fe0",
+                "content-type": "text/xml",
+                "content-length": "451",
+                "date": "Sun, 29 Sep 2019 21:07:46 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_credential_sts_regional/sts.GetCallerIdentity_1.json
+++ b/tests/data/placebo/test_credential_sts_regional/sts.GetCallerIdentity_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Account": "644160558196", 
+        "UserId": "AIDAJEZOTH6YPO3DY45QW", 
+        "Arn": "arn:aws:iam::644160558196:user/kapil"
+    }
+}

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
 from botocore.exceptions import ClientError
+import placebo
 
 from c7n.credentials import SessionFactory, assumed_session
 from c7n.version import version
@@ -31,24 +33,31 @@ class Credential(BaseTest):
             session._session.user_agent().startswith("CloudCustodian/%s" % version)
         )
 
-    def xtest_assumed_session(self):
-        # placebo's datetime bug bites again
-        # https://github.com/garnaat/placebo/pull/50
+    def test_assumed_session(self):
         factory = self.replay_flight_data("test_credential_sts")
-        user = factory().client("iam").get_user()
         session = assumed_session(
-            "arn:aws:iam::644160558196:role/CloudCustodianRole",
-            "custodian-dev",
+            role_arn='arn:aws:iam::644160558196:role/CustodianGuardDuty',
+            session_name="custodian-dev",
             session=factory(),
         )
+
+        # attach the placebo flight recorder to the new session.
+        pill = placebo.attach(
+            session, os.path.join(self.placebo_dir, 'test_credential_sts'))
+        if self.recording:
+            pill.record()
+        else:
+            pill.playback()
+        self.addCleanup(pill.stop)
+
         try:
-            session.client("iam").get_user()
+            identity = session.client("sts").get_caller_identity()
         except ClientError as e:
             self.assertEqual(e.response["Error"]["Code"], "ValidationError")
-        else:
-            self.fail("sts user not identifyable this way")
 
-        self.assertEqual(user["User"]["UserName"], "kapil")
+        self.assertEqual(
+            identity['Arn'],
+            'arn:aws:sts::644160558196:assumed-role/CustodianGuardDuty/custodian-dev')
 
     def test_policy_name_user_agent(self):
         session = SessionFactory("us-east-1")


### PR DESCRIPTION
closes #4874 

based on previous #4875 this time with region_name passing for regional client usage.