### PR TITLE
asg - use mixed instances policy launch template if present

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -125,6 +125,11 @@ class LaunchInfo(object):
         if lid is not None:
             return (lid['LaunchTemplateId'], lid['Version'])
 
+        if 'MixedInstancesPolicy' in asg:
+            mip_spec = asg['MixedInstancesPolicy'][
+                'LaunchTemplate']['LaunchTemplateSpecification']
+            return (mip_spec['LaunchTemplateId'], mip_spec['Version'])
+
         # we've noticed some corner cases where the asg name is the lc name, but not
         # explicitly specified as launchconfiguration attribute.
         lid = asg['AutoScalingGroupName']

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1888,12 +1888,17 @@ class LaunchTemplate(query.QueryResourceManager):
     def get_asg_templates(self, asgs):
         templates = {}
         for a in asgs:
-            if 'LaunchTemplate' not in a:
+            t = None
+            if 'LaunchTemplate' in a:
+                t = a['LaunchTemplate']
+            elif 'MixedInstancesPolicy' in a:
+                t = a['MixedInstancesPolicy'][
+                    'LaunchTemplate']['LaunchTemplateSpecification']
+            if t is None:
                 continue
-            t = a['LaunchTemplate']
             templates.setdefault(
-                (t['LaunchTemplateId'], t['Version']), []).append(
-                    a['AutoScalingGroupName'])
+                (t['LaunchTemplateId'],
+                 t['Version']), []).append(a['AutoScalingGroupName'])
         return templates
 
 

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -20,6 +20,7 @@ from .common import BaseTest
 
 from c7n.resources.asg import LaunchInfo
 
+
 class LaunchConfigTest(BaseTest):
 
     def test_config_unused(self):
@@ -80,15 +81,14 @@ class AutoScalingTemplateTest(BaseTest):
         d = {
             "AutoScalingGroupName": "devx",
             "MixedInstancesPolicy": {
-            "LaunchTemplate": {
-                "LaunchTemplateSpecification": {
-                    "LaunchTemplateId": "lt-0877401c93c294001",
-                    "LaunchTemplateName": "test",
-                    "Version": "4"
+                "LaunchTemplate": {
+                    "LaunchTemplateSpecification": {
+                        "LaunchTemplateId": "lt-0877401c93c294001",
+                        "LaunchTemplateName": "test",
+                        "Version": "4"},
+                    "Overrides": [{"InstanceType": "t1.micro"},
+                                  {"InstanceType": "t2.small"}]
                 },
-                "Overrides": [{"InstanceType": "t1.micro"},
-                              {"InstanceType": "t2.small"}]
-            },
                 "InstancesDistribution": {
                     "OnDemandAllocationStrategy": "prioritized",
                     "OnDemandBaseCapacity": 1,
@@ -108,7 +108,8 @@ class AutoScalingTemplateTest(BaseTest):
         p = self.load_policy({"name": "mixed-instance", "resource": "asg"})
         self.assertEqual(
             list(p.resource_manager.get_resource_manager(
-                'launch-template-version').get_asg_templates([d]).keys()), [("lt-0877401c93c294001", "4")])
+                'launch-template-version').get_asg_templates([d]).keys()),
+            [("lt-0877401c93c294001", "4")])
         self.assertEqual(
             LaunchInfo(p.resource_manager).get_launch_id(d), ("lt-0877401c93c294001", "4"))
 

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -18,6 +18,7 @@ from dateutil import tz as tzutil
 
 from .common import BaseTest
 
+from c7n.resources.asg import LaunchInfo
 
 class LaunchConfigTest(BaseTest):
 
@@ -71,6 +72,45 @@ class TestUserData(BaseTest):
         )
         resources = policy.run()
         self.assertGreater(len(resources), 0)
+
+
+class AutoScalingTemplateTest(BaseTest):
+
+    def test_asg_mixed_instance_templates(self):
+        d = {
+            "AutoScalingGroupName": "devx",
+            "MixedInstancesPolicy": {
+            "LaunchTemplate": {
+                "LaunchTemplateSpecification": {
+                    "LaunchTemplateId": "lt-0877401c93c294001",
+                    "LaunchTemplateName": "test",
+                    "Version": "4"
+                },
+                "Overrides": [{"InstanceType": "t1.micro"},
+                              {"InstanceType": "t2.small"}]
+            },
+                "InstancesDistribution": {
+                    "OnDemandAllocationStrategy": "prioritized",
+                    "OnDemandBaseCapacity": 1,
+                    "OnDemandPercentageAboveBaseCapacity": 0,
+                    "SpotAllocationStrategy": "capacity-optimized"
+                }
+            },
+            "MinSize": 1,
+            "MaxSize": 1,
+            "DesiredCapacity": 1,
+            "DefaultCooldown": 300,
+            "AvailabilityZones": ["us-east-1d", "us-east-1e"],
+            "HealthCheckType": "EC2",
+            "HealthCheckGracePeriod": 300,
+            "VPCZoneIdentifier": "subnet-3a334610,subnet-e3b194de"}
+
+        p = self.load_policy({"name": "mixed-instance", "resource": "asg"})
+        self.assertEqual(
+            list(p.resource_manager.get_resource_manager(
+                'launch-template-version').get_asg_templates([d]).keys()), [("lt-0877401c93c294001", "4")])
+        self.assertEqual(
+            LaunchInfo(p.resource_manager).get_launch_id(d), ("lt-0877401c93c294001", "4"))
 
 
 class AutoScalingTest(BaseTest):


### PR DESCRIPTION
closes #5001 

this revamps asg launch handling to take into account that a given asg using mixed instance policy which has a separate key for launch  template associated to it. https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html.
