### PR TITLE
 aws - new config support on existing custodian resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,6 @@ tools here
 
 - [**_Omni SSM_:**](https://cloudcustodian.io/docs/tools/omnissm.html) EC2 Systems Manager Automation
 
-- **_Sentry_:** Cloudwatch Log parsing for python tracebacks to integrate with
-    <https://sentry.io/welcome/>
-
 - [**_Mugc_:**](https://github.com/cloud-custodian/cloud-custodian/tree/master/tools/ops#mugc) A utility used to clean up Cloud Custodian Lambda policies that are deployed in an AWS environment.
 
 Contributing

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -390,6 +390,8 @@ class QueryResourceManager(ResourceManager):
             'Throttling',
             'Client.RequestLimitExceeded')))
 
+    source_mapping = sources
+
     def __init__(self, data, options):
         super(QueryResourceManager, self).__init__(data, options)
         self.source = self.get_source(self.source_type)
@@ -399,7 +401,7 @@ class QueryResourceManager(ResourceManager):
         return self.data.get('source', 'describe')
 
     def get_source(self, source_type):
-        return sources.get(source_type)(self)
+        return self.source_mapping.get(source_type)(self)
 
     @classmethod
     def has_arn(cls):

--- a/c7n/resources/acm.py
+++ b/c7n/resources/acm.py
@@ -18,6 +18,14 @@ from c7n.tags import universal_augment
 from c7n.utils import type_schema, local_session
 
 
+class DescribeCertificate(DescribeSource):
+
+    def augment(self, resources):
+        return universal_augment(
+            self.manager,
+            super(DescribeCertificate, self).augment(resources))
+
+
 @resources.register('acm-certificate')
 class Certificate(QueryResourceManager):
 
@@ -41,21 +49,10 @@ class Certificate(QueryResourceManager):
         arn_type = 'certificate'
         universal_taggable = object()
 
-    def get_source(self, source_type):
-        if source_type == 'describe':
-            return DescribeCertificate(self)
-        elif source_type == 'config':
-            return ConfigSource(self)
-        raise ValueError("Unsupported source: %s for %s" % (
-            source_type, self.resource_type.config_type))
-
-
-class DescribeCertificate(DescribeSource):
-
-    def augment(self, resources):
-        return universal_augment(
-            self.manager,
-            super(DescribeCertificate, self).augment(resources))
+    source_mapping = {
+        'describe': DescribeCertificate,
+        'config': ConfigSource
+    }
 
 
 @Certificate.action_registry.register('delete')

--- a/c7n/resources/code.py
+++ b/c7n/resources/code.py
@@ -168,3 +168,4 @@ class CodeDeployPipeline(QueryResourceManager):
         date = 'created'
         # Note this is purposeful, codepipeline don't have a separate type specifier.
         arn_type = ""
