### PR TITLE
Correct the 'description' of the sample policy in GCP Getting Started docs, regex filter - add quotes and two more examples

### DIFF
--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -143,9 +143,19 @@ There are several ways to get a list of possible keys for each resource.
 
       filters:
          - type: value
-           key: FunctionName                ─▶ The value from the describe call
+           key: FunctionName                ─▶ The value from the describe call, or resources.json
            op: regex                        ─▶ Special operator
-           value: (custodian|c7n)_\w+       ─▶ Regex string
+           value: '(custodian|c7n)_\w+'     ─▶ Regex string: match all values beginning with custodian_ or c7n_
+
+         - type: value
+           key: name                        ─▶ The value from the describe call, or resources.json
+           op: regex                        ─▶ Special operator
+           value: '^.*c7n.*$'               ─▶ Regex string: match all values containing c7n
+
+         - type: value
+           key: name                        ─▶ The value from the describe call, or resources.json
+           op: regex                        ─▶ Special operator
+           value: '^((?!c7n).)*$'           ─▶ Regex string: match all values not containing c7n
 
   1. These operators are implemented using ``re.match``. If a filter isn't working as expected take a look at the `re`__ documentation.
 

--- a/docs/source/gcp/gettingstarted.rst
+++ b/docs/source/gcp/gettingstarted.rst
@@ -99,7 +99,7 @@ Filename: ``custodian.yml``
     policies:
       - name: my-first-policy
         description: |
-          Stops all compute instances that contain the word "test"
+          Stops all compute instances that are named "test"
         resource: gcp.instance
         filters:
           - type: value


### PR DESCRIPTION
Correct the 'description' of the sample policy to correctly describe the logic, which is that the name of the instance has to match the name "test" exactly, not contain the word "test"