### PR TITLE
Change c7n-mailer default runtime from python2.7 to python3.7

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -121,7 +121,7 @@ def setup_defaults(config):
     config.setdefault('region', 'us-east-1')
     config.setdefault('ses_region', config.get('region'))
     config.setdefault('memory', 1024)
-    config.setdefault('runtime', 'python2.7')
+    config.setdefault('runtime', 'python3.7')
     config.setdefault('timeout', 300)
     config.setdefault('subnets', None)
     config.setdefault('security_groups', None)

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -26,6 +26,21 @@ class StripPrefix(unittest.TestCase):
         self.assertEqual(utils.strip_prefix('', 'aws.'), '')
 
 
+def test_config_defaults():
+    config = {}
+    utils.setup_defaults(config)
+    for k, v in list(config.items()):
+        if v is None:
+            config.pop(k)
+    assert config == dict(
+        region='us-east-1',
+        ses_region='us-east-1',
+        memory=1024,
+        timeout=300,
+        runtime='python3.7',
+        contact_tags=[])
+
+
 class GetResourceTagTargets(unittest.TestCase):
 
     def test_target_tag_list(self):


### PR DESCRIPTION
While the Docker image for c7n-mailer is based on Python 3.7, the Lambda still defaults to deploying with the 2.7 runtime. Given the impending EOL of 2.7 and the fact that the mailer runs fine under 3.7, I believe we should default the runtime to 3.7. We've been running our mailers under 3.7 for about a week and all is well.

I haven't incremented the mailer version number in this PR, and there are no tests for the changed method (that I could find).