### PR TITLE
core - switch registry subscriber notify to on resource load

### DIFF
--- a/c7n/provider.py
+++ b/c7n/provider.py
@@ -64,7 +64,11 @@ class Provider(object):
     @classmethod
     def get_resource_types(cls, resource_types):
         """Return the resource classes for the given type names"""
-        return import_resource_classes(cls.resource_map, resource_types)
+        resource_classes, not_found = import_resource_classes(
+            cls.resource_map, resource_types)
+        for r in resource_classes:
+            cls.resources.notify(r)
+        return resource_classes, not_found
 
 
 def import_resource_classes(resource_map, resource_types):
@@ -73,11 +77,12 @@ def import_resource_classes(resource_map, resource_types):
 
     mod_map = {}
     rmods = set()
-    not_found = []
+    not_found = set()
+    found = []
 
     for r in resource_types:
         if r not in resource_map:
-            not_found.append(r)
+            not_found.add(r)
             continue
         rmodule, rclass = resource_map[r].rsplit('.', 1)
         rmods.add(rmodule)
@@ -85,10 +90,16 @@ def import_resource_classes(resource_map, resource_types):
     for rmodule in rmods:
         mod_map[rmodule] = importlib.import_module(rmodule)
 
-    return [getattr(mod_map[rmodule], rclass, None) for
-            rmodule, rclass in [
-                resource_map[r].rsplit('.', 1) for r in resource_types
-                if r in resource_map]], not_found
+    for rtype in resource_types:
+        if rtype in not_found:
+            continue
+        rmodule, rclass = resource_map[rtype].rsplit('.', 1)
+        r = getattr(mod_map[rmodule], rclass, None)
+        if r is None:
+            not_found.append(rtype)
+        else:
+            found.append(r)
+    return found, list(not_found)
 
 
 # nosetests seems to think this function is a test

--- a/c7n/provider.py
+++ b/c7n/provider.py
@@ -96,7 +96,7 @@ def import_resource_classes(resource_map, resource_types):
         rmodule, rclass = resource_map[rtype].rsplit('.', 1)
         r = getattr(mod_map[rmodule], rclass, None)
         if r is None:
-            not_found.append(rtype)
+            not_found.add(rtype)
         else:
             found.append(r)
     return found, list(not_found)

--- a/c7n/registry.py
+++ b/c7n/registry.py
@@ -69,7 +69,7 @@ class PluginRegistry(object):
             klass.type = name
             klass.type_aliases = aliases
             self._factories[name] = klass
-            self.notify(klass)
+#            self.notify(klass)
             return klass
 
         # invoked as class decorator
@@ -79,7 +79,7 @@ class PluginRegistry(object):
             self._factories[name] = klass
             klass.type = name
             klass.type_aliases = aliases
-            self.notify(klass)
+#            self.notify(klass)
             return klass
         return _register_class
 

--- a/c7n/registry.py
+++ b/c7n/registry.py
@@ -56,8 +56,6 @@ class PluginRegistry(object):
 
     def subscribe(self, func):
         self._subscribers.append(func)
-        for p in self.values():
-            func(self, p)
 
     def register(self, name, klass=None, condition=True,
                  condition_message="Missing dependency for {}",
@@ -69,7 +67,6 @@ class PluginRegistry(object):
             klass.type = name
             klass.type_aliases = aliases
             self._factories[name] = klass
-#            self.notify(klass)
             return klass
 
         # invoked as class decorator
@@ -79,7 +76,6 @@ class PluginRegistry(object):
             self._factories[name] = klass
             klass.type = name
             klass.type_aliases = aliases
-#            self.notify(klass)
             return klass
         return _register_class
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -57,9 +57,9 @@ class RegistryTest(unittest.TestCase):
         class _plugin_impl2:
             pass
 
-        self.assertEqual(observed[0], (registry, _plugin_impl1))
+        self.assertEqual(observed, [])
 
-        self.assertEqual(len(observed), 1)
+        registry.notify(_plugin_impl1)
         registry.notify(_plugin_impl2)
 
         self.assertEqual(observed[1], (registry, _plugin_impl2))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -58,6 +58,10 @@ class RegistryTest(unittest.TestCase):
             pass
 
         self.assertEqual(observed[0], (registry, _plugin_impl1))
+
+        self.assertEqual(len(observed), 1)
+        registry.notify(_plugin_impl2)
+
         self.assertEqual(observed[1], (registry, _plugin_impl2))
         self.assertEqual(list(sorted(registry.keys())), ['hot', 'water'])
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -26,7 +26,18 @@ from c7n.utils import yaml_load
 from .common import BaseTest
 
 
-class UniversalAugmentTest(BaseTest):
+class UniversalTagTest(BaseTest):
+
+    def test_auto_tag_registration(self):
+        try:
+            self.load_policy({
+                'name': 'sfn-auto',
+                'resource': 'step-machine',
+                'mode': {'type': 'cloudtrail',
+                         'events': [{'ids': 'some', 'service': 'thing', 'name': 'wicked'}]},
+                'actions': [{'type': 'auto-tag-user', 'tag': 'creator'}]})
+        except Exception as e:
+            self.fail('auto-tag policy failed to load %s' % e)
 
     def test_universal_augment_resource_missing_tags(self):
         session_factory = self.replay_flight_data('test_tags_universal_augment_missing_tags')
@@ -46,9 +57,6 @@ class UniversalAugmentTest(BaseTest):
         )
         results = policy.run()
         self.assertTrue('Tags' in results[0])
-
-
-class UniversalTagRetry(BaseTest):
 
     def test_retry_no_error(self):
         mock = MagicMock()

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -34,7 +34,7 @@ class UniversalTagTest(BaseTest):
                 'name': 'sfn-auto',
                 'resource': 'step-machine',
                 'mode': {'type': 'cloudtrail',
-                         'events': [{'ids': 'some', 'service': 'thing', 'name': 'wicked'}]},
+                         'events': [{'ids': 'some', 'source': 'thing', 'event': 'wicked'}]},
                 'actions': [{'type': 'auto-tag-user', 'tag': 'creator'}]})
         except Exception as e:
             self.fail('auto-tag policy failed to load %s' % e)

--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -64,7 +64,6 @@ ResourceMap = {
     "gcp.log-exclusion": "c7n_gcp.resources.logging.LogExclusion",
     "gcp.log-project-metric": "c7n_gcp.resources.logging.LogProjectMetric",
     "gcp.log-project-sink": "c7n_gcp.resources.logging.LogProjectSink",
-    "gcp.logsink": "c7n_gcp.resources.logging.LogSink",
     "gcp.ml-job": "c7n_gcp.resources.mlengine.MLJob",
     "gcp.ml-model": "c7n_gcp.resources.mlengine.MLModel",
     "gcp.organization": "c7n_gcp.resources.resourcemanager.Organization",


### PR DESCRIPTION
closes #5379 

this removes any notion of implicit invocation of the registry subscribers (on subscriber registration or new registry entry), versus subscribers always being invoked explicitly, in this case on resource loading.