### PR TITLE
core - examples doc test improvements

### DIFF
--- a/c7n/actions/policy.py
+++ b/c7n/actions/policy.py
@@ -62,7 +62,7 @@ class ModifyPolicyBase(BaseAction):
     .. code-block:: yaml
 
            policies:
-              - name: sns-cross-account
+              - name: sns-yank-cross-account
                 resource: sns
                 filters:
                   - type: cross-account

--- a/c7n/filters/kms.py
+++ b/c7n/filters/kms.py
@@ -29,7 +29,7 @@ class KmsRelatedFilter(RelatedResourceFilter):
         .. code-block:: yaml
 
             policies:
-                - name:
+                - name: dms-encrypt-key-check
                   resource: dms-instance
                   filters:
                     - type: kms-key

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -378,7 +378,7 @@ class ServiceUsage(Filter):
 
     .. code-block:: yaml
 
-      - name: unused-users
+      - name: usage-unused-users
         resource: iam-user
         filters:
           - type: usage
@@ -1678,7 +1678,7 @@ class UserDelete(BaseAction):
       .. code-block:: yaml
 
         # using a 'credential' filter'
-        - name: iam-only-whitelisted-users
+        - name: iam-only-whitelisted-users-credential
           resource: iam-user
           filters:
             - type: credential
@@ -1691,7 +1691,7 @@ class UserDelete(BaseAction):
             - delete
 
         # using a 'username' filter with 'UserName'
-        - name: iam-only-whitelisted-users
+        - name: iam-only-whitelisted-users-username
           resource: iam-user
           filters:
             - type: value
@@ -1704,7 +1704,7 @@ class UserDelete(BaseAction):
             - delete
 
          # using a 'username' filter with 'Arn'
-        - name: iam-only-whitelisted-users
+        - name: iam-only-whitelisted-users-arn
           resource: iam-user
           filters:
             - type: value
@@ -1735,15 +1735,15 @@ class UserDelete(BaseAction):
                 the username is included in whitelist
               resource: iam-user
               filters:
-                - type: username
+                - type: value
                   key: UserName
                   op: not-in
                   value:
                     - valid-user-1
                     - valid-user-2
                 - type: credential
-                  key: Status
-                  value: Active
+                  key: password_enabled
+                  value: true
               actions:
                 - type: delete
                   options:

--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -299,7 +299,7 @@ class KmsKeyRotation(BaseAction):
 
     .. code-block:: yaml
 
-        policy:
+        policies:
           - name: enable-cmk-rotation
             resource: kms-key
             filters:

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1199,7 +1199,7 @@ class RegionCopySnapshot(BaseAction):
       - name: copy-encrypted-snapshots
         description: |
           copy snapshots under 1 day old to dr region with kms
-        resource: rdb-snapshot
+        resource: rds-snapshot
         region: us-east-1
         filters:
          - Status: available
@@ -1214,7 +1214,7 @@ class RegionCopySnapshot(BaseAction):
             target_key: arn:aws:kms:us-east-2:0000:key/cb291f53-c9cf61
             copy_tags: true
             tags:
