### PR TITLE
core - fix lazy load schema gen for empty policy set

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -331,6 +331,9 @@ def generate(resource_types=()):
         }
     }
 
+    # allow empty policies with lazy load
+    if not resource_refs:
+        schema['properties']['policies']['items'] = {'type': 'object'}
     return schema
 
 


### PR DESCRIPTION
closes #5502 

with lazy loading schema generation for an empty policy set would generate an invalid schema causing the below error when checking the generated schema.

```
(c7n-poet-v1) ➜  custodian git:(upstream) ✗ custodian run -c appservice.yml -s out -v
Traceback (most recent call last):
  File "/Users/kapilt/.pyenv/versions/c7n-poet-v1/bin/custodian", line 11, in <module>
    load_entry_point('c7n', 'console_scripts', 'custodian')()
  File "/Users/kapilt/projects/custodian/c7n/cli.py", line 374, in main
    command(config)
  File "/Users/kapilt/projects/custodian/c7n/commands.py", line 64, in _load_policies
    collection = policy_load(options, fp, validate=validate, vars=vars)
  File "/Users/kapilt/projects/custodian/c7n/policy.py", line 59, in load
    errors = validate(data)
  File "/Users/kapilt/projects/custodian/c7n/schema.py", line 49, in validate
    JsonSchemaValidator.check_schema(schema)
  File "/Users/kapilt/.pyenv/versions/3.8.2/envs/c7n-poet-v1/lib/python3.8/site-packages/jsonschema/validators.py", line 294, in check_schema
    raise exceptions.SchemaError.create_from(error)
jsonschema.exceptions.SchemaError: {'anyOf': []} is not valid under any of the given schemas

Failed validating 'anyOf' in metaschema['properties']['properties']['additionalProperties']['properties']['items']:
    {'anyOf': [{'$ref': '#'}, {'$ref': '#/definitions/schemaArray'}],
     'default': {}}

On schema['properties']['policies']['items']:
    {'anyOf': []}
```

with the change, we restore our original warning message.

```
(c7n-poet-v1) ➜  custodian git:(upstream) ✗ custodian run -c appservice.yml -s out -v
2020-03-26 05:47:29,633: custodian.commands:DEBUG Loaded file appservice.yml. Contains 0 policies
2020-03-26 05:47:29,633: custodian.commands:WARNING Empty policy file(s).  Nothing to do.
```