### PR TITLE
aws - fix typo in account registry keys

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -36,8 +36,8 @@ from c7n.query import QueryResourceManager
 from c7n.resources.iam import CredentialReport
 from c7n.resources.securityhub import OtherResourcePostFinding
 
-filters = FilterRegistry('aws.account.actions')
-actions = ActionRegistry('aws.account.filters')
+filters = FilterRegistry('aws.account.filters')
+actions = ActionRegistry('aws.account.actions')
 
 retry = staticmethod(QueryResourceManager.retry)
 filters.register('missing', Missing)


### PR DESCRIPTION
house keeping.. didn't actually affect anything as the keys aren't really used, and the registries are referenced off query manager by attribute name which was correct.

came up in #5031