### PR TITLE
pin dependencies for py27 (#3558)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,52 @@
 import os
+import sys
 from io import open
 from setuptools import setup, find_packages
 
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
+
+
+REQUIREMENTS = [
+    "boto3>=1.9.228",
+    "botocore>=1.13.46",
+    "python-dateutil>=2.6,<3.0.0",
+    "PyYAML>=5.1",
+    "jsonschema",
+    "jsonpatch>=1.21",
+    "argcomplete",
+    "tabulate>=0.8.2",
+    "urllib3",
+    "certifi",
+] if sys.version_info > (3,) else [
+    "argcomplete==1.11.1",
+    "attrs==19.3.0",
+    "backports.functools-lru-cache==1.6.1",
+    "boto3==1.11.15",
+    "botocore==1.14.15",
+    "certifi==2019.11.28",
+    "configparser==4.0.2",
+    "contextlib2==0.6.0.post1",
+    "docutils==0.15.2",
+    "functools32==3.2.3.post2",
+    "futures==3.3.0",
+    "importlib-metadata==1.5.0",
+    "jmespath==0.9.4",
+    "jsonpatch==1.25",
+    "jsonpointer==2.0",
+    "jsonschema==3.2.0",
+    "pathlib2==2.3.5",
+    "pyrsistent==0.15.7",
+    "python-dateutil==2.8.1",
+    "PyYAML==5.3",
+    "s3transfer==0.3.3",
+    "scandir==1.10.0",
+    "six==1.14.0",
+    "tabulate==0.8.6",
+    "urllib3==1.25.8",
+    "zipp==1.1.0",
+]
 
 
 setup(
@@ -30,19 +72,5 @@ setup(
     entry_points={
         'console_scripts': [
             'custodian = c7n.cli:main']},
-    install_requires=[
-        "boto3>=1.9.228",
-        "botocore>=1.13.46",
-        "python-dateutil>=2.6,<3.0.0",
-        "PyYAML>=5.1",
-        "jsonschema",
-        "jsonpatch>=1.21",
-        "argcomplete",
-        "tabulate>=0.8.2",
-        "urllib3",
-        "certifi"
-    ],
-    extra_requires={
-        ":python_version<'3.3'": ["backports.functools-lru-cache"]
-    }
+    install_requires=REQUIREMENTS,
 )


### PR DESCRIPTION
Solution proposal to address concern in #3558#issuecomment-584611448

```
❯ pipenv graph

c7n==0.8.46.1.dev19+gf9c9c9f0f.d20200211
  - argcomplete [required: Any, installed: 1.11.1]
    - importlib-metadata [required: >=0.23,<2, installed: 1.5.0]
      - configparser [required: >=3.5, installed: 4.0.2]
      - contextlib2 [required: Any, installed: 0.6.0.post1]
      - pathlib2 [required: Any, installed: 2.3.5]
        - scandir [required: Any, installed: 1.10.0]
        - six [required: Any, installed: 1.14.0]
      - zipp [required: >=0.5, installed: 1.1.0]
        - contextlib2 [required: Any, installed: 0.6.0.post1]
  - backports.functools-lru-cache [required: Any, installed: 1.6.1]
  - boto3 [required: >=1.9.228, installed: 1.11.15]
    - botocore [required: >=1.14.15,<1.15.0, installed: 1.14.15]
      - docutils [required: >=0.10,<0.16, installed: 0.15.2]
      - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
      - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
        - six [required: >=1.5, installed: 1.14.0]
      - urllib3 [required: >=1.20,<1.26, installed: 1.25.8]
    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
    - s3transfer [required: >=0.3.0,<0.4.0, installed: 0.3.3]
      - botocore [required: >=1.12.36,<2.0a.0, installed: 1.14.15]
        - docutils [required: >=0.10,<0.16, installed: 0.15.2]
        - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
        - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
          - six [required: >=1.5, installed: 1.14.0]
        - urllib3 [required: >=1.20,<1.26, installed: 1.25.8]
      - futures [required: >=2.2.0,<4.0.0, installed: 3.3.0]
  - botocore [required: >=1.13.46, installed: 1.14.15]
    - docutils [required: >=0.10,<0.16, installed: 0.15.2]
    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
    - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
      - six [required: >=1.5, installed: 1.14.0]
    - urllib3 [required: >=1.20,<1.26, installed: 1.25.8]
  - certifi [required: Any, installed: 2019.11.28]
  - jsonpatch [required: >=1.21, installed: 1.25]
    - jsonpointer [required: >=1.9, installed: 2.0]
  - jsonschema [required: Any, installed: 3.2.0]
    - attrs [required: >=17.4.0, installed: 19.3.0]
    - functools32 [required: Any, installed: 3.2.3.post2]
    - importlib-metadata [required: Any, installed: 1.5.0]
      - configparser [required: >=3.5, installed: 4.0.2]
      - contextlib2 [required: Any, installed: 0.6.0.post1]
      - pathlib2 [required: Any, installed: 2.3.5]
        - scandir [required: Any, installed: 1.10.0]
        - six [required: Any, installed: 1.14.0]
      - zipp [required: >=0.5, installed: 1.1.0]
        - contextlib2 [required: Any, installed: 0.6.0.post1]
    - pyrsistent [required: >=0.14.0, installed: 0.15.7]
      - six [required: Any, installed: 1.14.0]
    - setuptools [required: Any, installed: 44.0.0]
    - six [required: >=1.11.0, installed: 1.14.0]
  - python-dateutil [required: >=2.6,<3.0.0, installed: 2.8.1]
    - six [required: >=1.5, installed: 1.14.0]
  - PyYAML [required: >=5.1, installed: 5.3]
  - tabulate [required: >=0.8.2, installed: 0.8.6]
  - urllib3 [required: Any, installed: 1.25.8]
```