### PR TITLE
Support value filters for IpProtocol

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1143,7 +1143,12 @@ SGPermissionSchema = {
     'Ports': {'type': 'array', 'items': {'type': 'integer'}},
     'SelfReference': {'type': 'boolean'},
     'OnlyPorts': {'type': 'array', 'items': {'type': 'integer'}},
-    'IpProtocol': {'enum': ["-1", -1, 'tcp', 'udp', 'icmp', 'icmpv6']},
+    'IpProtocol': {
+        'oneOf': [
+            {'enum': ["-1", -1, 'tcp', 'udp', 'icmp', 'icmpv6']},
+            {'$ref': '#/definitions/filters/value'}
+        ]
+    },
     'FromPort': {'oneOf': [
         {'$ref': '#/definitions/filters/value'},
         {'type': 'integer'}]},


### PR DESCRIPTION
The IpProtocol field schema only supported an enum of values, but it actual supports a full value filter under the hood.

This just updates the schema to support the value filter in rules (note that this was a regression a while ago based on the filter definition)