### PR TITLE
Add policy-test tool for empirically testing c7n policies

### DIFF
--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -273,7 +273,7 @@ class PillTest(CustodianTestCore):
     def cleanUp(self):
         self.pill = None
 
-    def record_flight_data(self, test_case, zdata=False, augment=False):
+    def record_flight_data(self, test_case, zdata=False, augment=False, assume_role=None):
         self.recording = True
         test_dir = os.path.join(self.placebo_dir, test_case)
         if not (zdata or augment):
@@ -302,16 +302,16 @@ class PillTest(CustodianTestCore):
                 # assume role api calls creds into test data, they will
                 # go stale, but its best to modify before commiting.
                 # Disabled by default.
-                if 0 and (assume is not False and fake.assume_role):
+                if assume is not False and assume_role:
                     client = session.client('sts')
                     creds = client.assume_role(
-                        RoleArn=fake.assume_role,
+                        RoleArn=assume_role,
                         RoleSessionName='CustodianTest')['Credentials']
                     new_session = boto3.Session(
                         aws_access_key_id=creds['AccessKeyId'],
                         aws_secret_access_key=creds['SecretAccessKey'],
                         aws_session_token=creds['SessionToken'],
-                        region_name=region or fake.region or default_region)
+                        region_name=region or default_region)
                 elif region and region != default_region:
                     new_session = boto3.Session(region_name=region)
 

--- a/tools/utils/policy_test
+++ b/tools/utils/policy_test
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import json
+import yaml
+import tests.common
+import c7n.credentials
+import c7n.utils
+import placebo
+import shutil
+import boto3
+
+parser = argparse.ArgumentParser('Policy Tester')
+parser.add_argument('--assume', dest='assume_role', help='Role to assume')
+subparsers = parser.add_subparsers(dest='command', help='Execution mode')
+subparsers.required=True
+
+record_parser = subparsers.add_parser('record')
+record_parser.add_argument('--cache', type=str, default='cache', help='Cache dir to write to')
+record_parser.add_argument('policy', type=argparse.FileType('r'), help='Policy file to consume')
+record_parser.add_argument('name', type=str, help='Name of the policy')
+
+test_parser = subparsers.add_parser('replay')
+test_parser.add_argument('--cache', type=str, default='cache' help='Cache dir to consume')
+test_parser.add_argument('policy', type=argparse.FileType('r'), help='Policy file to consume')
+test_parser.add_argument('name', type=str, help='Name of the policy')
+
+args = parser.parse_args()
+
+class TestPolicy(tests.zpill.PillTest):
+    def __init__(self, policy, cache, assume_role=None):
+        self.policy = policy
+        self.assume_role = assume_role
+        self.account_id = None
+        self.cleanup = []
+        self.placebo_dir = cache
+        self.test_dir = os.path.join(self.placebo_dir, self.policy['name'])
+        if assume_role:
+            self.account_id = self.assume_role.split(':')[4]
+
+    def run(self, replay):
+        if replay:
+            session_factory = self.replay_flight_data(self.policy['name'])
+            output_dir = None
+        else:
+            session_factory = self.record_flight_data(self.policy['name'], assume_role=self.assume_role)
+            output_dir = self.placebo_dir
+
+        policy = self.load_policy(
+            self.policy,
+            config={'dryrun': True, 'output_dir': output_dir, 'account_id': self.account_id},
+            session_factory=session_factory,
+            validate=True,
+            output_dir=output_dir,
+        )
+        resources = policy.run()
+        resources = c7n.utils.loads(c7n.utils.dumps(resources))
+
+        if replay:
+            with open(os.path.join(self.test_dir, 'resources.json'), 'r') as fh:
+                old_resources = c7n.utils.loads(fh.read())
+                print(resources == old_resources)
+
+        for func, args, kw in self.cleanup:
+            func(*args, **kw)
+
+    def addCleanup(self, func, *args, **kw):
+        self.cleanup.append((func, args, kw))
+
+def get_policy(policies, name):
+    policies = policies.get('policies', [])
+    for policy in policies:
+        if policy.get('name') == name:
+            return policy
+
+    return None
+
+policy = get_policy(yaml.safe_load(args.policy), args.name)
+if policy is None:
+    print("Policy not found!")
+
+replay = args.command == 'replay'
+runner = TestPolicy(policy, args.cache, args.assume_role)
+runner.run(replay=replay)


### PR DESCRIPTION
This PR adds the `policy-test` tool we were chatting about in gitter.

There are 2 commands:
- `record` saves all responses to the output directory.
- `replay` uses the saved responses to test whether the policy matches the output. Outputs `True` on success

Notes:
- The changes to `test/zpill.py` were the minimum required to get `assume_role` working.
- The placebo library breaks when trying to record certain resources. There's a pending [PR](https://github.com/garnaat/placebo/pull/70) to fix this.
- I tried adding a mode to test all policies in the policy file. However, all boto3 clients after the initial policy seemed to hit AWS directly. Is there some caching going on that I need to bust before executing another test?

Happy to discuss & make changes.