### PR TITLE
aws - fix cloud watch log group name construction

### DIFF
--- a/c7n/log.py
+++ b/c7n/log.py
@@ -82,7 +82,7 @@ class CloudWatchLogHandler(logging.Handler):
         # Logging module internally is tracking all handlers, for final
         # cleanup atexit, custodian is a bit more explicitly scoping shutdown to
         # each policy, so use a sentinel value to avoid deadlocks.
-        self.shutdown = False
+        self.shutdown = True
         retry = get_retry(('ThrottlingException',))
         try:
             client = self.session_factory().client('logs')
@@ -113,6 +113,7 @@ class CloudWatchLogHandler(logging.Handler):
 
         msg = self.format_message(message)
         if not self.transport:
+            self.shutdown = False
             self.start_transports()
         self.buf.append(msg)
         self.flush_buffers(

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -231,11 +231,13 @@ class CloudWatchLogOutput(LogOutput):
 
     def __init__(self, ctx, config=None):
         super(CloudWatchLogOutput, self).__init__(ctx, config)
-        if self.config.get('netloc') == 'master':
-            self.log_group = self.config.get('path').strip("/")
+        if self.config['netloc'] == 'master' or not self.config['netloc']:
+            self.log_group = self.config['path'].strip('/')
         else:
-            self.log_group = self.config.get('netloc')
-        self.region = self.config.get('region')
+            # join netloc to path for casual usages of aws://log/group/name
+            self.log_group = "%s/%s" % (
+                self.config['netloc'], self.config['path'].strip('/'))
+        self.region = self.config.get('region', ctx.options.region)
         self.destination = (
             self.config.scheme == 'aws' and
             self.config.get('netloc') == 'master') and 'master' or None
@@ -251,27 +253,18 @@ class CloudWatchLogOutput(LogOutput):
             log_stream = self.config.get('stream').format(
                 region=self.ctx.options.region,
                 account=self.ctx.options.account_id,
-                policy=self.ctx.policy.name
-            )
+                policy=self.ctx.policy.name,
+                now=datetime.datetime.utcnow())
         return log_stream
 
     def get_handler(self):
         log_stream = self.construct_stream_name()
