### PR TITLE
ci - enable python 3.8 test runner

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
 
 - job: 'Test'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'Ubuntu-18.04'
   strategy:
     matrix:
       Python27:
@@ -63,7 +63,10 @@ jobs:
       Python37:
         python.version: '3.7'
         TOXENV: py37
-    maxParallel: 3
+      Python37:
+        python.version: '3.8'
+        TOXENV: py38
+    maxParallel: 4
 
   steps:
   - checkout: self

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
 
 - job: 'Lint'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'Ubuntu-18.04'
   steps:
     - checkout: self
       fetchDepth: 1
@@ -29,7 +29,7 @@ jobs:
 
 - job: 'Docs'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'Ubuntu-18.04'
   steps:
   - checkout: self
     fetchDepth: 1
@@ -63,7 +63,7 @@ jobs:
       Python37:
         python.version: '3.7'
         TOXENV: py37
-      Python37:
+      Python38:
         python.version: '3.8'
         TOXENV: py38
     maxParallel: 4
@@ -157,7 +157,7 @@ jobs:
 - job: 'CustodianCask'
   displayName: 'Container Cask'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'Ubuntu-18.04'
 
   steps:
   - task: GoTool@0

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,10 @@ commands =
 commands =
     py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
 
+[testenv:py38]
+commands =
+    py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
+
 [testenv:py36-cov]
 commands =
     py.test -n {env:C7N_TEST_WORKERS:auto} --cov c7n --cov tools/c7n_azure/c7n_azure --cov tools/c7n_gcp/c7n_gcp --cov tools/c7n_kube/c7n_kube --cov tools/c7n_mailer/c7n_mailer tests tools {posargs}


### PR DESCRIPTION
addresses #5080 

also update ubuntu linux versions to 18.04 (from 16.04) across the board.