### PR TITLE
AMI filtering shouldn't expect a LaunchTemplate version

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1896,9 +1896,9 @@ class LaunchTemplate(query.QueryResourceManager):
                     'LaunchTemplate']['LaunchTemplateSpecification']
             if t is None:
                 continue
-            templates.setdefault(
-                (t['LaunchTemplateId'],
-                 t['Version']), []).append(a['AutoScalingGroupName'])
+
+            templateKey = (t['LaunchTemplateId'], t.get('Version', None))
+            templates.setdefault(templateKey, []).append(a['AutoScalingGroupName'])
         return templates
 
 


### PR DESCRIPTION
We've seen data where the LaunchTemplate (on the ASG directly)
has no version attribute at all - so we should use .get with a default
of None instead, to avoid raising an exception.