### PR TITLE
Added all the s3 inventory optional fields

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -2488,7 +2488,9 @@ class SetInventory(BucketActionBase):
         format={'enum': ['CSV', 'ORC', 'Parquet']},
         fields={'type': 'array', 'items': {'enum': [
             'Size', 'LastModifiedDate', 'StorageClass', 'ETag',
-            'IsMultipartUploaded', 'ReplicationStatus', 'EncryptionStatus']}})
+            'IsMultipartUploaded', 'ReplicationStatus', 'EncryptionStatus',
+            'ObjectLockRetainUntilDate', 'ObjectLockMode', 'ObjectLockLegalHoldStatus',
+            'IntelligentTieringAccessTier']}})
 
     permissions = ('s3:PutInventoryConfiguration', 's3:GetInventoryConfiguration')
 


### PR DESCRIPTION
Added all the s3 inventory optional fields to set-inventory schema check 
'Size'|'LastModifiedDate'|'StorageClass'|'ETag'|'IsMultipartUploaded'|'ReplicationStatus'|'EncryptionStatus'|'ObjectLockRetainUntilDate'|'ObjectLockMode'|'ObjectLockLegalHoldStatus'|'IntelligentTieringAccessTier'

https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html