### PR TITLE
core - vendored ipaddress use 3.8 compatible interpolation

### DIFF
--- a/c7n/ipaddress.py
+++ b/c7n/ipaddress.py
@@ -1113,7 +1113,8 @@ class _BaseNetwork(_IPAddressBase):
         try:
             # Always false if one is v4 and the other is v6.
             if a._version != b._version:
-                raise TypeError("%s and %s are not of the same version" (a, b))
+                raise TypeError(
+                    "%s and %s are not of the same version" % (a, b))
             return (b.network_address <= a.network_address and
                     b.broadcast_address >= a.broadcast_address)
         except AttributeError:


### PR DESCRIPTION
addresses a warning when using with python 3.8