### PR TITLE
azure - fix lazy load output plugin regression

### DIFF
--- a/tools/c7n_azure/c7n_azure/entry.py
+++ b/tools/c7n_azure/c7n_azure/entry.py
@@ -19,4 +19,5 @@ from c7n_azure.provider import Azure  # NOQA
 def initialize_azure():
     # import execution modes
     import c7n_azure.policy
-    import c7n_azure.container_host.modes  # noqa
+    import c7n_azure.container_host.modes
+    import c7n_azure.output # noqa


### PR DESCRIPTION
fix a regression from lazy loading work, azure outputs weren't being registered in the entry point, and were unknown as a result on the cli.

closes #5321 