### PR TITLE
tools/c7n_policystream - pin pygit2 versions

### DIFF
--- a/tools/c7n_policystream/requirements.txt
+++ b/tools/c7n_policystream/requirements.txt
@@ -2,7 +2,7 @@ click
 boto3
 requests
 c7n
-pygit2
+pygit2==1.0.3
 PyYAML>=4.2b4
 sqlalchemy
 urllib3>=1.24.1

--- a/tools/c7n_policystream/setup.py
+++ b/tools/c7n_policystream/setup.py
@@ -38,7 +38,8 @@ setup(
         'console_scripts': [
             'c7n-policystream = policystream:cli']},
     install_requires=[
-        "c7n", "click", "pygit2",
+        "c7n", "click",
+        "pygit2==1.0.3",
         "python-dateutil", "jmespath", "requests",
         "pyyaml>=4.2b4"]
 )


### PR DESCRIPTION
pygit2 1.1 depends on libgit2 1.1 which is not packaged or available in any distribution at the moment.

verified docker image build working with this change.