### PR TITLE
azure - fix bug caused by incorrect cleanup for Azure Functions

### DIFF
--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -70,6 +70,8 @@ class FunctionPackage(object):
     def _add_functions_required_files(self, policy, queue_name=None):
         s = local_session(Session)
 
+        has_event_trigger_mode = False
+
         for target_sub_id in self.target_sub_ids:
             name = self.name + ("_" + target_sub_id if target_sub_id else "")
             # generate and add auth
@@ -89,9 +91,11 @@ class FunctionPackage(object):
 
                 self.pkg.add_contents(dest=name + '/config.json',
                                       contents=policy_contents)
-                self._add_host_config(policy['mode']['type'])
-            else:
-                self._add_host_config(None)
+                if policy['mode']['type'] == FUNCTION_EVENT_TRIGGER_MODE:
+                    has_event_trigger_mode = True
+
+        self._add_host_config(
+            FUNCTION_EVENT_TRIGGER_MODE if has_event_trigger_mode else None)
 
     def _add_host_config(self, mode):
         config = copy.deepcopy(FUNCTION_HOST_CONFIG)

--- a/tools/c7n_azure/c7n_azure/handler.py
+++ b/tools/c7n_azure/c7n_azure/handler.py
@@ -64,7 +64,7 @@ def run(event, context, subscription_id=None):
         for p in policies:
             try:
                 p.push(event, context)
-            except (CloudError, AzureHttpError) as error:
+            except Exception as error:
                 log.error("Unable to process policy: %s :: %s" % (p.name, error))
 
     reset_session_cache()


### PR DESCRIPTION
- Fix `host.json` is added multiple times warning message.. No real bug atm because there is no way to deploy mix of event driven and timer functions, but it will be in the future.
- `handler.py` should catch all exceptions. It might be Policy Validation or other c7n runtime exception.. If it is not handled, we don't cleanup the cache and as a result one failure affects multiple policies if running in the same underlying container.