### PR TITLE
aws.asg - allow msg in mark-for-op for consistency

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1395,6 +1395,7 @@ class MarkForOp(TagDelayedAction):
         key={'type': 'string'},
         tag={'type': 'string'},
         tz={'type': 'string'},
+        msg={'type': 'string'},
         message={'type': 'string'},
         days={'type': 'number', 'minimum': 0},
         hours={'type': 'number', 'minimum': 0})
@@ -1406,7 +1407,7 @@ class MarkForOp(TagDelayedAction):
         d = {
             'op': self.data.get('op', 'stop'),
             'tag': self.data.get('key', self.data.get('tag', DEFAULT_TAG)),
-            'msg': self.data.get('message', self.default_template),
+            'msg': self.data.get('message', self.data.get('msg', self.default_template)),
             'tz': self.data.get('tz', 'utc'),
             'days': self.data.get('days', 0),
             'hours': self.data.get('hours', 0)}


### PR DESCRIPTION
This adds the `msg` attribute to the schema for `mark-for-op` for ASG resources so that it can follow the same structure as all of the other resources.  Was odd to discover ASGs required `message` instead.