### PR TITLE
azure - fix Sendgrid multiple recipients

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/sendgrid_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/sendgrid_delivery.py
@@ -89,7 +89,7 @@ class SendGridDelivery(object):
         for email_to_addrs, message in six.iteritems(to_addrs_to_email_messages_map):
             for to_address in email_to_addrs:
                 try:
-                    mail = SendGridDelivery._sendgrid_mail_from_email_message(message)
+                    mail = SendGridDelivery._sendgrid_mail_from_email_message(message, to_address)
                     self.sendgrid_client.send(mail)
                 except (exceptions.UnauthorizedError, exceptions.BadRequestsError) as e:
                     self.logger.warning(
@@ -107,7 +107,7 @@ class SendGridDelivery(object):
         return True
 
     @staticmethod
-    def _sendgrid_mail_from_email_message(message):
+    def _sendgrid_mail_from_email_message(message, to_address):
         """
         Create a Mail object from an instance of email.message.EmailMessage.
 
@@ -123,7 +123,7 @@ class SendGridDelivery(object):
             subject=message.get('Subject'),
 
             # Create a To object instead of an Email object
-            to_emails=To(message.get('To')),
+            to_emails=To(to_address),
         )
         try:
             body = message.get_content()

--- a/tools/c7n_mailer/tests/common.py
+++ b/tools/c7n_mailer/tests/common.py
@@ -506,7 +506,58 @@ ASQ_MESSAGE_DATADOG = '''{
    ]
 }'''
 
-
+ASQ_MESSAGE_MULTIPLE_ADDRS = '''{
+   "account":"subscription",
+   "account_id":"ee98974b-5d2a-4d98-a78a-382f3715d07e",
+   "region":"all",
+   "action":{
+      "to":[
+        "tag:owner",
+        "user@domain.com"
+      ],
+      "template":"default",
+      "priority_header":"2",
+      "type":"notify",
+      "transport":{
+         "queue":"https://test.queue.core.windows.net/testcc",
+         "type":"asq"
+      },
+      "subject":"testing notify action"
+   },
+   "policy":{
+      "resource":"azure.keyvault",
+      "name":"test-notify-for-keyvault",
+      "actions":[
+         {
+            "to":[
+              "tag:owner",
+              "user@domain.com"
+            ],
+            "template":"default",
+            "priority_header":"2",
+            "type":"notify",
+            "transport":{
+               "queue":"https://test.queue.core.windows.net/testcc",
+               "type":"asq"
+            },
+            "subject":"testing notify action"
+         }
+      ]
+   },
+   "event":null,
+   "resources":[
+      {
+         "name":"cckeyvault1",
+         "tags":{
+            "owner":"user2@domain.com"
+         },
+         "resourceGroup":"test_keyvault",
+         "location":"southcentralus",
+         "type":"Microsoft.KeyVault/vaults",
+         "id":"/subscriptions/ee98974b-5d2a-4d98-a78a-382f3715d07e/resourceGroups/test_keyvault/providers/Microsoft.KeyVault/vaults/cckeyvault1"
+      }
+   ]
+}'''
 # Monkey-patch ldap3 to work around a bytes/text handling bug.
 
 _safe_rdn = mockBase.safe_rdn


### PR DESCRIPTION
PR fixes Issue #5346 

The mail object was not being updated when looping over the `to_address` field, causing the first email address in the field to receive all the emails