### PR TITLE
Filter the accounts to be run by account id

### DIFF
--- a/c7n/cwe.py
+++ b/c7n/cwe.py
@@ -67,6 +67,10 @@ class CloudWatchEvents(object):
             'ids': 'responseElements.volumeId',
             'source': 'ec2.amazonaws.com'},
 
+        'CreateSnapshot': {
+            'ids': 'responseElements.snapshotId',
+            'source': 'ec2.amazonaws.com'},
+
         'SetLoadBalancerPoliciesOfListener': {
             'ids': 'requestParameters.loadBalancerName',
             'source': 'elasticloadbalancing.amazonaws.com'},

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -239,7 +239,8 @@ def filter_accounts(accounts_config, tags, accounts, not_accounts=None):
     for a in accounts_config.get('accounts', ()):
         if not_accounts and a['name'] in not_accounts:
             continue
-        if accounts and a['name'] not in accounts:
+        account_id = a.get('account_id') or a.get('project_id') or a.get('subscription_id') or ''
+        if accounts and a['name'] not in accounts and account_id not in accounts:
             continue
         if tags:
             found = set()


### PR DESCRIPTION
According to documents[1], you can filter the accounts to be run against by either passing the account name or id via the -a flag, which can be specified multiple times.

But currently seems only support filter the accounts by account name[2].

[1] https://cloudcustodian.io/docs/tools/c7n-org.html#selecting-accounts-and-policy-for-execution
[2] https://github.com/cloud-custodian/cloud-custodian/blob/master/tools/c7n_org/c7n_org/cli.py#L242-L243