### PR TITLE
releng - change setup syntax of lru-cache backports dep for py<3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,7 @@ setup(
         "argcomplete",
         "tabulate>=0.8.2",
         "urllib3",
-        "certifi"
-    ],
-    extra_requires={
-        ":python_version<'3.3'": ["backports.functools-lru-cache"]
-    }
+        "certifi",
+        "backports.functools-lru-cache;python_version<'3.3'"
+    ]
 )


### PR DESCRIPTION
I believe the intention is to install `backports.functools-lru-cache` if the Python version is < 3.3.