### PR TITLE
aws - ec2 stop - add new error code for graviton instances

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -994,7 +994,7 @@ class Start(BaseAction, StateTransitionFilter):
     def process_instance_set(self, client, instances, itype, izone):
         # Setup retry with insufficient capacity as well
         retryable = ('InsufficientInstanceCapacity', 'RequestLimitExceeded',
-                     'Client.RequestLimitExceeded'),
+                     'Client.RequestLimitExceeded', 'Server.InsufficientInstanceCapacity'),
         retry = utils.get_retry(retryable, max_attempts=5)
         instance_ids = [i['InstanceId'] for i in instances]
         while instance_ids:


### PR DESCRIPTION
closes #5235 