### PR TITLE
releng - docker degunk/strip azure sdks for 25% image size savings

### DIFF
--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -18,6 +18,7 @@ RUN adduser --disabled-login custodian
 RUN apt-get --yes update && apt-get --yes upgrade \
  && apt-get --yes install build-essential \
  && pip3 install -r requirements-dev.txt  . \
+ && python3 /src/tools/dev/dockerstripazure.py --remove \
  && apt-get --yes remove build-essential \
  && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
  && rm -Rf /var/cache/apt/ \

--- a/tools/dev/dockerstripazure.py
+++ b/tools/dev/dockerstripazure.py
@@ -54,7 +54,6 @@ def main(remove):
     human_size = GetHumanSize(total_size)
     print(f"removed {total_files} files {human_size} saved")
 
-    
 
 def GetHumanSize(size, precision=2):
     # interesting discussion on 1024 vs 1000 as base
@@ -69,11 +68,4 @@ def GetHumanSize(size, precision=2):
 
 
 if __name__ == '__main__':
-    try:
-        main()
-    except Exception:
-        import sys, traceback, pdb
-        traceback.print_exc()
-        pdb.post_mortem(sys.exc_info()[-1])
-
-        
+    main()

--- a/tools/dev/dockerstripazure.py
+++ b/tools/dev/dockerstripazure.py
@@ -1,0 +1,79 @@
+"""
+Azure SDKS are full of generated stuff that no one cares about to the tune of
+at least a 100Mb of fluff on an sdk data set size of 300Mb+.
+"""
+
+import click
+import importlib
+import os
+import shutil
+from c7n.resources import load_resources
+from c7n.provider import clouds
+
+
+@click.command()
+@click.option('--remove', default=False, is_flag=True)
+def main(remove):
+    load_resources('azure.*')
+    service_clients = set()
+    for k, v in clouds['azure'].resources.items():
+        service_clients.add((
+            v.resource_type.service,
+            v.resource_type.client))
+
+    total_files = 0
+    total_size = 0
+    for module, klass in sorted(service_clients):
+        if not klass:
+            continue
+
+        _module = importlib.import_module(module)
+        _klass = getattr(_module, klass)
+        default_version = getattr(_klass, 'DEFAULT_API_VERSION', None)
+        mod_dir = os.path.dirname(_module.__file__)
+        versions = [m for m in os.listdir(mod_dir)
+                    if m.startswith('v') and m[1].isdigit()]
+        if len(versions) < 2:
+            continue
+        default_version = "v%s" % default_version.replace('.', '_').replace('-', '_')
+        versions.remove(default_version)
+        size = 0
+        fcount = 0
+        for v in versions:
+            for root, dirs, files in os.walk(os.path.join(mod_dir, v)):
+                for f in files:
+                    size += os.path.getsize(os.path.join(root, f))
+                fcount += 1
+            if remove:
+                shutil.rmtree(os.path.join(mod_dir, v))
+        total_files += fcount
+        total_size += size
+        human_size = GetHumanSize(size)
+        print(f"{module}: {default_version} removed {fcount} files {human_size} saved")
+
+    human_size = GetHumanSize(total_size)
+    print(f"removed {total_files} files {human_size} saved")
+
+    
+
+def GetHumanSize(size, precision=2):
+    # interesting discussion on 1024 vs 1000 as base
+    # https://en.wikipedia.org/wiki/Binary_prefix
+    suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+    suffixIndex = 0
+    while size > 1024:
+        suffixIndex += 1
+        size = size / 1024.0
+
+    return "%.*f %s" % (precision, size, suffixes[suffixIndex])
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception:
+        import sys, traceback, pdb
+        traceback.print_exc()
+        pdb.post_mortem(sys.exc_info()[-1])
+
+        


### PR DESCRIPTION
its actually a bit rmore then the example below, and there's probably more gold in these hills if we clean out the pypi metadata, which has books of documentation in some of the readmes.

```
azure.keyvault: v7_0 removed 4 files 891.04 KB saved
azure.mgmt.authorization: v2018_09_01_preview removed 24 files 482.93 KB saved
azure.mgmt.compute: v2019_07_01 removed 72 files 14.29 MB saved
azure.mgmt.containerregistry: v2019_04_01 removed 24 files 2.41 MB saved
azure.mgmt.containerservice: v2020_01_01 removed 72 files 3.74 MB saved
azure.mgmt.dns: v2018_05_01 removed 12 files 384.45 KB saved
azure.mgmt.eventhub: v2017_04_01 removed 12 files 571.27 KB saved
azure.mgmt.iothub: v2019_11_04 removed 36 files 2.42 MB saved
azure.mgmt.keyvault: v2018_02_14 removed 6 files 237.41 KB saved
azure.mgmt.network: v2019_09_01 removed 138 files 78.68 MB saved
azure.mgmt.resource.policy: v2019_09_01 removed 48 files 1.47 MB saved
azure.mgmt.storage: v2019_06_01 removed 60 files 4.38 MB saved
azure.mgmt.web: v2019_08_01 removed 42 files 11.60 MB saved
removed 550 files 121.51 MB saved
```