### PR TITLE
releng - minimize syscalls/disk writes during tests

### DIFF
--- a/c7n/ctx.py
+++ b/c7n/ctx.py
@@ -61,7 +61,7 @@ class ExecutionContext(object):
 
         # Always do file/blob storage outputs
         self.output_logs = None
-        if not isinstance(self.logs, log_outputs['default']):
+        if not isinstance(self.logs, (log_outputs['default'], log_outputs['null'])):
             self.output_logs = log_outputs.select(None, self)
 
         # Look for customizations, but fallback to default

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -347,12 +347,16 @@ class LogOutput(object):
 
     def join_log(self):
         self.handler = self.get_handler()
+        if self.handler is None:
+            return
         self.handler.setLevel(logging.DEBUG)
         self.handler.setFormatter(logging.Formatter(self.log_format))
         mlog = logging.getLogger('custodian')
         mlog.addHandler(self.handler)
 
     def leave_log(self):
+        if self.handler is None:
+            return
         mlog = logging.getLogger('custodian')
         mlog.removeHandler(self.handler)
         self.handler.flush()
@@ -372,6 +376,40 @@ class LogFile(LogOutput):
 
     def get_handler(self):
         return logging.FileHandler(self.log_path)
+
+
+@log_outputs.register('null')
+class NullLog(LogOutput):
+    # default - for unit tests
+
+    def __repr__(self):
+        return "<Null Log>"
+
+    @property
+    def log_path(self):
+        return "xyz/log.txt"
+
+    def get_handler(self):
+        return None
+
+
+@blob_outputs.register('null')
+class NullBlobOutput(object):
+    # default - for unit tests
+
+    def __init__(self, ctx, config):
+        self.ctx = ctx
+        self.config = config
+        self.root_dir = 'xyz'
+
+    def __repr__(self):
+        return "<null blob output>"
+
+    def __enter__(self):
+        return
+
+    def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
+        return
 
 
 @blob_outputs.register('file')

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -28,7 +28,7 @@ import six
 from c7n.cwe import CloudWatchEvents
 from c7n.ctx import ExecutionContext
 from c7n.exceptions import PolicyValidationError, ClientError, ResourceLimitExceeded
-from c7n.output import DEFAULT_NAMESPACE
+from c7n.output import DEFAULT_NAMESPACE, NullBlobOutput
 from c7n.resources import load_resources
 from c7n.registry import PluginRegistry
 from c7n.provider import clouds, get_resource_class
@@ -1059,6 +1059,8 @@ class Policy(object):
     run = __call__
 
     def _write_file(self, rel_path, value):
+        if isinstance(self.ctx.output, NullBlobOutput):
+            return
         with open(os.path.join(self.ctx.log_dir, rel_path), 'w') as fh:
             fh.write(value)
 

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -584,8 +584,7 @@ class AWS(Provider):
 
                 if len(options.regions) > 1 or 'all' in options.regions and getattr(
                         options, 'output_dir', None):
-                    options_copy.output_dir = (
-                        options.output_dir.rstrip('/') + '/%s' % region)
+                    options_copy.output_dir = join_output(options.output_dir, region)
                 policies.append(
                     Policy(p.data, options_copy,
                            session_factory=policy_collection.session_factory()))
@@ -596,6 +595,12 @@ class AWS(Provider):
             # is stable.
             sorted(policies, key=operator.attrgetter('options.region')),
             options)
+
+
+def join_output(output_dir, suffix):
+    if output_dir.endswith('://'):
+        return output_dir + suffix
+    return output_dir.rstrip('/') + '/%s' % suffix
 
 
 def fake_session():

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -71,6 +71,7 @@ from c7n.filters import (
     FilterRegistry, Filter, CrossAccountAccessFilter, MetricsFilter,
     ValueFilter)
 from c7n.manager import resources
+from c7n.output import NullBlobOutput
 from c7n import query
 from c7n.resources.securityhub import PostFinding
 from c7n.tags import RemoveTag, Tag, TagActionFilter, TagDelayedAction
@@ -1768,7 +1769,9 @@ class ScanBucket(BucketActionBase):
         return results
 
     def write_denied_buckets_file(self):
