### PR TITLE
RDS delete/restore - minor tweaks, EC2-Classic support

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -51,6 +51,8 @@ import operator
 import re
 from decimal import Decimal as D, ROUND_HALF_UP
 
+from datetime import datetime
+from dateutil.tz import tzutc
 from distutils.version import LooseVersion
 from botocore.exceptions import ClientError
 from concurrent.futures import as_completed
@@ -1003,7 +1005,9 @@ class LatestSnapshot(Filter):
                 resources, operator.itemgetter('DBInstanceIdentifier')):
             results.append(
                 sorted(snapshots,
-                       key=operator.itemgetter('SnapshotCreateTime'))[-1])
+                       key=lambda x: x.get(
+                           'SnapshotCreateTime',
+                           datetime(1900, 1, 1).replace(tzinfo=tzutc())))[-1])
         return results
 
 


### PR DESCRIPTION
Doing some cleanup of legacy RDS resources recently, I ran into a few issues with the RDS delete and snapshot restore actions:

* An old manual snapshot in a legacy account had no creation date, causing restore-time `KeyError`s while looking up the latest snapshot.
* Deletes with `copy-restore-info` failed on EC2-Classic RDS instances due to attribute differences.
* The `join` logic in `copy-restore-info` used a different delimiter than the `split` in an associated snapshot restore.

The changes in this PR address those issues, but I'm not sure they all make sense upstream. EC2-Classic and dateless manual snapshots are pretty uncommon, and may not be worth the overhead to support.

If a subset of these changes _does_ make sense upstream, they likely still need some touch-ups.