+        config_type = "AWS::CodePipeline::Pipeline"

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -26,29 +26,6 @@ from c7n.utils import (
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter
 
 
-@resources.register('dynamodb-table')
-class Table(query.QueryResourceManager):
-
-    class resource_type(query.TypeInfo):
-        service = 'dynamodb'
-        arn_type = 'table'
-        enum_spec = ('list_tables', 'TableNames', None)
-        detail_spec = ("describe_table", "TableName", None, "Table")
-        id = 'TableName'
-        name = 'TableName'
-        date = 'CreationDateTime'
-        dimension = 'TableName'
-        config_type = 'AWS::DynamoDB::Table'
-        universal_taggable = object()
-
-    def get_source(self, source_type):
-        if source_type == 'describe':
-            return DescribeTable(self)
-        elif source_type == 'config':
-            return ConfigTable(self)
-        raise ValueError('invalid source %s' % source_type)
-
-
 class ConfigTable(query.ConfigSource):
 
     def load_resource(self, item):
@@ -76,6 +53,27 @@ class DescribeTable(query.DescribeSource):
         return universal_augment(
             self.manager,
             super(DescribeTable, self).augment(resources))
+
+
+@resources.register('dynamodb-table')
+class Table(query.QueryResourceManager):
+
+    class resource_type(query.TypeInfo):
+        service = 'dynamodb'
+        arn_type = 'table'
+        enum_spec = ('list_tables', 'TableNames', None)
+        detail_spec = ("describe_table", "TableName", None, "Table")
+        id = 'TableName'
+        name = 'TableName'
+        date = 'CreationDateTime'
+        dimension = 'TableName'
+        config_type = 'AWS::DynamoDB::Table'
+        universal_taggable = object()
+
+    source_mapping = {
+        'describe': DescribeTable,
+        'config': ConfigTable
+    }
 
 
 class StatusFilter:
@@ -373,7 +371,7 @@ class DynamoDbAccelerator(query.QueryResourceManager):
         enum_spec = ('describe_clusters', 'Clusters', None)
         id = 'ClusterArn'
         name = 'ClusterName'
-        config_type = 'AWS::DAX::Cluster'
+        # config_type = 'AWS::DAX::Cluster'
 
     permissions = ('dax:ListTags',)
 

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -17,29 +17,9 @@ from c7n.actions import RemovePolicyBase, Action
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import CrossAccountAccessFilter, Filter, ValueFilter
 from c7n.manager import resources
-from c7n.query import DescribeSource, QueryResourceManager, TypeInfo
+from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
 from c7n import tags
 from c7n.utils import local_session, type_schema
-
-
-@resources.register('ecr')
-class ECR(QueryResourceManager):
-
-    class resource_type(TypeInfo):
-        service = 'ecr'
-        enum_spec = ('describe_repositories', 'repositories', None)
-        name = "repositoryName"
-        arn = id = "repositoryArn"
-        arn_type = 'repository'
-        filter_name = 'repositoryNames'
-        filter_type = 'list'
-        # config_type = 'AWS::ECR::Repository'
-
-    def get_source(self, source_type):
-        source = super().get_source(source_type)
-        if source_type == 'describe':
-            source = DescribeECR(self)
-        return source
 
 
 class DescribeECR(DescribeSource):
@@ -55,6 +35,26 @@ class DescribeECR(DescribeSource):
             except client.exceptions.RepositoryNotFoundException:
                 continue
         return results
+
+
+@resources.register('ecr')
+class ECR(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'ecr'
+        enum_spec = ('describe_repositories', 'repositories', None)
+        name = "repositoryName"
+        arn = id = "repositoryArn"
+        arn_type = 'repository'
+        filter_name = 'repositoryNames'
+        filter_type = 'list'
+        # config_type = 'AWS::ECR::Repository'
+
+    source_mapping = {
+        'describe': DescribeECR,
+        'config': ConfigSource
+    }
+
 
 
 @ECR.action_registry.register('tag')

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -45,7 +45,7 @@ class ECR(QueryResourceManager):
 class DescribeECR(DescribeSource):
 
     def augment(self, resources):
-        client = local_session(self.session_factory).client('ecr')
+        client = local_session(self.manager.session_factory).client('ecr')
         results = []
         for r in resources:
             try:

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -56,7 +56,6 @@ class ECR(QueryResourceManager):
     }
 
 
-
 @ECR.action_registry.register('tag')
 class ECRTag(tags.Tag):
 

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -33,7 +33,7 @@ class ECR(QueryResourceManager):
         arn_type = 'repository'
         filter_name = 'repositoryNames'
         filter_type = 'list'
-        config_type = 'AWS::ECR::Repository'
+        # config_type = 'AWS::ECR::Repository'
 
     def get_source(self, source_type):
         source = super().get_source(source_type)

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -17,7 +17,7 @@ from c7n.actions import RemovePolicyBase, Action
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import CrossAccountAccessFilter, Filter, ValueFilter
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import DescribeSource, QueryResourceManager, TypeInfo
 from c7n import tags
 from c7n.utils import local_session, type_schema
 
@@ -35,6 +35,15 @@ class ECR(QueryResourceManager):
         filter_type = 'list'
         config_type = 'AWS::ECR::Repository'
 
+    def get_source(self, source_type):
+        source = super().get_source(source_type)
+        if source_type == 'describe':
+            source = DescribeECR(self)
+        return source
+
+
+class DescribeECR(DescribeSource):
+
     def augment(self, resources):
         client = local_session(self.session_factory).client('ecr')
         results = []
@@ -45,7 +54,6 @@ class ECR(QueryResourceManager):
                 results.append(r)
             except client.exceptions.RepositoryNotFoundException:
                 continue
-
         return results
 
 

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -33,6 +33,7 @@ class ECR(QueryResourceManager):
         arn_type = 'repository'
         filter_name = 'repositoryNames'
         filter_type = 'list'
+        config_type = 'AWS::ECR::Repository'
 
     def augment(self, resources):
         client = local_session(self.session_factory).client('ecr')

--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -57,7 +57,7 @@ class ECSCluster(query.QueryResourceManager):
             'describe_clusters', 'clusters', None, 'clusters', {'include': ['TAGS']})
         name = "clusterName"
         arn = id = "clusterArn"
-        config_type = 'AWS::ECS::Cluster'
+        # config_type = 'AWS::ECS::Cluster'
 
     def augment(self, resources):
         resources = super(ECSCluster, self).augment(resources)
@@ -164,7 +164,7 @@ class Service(query.ChildResourceManager):
         enum_spec = ('list_services', 'serviceArns', None)
         parent_spec = ('ecs', 'cluster', None)
         supports_trailevents = True
-        config_type = 'AWS::ECS:Service'
+        # config_type = 'AWS::ECS:Service'
 
     @property
     def source_type(self):
@@ -465,7 +465,7 @@ class TaskDefinition(query.QueryResourceManager):
         service = 'ecs'
         arn = id = name = 'taskDefinitionArn'
         enum_spec = ('list_task_definitions', 'taskDefinitionArns', None)
-        config_type = 'AWS::ECS::TaskDefinition'
+        # config_type = 'AWS::ECS::TaskDefinition'
 
     def get_resources(self, ids, cache=True):
         if cache:

--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -57,6 +57,7 @@ class ECSCluster(query.QueryResourceManager):
             'describe_clusters', 'clusters', None, 'clusters', {'include': ['TAGS']})
         name = "clusterName"
         arn = id = "clusterArn"
+        config_type = 'AWS::ECS::Cluster'
 
     def augment(self, resources):
         resources = super(ECSCluster, self).augment(resources)
@@ -163,6 +164,7 @@ class Service(query.ChildResourceManager):
         enum_spec = ('list_services', 'serviceArns', None)
         parent_spec = ('ecs', 'cluster', None)
         supports_trailevents = True
+        config_type = 'AWS::ECS:Service'
 
     @property
     def source_type(self):
@@ -463,6 +465,7 @@ class TaskDefinition(query.QueryResourceManager):
         service = 'ecs'
         arn = id = name = 'taskDefinitionArn'
         enum_spec = ('list_task_definitions', 'taskDefinitionArns', None)
+        config_type = 'AWS::ECS::TaskDefinition'
 
     def get_resources(self, ids, cache=True):
         if cache:

--- a/c7n/resources/eks.py
+++ b/c7n/resources/eks.py
@@ -32,7 +32,7 @@ class EKS(QueryResourceManager):
         detail_spec = ('describe_cluster', 'name', None, 'cluster')
         id = name = 'name'
         date = 'createdAt'
