### PR TITLE
Minor IAM docs fix

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1213,7 +1213,7 @@ class CredentialReport(Filter):
            key: password_last_used
            value: absent
          - type: credential
-           key: access_keys.last_used
+           key: access_keys.last_used_date
            value_type: age
            value: 30
            op: less-than


### PR DESCRIPTION
`access_keys.last_used` is not a valid part of the `credential` schema
https://github.com/cloud-custodian/cloud-custodian/blob/e2c7b4038d4ce434727a2f122027b63b24b0cb47/c7n/resources/iam.py#L1236-L1253
