### PR TITLE
Docker container using distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ LABEL name="custodian" \
       homepage="http://github.com/cloud-custodian/cloud-custodian" \
       maintainer="Custodian Community <https://cloudcustodian.io>"
 
+RUN adduser --disabled-login custodian \
+ && mkdir /output \
+ && chown custodian: /output
+
 # Transfer Custodian source into container by directory
 # to minimize size
 ADD pyproject.toml poetry.lock README.md /src/
@@ -18,7 +22,6 @@ ADD tools/c7n_mailer /src/tools/c7n_mailer
 
 WORKDIR /src
 
-RUN adduser --disabled-login custodian
 RUN apt-get --yes update \
  && apt-get --yes install build-essential curl python3-venv --no-install-recommends \
  && python3 -m venv /usr/local \
@@ -33,6 +36,9 @@ RUN apt-get --yes update \
 FROM gcr.io/distroless/python3-debian10
 COPY --from=build-env /src /src
 COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /output /output
+COPY --from=build-env /etc/passwd /etc/passwd
+USER custodian
 WORKDIR /home/custodian
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 VOLUME ["/home/custodian"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,32 @@
 FROM debian:10-slim as build-env
+ARG providers="azure gcp kube"
+
+# pre-requisite distro deps, and build env setup
+RUN adduser --disabled-login custodian
+RUN apt-get --yes update
+RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
+RUN python3 -m venv /usr/local
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+
+WORKDIR /src
+
+# Add core & aws packages
+ADD pyproject.toml poetry.lock README.md /src/
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install
+
+# Add provider packagees
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+
+# Install requested providers
+RUN . /usr/local/bin/activate && for pkg in $providers; do cd tools/c7n_$pkg && $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN mkdir /output
+
+# Distroless Container
+FROM gcr.io/distroless/python3-debian10
 
 LABEL name="custodian" \
       description="Cloud Management Rules Engine" \
@@ -6,38 +34,12 @@ LABEL name="custodian" \
       homepage="http://github.com/cloud-custodian/cloud-custodian" \
       maintainer="Custodian Community <https://cloudcustodian.io>"
 
-RUN adduser --disabled-login custodian \
- && mkdir /output \
- && chown custodian: /output
-
-# Transfer Custodian source into container by directory
-# to minimize size
-ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_org /src/tools/c7n_org
-ADD tools/c7n_mailer /src/tools/c7n_mailer
-
-WORKDIR /src
-
-RUN apt-get --yes update \
- && apt-get --yes install build-essential curl python3-venv --no-install-recommends \
- && python3 -m venv /usr/local \
- && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 \
- && . /usr/local/bin/activate \
- && $HOME/.poetry/bin/poetry install --no-dev \
- && cd tools/c7n_azure && $HOME/.poetry/bin/poetry install && cd ../.. \
- && cd tools/c7n_gcp && $HOME/.poetry/bin/poetry install && cd ../.. \
- && cd tools/c7n_kube && $HOME/.poetry/bin/poetry install && cd ../..
-
-# Distroless Container
-FROM gcr.io/distroless/python3-debian10
 COPY --from=build-env /src /src
 COPY --from=build-env /usr/local /usr/local
-COPY --from=build-env /output /output
 COPY --from=build-env /etc/passwd /etc/passwd
+COPY --from=build-env /etc/group /etc/group
+COPY --from=build-env /output /output
+
 USER custodian
 WORKDIR /home/custodian
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install
+RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
+RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packagees
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10 as build-env
+FROM debian:10-slim as build-env
 
 LABEL name="custodian" \
       description="Cloud Management Rules Engine" \
@@ -30,7 +30,7 @@ RUN apt-get --yes update \
  && $HOME/.poetry/bin/poetry install --no-dev \
  && cd tools/c7n_azure && $HOME/.poetry/bin/poetry install && cd ../.. \
  && cd tools/c7n_gcp && $HOME/.poetry/bin/poetry install && cd ../.. \
- && cd tools/c7n_kube && $HOME/.poetry/bin/poetry install && cd ../.. 
+ && cd tools/c7n_kube && $HOME/.poetry/bin/poetry install && cd ../..
 
 # Distroless Container
 FROM gcr.io/distroless/python3-debian10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:10-slim as build-env
-ARG providers="azure gcp kube"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login custodian
@@ -22,6 +21,7 @@ ADD tools/c7n_azure /src/tools/c7n_azure
 ADD tools/c7n_kube /src/tools/c7n_kube
 
 # Install requested providers
+ARG providers="azure gcp kube"
 RUN . /usr/local/bin/activate && for pkg in $providers; do cd tools/c7n_$pkg && $HOME/.poetry/bin/poetry install && cd ../../; done
 
 RUN mkdir /output

--- a/tools/c7n_mailer/Dockerfile
+++ b/tools/c7n_mailer/Dockerfile
@@ -1,4 +1,37 @@
-FROM python:3.7-slim-stretch
+FROM debian:10-slim as build-env
+
+# pre-requisite distro deps, and build env setup
+RUN adduser --disabled-login custodian
+RUN apt-get --yes update
+RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
+RUN python3 -m venv /usr/local
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+
+WORKDIR /src
+
+# Add core & aws packages
+ADD pyproject.toml poetry.lock README.md /src/
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
+RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+
+# Add provider packagees
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+
+# Install requested providers
+ARG providers="azure"
+RUN . /usr/local/bin/activate && for pkg in $providers; do cd tools/c7n_$pkg && $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN mkdir /output
+
+# Install c7n-mailer
+ADD tools/c7n_mailer /src/tools/c7n_mailer
+RUN . /usr/local/bin/activate && cd tools/c7n_mailer && $HOME/.poetry/bin/poetry install
+
+# Distroless Container
+FROM gcr.io/distroless/python3-debian10
 
 LABEL name="mailer" \
       description="Cloud Custodian Notification Delivery" \
@@ -6,22 +39,11 @@ LABEL name="mailer" \
       homepage="https://cloudcustodian.io" \
       maintainer="Custodian Community <https://cloudcustodian.io>"
 
-# Transfer Custodian source into container by directory
-# to minimize size
-ADD setup.py README.md requirements-dev.txt requirements.txt /src/
-ADD c7n /src/c7n/
-ADD tools /src/tools/
-
-WORKDIR /src
-RUN adduser --disabled-login custodian
-RUN apt-get --yes update && apt-get --yes upgrade \
- && apt-get --yes install build-essential \
- && pip3 install -r requirements-dev.txt \
- && apt-get --yes remove build-essential \
- && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
- && rm -Rf /var/cache/apt/ \
- && rm -Rf /var/lib/apt/lists/* \
- && rm -Rf /root/.cache/
+COPY --from=build-env /src /src
+COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /etc/passwd /etc/passwd
+COPY --from=build-env /etc/group /etc/group
+COPY --from=build-env /output /output
 
 USER custodian
 WORKDIR /home/custodian

--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -1,4 +1,37 @@
-FROM python:3.7-slim-stretch
+FROM debian:10-slim as build-env
+ARG providers="azure gcp kube"
+
+# pre-requisite distro deps, and build env setup
+RUN adduser --disabled-login custodian
+RUN apt-get --yes update
+RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
+RUN python3 -m venv /usr/local
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+
+WORKDIR /src
+
+# Add core & aws packages
+ADD pyproject.toml poetry.lock README.md /src/
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
+RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+
+# Add provider packagees
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+
+# Install requested providers
+RUN . /usr/local/bin/activate && for pkg in $providers; do cd tools/c7n_$pkg && $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN mkdir /output
+
+# Install c7n-org
+ADD tools/c7n_org /src/tools/c7n_org
+RUN . /usr/local/bin/activate && cd tools/c7n_org && $HOME/.poetry/bin/poetry install
+
+# Distroless Container
+FROM gcr.io/distroless/python3-debian10
 
 LABEL name="c7n-org" \
       description="Cloud Custodian Organization Runner" \
@@ -6,25 +39,11 @@ LABEL name="c7n-org" \
       homepage="http://github.com/cloud-custodian/cloud-custodian" \
       maintainer="Custodian Community <https://cloudcustodian.io>"
 
-# Transfer Custodian source into container by directory
-# to minimize size.
-# Note: build root is the root of the checkout.
-ADD setup.py README.md requirements-dev.txt requirements.txt /src/
-ADD c7n /src/c7n/
-ADD tools /src/tools/
-
-WORKDIR /src
-RUN adduser --disabled-login custodian
-RUN apt-get --yes update && apt-get --yes upgrade \
- && apt-get --yes install build-essential \
- && pip3 install -r requirements-dev.txt  . \
- && apt-get --yes remove build-essential \
- && apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
- && rm -Rf /var/cache/apt/ \
- && rm -Rf /var/lib/apt/lists/* \
- && rm -Rf /root/.cache/ \
- && mkdir /output \
- && chown custodian: /output
+COPY --from=build-env /src /src
+COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /etc/passwd /etc/passwd
+COPY --from=build-env /etc/group /etc/group
+COPY --from=build-env /output /output
 
 USER custodian
 WORKDIR /home/custodian
@@ -32,4 +51,3 @@ ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 VOLUME ["/home/custodian"]
 ENTRYPOINT ["/usr/local/bin/c7n-org"]
 CMD ["--help"]
-

--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:10-slim as build-env
-ARG providers="azure gcp kube"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login custodian
@@ -22,6 +21,7 @@ ADD tools/c7n_azure /src/tools/c7n_azure
 ADD tools/c7n_kube /src/tools/c7n_kube
 
 # Install requested providers
+ARG providers="azure gcp kube"
 RUN . /usr/local/bin/activate && for pkg in $providers; do cd tools/c7n_$pkg && $HOME/.poetry/bin/poetry install && cd ../../; done
 
 RUN mkdir /output

--- a/tools/c7n_policystream/Dockerfile
+++ b/tools/c7n_policystream/Dockerfile
@@ -1,37 +1,66 @@
-FROM ubuntu:disco
+FROM debian:10-slim as build-env
 
+# pre-requisite distro deps, and build env setup
+RUN adduser --disabled-login custodian
+RUN apt-get --yes update
+RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
+RUN python3 -m venv /usr/local
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+
+WORKDIR /src
+
+# Add core & aws packages
+ADD pyproject.toml poetry.lock README.md /src/
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
+RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+
+# Add provider packagees
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+
+# Install requested providers
+ARG providers="azure gcp kube"
+RUN . /usr/local/bin/activate && for pkg in $providers; do cd tools/c7n_$pkg && $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN mkdir /output
+
+# Compile libgit2
+RUN apt-get -y install wget cmake libssl-dev libffi-dev git
+RUN mkdir build && \
+	wget https://github.com/libgit2/libgit2/releases/download/v1.0.0/libgit2-1.0.0.tar.gz && \
+	cd build && \
+	tar xzf ../libgit2-1.0.0.tar.gz && \
+	cd libgit2-1.0.0 && \
+	mkdir build && cd build && \
+	cmake .. && \
+	make install
+
+# Install c7n-policystream
+ADD tools/c7n_policystream /src/tools/c7n_policystream
+RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/poetry install
+
+# Verify the install
+#  - policystream is not in ci due to libgit2 compilation needed
+#  - as a sanity check to distributing known good assets / we test here
+RUN . /usr/local/bin/activate && pytest tools/c7n_policystream
+
+
+# Distroless Container
+FROM gcr.io/distroless/python3-debian10
 LABEL name="policystream" \
       description="Custodian policy changes streamed from Git" \
       repository="http://github.com/cloud-custodian/cloud-custodian" \
       homepage="http://github.com/cloud-custodian/cloud-custodian" \
       maintainer="Kapil Thangavelu <http://twitter.com/kapilvt>"
 
-# Note this must be run from the root directory of the checkout
-# as we install custodian w/ aws, azure, and gcp support from the same
-# repo.
+COPY --from=build-env /src /src
+COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /etc/passwd /etc/passwd
+COPY --from=build-env /etc/group /etc/group
+COPY --from=build-env /output /output
 
-# Transfer Custodian source into container by directory
-# to minimize size
-ADD setup.py README.md requirements-dev.txt requirements.txt /src/
-ADD c7n /src/c7n/
-ADD tools /src/tools/
-
-WORKDIR /src
-RUN adduser --home /home/custodian --disabled-login custodian
-
-RUN apt-get --yes update && apt-get --yes upgrade \
-	&& apt-get --yes install build-essential libgit2-dev libffi-dev python3-pip \
-           python3-dev python3-setuptools python3-six python3-wheel \
-           python3-cryptography python3-idna \
-	&& pip3 install -r requirements-dev.txt  . \
-	&& pip3 install -r tools/c7n_policystream/requirements.txt tools/c7n_policystream \
-	&& apt-get --yes remove build-essential \
-	&& apt-get purge --yes --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-	&& rm -Rf /var/cache/apt/ \
-	&& rm -Rf /var/lib/apt/lists/* \
-	&& rm -Rf /root/.cache/ \
-        && mkdir /output \
-        && chown custodian: /output
 
 USER custodian
 WORKDIR /home/custodian

--- a/tools/c7n_policystream/Dockerfile
+++ b/tools/c7n_policystream/Dockerfile
@@ -29,13 +29,14 @@ RUN mkdir /output
 # Compile libgit2
 RUN apt-get -y install wget cmake libssl-dev libffi-dev git
 RUN mkdir build && \
-	wget https://github.com/libgit2/libgit2/releases/download/v1.0.0/libgit2-1.0.0.tar.gz && \
+	wget -q https://github.com/libgit2/libgit2/releases/download/v1.0.0/libgit2-1.0.0.tar.gz && \
 	cd build && \
 	tar xzf ../libgit2-1.0.0.tar.gz && \
 	cd libgit2-1.0.0 && \
 	mkdir build && cd build && \
 	cmake .. && \
-	make install
+	make install && \
+        rm -Rf /src/build
 
 # Install c7n-policystream
 ADD tools/c7n_policystream /src/tools/c7n_policystream

--- a/tools/c7n_policystream/poetry.lock
+++ b/tools/c7n_policystream/poetry.lock
@@ -186,6 +186,19 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 
 [[package]]
 category = "dev"
+description = "Rolling backport of unittest.mock for all Pythons"
+name = "mock"
+optional = false
+python-versions = ">=3.6"
+version = "4.0.2"
+
+[package.extras]
+build = ["twine", "wheel", "blurb"]
+docs = ["sphinx"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
+category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
@@ -382,7 +395,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ed1e1bb23732687405020a3946fbc21713321c32a723052254b2b3878a44a56e"
+content-hash = "573d47d4106b609fd79fd5591775b9bf5d2b1f39918ba057f03b8bc43ab30a50"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -442,6 +455,10 @@ jmespath = [
 jsonschema = [
     {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
+]
+mock = [
+    {file = "mock-4.0.2-py3-none-any.whl", hash = "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0"},
+    {file = "mock-4.0.2.tar.gz", hash = "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"},
 ]
 more-itertools = [
     {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},

--- a/tools/c7n_policystream/pyproject.toml
+++ b/tools/c7n_policystream/pyproject.toml
@@ -29,6 +29,7 @@ jmespath = "^0.9.4"
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.5"
 c7n = {path = "../..", develop = true}
+mock = "^4.0.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Tested as working with my AWS SecurityHub Automated Remediations workshop.  Have not tested other modules and tools

Purpose: Smaller container (currently 73.23 as reported on Dockerhub) and less attack surface.