-        config_type = 'AWS::EKS::Cluster'
+        # config_type = 'AWS::EKS::Cluster'
 
     def augment(self, resources):
         resources = super(EKS, self).augment(resources)

--- a/c7n/resources/eks.py
+++ b/c7n/resources/eks.py
@@ -32,6 +32,7 @@ class EKS(QueryResourceManager):
         detail_spec = ('describe_cluster', 'name', None, 'cluster')
         id = name = 'name'
         date = 'createdAt'
+        config_type = 'AWS::EKS::Cluster'
 
     def augment(self, resources):
         resources = super(EKS, self).augment(resources)

--- a/c7n/resources/elasticbeanstalk.py
+++ b/c7n/resources/elasticbeanstalk.py
@@ -15,7 +15,7 @@
 import logging
 
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
 from c7n import utils
 from c7n import tags
 from c7n.utils import local_session, type_schema
@@ -41,6 +41,13 @@ class ElasticBeanstalk(QueryResourceManager):
         )
         filter_name = 'ApplicationNames'
         filter_type = 'list'
+        config_type = 'AWS::ElasticBeanstalk::Application'
+
+
+class DescribeEnvironment(DescribeSource):
+
+    def augment(self, resources):
+        return _eb_env_tags(resources, self.manager.session_factory, self.manager.retry)
 
 
 @resources.register('elasticbeanstalk-environment')
@@ -61,12 +68,13 @@ class ElasticBeanstalkEnvironment(QueryResourceManager):
         )
         filter_name = 'EnvironmentNames'
         filter_type = 'list'
+        config_type = 'AWS::ElasticBeanstalk::Environment'
 
     permissions = ('elasticbeanstalk:ListTagsForResource',)
-
-    def augment(self, envs):
-        return _eb_env_tags(envs, self.session_factory, self.retry)
-
+    source_mapping = {
+        'describe': DescribeEnvironment,
+        'config': ConfigSource
+    }
 
 ElasticBeanstalkEnvironment.filter_registry.register(
     'tag-count', tags.TagCountFilter)

--- a/c7n/resources/elasticbeanstalk.py
+++ b/c7n/resources/elasticbeanstalk.py
@@ -76,6 +76,7 @@ class ElasticBeanstalkEnvironment(QueryResourceManager):
         'config': ConfigSource
     }
 
