### PR TITLE
ec2-ebs: Add copy-volume-tags when Snapshotting

### DIFF
--- a/tests/data/placebo/test_ebs_snapshot_copy_tags/ec2.CreateSnapshot_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_copy_tags/ec2.CreateSnapshot_1.json
@@ -1,0 +1,49 @@
+{
+  "status_code": 200,
+  "data": {
+    "Description": "",
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "526a3e1a-2002-4ec6-8860-cc09008173ac",
+      "HTTPHeaders": {
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding",
+        "server": "AmazonEC2",
+        "content-type": "text/xml;charset=UTF-8",
+        "date": "Wed, 03 May 2017 14:43:16 GMT"
+      }
+    },
+    "Encrypted": false,
+    "VolumeId": "vol-0252f61378ede9d01",
+    "State": "pending",
+    "VolumeSize": 8,
+    "Progress": "",
+    "StartTime": {
+      "hour": 14,
+      "__class__": "datetime",
+      "month": 5,
+      "second": 17,
+      "microsecond": 0,
+      "year": 2017,
+      "day": 3,
+      "minute": 43
+    },
+    "SnapshotId": "snap-0c8b611065fed033e",
+    "Tags": [
+      {
+        "Value": "FancyTestInstancePrivate",
+        "Key": "Name"
+      },
+      {
+        "Key": "Stage",
+        "Value": "Dev"
+      },
+      {
+        "Key": "custodian_snapshot",
+        "Value": ""
+      }
+    ],
+    "OwnerId": "644160558196"
+  }
+}

--- a/tests/data/placebo/test_ebs_snapshot_copy_tags/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_copy_tags/ec2.DescribeSnapshots_1.json
@@ -1,0 +1,53 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "48383548-8c6e-47de-815e-33f0ebe7f580",
+      "HTTPHeaders": {
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding",
+        "server": "AmazonEC2",
+        "content-type": "text/xml;charset=UTF-8",
+        "date": "Wed, 03 May 2017 14:43:17 GMT"
+      }
+    },
+    "Snapshots": [
+      {
+        "Description": "",
+        "Encrypted": false,
+        "VolumeId": "vol-0252f61378ede9d01",
+        "State": "pending",
+        "VolumeSize": 8,
+        "Progress": "99%",
+        "StartTime": {
+          "hour": 14,
+          "__class__": "datetime",
+          "month": 5,
+          "second": 17,
+          "microsecond": 0,
+          "year": 2017,
+          "day": 3,
+          "minute": 43
+        },
+        "SnapshotId": "snap-0c8b611065fed033e",
+        "Tags": [
+          {
+            "Value": "FancyTestInstancePrivate",
+            "Key": "Name"
+          },
+          {
+            "Key": "Stage",
+            "Value": "Dev"
+          },
+          {
+            "Key": "custodian_snapshot",
+            "Value": ""
+          }
+        ],
+        "OwnerId": "644160558196"
+      }
+    ]
+  }
+}

--- a/tests/data/placebo/test_ebs_snapshot_copy_tags/ec2.DescribeVolumes_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_copy_tags/ec2.DescribeVolumes_1.json
@@ -1,0 +1,156 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "53e62ac7-14d4-4657-9385-e1ffeb34edea",
+      "HTTPHeaders": {
+        "transfer-encoding": "chunked",
+        "vary": "Accept-Encoding",
+        "server": "AmazonEC2",
+        "content-type": "text/xml;charset=UTF-8",
+        "date": "Wed, 03 May 2017 14:43:16 GMT"
+      }
+    },
+    "Volumes": [
+      {
+        "AvailabilityZone": "us-east-1b",
+        "Attachments": [
+          {
+            "AttachTime": {
+              "hour": 14,
+              "__class__": "datetime",
+              "month": 3,
+              "second": 28,
+              "microsecond": 0,
+              "year": 2017,
+              "day": 28,
+              "minute": 55
+            },
+            "InstanceId": "i-0a0b51bcf11a8cdfb",
+            "VolumeId": "vol-01adbb6a4f175941d",
+            "State": "attached",
+            "DeleteOnTermination": true,
+            "Device": "/dev/xvda"
+          }
+        ],
+        "Encrypted": false,
+        "VolumeType": "gp2",
+        "VolumeId": "vol-01adbb6a4f175941d",
+        "State": "in-use",
+        "Iops": 100,
+        "SnapshotId": "snap-037f1f9e6c8ea4d65",
+        "CreateTime": {
+          "hour": 14,
+          "__class__": "datetime",
+          "month": 3,
+          "second": 28,
+          "microsecond": 486000,
+          "year": 2017,
+          "day": 28,
+          "minute": 55
+        },
+        "Size": 8
+      },
+      {
+        "AvailabilityZone": "us-east-1b",
+        "Attachments": [
+          {
+            "AttachTime": {
+              "hour": 20,
+              "__class__": "datetime",
+              "month": 4,
+              "second": 21,
+              "microsecond": 0,
+              "year": 2017,
+              "day": 10,
+              "minute": 41
+            },
+            "InstanceId": "i-0be2fdca058278ea3",
+            "VolumeId": "vol-0252f61378ede9d01",
+            "State": "attached",
+            "DeleteOnTermination": true,
+            "Device": "/dev/sda1"
+          }
+        ],
+        "Tags": [
+          {
+            "Value": "FancyTestInstancePrivate",
+            "Key": "Name"
+          }
+        ],
+        "Encrypted": false,
+        "VolumeType": "gp2",
+        "VolumeId": "vol-0252f61378ede9d01",
+        "State": "in-use",
+        "Iops": 100,
+        "SnapshotId": "snap-00762b50998e9113b",
+        "CreateTime": {
+          "hour": 20,
+          "__class__": "datetime",
+          "month": 4,
+          "second": 21,
+          "microsecond": 977000,
+          "year": 2017,
+          "day": 10,
+          "minute": 41
+        },
+        "Size": 8,
+        "Tags": [
+          {
+            "Value": "FancyTestInstancePrivate",
+            "Key": "Name"
+          },
+          {
+            "Key": "Stage",
+            "Value": "Dev"
+          },
+          {
+            "Key": "DoNotCopy",
+            "Value": "ThisTag"
+          }
+        ]
+      },
+      {
+        "AvailabilityZone": "us-east-1d",
+        "Attachments": [
+          {
+            "AttachTime": {
+              "hour": 1,
+              "__class__": "datetime",
+              "month": 4,
+              "second": 40,
+              "microsecond": 0,
+              "year": 2017,
+              "day": 3,
+              "minute": 34
+            },
+            "InstanceId": "i-0aace5764d21d3105",
+            "VolumeId": "vol-0b5bc31549f55bdd2",
+            "State": "attached",
+            "DeleteOnTermination": true,
+            "Device": "/dev/xvda"
+          }
+        ],
+        "Encrypted": false,
+        "VolumeType": "gp2",
+        "VolumeId": "vol-0b5bc31549f55bdd2",
+        "State": "in-use",
+        "Iops": 100,
+        "SnapshotId": "snap-037f1f9e6c8ea4d65",
+        "CreateTime": {
+          "hour": 1,
+          "__class__": "datetime",
+          "month": 4,
+          "second": 40,
+          "microsecond": 677000,
+          "year": 2017,
+          "day": 3,
+          "minute": 34
+        },
+        "Size": 8
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds support for copy-volume-tags when snapshotting a standalone EBS volume.

closes #2915 
closes #2497 
closes #1777
