### PR TITLE
tools/ops/mugc - 2.7 compatibility on 0.8 rel branch

### DIFF
--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -197,7 +197,7 @@ def main():
     logging.getLogger('c7n.cache').setLevel(logging.WARNING)
 
     if not options.policy_regex:
-        options.policy_regex = f"^{options.prefix}.*"
+        options.policy_regex = "^{}.*".format(options.prefix)
 
     if not options.regions:
         options.regions = [os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')]


### PR DESCRIPTION
addresses #5347 for the 0.8 release branch where python 2.7 compatibility is maintained.