### PR TITLE
aws - ssm parameter fix arn generation

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -347,6 +347,8 @@ def generate_arn(
     arn = 'arn:%s:%s:%s:%s:' % (
         partition, service, region if region else '', account_id if account_id else '')
     if resource_type:
+        if resource.startswith(separator):
+            separator = ''
         arn = arn + '%s%s%s' % (resource_type, separator, resource)
     else:
         arn = arn + resource

--- a/tests/data/placebo/test_ssm_parameter_tag_arn/ssm.DescribeParameters_1.json
+++ b/tests/data/placebo/test_ssm_parameter_tag_arn/ssm.DescribeParameters_1.json
@@ -1,0 +1,73 @@
+{
+    "status_code": 200,
+    "data": {
+        "Parameters": [
+            {
+                "Name": "/gittersearch/token",
+                "Type": "String",
+                "LastModifiedDate": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 8,
+                    "day": 11,
+                    "hour": 15,
+                    "minute": 22,
+                    "second": 16,
+                    "microsecond": 376000
+                },
+                "LastModifiedUser": "arn:aws:iam::123456789123:user/deputy",
+                "Version": 2,
+                "Tier": "Standard",
+                "Policies": []
+            },
+            {
+                "Name": "Bar",
+                "Type": "String",
+                "LastModifiedDate": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 2,
+                    "day": 28,
+                    "hour": 15,
+                    "minute": 14,
+                    "second": 58,
+                    "microsecond": 394000
+                },
+                "LastModifiedUser": "arn:aws:iam::123456789123:root",
+                "Description": "Missing",
+                "Version": 1,
+                "Tier": "Standard",
+                "Policies": []
+            },
+            {
+                "Name": "Foo",
+                "Type": "String",
+                "LastModifiedDate": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 2,
+                    "day": 28,
+                    "hour": 15,
+                    "minute": 14,
+                    "second": 49,
+                    "microsecond": 412000
+                },
+                "LastModifiedUser": "arn:aws:iam::123456789123:root",
+                "Version": 1,
+                "Tier": "Standard",
+                "Policies": []
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "c4776bce-8b94-4a33-b0f5-0a37c2280acd",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c4776bce-8b94-4a33-b0f5-0a37c2280acd",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "606",
+                "date": "Fri, 28 Feb 2020 20:52:21 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_ssm_parameter_tag_arn/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_ssm_parameter_tag_arn/tagging.GetResources_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:ssm:us-east-1:123456789123:parameter/Foo",
+                "Tags": [
+                    {
+                        "Key": "App",
+                        "Value": "Magic"
+                    },
+                    {
+                        "Key": "Env",
+                        "Value": "Prod"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:ssm:us-east-1:123456789123:parameter/gittersearch/token",
+                "Tags": [
+                    {
+                        "Key": "App",
+                        "Value": "GitterSearch"
+                    },
+                    {
+                        "Key": "Env",
+                        "Value": "Dev"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "0ed4f989-5faf-4af2-8833-1b1e161bd3d2",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0ed4f989-5faf-4af2-8833-1b1e161bd3d2",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "340",
+                "date": "Fri, 28 Feb 2020 20:52:21 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -180,6 +180,21 @@ class TestSSM(BaseTest):
             CommandId=resources[0]['c7n:SendCommand'][0])
         self.assertEqual(result['Status'], 'Success')
 
+    def test_ssm_parameter_tag_arn(self):
+        session_factory = self.replay_flight_data("test_ssm_parameter_tag_arn")
+        p = self.load_policy({
+            'name': 'ssm-param-tags',
+            'resource': 'ssm-parameter',
+            'filters': [{'tag:Env': 'present'}]},
+            config={'account_id': '123456789123'},
+            session_factory=session_factory)
+        resources = p.resource_manager.get_resources(['/gittersearch/token'])
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['Tags'],
+            [{'Key': 'App', 'Value': 'GitterSearch'},
+             {'Key': 'Env', 'Value': 'Dev'}])
+
     @functional
     def test_ssm_parameter_not_secure(self):
         session_factory = self.replay_flight_data("test_ssm_parameter_not_secure")


### PR DESCRIPTION
a parameter with a lead slash would result in a double slash which would prevent tag augmentation using resource group tagging api.