### PR TITLE
core - gen requires fixes for python_version

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -300,7 +300,7 @@ def _package_deps(package, deps=None, ignore=()):
     pdeps = pkgmd.requires(package) or ()
     for r in pdeps:
         # skip optional deps
-        if ';' in r:
+        if ';' in r and 'extra' in r:
             continue
         for idx, c in enumerate(r):
             if not c.isalnum() and c not in ('-', '_', '.'):
@@ -311,8 +311,11 @@ def _package_deps(package, deps=None, ignore=()):
         if pkg_name in ignore:
             continue
         if pkg_name not in deps:
+            try:
+                _package_deps(pkg_name, deps, ignore)
+            except pkgmd.PackageNotFoundError as e:
+                continue
             deps.append(pkg_name)
-            _package_deps(pkg_name, deps, ignore)
     return deps
 
 

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -313,7 +313,7 @@ def _package_deps(package, deps=None, ignore=()):
         if pkg_name not in deps:
             try:
                 _package_deps(pkg_name, deps, ignore)
-            except pkgmd.PackageNotFoundError as e:
+            except pkgmd.PackageNotFoundError:
                 continue
             deps.append(pkg_name)
     return deps


### PR DESCRIPTION
fixes regression on trunk, wrt to ci

origin of the issue is some of our frozen package logic, that we use for c7n_azure and would like to for other packages.  the goal on those is to have packages published that work in perpetuity.  However, I'm not sure of the validity in all cases of what this logic is doing, there's all kinds of conditionals that apply to the requires statement (python_version, sys_platform) etc. which aren't really being handled correctly for all corner cases, even getting versions of a package is tricky if the dependency is specific to a particular version of python that isn't the one being used for packaging. doing something correct here will need quite a bit more thought/work, for now I'll merge the test fix,but the frozen release artifacts need more extensive testing across all py versions supported. alternatively using docker addresses.
