### PR TITLE
Replace security group name from GroupId to GroupName

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -465,7 +465,8 @@ class SecurityGroup(query.QueryResourceManager):
         service = 'ec2'
         arn_type = 'security-group'
         enum_spec = ('describe_security_groups', 'SecurityGroups', None)
-        name = id = 'GroupId'
+        id = 'GroupId'
+        name = 'GroupName'
         filter_name = "GroupIds"
         filter_type = 'list'
         config_type = "AWS::EC2::SecurityGroup"


### PR DESCRIPTION
Currently C7N only report security group `GroupID`,  adding `GroupName` is really more readable to report for users.