### PR TITLE
Exclude `.git` directory from docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 **/*.pyc
 *.egg-info/
 *.swp


### PR DESCRIPTION
The size of `.git` directory is 130M at the time of writing,
and all of it is being unnecessarily send to docker daemon
when building the images.

By excluding `.git`, the size of build context was reduced
from 173.9MB to 38.07MB.