### PR TITLE
Fixes merge_annotation for IAM access keys

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -220,11 +220,6 @@ class Filter:
         if not values and block_op != 'or':
             return
 
-        r_matched = r.setdefault(self.matched_annotation_key, [])
-        for k in values:
-            if k not in r_matched:
-                r_matched.append(k)
-
 
 def intersect_list(a, b):
     if b is None:

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.GetCredentialReport_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.GetCredentialReport_1.json
@@ -1,29 +1,18 @@
 {
-    "status_code": 200,
-    "data": {
-        "Content": "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\nzscholl,arn:aws:iam::123456789012:user/zscholl,2018-08-10T11:07:38+00:00,FALSE,N/A,N/A,N/A,FALSE,TRUE,2019-09-25T10:52:11+00:00,2019-09-25T10:58:00+00:00,us-west-1,s3,TRUE,2018-08-10T11:13:31+00:00,2020-04-02T13:08:00+00:00,us-west-1,s3,FALSE,N/A,FALSE,N/A\n",
-        "ReportFormat": "text/csv",
-        "GeneratedTime": {
-            "__class__": "datetime",
-            "year": 2020,
-            "month": 4,
-            "day": 2,
-            "hour": 16,
-            "minute": 20,
-            "second": 57,
-            "microsecond": 0
-        },
-        "ResponseMetadata": {
-            "RequestId": "f0c0abab-f5e3-11e8-acb5-7dfca7468def",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "x-amzn-requestid": "f0c0abab-f5e3-11e8-acb5-7dfca7468def",
-                "content-type": "text/xml",
-                "content-length": "8569",
-                "vary": "Accept-Encoding",
-                "date": "Thu, 02 Apr 2020 16:20:57 GMT"
-            },
-            "RetryAttempts": 0
-        }
-    }
+  "status_code": 200,
+  "data": {
+    "Content": "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\nzscholl,arn:aws:iam::123456789012:user/zscholl,2018-08-10T11:07:38+00:00,FALSE,N/A,N/A,N/A,FALSE,TRUE,2019-09-25T10:52:11+00:00,2019-09-25T10:58:00+00:00,us-west-1,s3,TRUE,2018-08-10T11:13:31+00:00,2020-04-02T13:08:00+00:00,us-west-1,s3,FALSE,N/A,FALSE,N/A\n",
+    "ReportFormat": "text/csv",
+    "GeneratedTime": {
+      "__class__": "datetime",
+      "year": 2020,
+      "month": 4,
+      "day": 2,
+      "hour": 16,
+      "minute": 20,
+      "second": 57,
+      "microsecond": 0
+    },
+    "ResponseMetadata": {}
+  }
 }

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.GetCredentialReport_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.GetCredentialReport_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "Content": "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\nzscholl,arn:aws:iam::123456789012:user/zscholl,2018-08-10T11:07:38+00:00,FALSE,N/A,N/A,N/A,FALSE,TRUE,2019-09-25T10:52:11+00:00,2019-09-25T10:58:00+00:00,us-west-1,s3,TRUE,2018-08-10T11:13:31+00:00,2020-04-02T13:08:00+00:00,us-west-1,s3,FALSE,N/A,FALSE,N/A\n",
+        "ReportFormat": "text/csv",
+        "GeneratedTime": {
+            "__class__": "datetime",
+            "year": 2020,
+            "month": 4,
+            "day": 2,
+            "hour": 16,
+            "minute": 20,
+            "second": 57,
+            "microsecond": 0
+        },
+        "ResponseMetadata": {
+            "RequestId": "f0c0abab-f5e3-11e8-acb5-7dfca7468def",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f0c0abab-f5e3-11e8-acb5-7dfca7468def",
+                "content-type": "text/xml",
+                "content-length": "8569",
+                "vary": "Accept-Encoding",
+                "date": "Thu, 02 Apr 2020 16:20:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.GetUser_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.GetUser_1.json
@@ -1,32 +1,22 @@
 {
-    "status_code": 200,
-    "data": {
-        "User": {
-            "Path": "/",
-            "UserName": "zscholl",
-            "UserId": "AIDAJEZOTH6YPO3DY45QW",
-            "Arn": "arn:aws:iam::123456789012:user/zscholl",
-            "CreateDate": {
-                "__class__": "datetime",
-                "year": 2018,
-                "month": 12,
-                "day": 6,
-                "hour": 16,
-                "minute": 6,
-                "second": 5,
-                "microsecond": 0
-            }
-        },
-        "ResponseMetadata": {
-            "RequestId": "a59813a6-1f5c-11e9-b74d-b5201ef1df02",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "x-amzn-requestid": "a59813a6-1f5c-11e9-b74d-b5201ef1df02",
-                "content-type": "text/xml",
-                "content-length": "576",
-                "date": "Thu, 02 Apr 2020 16:19:57 GMT"
-            },
-            "RetryAttempts": 0
-        }
-    }
+  "status_code": 200,
+  "data": {
+    "User": {
+      "Path": "/",
+      "UserName": "zscholl",
+      "UserId": "AIDAJEZOTH6YPO3DY45QW",
+      "Arn": "arn:aws:iam::123456789012:user/zscholl",
+      "CreateDate": {
+        "__class__": "datetime",
+        "year": 2018,
+        "month": 12,
+        "day": 6,
+        "hour": 16,
+        "minute": 6,
+        "second": 5,
+        "microsecond": 0
+      }
+    },
+    "ResponseMetadata": {}
+  }
 }

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.GetUser_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.GetUser_1.json
@@ -1,0 +1,32 @@
+{
+    "status_code": 200,
+    "data": {
+        "User": {
+            "Path": "/",
+            "UserName": "zscholl",
+            "UserId": "AIDAJEZOTH6YPO3DY45QW",
+            "Arn": "arn:aws:iam::123456789012:user/zscholl",
+            "CreateDate": {
+                "__class__": "datetime",
+                "year": 2018,
+                "month": 12,
+                "day": 6,
+                "hour": 16,
+                "minute": 6,
+                "second": 5,
+                "microsecond": 0
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "a59813a6-1f5c-11e9-b74d-b5201ef1df02",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "a59813a6-1f5c-11e9-b74d-b5201ef1df02",
+                "content-type": "text/xml",
+                "content-length": "576",
+                "date": "Thu, 02 Apr 2020 16:19:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.ListAccessKeys_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.ListAccessKeys_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccessKeyMetadata": [
+            {
+                "UserName": "zscholl",
+                "AccessKeyId": "AKIAJEZJDQQX4TZNRMKQ",
+                "Status": "Active",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 9,
+                    "day": 25,
+                    "hour": 10,
+                    "minute": 52,
+                    "second": 11,
+                    "microsecond": 0
+                }
+            },
+            {
+                "UserName": "zscholl",
+                "AccessKeyId": "AKIAIFX6HPKAM5F7JVAA",
+                "Status": "Active",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 8,
+                    "day": 10,
+                    "hour": 11,
+                    "minute": 12,
+                    "second": 31,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+            "RequestId": "f0df3074-f5e3-11e8-8700-7f377c0f7a24",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f0df3074-f5e3-11e8-8700-7f377c0f7a24",
+                "content-type": "text/xml",
+                "content-length": "761",
+                "date": "Thu, 02 Apr 2020 16:19:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.ListAccessKeys_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.ListAccessKeys_1.json
@@ -1,49 +1,39 @@
 {
-    "status_code": 200,
-    "data": {
-        "AccessKeyMetadata": [
-            {
-                "UserName": "zscholl",
-                "AccessKeyId": "AKIAJEZJDQQX4TZNRMKQ",
-                "Status": "Active",
-                "CreateDate": {
-                    "__class__": "datetime",
-                    "year": 2019,
-                    "month": 9,
-                    "day": 25,
-                    "hour": 10,
-                    "minute": 52,
-                    "second": 11,
-                    "microsecond": 0
-                }
-            },
-            {
-                "UserName": "zscholl",
-                "AccessKeyId": "AKIAIFX6HPKAM5F7JVAA",
-                "Status": "Active",
-                "CreateDate": {
-                    "__class__": "datetime",
-                    "year": 2018,
-                    "month": 8,
-                    "day": 10,
-                    "hour": 11,
-                    "minute": 12,
-                    "second": 31,
-                    "microsecond": 0
-                }
-            }
-        ],
-        "IsTruncated": false,
-        "ResponseMetadata": {
-            "RequestId": "f0df3074-f5e3-11e8-8700-7f377c0f7a24",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "x-amzn-requestid": "f0df3074-f5e3-11e8-8700-7f377c0f7a24",
-                "content-type": "text/xml",
-                "content-length": "761",
-                "date": "Thu, 02 Apr 2020 16:19:57 GMT"
-            },
-            "RetryAttempts": 0
+  "status_code": 200,
+  "data": {
+    "AccessKeyMetadata": [
+      {
+        "UserName": "zscholl",
+        "AccessKeyId": "AKIAJEZJDQQX4TZNRMKQ",
+        "Status": "Active",
+        "CreateDate": {
+          "__class__": "datetime",
+          "year": 2019,
+          "month": 9,
+          "day": 25,
+          "hour": 10,
+          "minute": 52,
+          "second": 11,
+          "microsecond": 0
         }
-    }
+      },
+      {
+        "UserName": "zscholl",
+        "AccessKeyId": "AKIAIFX6HPKAM5F7JVAA",
+        "Status": "Active",
+        "CreateDate": {
+          "__class__": "datetime",
+          "year": 2018,
+          "month": 8,
+          "day": 10,
+          "hour": 11,
+          "minute": 12,
+          "second": 31,
+          "microsecond": 0
+        }
+      }
+    ],
+    "IsTruncated": false,
+    "ResponseMetadata": {}
+  }
 }

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.ListUsers_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.ListUsers_1.json
@@ -1,36 +1,25 @@
 {
-    "status_code": 200,
-    "data": {
-        "Users": [
-            {
-                "Path": "/",
-                "UserName": "zscholl",
-                "UserId": "AIDAJEZOTH6YPO3DY45QW",
-                "Arn": "arn:aws:iam::123456789012:user/zscholl",
-                "CreateDate": {
-                    "__class__": "datetime",
-                    "year": 2016,
-                    "month": 5,
-                    "day": 16,
-                    "hour": 19,
-                    "minute": 3,
-                    "second": 36,
-                    "microsecond": 0
-                }
-            }
-        ],
-        "IsTruncated": false,
-        "ResponseMetadata": {
-            "RequestId": "f0b4c496-f5e3-11e8-acb5-7dfca7468def",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "x-amzn-requestid": "f0b4c496-f5e3-11e8-acb5-7dfca7468def",
-                "content-type": "text/xml",
-                "content-length": "5180",
-                "vary": "Accept-Encoding",
-                "date": "Thu, 02 Apr 2020 16:20:57 GMT"
-            },
-            "RetryAttempts": 0
+  "status_code": 200,
+  "data": {
+    "Users": [
+      {
+        "Path": "/",
+        "UserName": "zscholl",
+        "UserId": "AIDAJEZOTH6YPO3DY45QW",
+        "Arn": "arn:aws:iam::123456789012:user/zscholl",
+        "CreateDate": {
+          "__class__": "datetime",
+          "year": 2016,
+          "month": 5,
+          "day": 16,
+          "hour": 19,
+          "minute": 3,
+          "second": 36,
+          "microsecond": 0
         }
-    }
+      }
+    ],
+    "IsTruncated": false,
+    "ResponseMetadata": {}
+  }
 }

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.ListUsers_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.ListUsers_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "data": {
+        "Users": [
+            {
+                "Path": "/",
+                "UserName": "zscholl",
+                "UserId": "AIDAJEZOTH6YPO3DY45QW",
+                "Arn": "arn:aws:iam::123456789012:user/zscholl",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2016,
+                    "month": 5,
+                    "day": 16,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 36,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+            "RequestId": "f0b4c496-f5e3-11e8-acb5-7dfca7468def",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f0b4c496-f5e3-11e8-acb5-7dfca7468def",
+                "content-type": "text/xml",
+                "content-length": "5180",
+                "vary": "Accept-Encoding",
+                "date": "Thu, 02 Apr 2020 16:20:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.UpdateAccessKey_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.UpdateAccessKey_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "f0e6f8c7-f5e3-11e8-8700-7f377c0f7a24",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f0e6f8c7-f5e3-11e8-8700-7f377c0f7a24",
+                "content-type": "text/xml",
+                "content-length": "210",
+                "date": "Thu, 02 Apr 2020 16:20:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.UpdateAccessKey_1.json
+++ b/tests/data/placebo/test_iam_user_credential_reverse_filter_delete/iam.UpdateAccessKey_1.json
@@ -1,16 +1,6 @@
 {
-    "status_code": 200,
-    "data": {
-        "ResponseMetadata": {
-            "RequestId": "f0e6f8c7-f5e3-11e8-8700-7f377c0f7a24",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "x-amzn-requestid": "f0e6f8c7-f5e3-11e8-8700-7f377c0f7a24",
-                "content-type": "text/xml",
-                "content-length": "210",
-                "date": "Thu, 02 Apr 2020 16:20:57 GMT"
-            },
-            "RetryAttempts": 0
-        }
-    }
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {}
+  }
 }

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -61,6 +61,45 @@ class TestFilter(unittest.TestCase):
         filter_instance = base_filters.Filter({})
         self.assertIsInstance(filter_instance, base_filters.Filter)
 
+    def test_merge_annotation(self):
+        filter_instance1 = base_filters.Filter({})
+        filter_instance2 = base_filters.Filter({})
+        filter_instance1.matched_annotation_key = 'c7n:matched-keys'
+        filter_instance2.matched_annotation_key = 'c7n:matched-keys'
+        filter_instance1.get_block_operator = lambda: 'and'
+        filter_instance2.get_block_operator = lambda: 'and'
+
+        resource1 = {'Arn': 'arn:aws:iam::123456789012:user/zscholl',
+        'CreateDate': datetime(2020, 1, 2, 17, 53, 23, 976000, tzinfo=tz.tzutc()),
+        'Path': '/',
+        'UserId': 'xafegj4qjwfl3mpuvyj5',
+        'UserName': 'zscholl'}
+        resource2 = {'Arn': 'arn:aws:iam::123456789012:user/zscholl',
+        'CreateDate': datetime(2020, 1, 2, 17, 53, 23, 976000, tzinfo=tz.tzutc()),
+        'Path': '/',
+        'UserId': 'xafegj4qjwfl3mpuvyj5',
+        'UserName': 'zscholl'}
+
+        value1 = {'active': True, 'c7n:match-type': 'credential',
+                 'last_rotated': '2019-01-04T17:53:24+00:00',
+                 'last_used_date': '2019-01-04T17:53:24+00:00',
+                 'last_used_region': 'not_supported',
+                 'last_used_service': 'not_supported'}
+
+        value2 = {'active': True, 'c7n:match-type': 'credential',
+                 'last_rotated': '2020-01-02T18:53:24+00:00',
+                 'last_used_date': '2020-01-04T17:53:24+00:00',
+                 'last_used_region': 'not_supported',
+                 'last_used_service': 'not_supported'}
+        filter_instance1.merge_annotation(resource1, 'c7n:matched-keys', [value1, value2])
+        filter_instance1.merge_annotation(resource1, 'c7n:matched-keys', [value1])
+
+        filter_instance2.merge_annotation(resource2, 'c7n:matched-keys', [value1])
+        filter_instance2.merge_annotation(resource2, 'c7n:matched-keys', [value1, value2])
+
+        self.assertEqual(resource1, resource2)
+
+
 
 class TestOrFilter(unittest.TestCase):
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -100,7 +100,6 @@ class TestFilter(unittest.TestCase):
         self.assertEqual(resource1, resource2)
 
 
-
 class TestOrFilter(unittest.TestCase):
 
     def test_or(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -70,15 +70,15 @@ class TestFilter(unittest.TestCase):
         filter_instance2.get_block_operator = lambda: 'and'
 
         resource1 = {'Arn': 'arn:aws:iam::123456789012:user/zscholl',
-        'CreateDate': datetime(2020, 1, 2, 17, 53, 23, 976000, tzinfo=tz.tzutc()),
-        'Path': '/',
-        'UserId': 'xafegj4qjwfl3mpuvyj5',
-        'UserName': 'zscholl'}
+                     'CreateDate': datetime(2020, 1, 2, 17, 53, 23, 976000, tzinfo=tz.tzutc()),
+                     'Path': '/',
+                     'UserId': 'xafegj4qjwfl3mpuvyj5',
+                     'UserName': 'zscholl'}
         resource2 = {'Arn': 'arn:aws:iam::123456789012:user/zscholl',
-        'CreateDate': datetime(2020, 1, 2, 17, 53, 23, 976000, tzinfo=tz.tzutc()),
-        'Path': '/',
-        'UserId': 'xafegj4qjwfl3mpuvyj5',
-        'UserName': 'zscholl'}
+                     'CreateDate': datetime(2020, 1, 2, 17, 53, 23, 976000, tzinfo=tz.tzutc()),
+                     'Path': '/',
+                     'UserId': 'xafegj4qjwfl3mpuvyj5',
+                     'UserName': 'zscholl'}
 
         value1 = {'active': True, 'c7n:match-type': 'credential',
                  'last_rotated': '2019-01-04T17:53:24+00:00',


### PR DESCRIPTION
## Problem
We noticed an issue with the `credential` filters when attempting to filter on a user with two existing keys.

What we wanted to do was disable any keys on a user that were created more than 90 days ago and also had not been used in at least 90 days.

This was the policy used:
```
policies:
  - name: disable-90-day-old-key
    resource: iam-user
    filters:
      - type: credential
        key: access_keys.last_used_date
        value_type: age
        value: 90
        op: gte
      - type: credential
        key: access_keys.last_rotated
        value_type: age
        value: 90
        op: gte

    actions:
      - type: remove-keys
        disable: true
        matched: true
```

This policy was run on a user with:
ACCESS_KEY_1: created more than 90 days ago, used more than 90 days ago
ACCESS_KEY_2: created more than 90 days ago, used yesterday

It disabled both of these keys.

I discovered that if we flipped the order of the filters then the expected behavior happened, where just ACCESS_KEY_1 is disabled.

Here's what the working policy looked like:
```
policies:
  - name: disable-90-day-old-key
    resource: iam-user
    filters:
      - type: credential
        key: access_keys.last_rotated
        value_type: age
        value: 90
        op: gte
      - type: credential
        key: access_keys.last_used_date
        value_type: age
        value: 90
        op: gte

    actions:
      - type: remove-keys
        disable: true
        matched: true
```

My expectation was that order would not matter for these filters.

## Solution
I stepped through the policy evaluation logic for these two policies and found the difference in logic resulted from [this](https://github.com/cloud-custodian/cloud-custodian/blob/ac3feeedb85458bb11836ed01e18289983ea00fb/c7n/filters/core.py#L225-L228) loop.

In the case of the first policy, the `merge_annotation` function puts ACCESS_KEY_1 into the match list on the first pass, because it's the only key not used for over 90 days. However, on the second pass the `merge_annotation` function is passed  both keys to merge in. This goes fine until that loop.

During that loop, `values` has both of the keys that just matched the `last_rotated` filter and `r_matched` has just the first key in it. Since the loop is looking at all keys in `values` it sees that ACCESS_KEY_2 is not in `r_matched` so adds it.

The result is that both keys end up in the matched list and get disabled instead of just the one.

## Testing

I tested our access key removal policies with this change and they all worked as expected, even with the order of filters reversed.

I had a look at the existing cloud custodian tests and I'm not sure how to add a test for this condition, but all existing tests passed on my local machine with this change.

