### PR TITLE
aws - mark IAM policy as "used" if it is used as a permissions boundary

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -935,6 +935,7 @@ class RoleDelete(BaseAction):
 @Policy.filter_registry.register('used')
 class UsedIamPolicies(Filter):
     """Filter IAM policies that are being used
+    (either attached to some roles or used as a permissions boundary).
 
     :example:
 
@@ -951,12 +952,14 @@ class UsedIamPolicies(Filter):
     permissions = ('iam:ListPolicies',)
 
     def process(self, resources, event=None):
-        return [r for r in resources if r['AttachmentCount'] > 0]
+        return [r for r in resources if
+                r['AttachmentCount'] > 0 or r.get('PermissionsBoundaryUsageCount', 0) > 0]
 
 
 @Policy.filter_registry.register('unused')
 class UnusedIamPolicies(Filter):
     """Filter IAM policies that are not being used
+    (neither attached to any roles nor used as a permissions boundary).
 
     :example:
 
@@ -973,7 +976,8 @@ class UnusedIamPolicies(Filter):
     permissions = ('iam:ListPolicies',)
 
     def process(self, resources, event=None):
-        return [r for r in resources if r['AttachmentCount'] == 0]
+        return [r for r in resources if
+                r['AttachmentCount'] == 0 and r.get('PermissionsBoundaryUsageCount', 0) == 0]
 
 
 @Policy.filter_registry.register('has-allow-all')

--- a/tests/data/placebo/test_iam_policy_attached/iam.ListPolicies_1.json
+++ b/tests/data/placebo/test_iam_policy_attached/iam.ListPolicies_1.json
@@ -278,6 +278,7 @@
                     "minute": 40
                 }, 
                 "AttachmentCount": 0, 
+                "PermissionsBoundaryUsageCount": 1,
                 "IsAttachable": true, 
                 "PolicyId": "ANPAI3VAJF5ZCRZ7MCQE6", 
                 "DefaultVersionId": "v1", 

--- a/tests/data/placebo/test_iam_policy_unattached/iam.ListPolicies_1.json
+++ b/tests/data/placebo/test_iam_policy_unattached/iam.ListPolicies_1.json
@@ -278,6 +278,7 @@
                     "minute": 40
                 }, 
                 "AttachmentCount": 0, 
+                "PermissionsBoundaryUsageCount": 1,
                 "IsAttachable": true, 
                 "PolicyId": "ANPAI3VAJF5ZCRZ7MCQE6", 
                 "DefaultVersionId": "v1", 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -665,7 +665,7 @@ class IamPolicyFilterUsage(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertEqual(len(resources), 6)
+        self.assertEqual(len(resources), 7)
 
     def test_iam_unattached_policies(self):
         session_factory = self.replay_flight_data("test_iam_policy_unattached")
@@ -679,7 +679,7 @@ class IamPolicyFilterUsage(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertEqual(len(resources), 203)
+        self.assertEqual(len(resources), 202)
 
 
 class IamPolicy(BaseTest):


### PR DESCRIPTION
**The problem:**

If an IAM security policy is not attached to any roles, it is marked as "unused" by Cloud Custodian, even if it is being used as a permissions boundary.

**Evaluation:**

The recent versions of AWS CLI/API return `PermissionsBoundaryUsageCount` attribute that can be used to determine if a policy is being used as a permissions boundary. For example:

```json
        {
            "PolicyName": "ViewOnlyAccess",
            "PolicyId": "ANPAID22R6XPJATWOFDK6",
            "Arn": "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess",
            "Path": "/job-function/",
            "DefaultVersionId": "v7",
            "AttachmentCount": 0,
            "PermissionsBoundaryUsageCount": 0,
            "IsAttachable": true,
            "CreateDate": "2016-11-10T17:20:15Z",
            "UpdateDate": "2018-10-15T18:34:54Z"
        }
```

I am having to work around the current c7n limitation by adding an extra filter like this:

```yaml
    filters:
      - type: unused
      - type: value
        key: Arn
        op: contains
        value: "arn:aws:iam::{account_id}:policy/"
      - type: value
        key: PermissionsBoundaryUsageCount
        op: equal
        value_type: integer
        value: 0
```

**The proposal:**

This pull request integrates checks for `PermissionsBoundaryUsageCount` directly into the `used` and `unused` checks for `iam-policy` resource.
I had to treat the new attribute as optional, because the replay files in tests date back to 2016 and do not have that attribute. I had to fudge one policy for each test to achieve enough test coverage.
It would be great to re-generate those test files using the new version of the AWS API, but it's not something I can do.