### PR TITLE
change default lambda runtime to python3.8

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -868,7 +868,7 @@ class PolicyLambda(AbstractLambdaFunction):
 
     @property
     def runtime(self):
-        return self.policy.data['mode'].get('runtime', 'python3.7')
+        return self.policy.data['mode'].get('runtime', 'python3.8')
 
     @property
     def memory_size(self):

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -840,7 +840,7 @@ class PolicyLambdaProvision(BaseTest):
                 "KMSKeyArn": "",
                 "MemorySize": 512,
                 "Role": "",
-                "Runtime": "python3.7",
+                "Runtime": "python3.8",
                 "Tags": {},
                 "Timeout": 900,
                 "TracingConfig": {"Mode": "PassThrough"},


### PR DESCRIPTION
Change default to use latest python runtime, 3.8, which also uses the latest version of Amazon Linux 2.