### PR TITLE
Fix expectations for Cloudtrail in c7n-mailer

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -279,9 +279,8 @@ def resource_format(resource, resource_type):
             resource['account_id'],
             resource['account_name'])
     elif resource_type == 'cloudtrail':
-        return " %s %s" % (
-            resource['account_id'],
-            resource['account_name'])
+        return "%s" % (
+            resource['Name'])
     elif resource_type == 'vpc':
         return "%s " % (
             resource['VpcId'])

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -74,6 +74,27 @@ class ResourceFormat(unittest.TestCase):
             'loadbalancer/app/dev/1234567890'
             '  zones: 0  scheme: internal')
 
+    def test_cloudtrail(self):
+        self.assertEqual(
+            utils.resource_format(
+                {
+                    "Name": "trail-x",
+                    "S3BucketName": "trail-x-bucket",
+                    "IncludeGlobalServiceEvents": True,
+                    "IsMultiRegionTrail": False,
+                    "HomeRegion": "eu-west-2",
+                    "TrailARN": "arn:aws:cloudtrail:eu-west-2:123456789012:trail/trail-x",
+                    "LogFileValidationEnabled": True,
+                    "HasCustomEventSelectors": False,
+                    "HasInsightSelectors": False,
+                    "IsOrganizationTrail": False,
+                    "Tags": [],
+                },
+                "aws.cloudtrail",
+            ),
+            "trail-x",
+        )
+
 
 class GetAwsUsernameFromEvent(unittest.TestCase):
 


### PR DESCRIPTION
Without this change, the mailer will crash. I have also added test
that is listing all fields of real Cloudtrail resource.