### PR TITLE
Use our internal ComparableVersion for comparing versions in RDS

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -51,7 +51,7 @@ import operator
 import re
 from decimal import Decimal as D, ROUND_HALF_UP
 
-from distutils.version import LooseVersion
+from c7n.filters.core import ComparableVersion
 from botocore.exceptions import ClientError
 from concurrent.futures import as_completed
 
@@ -237,7 +237,7 @@ def _get_available_engine_upgrades(client, major=False):
             for t in v['ValidUpgradeTarget']:
                 if not major and t['IsMajorVersionUpgrade']:
                     continue
-                if LooseVersion(t['EngineVersion']) > LooseVersion(
+                if ComparableVersion(t['EngineVersion']) > ComparableVersion(
                         results[v['Engine']].get(v['EngineVersion'], '0.0.0')):
                     results[v['Engine']][v['EngineVersion']] = t['EngineVersion']
     return results


### PR DESCRIPTION
The current version uses distutils LooseVersion, which has issues with comparisons of some types, failing with:

```
TypeError: unorderable types: str() < int()
```

The version filter handles this by using a custom version subclass that rescues that situation, which this makes effort to handle.