### PR TITLE
azure - consumption function timeout

### DIFF
--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -111,9 +111,12 @@ FUNCTION_HOST_CONFIG = {
         "healthCheckThreshold": 6,
         "counterThreshold": 0.80
     },
-    "functionTimeout": "00:05:00",
+    "functionTimeout": "00:10:00",
     "logging": {
-        "fileLoggingMode": "debugOnly"
+        "fileLoggingMode": "always",
+        "logLevel": {
+            "default": "Debug"
+        }
     },
     "extensions": {
         "http": {


### PR DESCRIPTION
per user report on gitter (@justinhauer ), this increases the timeout to the max supported on consumption plans (10m).

closes #5113 