### PR TITLE
aws - acm describe certs

### DIFF
--- a/c7n/resources/acm.py
+++ b/c7n/resources/acm.py
@@ -25,7 +25,14 @@ class Certificate(QueryResourceManager):
 
     class resource_type(TypeInfo):
         service = 'acm'
-        enum_spec = ('list_certificates', 'CertificateSummaryList', None)
+        enum_spec = (
+            'list_certificates',
+            'CertificateSummaryList',
+            {'Includes': {
+                'keyTypes': ','.join([
+                    'RSA_2048', 'RSA_1024', 'RSA_4096',
+                    'EC_prime256v1', 'EC_secp384r1',
+                    'EC_secp521r1'])}})
         id = 'CertificateArn'
         name = 'DomainName'
         date = 'CreatedAt'

--- a/c7n/resources/acm.py
+++ b/c7n/resources/acm.py
@@ -29,10 +29,10 @@ class Certificate(QueryResourceManager):
             'list_certificates',
             'CertificateSummaryList',
             {'Includes': {
-                'keyTypes': ','.join([
+                'keyTypes': [
                     'RSA_2048', 'RSA_1024', 'RSA_4096',
                     'EC_prime256v1', 'EC_secp384r1',
-                    'EC_secp521r1'])}})
+                    'EC_secp521r1']}})
         id = 'CertificateArn'
         name = 'DomainName'
         date = 'CreatedAt'


### PR DESCRIPTION
per gitter, acm certs only include 2048 rsa certs by default, expand via static parameters to pull full set.