### PR TITLE
aws - glacier - support name for id instead of arn in lambda mode

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -88,8 +88,8 @@ jobs:
     displayName: 'Tox'
 
   - script: |
-      coverage xml && \
-      bash <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/4983e44223dad1a7b9291eaee166a54fd6e0b15f/codecov) -Z \
+      ./.tox/$TOXENV/bin/coverage xml && \
+      bash <(curl -s https://codecov.io/bash) -Z \
        -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix \
        -f coverage.xml
     displayName: 'Publish Code Coverage'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
 
   - script: |
       coverage xml && \
-      bash <(curl -s https://codecov.io/bash) -Z \
+      bash <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/4983e44223dad1a7b9291eaee166a54fd6e0b15f/codecov) -Z \
        -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix \
        -f coverage.xml
     displayName: 'Publish Code Coverage'

--- a/c7n/resources/glacier.py
+++ b/c7n/resources/glacier.py
@@ -33,8 +33,8 @@ class Glacier(QueryResourceManager):
     class resource_type(TypeInfo):
         service = 'glacier'
         enum_spec = ('list_vaults', 'VaultList', None)
-        name = "VaultName"
-        arn = id = "VaultARN"
+        id = "VaultName"
+        arn = "VaultARN"
         arn_type = 'vaults'
         universal_taggable = True
 

--- a/c7n/resources/glacier.py
+++ b/c7n/resources/glacier.py
@@ -33,7 +33,7 @@ class Glacier(QueryResourceManager):
     class resource_type(TypeInfo):
         service = 'glacier'
         enum_spec = ('list_vaults', 'VaultList', None)
-        id = "VaultName"
+        name = id = "VaultName"
         arn = "VaultARN"
         arn_type = 'vaults'
         universal_taggable = True

--- a/tests/data/placebo/test_iam_user_credential_multi_delete/iam.GetCredentialReport_1.json
+++ b/tests/data/placebo/test_iam_user_credential_multi_delete/iam.GetCredentialReport_1.json
@@ -1,7 +1,7 @@
 {
     "status_code": 200,
     "data": {
-        "Content": "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\nkapil,arn:aws:iam::644160558196:user/kapil,2016-05-16T19:03:36+00:00,true,2018-12-01T14:56:42+00:00,2018-09-12T13:53:09+00:00,2018-12-11T13:53:09+00:00,false,true,2018-01-14T10:26:37+00:00,2018-11-21T06:54:00+00:00,us-east-1,ecr,true,2016-06-24T20:30:37+00:00,2018-12-01T22:25:00+00:00,us-east-1,sts,false,N/A,false,N/A\n",
+        "Content": "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\nkapil,arn:aws:iam::644160558196:user/kapil,2016-05-16T19:03:36+00:00,true,2018-12-01T14:56:42+00:00,2018-09-12T13:53:09+00:00,2018-12-11T13:53:09+00:00,false,true,2019-12-14T10:26:37+00:00,2018-11-21T06:54:00+00:00,us-east-1,ecr,true,2016-06-24T20:30:37+00:00,2018-12-01T22:25:00+00:00,us-east-1,sts,false,N/A,false,N/A\n",
         "ReportFormat": "text/csv",
         "GeneratedTime": {
             "__class__": "datetime",


### PR DESCRIPTION
I had to make this update for a glacier policy to run in lambda mode because the cloud trail event does not return the m.id as expected, it actually only returns VaultName, to get VaultARN we need to parse the response. Does this make sense?