### PR TITLE
core - improve missing provider error

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -902,8 +902,9 @@ class Policy(object):
         return self.data.get('mode', {'type': 'pull'})['type']
 
     def get_execution_mode(self):
-        exec_mode = execution[self.execution_mode]
-        if exec_mode is None:
+        try:
+            exec_mode = execution[self.execution_mode]
+        except KeyError:
             return None
         return exec_mode(self)
 

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -819,6 +819,14 @@ class ConfigRuleMode(LambdaMode):
         return resources
 
 
+def get_session_factory(provider_name, options):
+    try:
+        return clouds[provider_name]().get_session_factory(options)
+    except KeyError:
+        raise RuntimeError(
+            "%s provider not installed" % provider_name)
+
+
 class Policy(object):
 
     log = logging.getLogger('custodian.policy')
@@ -828,7 +836,8 @@ class Policy(object):
         self.options = options
         assert "name" in self.data
         if session_factory is None:
-            session_factory = clouds[self.provider_name]().get_session_factory(options)
+            session_factory = get_session_factory(
+                self.provider_name, options)
         self.session_factory = session_factory
         self.ctx = ExecutionContext(self.session_factory, self, self.options)
         self.resource_manager = self.load_resource_manager()

--- a/c7n/registry.py
+++ b/c7n/registry.py
@@ -95,7 +95,10 @@ class PluginRegistry(object):
         return key in self._factories
 
     def __getitem__(self, name):
-        return self.get(name)
+        v = self.get(name)
+        if v is None:
+            raise KeyError(name)
+        return v
 
     def get(self, name):
         factory = self._factories.get(name)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -63,6 +63,12 @@ class DummyResource(manager.ResourceManager):
 
 class PolicyMeta(BaseTest):
 
+    def test_policy_missing_provider_session(self):
+        self.assertRaises(
+            RuntimeError,
+            policy.get_session_factory,
+            'nosuchthing', Bag())
+
     def test_policy_detail_spec_permissions(self):
         policy = self.load_policy(
             {"name": "kinesis-delete", "resource": "kinesis", "actions": ["delete"]}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -29,6 +29,15 @@ class RegistryTest(unittest.TestCase):
         self.assertEqual(list(registry.values()), [klass])
         registry.unregister('dust')
 
+    def test_registry_getitem_keyerror(self):
+        registry = PluginRegistry('dummy')
+        try:
+            registry['xyz']
+        except KeyError:
+            pass
+        else:
+            self.fail('should have raised keyerror')
+
     def test_event_subscriber(self):
 
         observed = []

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -656,6 +656,7 @@ def run(config, use, output_dir, accounts, tags, region,
                 log.warning(
                     "Error running policy in %s @ %s exception: %s",
                     a['name'], r, f.exception())
+                continue
 
             account_region_pcounts, account_region_success = f.result()
             for p in account_region_pcounts:


### PR DESCRIPTION
users in chat were reporting issues with c7n-org due to a bad installation which and using resources in their policy files from uninstalled providers. 