### PR TITLE
Update policy document for CloudCustodian-QuickStart

### DIFF
--- a/docs/source/_static/custodian-quickstart-policy.json
+++ b/docs/source/_static/custodian-quickstart-policy.json
@@ -7,7 +7,8 @@
           "ec2:CreateTags",
           "ec2:DeleteTags",
           "ec2:DescribeInstances",
-          "ec2:TerminateInstances"
+          "ec2:TerminateInstances",
+          "ec2:DescribeVolumes"
         ],
         "Effect": "Allow",
         "Resource": "*"


### PR DESCRIPTION
The lambda fails since the role attached to it (the lambda) cannot describe the volume on the ec2 instance and throws an error: error:An error occurred (UnauthorizedOperation) when calling the DescribeVolumes operation: You are not authorized to perform this operation.