### PR TITLE
releng - use dev suffix as fallback version to prevent pypi installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 
 setup(
     name="c7n",
-    use_scm_version={'write_to': 'c7n/version.py', 'fallback_version': '0.9.0-unreleased'},
+    use_scm_version={'write_to': 'c7n/version.py', 'fallback_version': '0.9.0dev'},
     setup_requires=['setuptools_scm'],
     description="Cloud Custodian - Policy Rules Engine",
     long_description=read('README.md'),


### PR DESCRIPTION
closes #5296 