### PR TITLE
releng - 0.8 release branch github actions for ci

### DIFF
--- a/.github/workflows/0.8-branch.yml
+++ b/.github/workflows/0.8-branch.yml
@@ -1,0 +1,39 @@
+name: Release Branch (0.8) Tests
+on:
+  - push:
+      branches:
+        - release/0.8
+  - pull_request:
+      branches:
+        - release/0.8
+
+jobs:      
+  Linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.8]
+        include:
+          - python-version: 2.7
+            tox-target: py27
+          - python-version: 3.8
+            tox-target: py38
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up cache
+        uses: actions/cache@v1
+        with:
+          path: .tox
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+      - name: Install Test Runner
+        run:
+          python -m pip install --ugprade pip && pip install tox codecov
+
+      - name: Test
+        run: |
+          tox -e ${{ matrix.tox-target }}

--- a/.github/workflows/0.8-branch.yml
+++ b/.github/workflows/0.8-branch.yml
@@ -1,11 +1,12 @@
 name: Release Branch (0.8) Tests
-on:
-  push:
-    branches:
-      - "release/0.8"
-  pull_request:
-    branches:
-      - "release/0.8"
+on: [push, pull_request]
+#on:
+#  push:
+#    branches:
+#      - "release/0.8"
+#  pull_request:
+#    branches:
+#      - "release/0.8"
 
 jobs:      
   Linux:
@@ -30,9 +31,11 @@ jobs:
         with:
           path: .tox
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
+
       - name: Install Test Runner
-        run:
-          python -m pip install --ugprade pip && pip install tox codecov
+        run: |
+          python -m pip install --ugprade pip
+          pip install tox codecov
 
       - name: Test
         run: |

--- a/.github/workflows/0.8-branch.yml
+++ b/.github/workflows/0.8-branch.yml
@@ -1,11 +1,11 @@
 name: Release Branch (0.8) Tests
 on:
-  - push:
-      branches:
-        - release/0.8
-  - pull_request:
-      branches:
-        - release/0.8
+  push:
+    branches:
+      - "release/0.8"
+  pull_request:
+    branches:
+      - "release/0.8"
 
 jobs:      
   Linux:


### PR DESCRIPTION
add some ci for python 2.7, 3.8 to the 0.8 release branch so we can remove the python 2.7 ci on trunk