### PR TITLE
release - 0.8.45.4 - version increments

### DIFF
--- a/c7n/version.py
+++ b/c7n/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = u"0.8.45.3"
+version = u"0.8.45.4"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 setup(
     name="c7n",
-    version='0.8.45.3',
+    version='0.8.45.4',
     description="Cloud Custodian - Policy Rules Engine",
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
@@ -25,9 +25,9 @@ setup(
             'custodian = c7n.cli:main']},
     install_requires=[
         "boto3>=1.9.228",
-        "botocore>=1.12.228",
-        "python-dateutil>=2.6,<2.8.1",
-        "PyYAML>=4.2b4",
+        "botocore>=1.13.46",
+        "python-dateutil>=2.6,<3.0.0",
+        "PyYAML>=5.1",
         "jsonschema",
         "jsonpatch>=1.21",
         "argcomplete",

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -31,7 +31,7 @@ extra_dependencies = ["azure-functions"] if sys.version_info[0] >= 3 else []
 
 setup(
     name="c7n_azure",
-    version='0.6.2',
+    version='0.6.3',
     description="Cloud Custodian - Azure Support",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tools/c7n_gcp/setup.py
+++ b/tools/c7n_gcp/setup.py
@@ -21,7 +21,7 @@ if os.path.exists('readme.md'):
 
 setup(
     name="c7n_gcp",
-    version='0.3.7',
+    version='0.3.8',
     description="Cloud Custodian - Google Cloud Provider",
     long_description=description,
     long_description_content_type='text/markdown',

--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -49,7 +49,7 @@ if path.exists(readme):
 
 setup(
     name="c7n_mailer",
-    version='0.5.6',
+    version='0.5.7',
     description="Cloud Custodian - Reference Mailer",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tools/c7n_org/setup.py
+++ b/tools/c7n_org/setup.py
@@ -21,7 +21,7 @@ if os.path.exists('README.md'):
 
 setup(
     name="c7n_org",
-    version='0.5.6',
+    version='0.5.7',
     description="Cloud Custodian - Multi Account",
     classifiers=[
         "Topic :: System :: Systems Administration",

--- a/tools/c7n_trailcreator/setup.py
+++ b/tools/c7n_trailcreator/setup.py
@@ -21,7 +21,7 @@ if os.path.exists('readme.md'):
 
 setup(
     name="c7n_trailcreator",
-    version='0.1.4',
+    version='0.1.5',
     description="Cloud Custodian - Retroactive Tag Resource Creators from CloudTrail",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
ChangeLog

# aws
 - aws - appelb web-acl filter restore support for any webacl (#5148)
 - aws - cloud trail tagging augment/actions/filters (#5100)
 - aws - ebs snapshot action, copy-volume-tags when Snapshotting (#5119)
 - aws - ecr set-immutable & set-scanning actions (#5062)
 - aws - eks tag actions/filters (#5061)
 - aws - fix typo in account registry names (#5083)
 - aws - flow-log filter handle s3 destinations when checking log-groups and log-format support (#5149)
 - aws - glacier - support name for id instead of arn (#5168)
 - aws - kinesis firehose and analytics tagging (#5051)
 - aws - phd mode - allow 'events' to be optional on account resource (#5066)
 - aws - phd mode - fix all events support (#5133)
 - aws - phd mode use global health endpoint in us-east-1 (#5147)
 - aws - rds upgrade filter and action fix pagination of available engine versions (#5058)
 - aws - redshift filter & action for logging  (#5179)
 - aws - route53 domain - simplify and retry tag augment (#5198)


# azure
 - azure - disable flaky tests for now (#5104)
 - azure - fix Azure nightly tests (#5060)
 - azure - fix nic effective route test (#5117)
 - azure - function increase timeout and logging (#5114)
 - azure - refactor lock action test & replace expensive sku (#5151)


# core
 - cli - validate - structure parsing should exit 1 on error (#5101)
 - core - fix bag/config attribute mutation (#5081)
 - core - frozen requirements generator (#5127)
 - core - improve missing provider import error (#5150)
 - core - update dependency freezes (#5120)


# docs
 - docs - additional mugc information (#5107)
 - docs - minor readme corrections in additional tools section  (#5126)
 - docs - security hub - post-finding add schema defaults (#5190)
 - docs - update iam policy document for quick start (#5155)


# gcp
 - gcp -  label/tagging actions/filters support (#5015)
 - gcp - disk snapshot - allow user formatting of name (#5053)


# other
 - Handle ImportError and FileNotFoundError (#5132)



# tests
 - ci - azure fix tests to work around sdk breaking change (#5195)
 - ci - enable python 3.8 test runner (#5082)
 - ci - fix another azure sdk breakage for cosmosdb mgmt (#5078)
 - ci - fix some test deprecation warnings (#5099)
 - ci - switch badge url (#5103)


# tools
 - tools/c7n-mailer - template functions add from_json as a filter (#5054)
 - tools/c7n-mailer - utils fix incorrect resource_type provider prefix stripping (#5152)
 - tools/c7n-org - aws account id regex schema validation (#5077)
 - tools/c7n-org - run-script exit(1) on failure (#5131)
 - tools/c7n-trailcreator - fix athena loading and update readme (#5135)
 - tools/dev - changelog generator support since date and a few more aliases (#5141)
 - tools/dev - pinned package generator use mu library (#5142)
 - tools/ops/mugc - fix prefix compatibility and document new features (#5098)
 - tools/ops/mugc - support removal of policies in file and regex policy selection (#5067)
