### PR TITLE
aws - handle asgs with multiple launch templates

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -140,9 +140,9 @@ class LaunchInfo(object):
     def get(self, asg):
         launches = []
         for lid in self.get_launch_ids(asg):
-            l = self.get_launch(lid)
-            if l:
-                launches.append(l)
+            launch = self.get_launch(lid)
+            if launch:
+                launches.append(launch)
         return launches
 
     def get_launch(self, lid):

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -702,6 +702,8 @@ class DefaultVpc(DefaultVpcBase):
 
 
 def deserialize_user_data(user_data):
+    if user_data is None:
+        return None
     data = base64.b64decode(user_data)
     # try raw and compressed
     try:
@@ -1888,11 +1890,17 @@ class LaunchTemplate(query.QueryResourceManager):
     def get_asg_templates(self, asgs):
         templates = {}
         for a in asgs:
-            if 'LaunchTemplate' not in a:
+            t = a.get('LaunchTemplate')
+            if t:
+                templates.setdefault(
+                    (t['LaunchTemplateId'], t['Version']), []).append(
+                        a['AutoScalingGroupName'])
+            if 'MixedInstancesPolicy' not in a:
                 continue
-            t = a['LaunchTemplate']
+            mip_spec = a['MixedInstancesPolicy'][
+                'LaunchTemplate']['LaunchTemplateSpecification']
             templates.setdefault(
-                (t['LaunchTemplateId'], t['Version']), []).append(
+                (mip_spec['LaunchTemplateId'], mip_spec['Version']), []).append(
                     a['AutoScalingGroupName'])
         return templates
 


### PR DESCRIPTION

closes #5001 

this revamps asg launch handling to take into account that a given asg may have multiple launch templates associated to it due to use of mixed instance policies (spot blending - https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html).

asg invalid and unencrypted will now flag for any template associated to an asg.  launch-config filter will match for either template associated to an asg. asg ami age will use the oldest age of images associated to either template.

ami and ebs-snapshot unused filters will now take into account these secondary templates.