-        if self.denied_buckets and self.manager.ctx.log_dir:
+        if (self.denied_buckets and
+            self.manager.ctx.log_dir and
+            not isinstance(self.manager.ctx.output, NullBlobOutput)):
             with open(
                     os.path.join(
                         self.manager.ctx.log_dir, 'denied.json'), 'w') as fh:

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1770,8 +1770,8 @@ class ScanBucket(BucketActionBase):
 
     def write_denied_buckets_file(self):
         if (self.denied_buckets and
-            self.manager.ctx.log_dir and
-            not isinstance(self.manager.ctx.output, NullBlobOutput)):
+                self.manager.ctx.log_dir and
+                not isinstance(self.manager.ctx.output, NullBlobOutput)):
             with open(
                     os.path.join(
                         self.manager.ctx.log_dir, 'denied.json'), 'w') as fh:

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -86,18 +86,21 @@ class CustodianTestCore(object):
         return ctx
 
     def load_policy(
-        self,
-        data,
-        config=None,
-        session_factory=None,
-        validate=C7N_VALIDATE,
-        output_dir=None,
-        cache=False,
+            self,
+            data,
+            config=None,
+            session_factory=None,
+            validate=C7N_VALIDATE,
+            output_dir='null://',
+            log_group='null://',
+            cache=False,
     ):
         pdata = {'policies': [data]}
         if not (config and isinstance(config, Config)):
             config = self._get_policy_config(
-                output_dir=output_dir, cache=cache, **(config or {}))
+                log_group=log_group,
+                output_dir=output_dir,
+                cache=cache, **(config or {}))
         collection = self.policy_loader.load_data(
             pdata, validate=validate,
             file_uri="memory://test",
@@ -109,7 +112,8 @@ class CustodianTestCore(object):
 
     def _get_policy_config(self, **kw):
         config = kw
-        config["output_dir"] = temp_dir = self.get_temp_dir()
+        if kw.get('output_dir') is None or config.get('cache'):
+            config["output_dir"] = temp_dir = self.get_temp_dir()
         if config.get('cache'):
             config["cache"] = os.path.join(temp_dir, "c7n.cache")
             config["cache_period"] = 300

--- a/tests/test_offhours.py
+++ b/tests/test_offhours.py
@@ -50,6 +50,7 @@ class OffHoursFilterTest(BaseTest):
                         },
                     ],
                 },
+                output_dir=None,
                 session_factory=session_factory,
             )
             resources = p.run()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -945,8 +945,8 @@ class TestPolicy(BaseTest):
             "actions": [{"days": 10, "type": "retention"}],
         }
         session_factory = self.replay_flight_data("test_logs_from_group")
-        config = {"log_group": "test-logs"}
-        policy = self.load_policy(p_data, config, session_factory)
+        policy = self.load_policy(
+            p_data, session_factory=session_factory, log_group='test-logs')
         logs = list(policy.get_logs("2016-11-01 00:00:00", "2016-11-30 11:59:59"))
         self.assertEqual(len(logs), 6)
         # entries look reasonable

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -666,6 +666,7 @@ class BucketDelete(BaseTest):
                 "filters": [{"Name": bname}],
                 "actions": [{"type": "delete", "remove-contents": True}],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
         resources = p.run()
@@ -1327,6 +1328,7 @@ class S3Test(BaseTest):
                 "filters": [{"Name": bname}],
                 "actions": ["encrypt-keys"],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
         p.run()
@@ -2442,6 +2444,7 @@ class S3Test(BaseTest):
                 "filters": [{"Name": bname}],
                 "actions": ["encrypt-keys"],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
         p.run()
@@ -2484,6 +2487,7 @@ class S3Test(BaseTest):
                 "filters": [{"Name": bname}],
                 "actions": ["encrypt-keys"],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
         p.run()
@@ -2538,6 +2542,7 @@ class S3Test(BaseTest):
                 "filters": [{"Name": bname}],
                 "actions": [{"type": "encrypt-keys", "report-only": True}],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
         report_resources = report_policy.run()
@@ -2551,6 +2556,7 @@ class S3Test(BaseTest):
                 "filters": [{"Name": bname}],
                 "actions": ["encrypt-keys"],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
         p.run()
@@ -2602,6 +2608,7 @@ class S3Test(BaseTest):
                 "filters": [{"Name": bname}],
                 "actions": [{"type": "encrypt-keys"}],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
 
@@ -2638,6 +2645,7 @@ class S3Test(BaseTest):
                     {"type": "encrypt-keys", "crypto": "aws:kms", "key-id": key_one}
                 ],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
         p.run()
@@ -2656,6 +2664,7 @@ class S3Test(BaseTest):
                     {"type": "encrypt-keys", "crypto": "aws:kms", "key-id": key_two}
                 ],
             },
+            output_dir=None,
             session_factory=session_factory,
         )
         p.run()

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ deps =
   -rrequirements-docs.txt
 
 [pytest]
+junit_family=xunit1
 ; for travis, we set this up as env var that we can override to limit concurrency
 addopts= --tb=native --durations 50 --junitxml=junit/test-results.xml
 markers =


### PR DESCRIPTION
implements a null-output, null-log.. locally it doesn't seem to make a whole lot of difference (for ref 66s quad core 2016 MacBook Pro), as its probably dominated by io to the the various sdks metadata, but it should clear up a couple of thousand sys calls/tempfiles, and may shave a few seconds on the test runners which have more pronounced io contention.