### PR TITLE
azure - fix consistent failures in live functionals

### DIFF
--- a/tools/c7n_azure/c7n_azure/handler.py
+++ b/tools/c7n_azure/c7n_azure/handler.py
@@ -24,6 +24,7 @@ from c7n.utils import reset_session_cache
 from c7n.config import Config
 from c7n.policy import PolicyCollection
 from c7n.resources import load_resources
+from c7n.structure import StructureParser
 
 from c7n_azure.provider import Azure
 
@@ -55,7 +56,7 @@ def run(event, context, subscription_id=None):
     if subscription_id is not None:
         options['account_id'] = subscription_id
 
-    load_resources()
+    load_resources(StructureParser().get_resource_types(policy_config))
 
     options = Azure().initialize(options)
 

--- a/tools/c7n_azure/tests_azure/templates/aks.json
+++ b/tools/c7n_azure/tests_azure/templates/aks.json
@@ -17,7 +17,6 @@
             "name": "cctestaks",
             "location": "westus2",
             "properties": {
-                "kubernetesVersion": "1.12.8",
                 "dnsPrefix": "cctestaks-dns",
                 "agentPoolProfiles": [
                     {

--- a/tools/c7n_azure/tests_azure/tests_resources/test_storage.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_storage.py
@@ -362,6 +362,9 @@ class StorageTest(BaseTest):
         }, validate=True)
 
         resources = p.run()
+
+        self.sleep_in_live_mode(30)
+
         session = local_session(p.session_factory)
         token = StorageUtilities.get_storage_token(session)
         blob_settings = StorageSettingsUtilities.get_settings(
@@ -411,6 +414,9 @@ class StorageTest(BaseTest):
         }, validate=True)
 
         resources = p.run()
+
+        self.sleep_in_live_mode(30)
+
         session = local_session(p.session_factory)
         token = StorageUtilities.get_storage_token(session)
         blob_settings = StorageSettingsUtilities.get_settings(


### PR DESCRIPTION
- Add delay for diagnostic settings.. Will follow up with PG why we see this now
- Fix `handler.py` to use resources lazy load
- Fix AKS deployment template