### PR TITLE
core - schema semantic error  handle filters/actions w/ a resource key.

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -114,7 +114,7 @@ def specific_error(error):
     if r is not None:
         found = None
         for idx, v in enumerate(error.validator_value):
-            if v['$ref'].rsplit('/', 2)[1].endswith(r):
+            if '$ref' in v and v['$ref'].rsplit('/', 2)[1].endswith(r):
                 found = idx
                 break
         if found is not None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -285,6 +285,22 @@ class SchemaTest(BaseTest):
         self.assertIsInstance(resp[0], ValidationError)
         self.assertIsInstance(resp[1], ValidationError)
 
+    def test_semantic_error_with_nested_resource_key(self):
+        data = {
+            'policies': [{
+                'name': 'team-tag-ebs-snapshot-audit',
+                'resource': 'ebs-snapshot',
+                'actions': [
+                    {'type': 'copy-related-tag',
+                     'resource': 'ebs',
+                     'skip_missing': True,
+                     'key': 'VolumeId',
+                     'tags': 'Team'}]}]}
+        errors = list(self.validator.iter_errors(data))
+        self.assertEqual(len(errors), 1)
+        error = specific_error(errors[0])
+        self.assertTrue('Team' in error.message)
+
     def test_vars_and_tags(self):
         data = {
             "vars": {"alpha": 1, "beta": 2},


### PR DESCRIPTION
fixes error message confusion and closes #4998 