### PR TITLE
add defaults to securityhub's post-finding action schema documentation

### DIFF
--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -285,14 +285,14 @@ class PostFinding(Action):
         "post-finding",
         required=["types"],
         title={"type": "string", 'default': 'policy.name'},
-        description={'type': 'string', 'default': 
+        description={'type': 'string', 'default':
             'policy.description, or if not defined in policy then policy.name'},
         severity={"type": "number", 'default': 0},
         severity_normalized={"type": "number", "min": 0, "max": 100, 'default': 0},
         confidence={"type": "number", "min": 0, "max": 100},
         criticality={"type": "number", "min": 0, "max": 100},
         # Cross region aggregation
-        region={'type': 'string', 'description': 'cross-region aggregation target', 
+        region={'type': 'string', 'description': 'cross-region aggregation target',
             'default': 'current region'},
         recommendation={"type": "string"},
         recommendation_url={"type": "string"},

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -285,13 +285,15 @@ class PostFinding(Action):
         "post-finding",
         required=["types"],
         title={"type": "string", 'default': 'policy.name'},
-        description={'type': 'string', 'default': 'policy.description, or if not defined in policy then policy.name'},
+        description={'type': 'string', 'default': 
+            'policy.description, or if not defined in policy then policy.name'},
         severity={"type": "number", 'default': 0},
         severity_normalized={"type": "number", "min": 0, "max": 100, 'default': 0},
         confidence={"type": "number", "min": 0, "max": 100},
         criticality={"type": "number", "min": 0, "max": 100},
         # Cross region aggregation
-        region={'type': 'string', 'description': 'cross-region aggregation target', 'default': 'current region'},
+        region={'type': 'string', 'description': 'cross-region aggregation target', 
+            'default': 'current region'},
         recommendation={"type": "string"},
         recommendation_url={"type": "string"},
         fields={"type": "object"},

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -292,8 +292,7 @@ class PostFinding(Action):
         confidence={"type": "number", "min": 0, "max": 100},
         criticality={"type": "number", "min": 0, "max": 100},
         # Cross region aggregation
-        region={'type': 'string', 'description': 'cross-region aggregation target',
-            'default': 'current region'},
+        region={'type': 'string', 'description': 'cross-region aggregation target'},
         recommendation={"type": "string"},
         recommendation_url={"type": "string"},
         fields={"type": "object"},

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -284,18 +284,18 @@ class PostFinding(Action):
     schema = type_schema(
         "post-finding",
         required=["types"],
-        title={"type": "string"},
-        description={'type': 'string'},
+        title={"type": "string", 'default': 'policy.name'},
+        description={'type': 'string', 'default': 'policy.description, or if not defined in policy then policy.name'},
         severity={"type": "number", 'default': 0},
         severity_normalized={"type": "number", "min": 0, "max": 100, 'default': 0},
         confidence={"type": "number", "min": 0, "max": 100},
         criticality={"type": "number", "min": 0, "max": 100},
         # Cross region aggregation
-        region={'type': 'string', 'description': 'cross-region aggregation target'},
+        region={'type': 'string', 'description': 'cross-region aggregation target', 'default': 'current region'},
         recommendation={"type": "string"},
         recommendation_url={"type": "string"},
         fields={"type": "object"},
-        batch_size={'type': 'integer', 'minimum': 1, 'maximum': 10},
+        batch_size={'type': 'integer', 'minimum': 1, 'maximum': 10, 'default': 1},
         types={
             "type": "array",
             "minItems": 1,


### PR DESCRIPTION
Simple adding of documentation of 4 default values to the securityhub post-finding schema