### PR TITLE
Azure - Indirect Dependency

### DIFF
--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -71,7 +71,10 @@ setup(
                       "azure-mgmt-network>=4.0.0",
                       "azure-mgmt-redis",
                       "azure-mgmt-resourcegraph",
-                      "azure-mgmt-resource~=4.0.0",
+                      # Indirect depencency from azure-cli-core. Since azure-cli-core
+                      # pins azure-mgmt-resource, this would need to match to prevent
+                      # a version conflict.
+                      # "azure-mgmt-resource",
                       "azure-mgmt-rdbms",
                       "azure-mgmt-search",
                       "azure-mgmt-sql",

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -71,10 +71,6 @@ setup(
                       "azure-mgmt-network>=4.0.0",
                       "azure-mgmt-redis",
                       "azure-mgmt-resourcegraph",
-                      # Indirect depencency from azure-cli-core. Since azure-cli-core
-                      # pins azure-mgmt-resource, this would need to match to prevent
-                      # a version conflict.
-                      # "azure-mgmt-resource",
                       "azure-mgmt-rdbms",
                       "azure-mgmt-search",
                       "azure-mgmt-sql",


### PR DESCRIPTION
#5333 

Addressing this error on setup:

```
ERROR: azure-cli-core 2.0.81 has requirement azure-mgmt-resource~=6.0, but you'll have azure-mgmt-resource 4.0.0 which is incompatible.
```

This allows using `azure-mgmt-resource` as an indirect requirement through the `azure-cli-core` dependency. Since `azure-cli-core` pins the major version of `azure-mgmt-resource`, the alternative would either be
* pin `azure-cli-core`, which could conflict with azure cli's installation
* or maintain a pin on `azure-mgmt-resource` to match whatever the latest `azure-cli-core` pins to

Once `azure-cli-core` is removed (#3844), we will need to specify `azure-mgmt-resource` as a dependency again.