### PR TITLE
Added from_json as a filter using a call to json.loads

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -38,6 +38,7 @@ def get_jinja_env(template_folders):
     env.filters['yaml_safe'] = functools.partial(yaml.safe_dump, default_flow_style=False)
     env.filters['date_time_format'] = date_time_format
     env.filters['get_date_time_delta'] = get_date_time_delta
+    env.filters['from_json'] = json.loads
     env.filters['get_date_age'] = get_date_age
     env.globals['format_resource'] = resource_format
     env.globals['format_struct'] = format_struct


### PR DESCRIPTION
I'm dealing with CW Alarms and part of the resource contains a JSON string called `StateReasonData` this includes recent datapoints which I'd like to use. However since it's a plain json object I need to convert it. This handles said conversion. I got this idea from ansible's jinja filters.