### PR TITLE
Fix bag

### DIFF
--- a/c7n/config.py
+++ b/c7n/config.py
@@ -25,6 +25,9 @@ class Bag(dict):
             return self[k]
         except KeyError:
             raise AttributeError(k)
+            
+    def __setattr__(self, k, v):
+        self[k] = v
 
 
 class Config(Bag):

--- a/c7n/config.py
+++ b/c7n/config.py
@@ -25,7 +25,7 @@ class Bag(dict):
             return self[k]
         except KeyError:
             raise AttributeError(k)
-            
+
     def __setattr__(self, k, v):
         self[k] = v
 


### PR DESCRIPTION
The Bag class retrieves values using it's parent `dict` class, but `setattr` modifies values in its local `__dict__` (default `object` behavior).

This causes problems like below:

```
b = Bag({'a': 1, 'b': 2})
b.a = 3
assert str(b) == "{'a': 1, 'b': 2}"
assert json.loads(json.dumps(b))['a'] == 1
assert b.a == 3
```

This causes the `config` properties in `metadata.json` in output files to *always* contain default/empty values:

https://github.com/cloud-custodian/cloud-custodian/blob/b73eccc80a64a60287a09deb74d8b47a1fd0ce75/c7n/ctx.py#L127-L138

I believe this also means that the `copy()` method on the `Config` class must be broken.

This change adds `__setattr__` such that new attributes are always set within the parent dict's internal state.