### PR TITLE
Fix mugc for full backwards compat

### DIFF
--- a/tools/ops/README.md
+++ b/tools/ops/README.md
@@ -3,6 +3,8 @@
 ## mugc
 mugc (mu garbage collection) is a utility used to clean up Cloud Custodian Lambda policies that are deployed in an AWS environment. mugc finds and deletes extant resources based on the prefix of the lambda name (default: `custodian-`).
 
+By default, mugc excludes resources within specified config files.  If you would like to invert this behavior and target them instead, use the `--present` flag.
+
 ### mugc Usage
 
 The only required argument is `-c`: a list of config (policy) files.
@@ -15,5 +17,5 @@ mugc also suports the following args:
 
 ```
 usage: mugc.py [-h] -c CONFIG_FILES [-r REGION] [--dryrun] [--profile PROFILE]
-               [--prefix PREFIX] [--assume ASSUME_ROLE] [-v]
+               [--prefix PREFIX] [--present] [--policy-regex POLICY_REGEX] [--assume ASSUME_ROLE] [-v]
 ```

--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -169,7 +169,7 @@ def setup_parser():
         "--prefix", default="custodian-",
         help="The Lambda name prefix to use for clean-up")
     parser.add_argument(
-        "--policy-regex", default="^custodian-.*",
+        "--policy-regex",
         help="The policy must match the regex")
     parser.add_argument("-p", "--policies", default=None, dest='policy_filter',
                         help="Only use named/matched policies")
@@ -195,6 +195,9 @@ def main():
     logging.getLogger('botocore').setLevel(logging.ERROR)
     logging.getLogger('urllib3').setLevel(logging.ERROR)
     logging.getLogger('c7n.cache').setLevel(logging.WARNING)
+
+    if not options.policy_regex:
+        options.policy_regex = f"^{options.prefix}.*"
 
     if not options.regions:
         options.regions = [os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')]


### PR DESCRIPTION
Did not have full backwards-compat without lazily setting the default for the regex.

Related:
https://github.com/cloud-custodian/cloud-custodian/pull/5067
https://github.com/cloud-custodian/cloud-custodian/issues/5089

