### PR TITLE
core - remove pkg resources

### DIFF
--- a/c7n/executor.py
+++ b/c7n/executor.py
@@ -13,31 +13,9 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from concurrent.futures import (
-    ProcessPoolExecutor, ThreadPoolExecutor)
-
-from c7n.registry import PluginRegistry
+from concurrent.futures import (ProcessPoolExecutor, ThreadPoolExecutor)  # noqa
 
 import threading
-
-
-class ExecutorRegistry(PluginRegistry):
-
-    def __init__(self, plugin_type):
-        super(ExecutorRegistry, self).__init__(plugin_type)
-
-        self.register('process', ProcessPoolExecutor)
-        self.register('thread', ThreadPoolExecutor)
-        self.register('main', MainThreadExecutor)
-
-
-def executor(name, **kw):
-    factory = executors.get(name)
-    # post element refactoring
-    # factory.validate(kw)
-    if factory is None:
-        raise ValueError("No Such Executor %s" % name)
-    return factory(**kw)
 
 
 class MainThreadExecutor(object):
@@ -104,6 +82,3 @@ class MainThreadFuture(object):
     def add_done_callback(self, fn):
         return fn(self)
 
-
-executors = ExecutorRegistry('executor')
-executors.load_plugins()

--- a/c7n/executor.py
+++ b/c7n/executor.py
@@ -81,4 +81,3 @@ class MainThreadFuture(object):
 
     def add_done_callback(self, fn):
         return fn(self)
-

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -338,8 +338,8 @@ def _package_deps(package, deps=None, ignore=()):
 def custodian_archive(packages=None):
     """Create a lambda code archive for running custodian.
 
-    Lambda archive currently always includes `c7n` and
-    `pkg_resources`. Add additional packages in the mode block.
+    Lambda archive currently always includes `c7n`.  Add additional
+    packages via function parameters, or in policy via mode block.
 
     Example policy that includes additional packages
 
@@ -355,7 +355,7 @@ def custodian_archive(packages=None):
     packages: List of additional packages to include in the lambda archive.
 
     """
-    modules = {'c7n', 'pkg_resources'}
+    modules = {'c7n'}
     if packages:
         modules = filter(None, modules.union(packages))
     return PythonPackageArchive(sorted(modules))

--- a/c7n/registry.py
+++ b/c7n/registry.py
@@ -117,17 +117,3 @@ class PluginRegistry(object):
 
     def items(self):
         return self._factories.items()
-
-    def load_plugins(self):
-        """ Load external plugins.
-
-        Custodian is intended to interact with internal and external systems
-        that are not suitable for embedding into the custodian code base.
-        """
-        try:
-            from pkg_resources import iter_entry_points
-        except ImportError:
-            return
-        for ep in iter_entry_points(group="custodian.%s" % self.plugin_type):
-            f = ep.load()
-            f()

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -995,7 +995,6 @@ class PythonArchiveTest(unittest.TestCase):
         archive.close()
         filenames = archive.get_filenames()
         self.assertTrue("c7n/__init__.py" in filenames)
-        self.assertTrue("pkg_resources/__init__.py" in filenames)
 
     def make_file(self):
         bench = tempfile.mkdtemp()


### PR DESCRIPTION
we stopped using pkg resources a while ago, this shrinks our core serverless archive size from 578480 -> 462588