### PR TITLE
C7n org regioncheck update

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -555,7 +555,7 @@ def run_account(account, region, policies_config, output_path,
             p.expand_variables(p.get_variables(account.get('vars', {})))
             p.validate()
 
-            if p.region and p.region != region:
+            if p.config.region and p.config.region != region:
                 continue
 
             log.debug(

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -554,10 +554,6 @@ def run_account(account, region, policies_config, output_path,
             # Variable expansion and non schema validation (not optional)
             p.expand_variables(p.get_variables(account.get('vars', {})))
             p.validate()
-
-            if p.config.region and p.config.region != region:
-                continue
-
             log.debug(
                 "Running policy:%s account:%s region:%s",
                 p.name, account['name'], region)

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -110,6 +110,13 @@ class OrgTest(TestUtils):
         self.patch(org, 'logging', logger)
         self.patch(org, 'run_account', run_account)
         self.change_cwd(run_dir)
+        runner = CliRunner()
+        result = runner.invoke(
+            org.cli,
+            ['run', '-c', 'accounts.yml', '-u', 'policies.yml',
+             '--debug', '-s', 'output', '--cache-path', 'cache'],
+            catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)        
 
     def test_cli_run_aws(self):
         run_dir = self.setup_run_dir()

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -116,7 +116,7 @@ class OrgTest(TestUtils):
             ['run', '-c', 'accounts.yml', '-u', 'policies.yml',
              '--debug', '-s', 'output', '--cache-path', 'cache'],
             catch_exceptions=False)
-        self.assertEqual(result.exit_code, 0)        
+        self.assertEqual(result.exit_code, 0)
 
     def test_cli_run_aws(self):
         run_dir = self.setup_run_dir()


### PR DESCRIPTION
address an issue from PolicyCollection change in #4466

Looks like region is being set to the policy.config.region instead of policy.region now and this line is throwing an error when running c7n-org. I believe this can be traced back to changes made in #4466.