### PR TITLE
Add c7n_guardian enhancement for getting regions out of yaml file

### DIFF
--- a/tools/c7n_guardian/readme.md
+++ b/tools/c7n_guardian/readme.md
@@ -40,6 +40,24 @@ accounts:
 
 ```
 
+Optionally you can include the region in the yaml instead of declaring
+them on the CLI.  To use this option the cli input should be ``` --region config ```
+
+```shell
+$ cat accounts.yml
+
+accounts:
+  - name: guard-duty-master
+    email: guard-duty-master@example.com
+    account_id: "2020202020202"
+    role: "arn:aws:iam::2020202020202:role/CustodianGuardDuty"
+    regions:
+      - us-east-1
+      - us-east-2
+    tags:
+      - prod
+```
+
 The cli also has support for disabling and reporting on accounts
 
 ```shell

--- a/tools/c7n_guardian/todo.md
+++ b/tools/c7n_guardian/todo.md
@@ -1,8 +1,4 @@
 
 - export
 
-- suspend
-
-- disable
-
 - remove-members


### PR DESCRIPTION
Our c7n_orgs yaml file already has the correct regions for each account we process, and the emails.  It would be really handy if c7n_guardian could use this file and respect the regions indicated in the file.  These updates were tested and working with our implementation. 