### PR TITLE
Fill AWS lambda assume role variable with partition name (#5253)

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -950,8 +950,9 @@ class Policy(object):
 
         if 'mode' in self.data:
             if 'role' in self.data['mode'] and not self.data['mode']['role'].startswith("arn:aws"):
-                self.data['mode']['role'] = "arn:aws:iam::%s:role/%s" % \
-                                            (self.options.account_id, self.data['mode']['role'])
+                partition = utils.get_partition(self.options.region)
+                self.data['mode']['role'] = "arn:%s:iam::%s:role/%s" % \
+                    (partition, self.options.account_id, self.data['mode']['role'])
 
         variables.update({
             # standard runtime variables for interpolation


### PR DESCRIPTION
Currently AWS lambda assume role hard code with default partition name
`aws`[1], it doesn't work in any other partition such as China.

This patch gets partion name by region and fills in policy data.

[1] https://github.com/cloud-custodian/cloud-custodian/blob/master/c7n/policy.py#L953-L954

closes #5253 