-        if self.destination == 'master':
-            handler = CloudWatchLogHandler(
-                log_group=self.log_group,
-                log_stream=log_stream,
-                session_factory=lambda x=None: self.ctx.session_factory(
-                    assume=False,
-                    region=self.region
-                )
-            )
-        else:
-            handler = CloudWatchLogHandler(
-                log_group=self.log_group,
-                log_stream=log_stream,
-                session_factory=lambda x=None: self.ctx.session_factory(region=self.region))
-        return handler
+        params = dict(
+            log_group=self.log_group, log_stream=log_stream,
+            session_factory=(
+                lambda x=None: self.ctx.session_factory(
+                    region=self.region, assume=self.destination != 'master')))
+        return CloudWatchLogHandler(**params)
 
     def __repr__(self):
         return "<%s to group:%s stream:%s>" % (

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -235,8 +235,8 @@ class CloudWatchLogOutput(LogOutput):
             self.log_group = self.config['path'].strip('/')
         else:
             # join netloc to path for casual usages of aws://log/group/name
-            self.log_group = "%s/%s" % (
-                self.config['netloc'], self.config['path'].strip('/'))
+            self.log_group = ("%s/%s" % (
+                self.config['netloc'], self.config['path'].strip('/'))).strip('/')
         self.region = self.config.get('region', ctx.options.region)
         self.destination = (
             self.config.scheme == 'aws' and

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -198,37 +198,52 @@ class OutputMetricsTest(BaseTest):
 
 
 class OutputLogsTest(BaseTest):
+    # cloud watch logging
 
-    def test_log_handler(self):
-        session_factory = self.replay_flight_data(
-            'test_log_handler')
-        conf = Bag({
-            'region': 'us-east-2',
-            'scheme': 'aws',
-            'netloc': 'master',
-            'path': 'custodian'
-        })
+    def test_default_log_group(self):
+        ctx = Bag(session_factory=None,
+                  options=Bag(account_id='001100', region='us-east-1'),
+                  policy=Bag(name='test', resource_type='ec2'))
+
+        log_output = output.log_outputs.select('custodian/xyz', ctx)
+        self.assertEqual(log_output.log_group, 'custodian/xyz')
+        self.assertEqual(log_output.construct_stream_name(), 'test')
+
+        log_output = output.log_outputs.select('/custodian/xyz/', ctx)
+        self.assertEqual(log_output.log_group, 'custodian/xyz')
+        self.assertEqual(log_output.construct_stream_name(), 'test')
+
+        log_output = output.log_outputs.select('aws://somewhere/out/there', ctx)
+        self.assertEqual(log_output.log_group, 'somewhere/out/there')
+        self.assertEqual(log_output.construct_stream_name(), 'test')
+
+        log_output = output.log_outputs.select('aws:///somewhere/out', ctx)
+        self.assertEqual(log_output.log_group, 'somewhere/out')
+        self.assertEqual(log_output.construct_stream_name(), 'test')
+
+        log_output = output.log_outputs.select(
+            "aws:///somewhere/out?stream={region}/{policy}", ctx)
+        self.assertEqual(log_output.log_group, 'somewhere/out')
+        self.assertEqual(log_output.construct_stream_name(), 'us-east-1/test')
+
+    def test_master_log_handler(self):
+        session_factory = self.replay_flight_data('test_log_handler')
         ctx = Bag(session_factory=session_factory,
-            options=Bag(account_id='001100', region='us-east-1'),
-            policy=Bag(name='test', resource_type='ec2'))
-        output = aws.CloudWatchLogOutput(ctx, conf)
-        stream = output.get_handler()
+                  options=Bag(account_id='001100', region='us-east-1'),
+                  policy=Bag(name='test', resource_type='ec2'))
+        log_output = output.log_outputs.select(
+            'aws://master/custodian?region=us-east-2', ctx)
+        stream = log_output.get_handler()
         self.assertTrue(stream.log_group == 'custodian')
         self.assertTrue(stream.log_stream == '001100/us-east-1/test')
 
     def test_stream_override(self):
         session_factory = self.replay_flight_data(
             'test_log_stream_override')
-        conf = Bag({
-            'region': 'us-east-2',
-            'scheme': 'aws',
-            'netloc': 'master',
-            'path': 'custodian',
-            'stream': "testing"
-        })
         ctx = Bag(session_factory=session_factory,
             options=Bag(account_id='001100', region='us-east-1'),
             policy=Bag(name='test', resource_type='ec2'))
-        output = aws.CloudWatchLogOutput(ctx, conf)
-        stream = output.get_handler()
+        log_output = output.log_outputs.select(
+            'aws://master/custodian?region=us-east-2&stream=testing', ctx)
+        stream = log_output.get_handler()
         self.assertTrue(stream.log_stream == 'testing')

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -211,15 +211,15 @@ class OutputLogsTest(BaseTest):
 
         log_output = output.log_outputs.select('/custodian/xyz/', ctx)
         self.assertEqual(log_output.log_group, 'custodian/xyz')
-        self.assertEqual(log_output.construct_stream_name(), 'test')
 
         log_output = output.log_outputs.select('aws://somewhere/out/there', ctx)
         self.assertEqual(log_output.log_group, 'somewhere/out/there')
-        self.assertEqual(log_output.construct_stream_name(), 'test')
 
         log_output = output.log_outputs.select('aws:///somewhere/out', ctx)
         self.assertEqual(log_output.log_group, 'somewhere/out')
-        self.assertEqual(log_output.construct_stream_name(), 'test')
+
+        log_output = output.log_outputs.select('aws://somewhere', ctx)
+        self.assertEqual(log_output.log_group, 'somewhere')
 
         log_output = output.log_outputs.select(
             "aws:///somewhere/out?stream={region}/{policy}", ctx)


### PR DESCRIPTION
closes #4950 which was a regression from #4809 and present in the 0.8.45.0 and 0.8.45.1 releases

- more exhaustive testing of log group configuration values to cover known defaults.
- add current time to custom stream formatting.
- CWL handler don't wait on queue until threads are started.

