### PR TITLE
aws - sechub custom action uses self-select pattern

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -1007,7 +1007,12 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
+        pattern = self.data.get('pattern')
+
         payload = {}
+        if pattern:
+            payload.update(pattern)
+
         if event_type == 'cloudtrail':
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
@@ -1148,8 +1153,11 @@ class SecurityHubAction(object):
     def __init__(self, policy, session_factory):
         self.policy = policy
         self.session_factory = session_factory
+
+        cwe_data = self.policy.data['mode']
+        cwe_data['pattern'] = {'resources': [self._get_arn()]}
         self.cwe = CloudWatchEventSource(
-            self.policy.data['mode'], session_factory)
+            cwe_data, session_factory)
 
     def __repr__(self):
         return "<SecurityHub Action %s>" % self.policy.name

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -558,6 +558,15 @@ class PolicyLambdaProvision(BaseTest):
         events = mu_policy.get_events(factory)
         self.assertEqual(len(events), 1)
         hub_action = events.pop()
+        self.assertEqual(
+            json.loads(hub_action.cwe.render_event_pattern()),
+            {'resources': [
+                'arn:aws:securityhub:us-east-1:644160558196:action/custom/sechub'],
+             'source': ['aws.securityhub'],
+             'detail-type': [
+                 'Security Hub Findings - Custom Action', 'Security Hub Insight Results'
+            ]})
+
         hub_action.cwe = cwe = mock.Mock(CloudWatchEventSource)
         cwe.get.return_value = False
         cwe.update.return_value = True


### PR DESCRIPTION
sans a self-select pattern custodian sec hub actions would receive all actions invokes.