### PR TITLE
Handle ImportError and FileNotFoundError for importlib_metadata

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -38,7 +38,7 @@ from concurrent.futures import ThreadPoolExecutor
 # Its also used for release engineering on our pypi uploads
 try:
     import importlib_metadata as pkgmd
-except ImportError:
+except (ImportError, FileNotFoundError):
     pkgmd = None
 
 


### PR DESCRIPTION
Azure Functions nightly tests are failing due to the exception:

```
Result: Failure
Exception: PackageNotFoundError: importlib_metadata
<...>
  File "/home/site/wwwroot/c7n/mu.py", line 40, in <module>
    import importlib_metadata as pkgmd
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 540, in <module>
    __version__ = version(__name__)
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 502, in version
    return distribution(distribution_name).version
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 475, in distribution
    return Distribution.from_name(distribution_name)
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 194, in from_name
    raise PackageNotFoundError(name)
```