### PR TITLE
aws - python 3.8 lambda policy support

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -405,7 +405,8 @@ class LambdaMode(ServerlessExecutionMode):
             # Lambda passthrough config
             'layers': {'type': 'array', 'items': {'type': 'string'}},
             'concurrency': {'type': 'integer'},
-            'runtime': {'enum': ['python2.7', 'python3.6', 'python3.7']},
+            'runtime': {'enum': ['python2.7', 'python3.6',
+                                 'python3.7', 'python3.8']},
             'role': {'type': 'string'},
             'timeout': {'type': 'number'},
             'memory': {'type': 'number'},

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -55,12 +55,13 @@ ROLE = "arn:aws:iam::644160558196:role/custodian-mu"
 
 def test_generate_requirements():
     lines = generate_requirements(
-        'boto3', ignore=('docutils', 's3transfer'))
+        'boto3', ignore=('docutils', 's3transfer', 'six'))
     packages = []
     for l in lines.split('\n'):
         pkg_name, version = l.split('==')
         packages.append(pkg_name)
-    assert packages == ['botocore', 'jmespath']
+    assert set(packages) == set([
+        'botocore', 'jmespath', 'urllib3', 'python-dateutil'])
 
 
 class Publish(BaseTest):


### PR DESCRIPTION
closes #5218

