### PR TITLE
Support passing in a credential-helper-cmd

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -63,6 +63,9 @@ def _default_options(p, blacklist=""):
     provider.add_argument("--external-id", default=None, dest="external_id",
                           help="External Id to provide when assuming a role")
 
+    provider.add_argument("--credential-helper-cmd", default=None, dest="credential_helper",
+                          help="Credential Helper command to invoke to fetch token information")
+
     config = p.add_argument_group(
         "config", "Policy config file(s) and policy selectors")
     # -c is deprecated.  Supported for legacy reasons

--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -17,6 +17,8 @@ Authentication utilities
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import json
+import subprocess
 
 from botocore.credentials import RefreshableCredentials
 from botocore.session import get_session
@@ -34,11 +36,12 @@ USE_STS_REGIONAL = os.environ.get(
 
 class SessionFactory(object):
 
-    def __init__(self, region, profile=None, assume_role=None, external_id=None):
+    def __init__(self, region, profile=None, assume_role=None, external_id=None, credential_helper=None):
         self.region = region
         self.profile = profile
         self.assume_role = assume_role
         self.external_id = external_id
+        self.credential_helper = credential_helper
         self.user_agent_name = "CloudCustodian"
         self.session_name = "CloudCustodian"
         if 'C7N_SESSION_SUFFIX' in os.environ:
@@ -52,7 +55,10 @@ class SessionFactory(object):
     policy_name = property(None, _set_policy_name)
 
     def __call__(self, assume=True, region=None):
-        if self.assume_role and assume:
+        if self.credential_helper:
+            session = credential_helper_session(
+                self.credential_helper, self.session_name, region or self.region)
+        elif self.assume_role and assume:
             session = Session(profile_name=self.profile)
             session = assumed_session(
                 self.assume_role, self.session_name, session,
@@ -74,6 +80,48 @@ class SessionFactory(object):
 
     def set_subscribers(self, subscribers):
         self._subscribers = subscribers
+
+def credential_helper_session(command, session_name, region=None):
+    """Role assumption / fetching, using a credential helper.
+
+    The helper program is expected to return the same JSON payload
+    as a call to STS would, just making it possible to use shell scripts.
+
+    The command is run using a shell.
+    """
+
+    def fetch_credentials():
+        env = os.environ.copy()
+        env['CUSTODIAN_SESSION_NAME'] = session_name
+        if region:
+            env['CUSTODIAN_CREDENTIALS_REGION'] = region
+        raw_response = subprocess.check_output(command, shell=True, env=env).strip()
+        parsed = json.loads(raw_response)
+        credentials = parsed['Credentials']
+
+        return dict(
+            access_key=credentials['AccessKeyId'],
+            secret_key=credentials['SecretAccessKey'],
+            token=credentials['SessionToken'],
+            expiry_time=credentials['Expiration'])
+
+    session_credentials = RefreshableCredentials.create_from_metadata(
+        metadata=fetch_credentials(),
+        refresh_using=fetch_credentials,
+        method='credential-helper')
+    # so dirty.. it hurts, no clean way to set this outside of the
+    # internals poke. There's some work upstream on making this nicer
+    # but its pretty baroque as well with upstream support.
+    # https://github.com/boto/boto3/issues/443
+    # https://github.com/boto/botocore/issues/761
+
+    s = get_session()
+    s._credentials = session_credentials
+    if region is None:
+        region = s.get_config_variable('region') or 'us-east-1'
+    s.set_config_variable('region', region)
+    return Session(botocore_session=s)
+
 
 
 def assumed_session(role_arn, session_name, session=None, region=None, external_id=None):

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -512,7 +512,8 @@ class AWS(object):
             options.region,
             options.profile,
             options.assume_role,
-            options.external_id)
+            options.external_id,
+            options.credential_helper)
 
     def initialize_policies(self, policy_collection, options):
         """Return a set of policies targetted to the given regions.


### PR DESCRIPTION
We have a situation where we assume a role in another account from where
the command is run, and want to allow using credentials for said account.

We can't use assumption directly in C7N - There are situations where we want
our additional capabilitys - and passing in credentials as environment
variables doesn't include refreshability.

This adds a new binary argument, which specifies a commnand to invoke
- allowing us to implement custom, refreshable auth using a command line
program.