### PR TITLE
aws - load resources only after event filters have been processed

### DIFF
--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -105,10 +105,12 @@ class ResourceManager(object):
     def filter_event(self, event=None):
         if not event:
             return True
+        resource_type = self.get_model()
+        fakes = [{resource_type.id: "fake"}]
         for f in self.filters:
             if self.is_only_event(f):
                 with self.ctx.tracer.subsegment("event-filter:%s" % f.type):
-                    result = f.process([{}], event)
+                    result = f.process(fakes, event)
                     if event.get('debug', False):
                         self.log.debug("applied event filter %s: %s", f, bool(result))
                     if not result:

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -100,7 +100,7 @@ class ResourceManager(object):
     def is_only_event(self, f):
         valid = set(['or', 'not', 'and', 'event'])
         ftypes = set([i.type for i in self.iter_filters(start=[f])])
-        return bool(ftypes - valid)
+        return not (ftypes - valid)
 
     def filter_event(self, event=None):
         if not event:

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -97,7 +97,7 @@ class ResourceManager(object):
             return klass(self.ctx, {'source': self.source_type})
         return klass(self.ctx, data or {})
 
-    def is_only_event(self, f):
+    def is_event_filter(self, f):
         valid = set(['or', 'not', 'and', 'event'])
         ftypes = set([i.type for i in self.iter_filters(start=[f])])
         return not (ftypes - valid)
@@ -106,11 +106,11 @@ class ResourceManager(object):
         if not event:
             return True
         resource_type = self.get_model()
-        fakes = [{resource_type.id: "fake"}]
+        fake_resources = [{resource_type.id: "fake"}]
         for f in self.filters:
-            if self.is_only_event(f):
+            if self.is_event_filter(f):
                 with self.ctx.tracer.subsegment("event-filter:%s" % f.type):
-                    result = f.process(fakes, event)
+                    result = f.process(fake_resources, event)
                     if event.get('debug', False):
                         self.log.debug("applied event filter %s: %s", f, bool(result))
                     if not result:
@@ -125,7 +125,7 @@ class ResourceManager(object):
         for f in self.filters:
             if not resources:
                 break
-            if skip_event_filters and self.is_only_event(f):
+            if skip_event_filters and self.is_event_filter(f):
                 continue
             rcount = len(resources)
 

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -98,7 +98,7 @@ class ResourceManager(object):
         return klass(self.ctx, data or {})
 
     def is_only_event(self, f):
-        valid = set('or', 'not', 'and', 'event')
+        valid = set(['or', 'not', 'and', 'event'])
         ftypes = set([i.type for i in self.iter_filters(start=f)])
         return bool(ftypes - valid)
 

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -107,7 +107,7 @@ class ResourceManager(object):
             return True
         for f in self.filters:
             if self.is_only_event(f):
-                with self.ctx.tracer.subsegment("event-filter:%" % f.type):
+                with self.ctx.tracer.subsegment("event-filter:%s" % f.type):
                     result = f.process([{}], event)
                     if event.get('debug', False):
                         self.log.debug("applied event filter %s: %s", f, bool(result))

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -99,7 +99,7 @@ class ResourceManager(object):
 
     def is_only_event(self, f):
         valid = set(['or', 'not', 'and', 'event'])
-        ftypes = set([i.type for i in self.iter_filters(start=f)])
+        ftypes = set([i.type for i in self.iter_filters(start=[f])])
         return bool(ftypes - valid)
 
     def filter_event(self, event=None):

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -505,12 +505,21 @@ class LambdaMode(ServerlessExecutionMode):
         metrics per normal.
         """
         self.setup_exec_environment(event)
+
+        # check only event filters first
+        if not self.policy.resource_manager.filter_event(event):
+            self.policy.log.info(
+                "policy:%s resources:%s no event match" % (
+                    self.policy.name, self.policy.resource_type))
+            return
+
+        # now load resource info to filter events
         resources = self.resolve_resources(event)
         if not resources:
             return resources
         rcount = len(resources)
         resources = self.policy.resource_manager.filter_resources(
-            resources, event)
+            resources, event, skip_event_filters=True)
 
         if 'debug' in event:
             self.policy.log.info(


### PR DESCRIPTION
This is a proposal to check any event filters first ... then load resource info to do other filters.  This lets us short-circuit events that won't match before having to hit any resource APIs at all.  Should help with #4621 