### PR TITLE
azure - move azure_cli_core to "cli_auth" extra

### DIFF
--- a/docs/source/azure/configuration/authentication.rst
+++ b/docs/source/azure/configuration/authentication.rst
@@ -14,6 +14,9 @@ If none of the following environment variables are set, Custodian will attempt t
 subscription from Azure CLI.  This requires that you have already run :code:`az login` and selected your subscription in
 Azure CLI.
 
+In order to enable this feature, you need to install extra `cli_auth` using `pip install c7n-azure[cli_auth]`.
+This is feature is useful for local policy development, but it is not recommended for production use.
+
 Service Principal
 -----------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ fakeredis==1.1.0
 # Local package required for c7n_mailer tests
 -e tools/c7n_mailer
 # Local package required for c7n_azure tests
--e tools/c7n_azure
+-e tools/c7n_azure[cli_auth]
 # Local package required for c7n_gcp tests
 -e tools/c7n_gcp
 # Local package required for c7n_kube tests

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -343,6 +343,10 @@ class CLIProvider(TokenProvider):
     def authenticate(self):
         # type: () -> TokenProvider.AuthenticationResult
 
+        if Profile == None:
+            raise Exception('Azure CLI authentication is not enabled. Please install `cli_auth`'
+                            'extra.\n `pip install c7n-azure[cli_auth]`')
+
         try:
             (credential,
              subscription_id,

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -79,6 +79,7 @@ setup(
                       "azure-mgmt-web",
                       "azure-mgmt-monitor",
                       "azure-mgmt-policyinsights",
+                      "azure-mgmt-resource",
                       "azure-mgmt-logic",
                       "azure-cosmos",
                       "azure-graphrbac",
@@ -98,11 +99,13 @@ setup(
                       "requests",
                       "PyJWT",
                       "c7n>=0.8.45.1",
-                      "azure-cli-core",
                       "adal",
                       "backports.functools_lru_cache",
                       "futures>=3.1.1",
                       "netaddr"] + extra_dependencies,
+    extras_require = {
+        "cli_auth": ["azure-cli-core"],
+    },
     package_data={str(''): [str('function_binding_resources/bin/*.dll'),
                             str('function_binding_resources/*.csproj'),
                             str('function_binding_resources/bin/*.json')]}


### PR DESCRIPTION
azure functions package is broken because `azure_cli_core` is excluded, so we don't install `azure_mgmt_resource` package.

`azure_cli_core` is used only for convenient policy development or tool testing during the development.

Moving it to an extra, so it is available to use, but needs to be explicitly enabled.