### PR TITLE
Add aws cloudtrail event CreateSnapshot shortcuts

### DIFF
--- a/c7n/cwe.py
+++ b/c7n/cwe.py
@@ -67,6 +67,10 @@ class CloudWatchEvents(object):
             'ids': 'responseElements.volumeId',
             'source': 'ec2.amazonaws.com'},
 
+        'CreateSnapshot': {
+            'ids': 'responseElements.snapshotId',
+            'source': 'ec2.amazonaws.com'},
+
         'SetLoadBalancerPoliciesOfListener': {
             'ids': 'requestParameters.loadBalancerName',
             'source': 'elasticloadbalancing.amazonaws.com'},


### PR DESCRIPTION
The event `CreateSnapshot` is very common, it maybe better to add it
to shotcuts.