### PR TITLE
aws - elastic-ip alias for network-addr resource

### DIFF
--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -103,6 +103,7 @@ ResourceMap = {
     "aws.ml-model": "c7n.resources.ml.MLModel",
     "aws.nat-gateway": "c7n.resources.vpc.NATGateway",
     "aws.network-acl": "c7n.resources.vpc.NetworkAcl",
+    "aws.elastic-ip": "c7n.resources.vpc.NetworkAddress",
     "aws.network-addr": "c7n.resources.vpc.NetworkAddress",
     "aws.ops-item": "c7n.resources.ssm.OpsItem",
     "aws.opswork-cm": "c7n.resources.opsworks.OpsworksCM",

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1752,7 +1752,7 @@ class AclAwsS3Cidrs(Filter):
         return results
 
 
-@resources.register('network-addr')
+@resources.register('elastic-ip', aliases=('network-addr',))
 class NetworkAddress(query.QueryResourceManager):
 
     class resource_type(query.TypeInfo):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,6 +122,7 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
   'prev_next_buttons_location': 'both',
   'style_external_links': True,
+  'analytics_id': "UA-162730326-1",
   # Toc options
   'collapse_navigation': False,
   'sticky_navigation': True,

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -867,6 +867,13 @@ class NetworkAddrTest(BaseTest):
         self.addCleanup(self.release_if_still_present, ec2, network_addr)
         self.assert_policy_released(factory, ec2, network_addr)
 
+    def test_elasticip_alias(self):
+        try:
+            self.load_policy({'name': 'eip', 'resource': 'aws.elastic-ip'}, validate=True)
+        except PolicyValidationError:
+            raise
+            self.fail("elastic ip alias failed")
+
     def test_release_attached_ec2(self):
         factory = self.replay_flight_data("test_release_attached_ec2")
 


### PR DESCRIPTION
closes #5508﻿
