### PR TITLE
aws - security hub - hub modes support cross account execution

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -499,29 +499,34 @@ class LambdaMode(ServerlessExecutionMode):
         If metrics execution option is enabled, custodian will generate
         metrics per normal.
         """
-        from c7n.actions import EventAction
-
-        mode = self.policy.data.get('mode', {})
-        if not bool(mode.get("log", True)):
-            root = logging.getLogger()
-            map(root.removeHandler, root.handlers[:])
-            root.handlers = [logging.NullHandler()]
-
+        self.setup_exec_environment(event)
         resources = self.resolve_resources(event)
         if not resources:
             return resources
+        rcount = len(resources)
         resources = self.policy.resource_manager.filter_resources(
             resources, event)
 
         if 'debug' in event:
-            self.policy.log.info("Filtered resources %d" % len(resources))
+            self.policy.log.info(
+                "Filtered resources %d of %d", len(resources), rcount)
 
         if not resources:
             self.policy.log.info(
                 "policy:%s resources:%s no resources matched" % (
                     self.policy.name, self.policy.resource_type))
             return
+        return self.run_resource_set(event, resources)
 
+    def setup_exec_environment(self, event):
+        mode = self.policy.data.get('mode', {})
+        if not bool(mode.get("log", True)):
+            root = logging.getLogger()
+            map(root.removeHandler, root.handlers[:])
+            root.handlers = [logging.NullHandler()]
+
+    def run_resource_set(self, event, resources):
+        from c7n.actions import EventAction
         with self.policy.ctx:
             self.policy.ctx.metrics.put_metric(
                 'ResourceCount', len(resources), 'Count', Scope="Policy",

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -464,6 +464,7 @@ class LambdaMode(ServerlessExecutionMode):
             member_role = member_role.format(account_id=member_id)
             utils.reset_session_cache()
             self.policy.options['account_id'] = member_id
+            self.policy.options['region'] = region
             self.policy.session_factory.region = region
             self.policy.session_factory.assume_role = member_role
             self.policy.log.info(

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -138,6 +138,16 @@ class Arn(namedtuple('_Arn', (
 
     __slots__ = ()
 
+    def __repr__(self):
+        return "<arn:%s:%s:%s:%s:%s%s%s>" % (
+            self.partition,
+            self.service,
+            self.region,
+            self.account_id,
+            self.resource_type,
+            self.separator,
+            self.resource)
+
     @classmethod
     def parse(cls, arn):
         parts = arn.split(':', 5)

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -250,6 +250,9 @@ class SecurityHub(LambdaMode):
             resource_arns = [
                 r for r in resource_map
                 if r.service == self.policy.resource_manager.resource_type.service]
+            if not resource_arns:
+                log.info("mode:security-hub no matching resources arns")
+                return []
             resources = self.policy.resource_manager.get_resources(
                 [r.resource for r in resource_arns])
         else:

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -205,7 +205,9 @@ class SecurityHub(LambdaMode):
         for (account_id, region), rarns in resource_sets.items():
             self.assume_member({'account': account_id, 'region': region})
             resources = self.resolve_resources(event)
-            result_sets[(account_id, region)] = self.run_resource_set(event, resources)
+            rset = result_sets.setdefault((account_id, region), [])
+            if resources:
+                rset.extend(self.run_resource_set(event, resources))
         return result_sets
 
     def get_resource_sets(self, event):

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -24,7 +24,7 @@ import logging
 
 from c7n.actions import Action
 from c7n.filters import Filter
-from c7n.exceptions import PolicyValidationError
+from c7n.exceptions import PolicyValidationError, PolicyExecutionError
 from c7n.manager import resources
 from c7n.policy import LambdaMode, execution
 from c7n.utils import (
@@ -222,9 +222,10 @@ class SecurityHub(LambdaMode):
         if (not self.policy.data['mode'].get('member-role') and
                 set((self.policy.options.account_id,)) != {
                     rarn.account_id for rarn in resource_arns}):
-            self.policy.log.warning((
-                'hub-mode not configured for multi-account member-role '
-                'but multiple resource accounts found'))
+            msg = ('hub-mode not configured for multi-account member-role '
+                   'but multiple resource accounts found')
+            self.policy.log.warning(msg)
+            raise PolicyExecutionError(msg)
         return resource_sets
 
     def get_resource_arns(self, event):

--- a/docs/source/aws/topics/securityhub.rst
+++ b/docs/source/aws/topics/securityhub.rst
@@ -33,7 +33,7 @@ custodian actions are resource specific.
 
 .. code-block:: yaml
 
-   policy:
+   policies:
      - name: remediate
        resource: aws.ec2
        mode:
@@ -51,7 +51,7 @@ guard duty (note custodian also has support for guard duty events directly).
 
 .. code-block:: yaml
 
-   policy:
+   policies:
      - name: remediate
        resource: aws.iam
        mode:

--- a/tests/data/cwe/event-securityhub-lambda-cross.json
+++ b/tests/data/cwe/event-securityhub-lambda-cross.json
@@ -1,0 +1,87 @@
+{
+    "version": "0",
+    "id": "4fa18fb8-cd5e-ffe6-bb73-36bac665af54",
+    "detail-type": "Security Hub Findings - Custom Action",
+    "source": "aws.securityhub",
+    "account": "519413311747",
+    "time": "2020-01-15T15:56:47Z",
+    "region": "us-east-1",
+    "resources": [
+        "arn:aws:securityhub:us-east-1:519413311747:action/custom/remediate"
+    ],
+    "detail": {
+        "actionName": "Lambda remediate",
+        "actionDescription": "remediate",
+        "findings": [
+            {
+                "SchemaVersion": "2018-10-08",
+                "ProductArn": "arn:aws:securityhub:us-east-1:644160558196:product/644160558196/default",
+                "AwsAccountId": "644160558196",
+                "Description": "Bad Lambda Monkey",
+                "Title": "lambda-finding",
+                "Id": "us-east-1/644160558196/356580e4704cf1222cbee13685416652/84a7b9799285262dbf00c7b214463dde",
+                "GeneratorId": "lambda-finding",
+                "CreatedAt": "2020-01-15T15:55:49.624441+00:00",
+                "UpdatedAt": "2020-01-15T15:55:49.624441+00:00",
+                "RecordState": "ACTIVE",
+                "Severity": {
+                    "Product": 0,
+                    "Normalized": 6
+                },
+                "Confidence": 100,
+                "Compliance": {
+                    "Status": "FAILED"
+                },
+                "ProductFields": {
+                    "resource": "aws.lambda",
+                    "ProviderName": "CloudCustodian",
+                    "ProviderVersion": "0.8.45.4",
+                    "aws/securityhub/FindingId": "arn:aws:securityhub:us-east-1:644160558196:product/644160558196/default/us-east-1/644160558196/356580e4704cf1222cbee13685416652/84a7b9799285262dbf00c7b214463dde",
+                    "aws/securityhub/SeverityLabel": "LOW",
+                    "aws/securityhub/ProductName": "Default",
+                    "aws/securityhub/CompanyName": "Personal"
+                },
+                "Resources": [
+                    {
+                        "Type": "Other",
+                        "Id": "arn:aws:lambda:us-east-1:644160558196:function:custodian-enterprise-ec2-instances-no-elastic-ip-isolate",
+                        "Region": "us-east-1",
+                        "Partition": "aws",
+                        "Details": {
+                            "Other": {
+                                "FunctionName": "custodian-enterprise-ec2-instances-no-elastic-ip-isolate",
+                                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-enterprise-ec2-instances-no-elastic-ip-isolate",
+                                "Runtime": "python3.7",
+                                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                                "Handler": "custodian_policy.run",
+                                "CodeSize": "544043",
+                                "Description": "OPS9 - Instances should not have public ips.\n",
+                                "Timeout": "60",
+                                "MemorySize": "512",
+                                "LastModified": "2019-06-21T19:13:22.979+0000",
+                                "CodeSha256": "PiBNBRB/LSwwtLdczV1z822kUD1Aq1eVPlLyvIualE4=",
+                                "Version": "",
+                                "VpcConfig": "{\n\"SubnetIds\": [],\n\"SecurityGroupIds\": [],\n\"VpcId\": \"\"\n}",
+                                "TracingConfig": "{\n\"Mode\": \"PassThrough\"\n}",
+                                "RevisionId": "8b24c19d-972a-4254-9bd8-8c6a9accf695",
+                                "Tags": "[\n{\n\"Key\": \"ASV\",\n\"Value\": \"ASVCLOUDCUSTODIAN\"\n},\n{\n\"Key\": \"CMDBEnvironment\",\n\"Value\": \"ENVPRCLOUDMAID\"\n},\n{\n\"Key\": \"OwnerContact\",\n\"Value\": \"cloudmaid@capitalone.com\"\n}\n]",
+                                "c7n:MatchedFilters": "[\n\"FunctionName\"\n]",
+                                "c7n:resource-type": "lambda"
+                            }
+                        },
+                        "Tags": {
+                            "ASV": "ASVCLOUDCUSTODIAN",
+                            "CMDBEnvironment": "ENVPRCLOUDMAID",
+                            "OwnerContact": "cloudmaid@capitalone.com"
+                        }
+                    }
+                ],
+                "Types": [
+                    "Software and Configuration Checks/Custodian/Monkey Lambda"
+                ],
+                "WorkflowState": "NEW"
+            }
+        ]
+    },
+    "debug": true
+}

--- a/tests/data/placebo/test_security_hub_multi_account_mode/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_security_hub_multi_account_mode/lambda.GetFunction_1.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "af166356-6774-490a-82c4-54d93b2ca7aa",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "date": "Wed, 15 Jan 2020 20:13:11 GMT",
+                "content-type": "application/json",
+                "content-length": "2966",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "af166356-6774-490a-82c4-54d93b2ca7aa"
+            },
+            "RetryAttempts": 0
+        },
+        "Configuration": {
+            "FunctionName": "custodian-enterprise-ec2-instances-no-elastic-ip-isolate",
+            "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-enterprise-ec2-instances-no-elastic-ip-isolate",
+            "Runtime": "python3.7",
+            "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+            "Handler": "custodian_policy.run",
+            "CodeSize": 544043,
+            "Description": "OPS9 - Instances should not have public ips.\n",
+            "Timeout": 60,
+            "MemorySize": 512,
+            "LastModified": "2019-06-21T19:13:22.979+0000",
+            "CodeSha256": "PiBNBRB/LSwwtLdczV1z822kUD1Aq1eVPlLyvIualE4=",
+            "Version": "$LATEST",
+            "VpcConfig": {
+                "SubnetIds": [],
+                "SecurityGroupIds": [],
+                "VpcId": ""
+            },
+            "TracingConfig": {
+                "Mode": "PassThrough"
+            },
+            "RevisionId": "8b24c19d-972a-4254-9bd8-8c6a9accf695",
+            "State": "Active",
+            "LastUpdateStatus": "Successful"
+        },
+        "Code": {
+            "RepositoryType": "S3",
+            "Location": "https://prod-04-2014-tasks.s3.us-east-1.amazonaws.com/snapshots/644160558196/custodian-enterprise-ec2-instances-no-elastic-ip-isolate-8adc3d46-6776-450a-8f10-bf32d6d6bb4a?versionId=9RgI8Cscav1QKif9yxPpnB4PwYAzfTxe&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEPT%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIQDhBQM3WpjIA500j5MaM9LVnRLuXcyFKXJVkEs%2F8C%2FbkAIgCc%2Buvhe7iuakDc0zbkB%2BPx%2FwG5pmrK2lFqzYBNU2XlkqtAMIfBAAGgw3NDk2Nzg5MDI4MzkiDB8OxwZmGrWRGqAKCSqRA0RtKH%2FHWnqfrjWuP5B8BB3nN6%2BPsHNg1OAuB%2FZZskE9hTLxkHu8NKPVuVV0lN2iXzus5O6z7QoK4O3QBRNwJTOLDdWiXEsLiFAhCWeJ%2FuFFfcYmH9uqwTjgEC5bcNrOE3pP1cVUMO1GKQHSXTxgbrcra0HE5GryBQjoeAKCF4CsGQ0n%2F884rqe3Sw%2Budw6QxVr3yPCIbQIdv82BKyzQ8qnkcP9xJ1uvkABb%2FyW012kVm5Qglbll27fdEbD41aDKQQ6fSHuWKr0NBC%2BvDx67e1HzFgvW25uDGqHirUzFRR6fr0275CwJ5IN5DSTcv2xAMho5J2d0%2B6EGGLmDtvfu1ekM78I9mllJB%2BeZDv6hzckVSRI23ItEn8D67C4%2FfJnAmoBjNoIQ7jRF8HKCs%2BvmfhKjlH4QwqkP6xmOdAUTxGRpluM0UfXsU3NGQGPxEe0PsmkwUYAV4LkYbOqJNKCeTFGRreBoCe2%2FmvZHEoCTgC%2FP3M8ToSgB2DcvZxhRTBoA2%2Blu7y2CFMf8Tt3RJ4sPw6AhMN3J%2FfAFOusB8yqt5eQlhNLdn%2FAyjs%2Bi6LC8Y9RZRL5b8MQ4a%2BFuS5GM8YL2cvsUpbx3PWJVf0x0c%2Bbg8FZElDfSxshweZQHEJjODwgTcSHXEeGKWzrxW8x6uylY9Q3cHWj7qngdLCCxLXawCW02V9L%2F9CTqwit9J14xZAH8D%2ByoLKzbrtqe3t18wbV%2FJNjMQ6uTDkXzpoBprLRBp9mbrx%2FaJ0rQy4SHaRZSvh6M3V1V7ZVa6Q1c1wR0khp%2FP7f9qoCj4ZUzPjgOBkViOGdEKOxIbMQ7CT34GL7uaQ8k8FEYnNq3KN7UjNCu4tiK3Q4Nsv4I8w%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20200115T201311Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Credential=ASIA25DCYHY3SZEDKWXZ%2F20200115%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=42c8ff4aa5c4feb39ef74c748954e36dab0355e361fc5fceded823322c4c42f6"
+        },
+        "Tags": {
+            "SecurityHubRemediated": "yeah",
+            "ASV": "ASVCLOUDCUSTODIAN",
+            "OwnerContact": "cloudmaid@capitalone.com",
+            "CMDBEnvironment": "ENVPRCLOUDMAID",
+            "c7n:FindingId:lambda-finding": "us-east-1/644160558196/356580e4704cf1222cbee13685416652/84a7b9799285262dbf00c7b214463dde:2020-01-15T15:55:49.624441+00:00"
+        }
+    }
+}

--- a/tests/data/placebo/test_security_hub_multi_account_mode/sts.AssumeRole_1.json
+++ b/tests/data/placebo/test_security_hub_multi_account_mode/sts.AssumeRole_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "Credentials": {
+            "AccessKeyId": "ASIAZL6XWCR2GOMA123",
+            "SecretAccessKey": "8MRAN32++RGwfMhuzLLB0kjV71hYROeJIz9abdEE",
+            "SessionToken": "FwoGZXIvYXdzEAYaDMqD1qEObDBTVaqTyiKxAXJSbRVG5CUSPyWhkLK/KrrkrlXyHN/ociAzIjVK5kQIV5+Nh1LDUb/vduDm15yjlj56iVHc80EvtaP3mCUioqf3U3z23bw5/gO/UsjXLEk6IhJkDyG8LL3TOtvzlVWKi6JaUoihcwOr/CblWgOQf9aXRb48lOFYUa7PjWtITMbtH3wUPQ9M/SjF7V+rMrZrm8Ckz2X1613exwC4/SEqHqPFBVxDqd9OaVjXIC7KU48oiSjU5P3wBTIt8K2FcwXiEASnxQj9unK2ztAjM1XAlzOocyY1i8L4XAQ4Fb2aJlmlg4WKobrb",
+            "Expiration": {
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 1,
+                "day": 15,
+                "hour": 21,
+                "minute": 13,
+                "second": 8,
+                "microsecond": 0
+            }
+        },
+        "AssumedRoleUser": {
+            "AssumedRoleId": "AROAIS6DAH72KKDTPRAXA:CustodianTest",
+            "Arn": "arn:aws:sts::644160558196:assumed-role/CustodianGuardDuty/CustodianTest"
+        },
+        "ResponseMetadata": {
+            "RequestId": "725dd3a7-37d3-11ea-bd96-29aca0018fe3",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "725dd3a7-37d3-11ea-bd96-29aca0018fe3",
+                "content-type": "text/xml",
+                "content-length": "1055",
+                "date": "Wed, 15 Jan 2020 20:13:08 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -80,7 +80,7 @@ class SecurityHubMode(BaseTest):
                 'arn:aws:iam::644160558196:user/kapil']))
 
     def test_resolve_multi_account_resource_sets(self):
-        factory = self.record_flight_data(
+        factory = self.replay_flight_data(
             'test_security_hub_multi_account_mode')
         policy = self.load_policy({
             'name': 'lambda-remediate',

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -16,7 +16,7 @@ from jsonschema.exceptions import ValidationError
 from c7n.exceptions import PolicyValidationError
 from .common import BaseTest, event_data
 
-
+import logging
 import time
 
 LambdaFindingId = "us-east-2/644160558196/81cc9d38b8f8ebfd260ecc81585b4bc9/9f5932aa97900b5164502f41ae393d23" # NOQA
@@ -78,6 +78,36 @@ class SecurityHubMode(BaseTest):
                 'arn:aws:iam::644160558196:user/david.shepherd2',
                 'arn:aws:iam::644160558196:user/david.yun',
                 'arn:aws:iam::644160558196:user/kapil']))
+
+    def test_resolve_multi_account_resource_sets(self):
+        factory = self.record_flight_data(
+            'test_security_hub_multi_account_mode')
+        policy = self.load_policy({
+            'name': 'lambda-remediate',
+            'resource': 'aws.lambda',
+            'mode': {
+                'type': 'hub-action',
+                'role': 'CustodianPolicyExecution',
+                'member-role': 'arn:aws:iam::{account_id}:role/CustodianGuardDuty'
+            }},
+            config={'region': 'us-east-2',
+                    'account_id': '519413311747'},
+            session_factory=factory)
+        hub = policy.get_execution_mode()
+        event = event_data('event-securityhub-lambda-cross.json')
+        partition_resources = hub.get_resource_sets(event)
+        self.assertEqual(
+            {p: list(map(repr, v)) for p, v in partition_resources.items()},
+            {('644160558196', 'us-east-1'): [
+                ("<arn:aws:lambda:us-east-1:644160558196:function:"
+                 "custodian-enterprise-ec2-instances-no-elastic-ip-isolate>")
+            ]})
+        output = self.capture_logging(policy.log.name, level=logging.INFO)
+        results = hub.run(event, {})
+        self.assertIn('Assuming member role:arn:aws:iam::644160558196', output.getvalue())
+        self.assertEqual(
+            results[('644160558196', 'us-east-1')][0]['FunctionName'],
+            'custodian-enterprise-ec2-instances-no-elastic-ip-isolate')
 
 
 class SecurityHubTest(BaseTest):


### PR DESCRIPTION
closes #5034

todo (not required, just optimizations)

 - [ ] check if the finding is in the same account/region and if so don't bother with role assume
 - [ ] try to sort the resource sets so that same account / master shows up first, and then the rest are ordered per by account_id, and region.
