### PR TITLE
encode report data as bytes when the --raw output param is used

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -119,7 +119,7 @@ def _report_options(p):
         '--days', type=float, default=1,
         help="Number of days of history to consider")
     p.add_argument(
-        '--raw', type=argparse.FileType('wb'),
+        '--raw', type=argparse.FileType('w'),
         help="Store raw json of collected records to given file path")
     p.add_argument(
         '--field', action='append', default=[], type=_key_val_pair,

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -119,7 +119,7 @@ def loads(body):
 
 def dumps(data, fh=None, indent=0):
     if fh:
-        return fh.write(str.encode(json.dumps(data, cls=DateTimeEncoder, indent=indent), 'utf-8'))
+        return json.dump(data, fh, cls=DateTimeEncoder, indent=indent)
     else:
         return json.dumps(data, cls=DateTimeEncoder, indent=indent)
 

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -119,7 +119,7 @@ def loads(body):
 
 def dumps(data, fh=None, indent=0):
     if fh:
-        return json.dump(data, fh, cls=DateTimeEncoder, indent=indent)
+        return fh.write(str.encode(json.dumps(data, cls=DateTimeEncoder, indent=indent), 'utf-8'))
     else:
         return json.dumps(data, cls=DateTimeEncoder, indent=indent)
 


### PR DESCRIPTION
resolves custodian --raw throwing error #5269

I tried to get the encoding to work within json.dump but was getting another TypeError  'descriptor 'encode' requires a 'str' object but received a 'bytes'' so instead, I decided to encode it in memory then write to the filehandler. I considered using ```sys.version_info >= 3``` so it would still be done the old way in 2.7 but in testing, I found that this solution works in both py27 and py37 so keeping it the same for consistency makes sense. @kapilt What do you think?