+
 ElasticBeanstalkEnvironment.filter_registry.register(
     'tag-count', tags.TagCountFilter)
 ElasticBeanstalkEnvironment.filter_registry.register(

--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -17,9 +17,33 @@ from c7n.actions import Action, ModifyVpcSecurityGroupsAction
 from c7n.filters import MetricsFilter
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter, VpcFilter
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
 from c7n.utils import chunks, local_session, type_schema
 from c7n.tags import Tag, RemoveTag, TagActionFilter, TagDelayedAction
+
+
+class DescribeDomain(DescribeSource):
+
+    def get_resources(self, resource_ids):
+        client = local_session(self.manager.session_factory).client('es')
+        return client.describe_elasticsearch_domains(
+            DomainNames=resource_ids)['DomainStatusList']
+
+    def augment(self, domains):
+        client = local_session(self.manager.session_factory).client('es')
+        model = self.manager.get_model()
+
+        def _augment(resource_set):
+            resources = self.manager.retry(
+                client.describe_elasticsearch_domains,
+                DomainNames=resource_set)['DomainStatusList']
+            for r in resources:
+                rarn = self.manager.generate_arn(r[model.id])
+                r['Tags'] = self.manager.retry(
+                    client.list_tags, ARN=rarn).get('TagList', [])
+            return resources
+
+        return _augment(domains)
 
 
 @resources.register('elasticsearch')
@@ -34,29 +58,12 @@ class ElasticSearchDomain(QueryResourceManager):
         id = 'DomainName'
         name = 'Name'
         dimension = "DomainName"
+        config_type = 'AWS::Elasticsearch::Domain'
 
-    def get_resources(self, resource_ids):
-        client = local_session(self.session_factory).client('es')
-        return client.describe_elasticsearch_domains(
-            DomainNames=resource_ids)['DomainStatusList']
-
-    def augment(self, domains):
-        client = local_session(self.session_factory).client('es')
-        model = self.get_model()
-
-        def _augment(resource_set):
-            resources = self.retry(
-                client.describe_elasticsearch_domains,
-                DomainNames=resource_set)['DomainStatusList']
-            for r in resources:
-                rarn = self.generate_arn(r[model.id])
-                r['Tags'] = self.retry(
-                    client.list_tags, ARN=rarn).get('TagList', [])
-            return resources
-
-        with self.executor_factory(max_workers=1) as w:
-            return list(itertools.chain(
-                *w.map(_augment, chunks(domains, 5))))
+    source_mapping = {
+        'describe': DescribeDomain,
+        'config': ConfigSource
+    }
 
 
 ElasticSearchDomain.filter_registry.register('marked-for-op', TagActionFilter)

--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import itertools
 
 from c7n.actions import Action, ModifyVpcSecurityGroupsAction
 from c7n.filters import MetricsFilter
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter, VpcFilter
 from c7n.manager import resources
 from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
-from c7n.utils import chunks, local_session, type_schema
+from c7n.utils import local_session, type_schema
 from c7n.tags import Tag, RemoveTag, TagActionFilter, TagDelayedAction
 
 

--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -35,6 +35,7 @@ class KinesisStream(QueryResourceManager):
         name = id = 'StreamName'
         dimension = 'StreamName'
         universal_taggable = True
+        config_type = 'AWS::Kinesis::Stream'
 
     def augment(self, resources):
         return universal_augment(
@@ -102,6 +103,7 @@ class DeliveryStream(QueryResourceManager):
         date = 'CreateTimestamp'
         dimension = 'DeliveryStreamName'
         universal_taggable = object()
+        config_type = 'AWS::KinesisFirehose::DeliveryStream'
 
     def augment(self, resources):
         return universal_augment(
@@ -225,6 +227,7 @@ class AnalyticsApp(QueryResourceManager):
         arn = id = "ApplicationARN"
         arn_type = 'application'
         universal_taggable = object()
+        config_type = 'AWS::KinesisAnalytics::Application'
 
     def augment(self, resources):
         return universal_augment(

--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -15,9 +15,15 @@ import jmespath
 
 from c7n.actions import Action
 from c7n.manager import resources
-from c7n.query import DescribeSource, QueryResourceManager, TypeInfo
+from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
 from c7n.tags import universal_augment
 from c7n.utils import local_session, type_schema, get_retry
+
+
+class DescribeStream(DescribeSource):
+
+    def augment(self, resources):
+        return universal_augment(self.manager, super().augment(resources))
 
 
 @resources.register('kinesis')
@@ -35,19 +41,12 @@ class KinesisStream(QueryResourceManager):
         name = id = 'StreamName'
         dimension = 'StreamName'
         universal_taggable = True
-        config_type = 'AWS::Kinesis::Stream'
+        # config_type = 'AWS::Kinesis::Stream'
 
-    def get_source(self, source_type):
-        source = super().get_source(source_type)
-        if source_type == 'describe':
-            source = DescribeStream(self)
-        return source
-
-
-class DescribeStream(DescribeSource):
-
-    def augment(self, resources):
-        return universal_augment(self.manager, super().augment(resources))
+    source_mapping = {
+        'describe': DescribeStream,
+        'config': ConfigSource
+    }
 
 
 @KinesisStream.action_registry.register('encrypt')
@@ -97,6 +96,12 @@ class Delete(Action):
                 StreamName=r['StreamName'])
 
 
+class DescribeDeliveryStream(DescribeSource):
+
+    def augment(self, resources):
+        return universal_augment(self.manager, super().augment(resources))
+
+
 @resources.register('firehose')
 class DeliveryStream(QueryResourceManager):
 
@@ -111,19 +116,12 @@ class DeliveryStream(QueryResourceManager):
         date = 'CreateTimestamp'
         dimension = 'DeliveryStreamName'
         universal_taggable = object()
-        config_type = 'AWS::KinesisFirehose::DeliveryStream'
+        # config_type = 'AWS::KinesisFirehose::DeliveryStream'
 
-    def get_source(self, source_type):
-        source = super().get_source(source_type)
-        if source_type == 'describe':
-            source = DescribeDeliveryStream(self)
-        return source
-
-
-class DescribeDeliveryStream(DescribeSource):
-
-    def augment(self, resources):
-        return universal_augment(self.manager, super().augment(resources))
+    source_mapping = {
+        'describe': DescribeDeliveryStream,
+        'config': ConfigSource
+    }
 
 
 @DeliveryStream.action_registry.register('delete')
@@ -231,6 +229,12 @@ class FirehoseEncryptS3Destination(Action):
                 client.update_destination(**params)
 
 
+class DescribeApp(DescribeSource):
+
+    def augment(self, resources):
+        return universal_augment(self.manager, super().augment(resources))
+
+
 @resources.register('kinesis-analytics')
 class AnalyticsApp(QueryResourceManager):
 
@@ -243,19 +247,12 @@ class AnalyticsApp(QueryResourceManager):
         arn = id = "ApplicationARN"
         arn_type = 'application'
         universal_taggable = object()
-        config_type = 'AWS::KinesisAnalytics::Application'
+        # config_type = 'AWS::KinesisAnalytics::Application'
 
-    def get_source(self, source_type):
-        source = super().get_source(source_type)
-        if source_type == 'describe':
-            source = DescribeApp(self)
-        return source
-
-
-class DescribeApp(DescribeSource):
-
-    def augment(self, resources):
-        return universal_augment(self.manager, super().augment(resources))
+    source_mapping = {
+        'config': ConfigSource,
+        'describe': DescribeApp
+    }
 
 
 @AnalyticsApp.action_registry.register('delete')

--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -15,7 +15,7 @@ import jmespath
 
 from c7n.actions import Action
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import DescribeSource, QueryResourceManager, TypeInfo
 from c7n.tags import universal_augment
 from c7n.utils import local_session, type_schema, get_retry
 
@@ -37,9 +37,17 @@ class KinesisStream(QueryResourceManager):
         universal_taggable = True
         config_type = 'AWS::Kinesis::Stream'
 
+    def get_source(self, source_type):
+        source = super().get_source(source_type)
+        if source_type == 'describe':
+            source = DescribeStream(self)
+        return source
+
+
+class DescribeStream(DescribeSource):
+
     def augment(self, resources):
-        return universal_augment(
-            self, super(KinesisStream, self).augment(resources))
+        return universal_augment(self.manager, super().augment(resources))
 
 
 @KinesisStream.action_registry.register('encrypt')
@@ -105,9 +113,17 @@ class DeliveryStream(QueryResourceManager):
         universal_taggable = object()
         config_type = 'AWS::KinesisFirehose::DeliveryStream'
 
+    def get_source(self, source_type):
+        source = super().get_source(source_type)
+        if source_type == 'describe':
+            source = DescribeDeliveryStream(self)
+        return source
+
+
+class DescribeDeliveryStream(DescribeSource):
+
     def augment(self, resources):
-        return universal_augment(
-            self, super(DeliveryStream, self).augment(resources))
+        return universal_augment(self.manager, super().augment(resources))
 
 
 @DeliveryStream.action_registry.register('delete')
@@ -229,9 +245,17 @@ class AnalyticsApp(QueryResourceManager):
         universal_taggable = object()
         config_type = 'AWS::KinesisAnalytics::Application'
 
+    def get_source(self, source_type):
+        source = super().get_source(source_type)
+        if source_type == 'describe':
+            source = DescribeApp(self)
+        return source
+
+
+class DescribeApp(DescribeSource):
+
     def augment(self, resources):
-        return universal_augment(
-            self, super(AnalyticsApp, self).augment(resources))
+        return universal_augment(self.manager, super().augment(resources))
 
 
 @AnalyticsApp.action_registry.register('delete')

--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -47,6 +47,7 @@ class Key(QueryResourceManager):
         name = "KeyId"
         id = "KeyArn"
         universal_taggable = True
+        config_type = 'AWS::KMS::Key'
 
     def augment(self, resources):
         client = local_session(self.session_factory).client('kms')

--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -18,7 +18,8 @@ import json
 from c7n.actions import RemovePolicyBase, BaseAction
 from c7n.filters import Filter, CrossAccountAccessFilter, ValueFilter
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, RetryPageIterator, TypeInfo
+from c7n.query import (
+    ConfigSource, DescribeSource, QueryResourceManager, RetryPageIterator, TypeInfo)
 from c7n.utils import local_session, type_schema
 from c7n.tags import universal_augment
 
@@ -37,20 +38,10 @@ class KeyAlias(QueryResourceManager):
         return [r for r in resources if 'TargetKeyId' in r]
 
 
-@resources.register('kms-key')
-class Key(QueryResourceManager):
-
-    class resource_type(TypeInfo):
-        service = 'kms'
-        arn_type = "key"
-        enum_spec = ('list_keys', 'Keys', None)
-        name = "KeyId"
-        id = "KeyArn"
-        universal_taggable = True
-        config_type = 'AWS::KMS::Key'
+class DescribeKey(DescribeSource):
 
     def augment(self, resources):
-        client = local_session(self.session_factory).client('kms')
+        client = local_session(self.manager.session_factory).client('kms')
 
         for r in resources:
             try:
@@ -66,7 +57,25 @@ class Key(QueryResourceManager):
                 else:
                     raise
 
-        return universal_augment(self, resources)
+        return universal_augment(self.manager, resources)
+
+
+@resources.register('kms-key')
+class Key(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'kms'
+        arn_type = "key"
+        enum_spec = ('list_keys', 'Keys', None)
+        name = "KeyId"
+        id = "KeyArn"
+        universal_taggable = True
+        config_type = 'AWS::KMS::Key'
+
+    source_mapping = {
+        'config': ConfigSource,
+        'describe': DescribeKey
+    }
 
 
 @Key.filter_registry.register('key-rotation-status')

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -77,6 +77,22 @@ filters = FilterRegistry('rds.filters')
 actions = ActionRegistry('rds.actions')
 
 
+class DescribeRDS(DescribeSource):
+
+    def augment(self, dbs):
+        return universal_augment(
+            self.manager, super(DescribeRDS, self).augment(dbs))
+
+
+class ConfigRDS(ConfigSource):
+
+    def load_resource(self, item):
+        resource = super(ConfigRDS, self).load_resource(item)
+        resource['Tags'] = [{u'Key': t['key'], u'Value': t['value']}
+          for t in item['supplementaryConfiguration']['Tags']]
+        return resource
+
+
 @resources.register('rds')
 class RDS(QueryResourceManager):
     """Resource manager for RDS DB instances.
@@ -112,29 +128,10 @@ class RDS(QueryResourceManager):
     filter_registry = filters
     action_registry = actions
 
-    def get_source(self, source_type):
-        if source_type == 'describe':
-            return DescribeRDS(self)
-        elif source_type == 'config':
-            return ConfigRDS(self)
-        raise ValueError("Unsupported source: %s for %s" % (
-            source_type, self.resource_type.config_type))
-
-
-class DescribeRDS(DescribeSource):
-
-    def augment(self, dbs):
-        return universal_augment(
-            self.manager, super(DescribeRDS, self).augment(dbs))
-
-
-class ConfigRDS(ConfigSource):
-
-    def load_resource(self, item):
-        resource = super(ConfigRDS, self).load_resource(item)
-        resource['Tags'] = [{u'Key': t['key'], u'Value': t['value']}
-          for t in item['supplementaryConfiguration']['Tags']]
-        return resource
+    source_mapping = {
+        'describe': DescribeRDS,
+        'config': ConfigRDS
+    }
 
 
 def _db_instance_eligible_for_backup(resource):
@@ -933,7 +930,7 @@ class RDSSubscription(QueryResourceManager):
             'describe_event_subscriptions', 'EventSubscriptionsList', None)
         name = id = "EventSubscriptionArn"
         date = "SubscriptionCreateTime"
-        config_type = "AWS::DB::EventSubscription"
+        #config_type = "AWS::DB::EventSubscription"
         # SubscriptionName isn't part of describe events results?! all the
         # other subscription apis.
         # filter_name = 'SubscriptionName'
@@ -1366,6 +1363,14 @@ class RDSModifyVpcSecurityGroups(ModifyVpcSecurityGroupsAction):
             )
 
 
+class DescribeSubnetGroup(DescribeSource):
+
+    def augment(self, resources):
+        _db_subnet_group_tags(
+            resources, self.manager.session_factory, self.manager.executor_factory, self.manager.retry)
+        return resources
+
+
 @resources.register('rds-subnet-group')
 class RDSSubnetGroup(QueryResourceManager):
     """RDS subnet group."""
@@ -1379,11 +1384,12 @@ class RDSSubnetGroup(QueryResourceManager):
         filter_name = 'DBSubnetGroupName'
         filter_type = 'scalar'
         permissions_enum = ('rds:DescribeDBSubnetGroups',)
+        config_type = 'AWS::RDS::DBSubnetGroup'
 
-    def augment(self, resources):
-        _db_subnet_group_tags(
-            resources, self.session_factory, self.executor_factory, self.retry)
-        return resources
+    source_mapping = {
+        'config': ConfigSource,
+        'describe': DescribeSubnetGroup
+    }
 
 
 def _db_subnet_group_tags(subnet_groups, session_factory, executor_factory, retry):

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -930,7 +930,7 @@ class RDSSubscription(QueryResourceManager):
             'describe_event_subscriptions', 'EventSubscriptionsList', None)
         name = id = "EventSubscriptionArn"
         date = "SubscriptionCreateTime"
-        #config_type = "AWS::DB::EventSubscription"
+        # config_type = "AWS::DB::EventSubscription"
         # SubscriptionName isn't part of describe events results?! all the
         # other subscription apis.
         # filter_name = 'SubscriptionName'
@@ -1367,7 +1367,8 @@ class DescribeSubnetGroup(DescribeSource):
 
     def augment(self, resources):
         _db_subnet_group_tags(
-            resources, self.manager.session_factory, self.manager.executor_factory, self.manager.retry)
+            resources, self.manager.session_factory,
+            self.manager.executor_factory, self.manager.retry)
         return resources
 
 

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -20,7 +20,7 @@ from c7n.filters import AgeFilter, CrossAccountAccessFilter
 from c7n.filters.offhours import OffHour, OnHour
 import c7n.filters.vpc as net_filters
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo, DescribeSource
+from c7n.query import ConfigSource, QueryResourceManager, TypeInfo, DescribeSource
 from c7n import tags
 from .aws import shape_validate
 from c7n.exceptions import PolicyValidationError
@@ -28,6 +28,12 @@ from c7n.utils import (
     type_schema, local_session, snapshot_identifier, chunks)
 
 log = logging.getLogger('custodian.rds-cluster')
+
+
+class DescribeCluster(DescribeSource):
+
+    def augment(self, resources):
+        return tags.universal_augment(self.manager, resources)
 
 
 @resources.register('rds-cluster')
@@ -46,8 +52,12 @@ class RDSCluster(QueryResourceManager):
         dimension = 'DBClusterIdentifier'
         universal_taggable = True
         permissions_enum = ('rds:DescribeDBClusters',)
+        config_type = 'AWS::RDS::DBCluster'
 
-    augment = tags.universal_augment
+    source_mapping = {
+        'config': ConfigSource,
+        'describe': DescribeCluster
+    }
 
 
 RDSCluster.filter_registry.register('offhour', OffHour)

--- a/c7n/resources/secretsmanager.py
+++ b/c7n/resources/secretsmanager.py
@@ -27,7 +27,7 @@ class SecretsManager(QueryResourceManager):
         service = 'secretsmanager'
         enum_spec = ('list_secrets', 'SecretList', None)
         detail_spec = ('describe_secret', 'SecretId', 'ARN', None)
-        config_type = 'AWS::SecretsManager::Secret'
+        # config_type = 'AWS::SecretsManager::Secret'
         arn = id = 'ARN'
         name = 'Name'
 

--- a/c7n/resources/secretsmanager.py
+++ b/c7n/resources/secretsmanager.py
@@ -27,6 +27,7 @@ class SecretsManager(QueryResourceManager):
         service = 'secretsmanager'
         enum_spec = ('list_secrets', 'SecretList', None)
         detail_spec = ('describe_secret', 'SecretId', 'ARN', None)
+        config_type = 'AWS::SecretsManager::Secret'
         arn = id = 'ARN'
         name = 'Name'
 

--- a/c7n/resources/shield.py
+++ b/c7n/resources/shield.py
@@ -30,6 +30,7 @@ class ShieldProtection(QueryResourceManager):
         id = 'Id'
         name = 'Name'
         arn = False
+        config_type = 'AWS::Shield::Protection'
 
 
 @resources.register('shield-attack')

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -17,10 +17,26 @@ from c7n.actions import RemovePolicyBase, ModifyPolicyBase, BaseAction
 from c7n.filters import CrossAccountAccessFilter, PolicyChecker
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
-from c7n.query import DescribeSource, QueryResourceManager, TypeInfo
+from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
 from c7n.resolver import ValuesFrom
 from c7n.utils import local_session, type_schema
 from c7n.tags import RemoveTag, Tag, TagDelayedAction, TagActionFilter
+
+
+class DescribeTopic(DescribeSource):
+
+    def augment(self, resources):
+        client = local_session(self.manager.session_factory).client('sns')
+
+        def _augment(r):
+            tags = self.manager.retry(client.list_tags_for_resource,
+                ResourceArn=r['TopicArn'])['Tags']
+            r['Tags'] = tags
+            return r
+
+        resources = super().augment(resources)
+        with self.manager.executor_factory(max_workers=3) as w:
+            return list(w.map(_augment, resources))
 
 
 @resources.register('sns')
@@ -45,28 +61,10 @@ class SNS(QueryResourceManager):
         )
 
     permissions = ('sns:ListTagsForResource',)
-
-    def get_source(self, source_type):
-        source = super().get_source(source_type)
-        if source_type == 'describe':
-            source = DescribeTopic(self)
-        return source
-
-
-class DescribeTopic(DescribeSource):
-
-    def augment(self, resources):
-        client = local_session(self.session_factory).client('sns')
-
-        def _augment(r):
-            tags = self.retry(client.list_tags_for_resource,
-                ResourceArn=r['TopicArn'])['Tags']
-            r['Tags'] = tags
-            return r
-
-        resources = super(SNS, self).augment(resources)
-        with self.executor_factory(max_workers=3) as w:
-            return list(w.map(_augment, resources))
+    source_mapping = {
+        'describe': DescribeTopic,
+        'config': ConfigSource
+    }
 
 
 SNS.filter_registry.register('marked-for-op', TagActionFilter)

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -35,6 +35,7 @@ class SNS(QueryResourceManager):
         id = 'TopicArn'
         name = 'DisplayName'
         dimension = 'TopicName'
+        config_type = 'AWS::SNS::Topic'
         default_report_fields = (
             'TopicArn',
             'DisplayName',

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -17,7 +17,7 @@ from c7n.actions import RemovePolicyBase, ModifyPolicyBase, BaseAction
 from c7n.filters import CrossAccountAccessFilter, PolicyChecker
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import DescribeSource, QueryResourceManager, TypeInfo
 from c7n.resolver import ValuesFrom
 from c7n.utils import local_session, type_schema
 from c7n.tags import RemoveTag, Tag, TagDelayedAction, TagActionFilter
@@ -45,6 +45,15 @@ class SNS(QueryResourceManager):
         )
 
     permissions = ('sns:ListTagsForResource',)
+
+    def get_source(self, source_type):
+        source = super().get_source(source_type)
+        if source_type == 'describe':
+            source = DescribeTopic(self)
+        return source
+
+
+class DescribeTopic(DescribeSource):
 
     def augment(self, resources):
         client = local_session(self.session_factory).client('sns')

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -51,7 +51,7 @@ class SNS(QueryResourceManager):
         id = 'TopicArn'
         name = 'DisplayName'
         dimension = 'TopicName'
-        config_type = 'AWS::SNS::Topic'
+        # config_type = 'AWS::SNS::Topic'
         default_report_fields = (
             'TopicArn',
             'DisplayName',

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -20,7 +20,7 @@ from c7n.filters import CrossAccountAccessFilter, MetricsFilter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
 from c7n.utils import local_session
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import DescribeSource, QueryResourceManager, TypeInfo
 from c7n.actions import BaseAction
 from c7n.utils import type_schema
 from c7n.tags import universal_augment
@@ -62,6 +62,15 @@ class SQS(QueryResourceManager):
                 continue
             ids_normalized.append(i.rsplit('/', 1)[-1])
         return super(SQS, self).get_resources(ids_normalized, cache)
+
+    def get_source(self, source_type):
+        source = super().get_source(source_type)
+        if source_type == 'describe':
+            source = DescribeQueue(self)
+        return source
+
+
+class DescribeQueue(DescribeSource):
 
     def augment(self, resources):
         client = local_session(self.session_factory).client('sqs')

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -20,10 +20,36 @@ from c7n.filters import CrossAccountAccessFilter, MetricsFilter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
 from c7n.utils import local_session
-from c7n.query import DescribeSource, QueryResourceManager, TypeInfo
+from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
 from c7n.actions import BaseAction
 from c7n.utils import type_schema
 from c7n.tags import universal_augment
+
+
+class DescribeQueue(DescribeSource):
+
+    def augment(self, resources):
+        client = local_session(self.manager.session_factory).client('sqs')
+
+        def _augment(r):
+            try:
+                queue = self.manager.retry(
+                    client.get_queue_attributes,
+                    QueueUrl=r,
+                    AttributeNames=['All'])['Attributes']
+                queue['QueueUrl'] = r
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AWS.SimpleQueueService.NonExistentQueue':
+                    return
+                if e.response['Error']['Code'] == 'AccessDenied':
+                    self.log.warning("Denied access to sqs %s" % r)
+                    return
+                raise
+            return queue
+
+        with self.manager.executor_factory(max_workers=2) as w:
+            return universal_augment(
+                self.manager, list(filter(None, w.map(_augment, resources))))
 
 
 @resources.register('sqs')
@@ -49,6 +75,11 @@ class SQS(QueryResourceManager):
             'ApproximateNumberOfMessages',
         )
 
+    source_mapping = {
+        'describe': DescribeQueue,
+        'config': ConfigSource
+    }
+
     def get_permissions(self):
         perms = super(SQS, self).get_permissions()
         perms.append('sqs:GetQueueAttributes')
@@ -63,37 +94,6 @@ class SQS(QueryResourceManager):
             ids_normalized.append(i.rsplit('/', 1)[-1])
         return super(SQS, self).get_resources(ids_normalized, cache)
 
-    def get_source(self, source_type):
-        source = super().get_source(source_type)
-        if source_type == 'describe':
-            source = DescribeQueue(self)
-        return source
-
-
-class DescribeQueue(DescribeSource):
-
-    def augment(self, resources):
-        client = local_session(self.session_factory).client('sqs')
-
-        def _augment(r):
-            try:
-                queue = self.retry(
-                    client.get_queue_attributes,
-                    QueueUrl=r,
-                    AttributeNames=['All'])['Attributes']
-                queue['QueueUrl'] = r
-            except ClientError as e:
-                if e.response['Error']['Code'] == 'AWS.SimpleQueueService.NonExistentQueue':
-                    return
-                if e.response['Error']['Code'] == 'AccessDenied':
-                    self.log.warning("Denied access to sqs %s" % r)
-                    return
-                raise
-            return queue
-
-        with self.executor_factory(max_workers=2) as w:
-            return universal_augment(
-                self, list(filter(None, w.map(_augment, resources))))
 
 
 @SQS.filter_registry.register('metrics')

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -95,7 +95,6 @@ class SQS(QueryResourceManager):
         return super(SQS, self).get_resources(ids_normalized, cache)
 
 
-
 @SQS.filter_registry.register('metrics')
 class MetricsFilter(MetricsFilter):
 

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -34,6 +34,7 @@ class SQS(QueryResourceManager):
         arn_type = ""
         enum_spec = ('list_queues', 'QueueUrls', None)
         detail_spec = ("get_queue_attributes", "QueueUrl", None, "Attributes")
+        config_type = 'AWS::SQS::Queue'
         id = 'QueueUrl'
         arn = "QueueArn"
         filter_name = 'QueueNamePrefix'

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1658,6 +1658,7 @@ class RouteTable(query.QueryResourceManager):
         filter_name = 'RouteTableIds'
         filter_type = 'list'
         id_prefix = "rtb-"
+        config_type = "AWS::EC2::RouteTable"
 
 
 @RouteTable.filter_registry.register('vpc')
@@ -1776,6 +1777,7 @@ class PeeringConnection(query.QueryResourceManager):
         filter_name = 'VpcPeeringConnectionIds'
         filter_type = 'list'
         id_prefix = "pcx-"
+        config_type = "AWS::EC2::VPCPeeringConnection"
 
 
 @PeeringConnection.filter_registry.register('cross-account')
@@ -2026,6 +2028,7 @@ class CustomerGateway(query.QueryResourceManager):
         filter_type = 'list'
         name = 'CustomerGatewayId'
         id_prefix = "cgw-"
+        config_type = 'AWS::EC2::CustomerGateway'
 
 
 @resources.register('internet-gateway')
@@ -2084,6 +2087,7 @@ class NATGateway(query.QueryResourceManager):
         filter_type = 'list'
         date = 'CreateTime'
         id_prefix = "nat-"
+        config_type = 'AWS::EC2::NatGateway'
 
 
 @NATGateway.action_registry.register('delete')
@@ -2139,6 +2143,7 @@ class VpcEndpoint(query.QueryResourceManager):
         filter_type = 'list'
         id_prefix = "vpce-"
         universal_taggable = object()
+        config_type = "AWS::EC2::VPCEndpoint"
 
 
 @VpcEndpoint.filter_registry.register('cross-account')

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -261,7 +261,6 @@ class PolicyMetaLint(BaseTest):
             raise AssertionError(
                 "Invalid config types \n %s" % ('\n'.join(bad_types)))
 
-
     def test_resource_meta_with_class(self):
         missing = set()
         for k, v in manager.resources.items():

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -198,21 +198,69 @@ class PolicyMetaLint(BaseTest):
             self.fail("%s dont have resource name for reporting" % (", ".join(names)))
 
     def test_config_resource_support(self):
+
+        # for several of these we express support as filter or action instead
+        # of a resource.
+        whitelist = {
+            'AWS::EC2::Host',
+            'AWS::EC2::RegisteredHAInstance',
+            'AWS::EC2::EgressOnlyInternetGateway',
+            'AWS::EC2::VPCEndpointService',
+            'AWS::EC2::FlowLog',
+            'AWS::RDS::DBSecurityGroup',
+            'AWS::RDS::EventSubscription',
+            'AWS::S3::AccountPublicAccessBlock',
+            'AWS::Redshift::ClusterParameterGroup',
+            'AWS::Redshift::ClusterSecurityGroup',
+            'AWS::Redshift::EventSubscription',
+            'AWS::SSM::ManagedInstanceInventory',
+            'AWS::AutoScaling::ScalingPolicy',
+            'AWS::AutoScaling::ScheduledAction',
+            'AWS::WAF::RateBasedRule',
+            'AWS::WAF::Rule',
+            'AWS::WAF::RuleGroup',
+            'AWS::WAFRegional::RateBasedRule',
+            'AWS::WAFRegional::Rule',
+            'AWS::WAFRegional::RuleGroup',
+            'AWS::ElasticBeanstalk::ApplicationVersion',
+            'AWS::WAFv2::WebACL',
+            'AWS::WAFv2::RuleGroup',
+            'AWS::WAFv2::IPSet',
+            'AWS::WAFv2::RegexPatternSet',
+            'AWS::WAFv2::ManagedRuleSet',
+            'AWS::XRay::EncryptionConfig',
+            'AWS::SSM::AssociationCompliance',
+            'AWS::SSM::PatchCompliance',
+            'AWS::ShieldRegional::Protection',
+            'AWS::Config::ResourceCompliance',
+            'AWS::ApiGatewayV2::Stage',
+            'AWS::ApiGatewayV2::Api',
+            'AWS::ServiceCatalog::CloudFormationProvisionedProduct',
+            'AWS::ServiceCatalog::CloudFormationProduct',
+            'AWS::ServiceCatalog::Portfolio'}
+
         resource_map = {}
         for k, v in manager.resources.items():
             if not v.resource_type.config_type:
                 continue
             resource_map[v.resource_type.config_type] = v
+        resource_config_types = set(resource_map)
+
         session = fake_session()._session
         model = session.get_service_model('config')
         shape = model.shape_for('ResourceType')
-        missing = []
-        for k in shape.enum:
-            if k not in resource_map:
-                missing.append(k)
+
+        config_types = set(shape.enum).difference(whitelist)
+        missing = config_types.difference(resource_config_types)
         if missing:
             raise AssertionError(
                 "Missing config types \n %s" % ('\n'.join(missing)))
+
+        bad_types = resource_config_types.difference(config_types)
+        if bad_types:
+            raise AssertionError(
+                "Invalid config types \n %s" % ('\n'.join(bad_types)))
+
 
     def test_resource_meta_with_class(self):
         missing = set()


### PR DESCRIPTION
closes #5677 
closes #5635 

this also adds a meta test to track on going config resource coverage

per https://awsapichanges.info/archive/changes/fcc5ef-config.html 