### PR TITLE
offhours : allow to disable the start and/or the stop of ressources

### DIFF
--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -103,7 +103,10 @@ The value of the tag must be one of the following:
     savings time, if applicable.)*
   * ``off=(time spec)`` and/or ``on=(time spec)`` matching time specifications
     supported by :py:class:`c7n.filters.offhours.ScheduleParser` as described
-    in the next section.
+    in the next section. Additionally, it's possible to specify ``off=disabled``
+    and/or ``on=disabled`` to completly disable offhours stopping (respectively
+    starting) - this way you can have a policy to stop ressources, without starting
+    them (or vice-verse).
 
 ScheduleParser Time Specifications
 ----------------------------------
@@ -621,10 +624,12 @@ class ScheduleParser(object):
                 return None
             key, value = kv
             if key != 'tz':
-                value = self.parse_resource_schedule(value)
+                if value != 'disabled':
+                    value = self.parse_resource_schedule(value)
             if value is None:
                 return None
-            schedule[key] = value
+            if value != 'disabled':
+                schedule[key] = value
 
         # add default timezone, if none supplied or blank
         if not schedule.get('tz'):


### PR DESCRIPTION
Fixes #5134
Sometimes, you want a policy that only stops ressources automatically, without
starting them automatically.
This patch provides the ability to specify a value of `disabled` for custom
values of the tag, in order to disable this action.
Ex:
```'off=[(M-F,21),(U,18)];on=disabled;tz=pt'``` will only stop ressource, never
automatically start them.