### PR TITLE
aws - ecr set-immutable & set-scanning actions

### DIFF
--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -63,6 +63,49 @@ class ECRTag(tags.Tag):
                 pass
 
 
+@ECR.action_registry.register('set-scanning')
+class ECRSetScanning(Action):
+
+    permissions = ('ecr:SetImageScanninConfigurationg',)
+    schema = type_schema(
+        'set-scanning',
+        state={'type': 'boolean', 'default': True})
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('ecr')
+        s = self.data.get('state', True)
+        for r in resources:
+            try:
+                client.put_image_scanning_configuration(
+                    registryId=r['registryId'],
+                    repositoryName=r['repositoryName'],
+                    imageScanningConfiguration={
+                        'scanOnPush': s})
+            except client.exceptions.RepositoryNotFoundException:
+                continue
+
+
+@ECR.action_registry.register('set-immutability')
+class ECRSetImmutability(Action):
+
+    permissions = ('ecr:SetImageTagImmutability',)
+    schema = type_schema(
+        'set-immutability',
+        state={'type': 'boolean', 'default': True})
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('ecr')
+        s = self.data.get('state', True) and 'IMMUTABLE' or 'MUTABLE'
+        for r in resources:
+            try:
+                client.put_image_tag_mutability(
+                    registryId=r['registryId'],
+                    repositoryName=r['repositoryName'],
+                    imageTagMutability=s)
+            except client.exceptions.RepositoryNotFoundException:
+                continue
+
+
 @ECR.action_registry.register('remove-tag')
 class ECRRemoveTags(tags.RemoveTag):
 

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -66,7 +66,7 @@ class ECRTag(tags.Tag):
 @ECR.action_registry.register('set-scanning')
 class ECRSetScanning(Action):
 
-    permissions = ('ecr:SetImageScanninConfigurationg',)
+    permissions = ('ecr:PutImageScanningConfiguration',)
     schema = type_schema(
         'set-scanning',
         state={'type': 'boolean', 'default': True})
@@ -88,7 +88,7 @@ class ECRSetScanning(Action):
 @ECR.action_registry.register('set-immutability')
 class ECRSetImmutability(Action):
 
-    permissions = ('ecr:SetImageTagImmutability',)
+    permissions = ('ecr:PutImageTagMutability',)
     schema = type_schema(
         'set-immutability',
         state={'type': 'boolean', 'default': True})

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -95,7 +95,7 @@ class ECRSetImmutability(Action):
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('ecr')
-        s = self.data.get('state', True) and 'IMMUTABLE' or 'MUTABLE'
+        s = 'IMMUTABLE' if self.data.get('state', True) else 'MUTABLE'
         for r in resources:
             try:
                 client.put_image_tag_mutability(

--- a/tests/data/placebo/test_ecr_set_immutability/api.ecr.DescribeRepositories_1.json
+++ b/tests/data/placebo/test_ecr_set_immutability/api.ecr.DescribeRepositories_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "repositories": [
+            {
+                "repositoryArn": "arn:aws:ecr:us-east-1:644160558196:repository/testrepo",
+                "registryId": "644160558196",
+                "repositoryName": "testrepo",
+                "repositoryUri": "644160558196.dkr.ecr.us-east-1.amazonaws.com/testrepo",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 11,
+                    "hour": 11,
+                    "minute": 57,
+                    "second": 36,
+                    "microsecond": 0
+                },
+                "imageTagMutability": "MUTABLE",
+                "imageScanningConfiguration": {
+                    "scanOnPush": false
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_ecr_set_immutability/api.ecr.DescribeRepositories_2.json
+++ b/tests/data/placebo/test_ecr_set_immutability/api.ecr.DescribeRepositories_2.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "repositories": [
+            {
+                "repositoryArn": "arn:aws:ecr:us-east-1:644160558196:repository/testrepo",
+                "registryId": "644160558196",
+                "repositoryName": "testrepo",
+                "repositoryUri": "644160558196.dkr.ecr.us-east-1.amazonaws.com/testrepo",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 11,
+                    "hour": 11,
+                    "minute": 57,
+                    "second": 36,
+                    "microsecond": 0
+                },
+                "imageTagMutability": "IMMUTABLE",
+                "imageScanningConfiguration": {
+                    "scanOnPush": false
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_ecr_set_immutability/api.ecr.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_ecr_set_immutability/api.ecr.ListTagsForResource_1.json
@@ -1,0 +1,1 @@
+{"status_code": 200, "data": {"tags": []}}

--- a/tests/data/placebo/test_ecr_set_immutability/api.ecr.PutImageTagMutability_1.json
+++ b/tests/data/placebo/test_ecr_set_immutability/api.ecr.PutImageTagMutability_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "registryId": "644160558196",
+        "repositoryName": "testrepo",
+        "imageTagMutability": "IMMUTABLE"
+    }
+}

--- a/tests/data/placebo/test_ecr_set_scanning/api.ecr.DescribeRepositories_1.json
+++ b/tests/data/placebo/test_ecr_set_scanning/api.ecr.DescribeRepositories_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "repositories": [
+            {
+                "repositoryArn": "arn:aws:ecr:us-east-1:644160558196:repository/testrepo",
+                "registryId": "644160558196",
+                "repositoryName": "testrepo",
+                "repositoryUri": "644160558196.dkr.ecr.us-east-1.amazonaws.com/testrepo",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 11,
+                    "hour": 11,
+                    "minute": 57,
+                    "second": 36,
+                    "microsecond": 0
+                },
+                "imageTagMutability": "IMMUTABLE",
+                "imageScanningConfiguration": {
+                    "scanOnPush": false
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_ecr_set_scanning/api.ecr.DescribeRepositories_2.json
+++ b/tests/data/placebo/test_ecr_set_scanning/api.ecr.DescribeRepositories_2.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "repositories": [
+            {
+                "repositoryArn": "arn:aws:ecr:us-east-1:644160558196:repository/testrepo",
+                "registryId": "644160558196",
+                "repositoryName": "testrepo",
+                "repositoryUri": "644160558196.dkr.ecr.us-east-1.amazonaws.com/testrepo",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 2,
+                    "day": 11,
+                    "hour": 11,
+                    "minute": 57,
+                    "second": 36,
+                    "microsecond": 0
+                },
+                "imageTagMutability": "IMMUTABLE",
+                "imageScanningConfiguration": {
+                    "scanOnPush": true
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_ecr_set_scanning/api.ecr.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_ecr_set_scanning/api.ecr.ListTagsForResource_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": []
+    }
+}

--- a/tests/data/placebo/test_ecr_set_scanning/api.ecr.PutImageScanningConfiguration_1.json
+++ b/tests/data/placebo/test_ecr_set_scanning/api.ecr.PutImageScanningConfiguration_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "registryId": "644160558196",
+        "repositoryName": "testrepo",
+        "imageScanningConfiguration": {
+            "scanOnPush": true
+        }
+    }
+}


### PR DESCRIPTION
actions to configure ecr tag immutability and image scanning on push.