### PR TITLE
aws - sts regional endpoints are off by default for now

### DIFF
--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -26,8 +26,10 @@ from c7n.version import version
 from c7n.utils import get_retry
 
 
-# 0.8.45.1 compatibility with global only sts endpoints, out of caution, remove in 0.8.46.1
-USE_STS_GLOBAL = os.environ.get('C7N_USE_STS_GLOBAL', '').lower() in ('yes', 'true')
+# we still have some issues (see #5023) to work through to switch to
+# default regional endpoints, for now its opt-in.
+USE_STS_REGIONAL = os.environ.get(
+    'C7N_USE_STS_REGIONAL', '').lower() in ('yes', 'true')
 
 
 class SessionFactory(object):
@@ -137,7 +139,7 @@ def get_sts_client(session, region):
 
     For the list of regional endpoints, see https://amzn.to/2ohJgtR
     """
-    if region and not USE_STS_GLOBAL:
+    if region and USE_STS_REGIONAL:
         endpoint_url = "https://sts.{}.amazonaws.com".format(region)
         region_name = region
     else:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -17,6 +17,7 @@ import os
 from botocore.exceptions import ClientError
 import placebo
 
+from c7n import credentials
 from c7n.credentials import SessionFactory, assumed_session, get_sts_client
 from c7n.version import version
 from c7n.utils import local_session
@@ -35,6 +36,8 @@ class Credential(BaseTest):
 
     def test_regional_sts(self):
         factory = self.replay_flight_data('test_credential_sts_regional')
+
+        self.patch(credentials, 'USE_STS_REGIONAL', True)
         client = get_sts_client(factory(), region='us-east-2')
         # unfortunately we have to poke at boto3 client internals to verify
         self.assertEqual(client._client_config.region_name, 'us-east-2')


### PR DESCRIPTION
addresses #5023 .. although leaving that issue open till we have a perm fix to the underlying issue wrt to regional endpoints.

this makes the use of sts regional endpoints default to off.