### PR TITLE
aws - cli improve error message for --region all without default region set

### DIFF
--- a/c7n/exceptions.py
+++ b/c7n/exceptions.py
@@ -24,6 +24,10 @@ class CustodianError(Exception):
     """
 
 
+class InvalidCliOption(CustodianError):
+    """a cli parameter was passed that was not valid"""
+
+
 class InvalidOutputConfig(CustodianError):
     """Invalid configuration for an output"""
 


### PR DESCRIPTION
improve error cli error message, per question on gitter.

the question is if we can default this to us-east-1 safely is open. lots of folks have proxies and vpc endpoints setup, so its not clear if we can or should. i vaguely recall we tried that previously.