-              - OriginRegion: us-east-1
+              OriginRegion: us-east-1
     """
 
     schema = type_schema(

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -21,6 +21,7 @@ from c7n.config import Config
 from c7n.loader import PolicyLoader
 from c7n.provider import clouds
 from c7n.resources import load_resources
+from c7n.schema import ElementSchema
 from c7n.utils import yaml_load
 
 from .common import BaseTest  # NOQA - loads providers for individual module testing
@@ -34,10 +35,13 @@ def get_doc_examples(resources):
             if cls in seen:
                 continue
             seen.add(cls)
-            if not cls.__doc__:
+
+            doc = ElementSchema.doc(cls)
+            if not doc:
                 continue
+
             # split on yaml and new lines
-            split_doc = [x.split('\n\n') for x in cls.__doc__.split('yaml')]
+            split_doc = [x.split('\n\n') for x in doc.split('yaml')]
             for item in itertools.chain.from_iterable(split_doc):
                 if 'policies:\n' in item:
                     policies.append((item, resource_name, cls.type))
@@ -59,6 +63,7 @@ def get_doc_policies(resources):
         for p in data.get('policies', []):
             if p['name'] in policies:
                 if policies[p['name']] != p:
+                    print('duplicate %s %s %s' % ( resource_name, el_name, p['name']))
                     duplicate_names.add(p['name'])
             else:
                 policies[p['name']] = p
@@ -70,8 +75,9 @@ def get_doc_policies(resources):
         print('Duplicate policy names:')
         for d in duplicate_names:
             print('\t{0}'.format(d))
+        raise AssertionError("Duplication doc policy names")
 
-    return policies, duplicate_names
+    return policies
 
 
 skip_condition = not (
@@ -85,19 +91,17 @@ skip_condition = not (
       sys.version_info.major == 3 and
       sys.version_info.minor == 6)))
 
-
+print('skip condition', skip_condition)
 @pytest.mark.skipif(skip_condition, reason="Doc tests must be explicitly enabled with C7N_DOC_TEST")
 @pytest.mark.parametrize("provider_name", ('aws', 'azure', 'gcp', 'k8s'))
 def test_doc_examples(provider_name):
     load_resources()
     loader = PolicyLoader(Config.empty())
     provider = clouds.get(provider_name)
-    policies, duplicate_names = get_doc_policies(provider.resources)
+    policies = get_doc_policies(provider.resources)
 
     for p in policies.values():
         loader.load_data({'policies': [p]}, 'memory://')
-
-    assert not duplicate_names
 
     for p in policies.values():
         # Note max name size here is 54 if it a lambda policy given

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -72,7 +72,8 @@ def get_doc_policies(resources):
         for p in data.get('policies', []):
             if p['name'] in policies:
                 if policies[p['name']] != p:
-                    print('duplicate %s %s %s' % ( resource_name, el_name, p['name']))
+                    print('duplicate %s %s %s' % (
+                        resource_name, el_name, p['name']))
                     duplicate_names.add(p['name'])
             else:
                 policies[p['name']] = p

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -100,7 +100,7 @@ skip_condition = not (
       sys.version_info.major == 3 and
       sys.version_info.minor == 6)))
 
-print('skip condition', skip_condition)
+
 @pytest.mark.skipif(skip_condition, reason="Doc tests must be explicitly enabled with C7N_DOC_TEST")
 @pytest.mark.parametrize("provider_name", ('aws', 'azure', 'gcp', 'k8s'))
 def test_doc_examples(provider_name):

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -70,9 +70,6 @@ def get_doc_policies(resources):
             raise
 
         for p in data.get('policies', []):
-            if not isinstance(p, dict):
-                __import__("pdb").set_trace()
-
             if p['name'] in policies:
                 if policies[p['name']] != p:
                     print('duplicate %s %s %s' % ( resource_name, el_name, p['name']))

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -45,6 +45,10 @@ def get_doc_examples(resources):
             for item in itertools.chain.from_iterable(split_doc):
                 if 'policies:\n' in item:
                     policies.append((item, resource_name, cls.type))
+                elif 'resource:' in item:
+                    item = 'policies:\n' + item
+                    policies.append((item, resource_name, cls.type))
+
     return policies
 
 
@@ -59,8 +63,16 @@ def get_doc_policies(resources):
     policies = {}
     duplicate_names = set()
     for ptext, resource_name, el_name in get_doc_examples(resources):
-        data = yaml_load(ptext)
+        try:
+            data = yaml_load(ptext)
+        except Exception:
+            print('failed %s %s\n %s' % (resource_name, el_name, ptext))
+            raise
+
         for p in data.get('policies', []):
+            if not isinstance(p, dict):
+                __import__("pdb").set_trace()
+
             if p['name'] in policies:
                 if policies[p['name']] != p:
                     print('duplicate %s %s %s' % ( resource_name, el_name, p['name']))

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -371,7 +371,7 @@ class DiagnosticSettingsFilter(ValueFilter):
 
     .. code-block:: yaml
 
-        policies
+        policies:
           - name: find-load-balancers-with-logs-enabled
             resource: azure.loadbalancer
             filters:
@@ -392,7 +392,7 @@ class DiagnosticSettingsFilter(ValueFilter):
 
     .. code-block:: yaml
 
-        policies
+        policies:
           - name: find-keyvaults-with-logs-enabled
             resource: azure.keyvault
             filters:

--- a/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
+++ b/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
@@ -110,8 +110,7 @@ class ResizePlan(AzureBaseAction):
                     type: resource
                     key: sku.name
               - type: resize-plan
-                size:
-                    size: S1
+                size: S1
 
     """
 

--- a/tools/c7n_azure/c7n_azure/resources/storage.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage.py
@@ -283,7 +283,7 @@ class StorageDiagnosticSettingsFilter(ValueFilter):
 
     .. code-block:: yaml
 
-        policies
+        policies:
           - name: find-load-balancers-with-logs-enabled
             resource: azure.loadbalancer
             filters:
@@ -304,7 +304,7 @@ class StorageDiagnosticSettingsFilter(ValueFilter):
 
     .. code-block:: yaml
 
-        policies
+        policies:
           - name: find-keyvaults-with-logs-enabled
             resource: azure.keyvault
             filters:


### PR DESCRIPTION
following up from #5435,  which corrected a doc example that shouldn't have passed validation, i dug into our automated tests on doc examples, and noticed a few deficiencies, which this pr attempts to correct.

doc test infrastructure 

- handle inherited doc strings
- error on invalid yaml (~half-dozen)
- handle missing `policies:` key (about 72 examples)

and then attempts to fix some of the examples.
