### PR TITLE
Fix lightsail-db resource lookup

### DIFF
--- a/c7n/resources/lightsail.py
+++ b/c7n/resources/lightsail.py
@@ -33,7 +33,7 @@ class Database(QueryResourceManager):
 
     class resource_type(TypeInfo):
         service = 'lightsail'
-        enum_spec = ('get_relational_databases', 'relationDatabases', None)
+        enum_spec = ('get_relational_databases', 'relationalDatabases', None)
         name = 'name'
         arn = id = 'arn'
         date = 'createdAt'


### PR DESCRIPTION
The response from the server is something like this:
```
{
    "status_code": 200,
    "data": {
        "relationalDatabases": [
            {
                "name": "Database-1",
```