### PR TITLE
c7n.resolver was not using cached results

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -37,9 +37,10 @@ class URIResolver:
         self.cache = cache
 
     def resolve(self, uri):
-        contents = self.cache.get(("uri-resolver", uri))
-        if contents is not None:
-            return contents
+        if self.cache:
+            contents = self.cache.get(("uri-resolver", uri))
+            if contents is not None:
+                return contents
 
         if uri.startswith('s3://'):
             contents = self.get_s3_uri(uri)
@@ -50,7 +51,8 @@ class URIResolver:
             with closing(urlopen(req)) as response:
                 contents = self.handle_response_encoding(response)
 
-        self.cache.save(("uri-resolver", uri), contents)
+        if self.cache:
+            self.cache.save(("uri-resolver", uri), contents)
         return contents
 
     def handle_response_encoding(self, response):
@@ -97,7 +99,7 @@ class ValuesFrom:
          url: s3://bucket/xyz/foo.json
          expr: [].AppId
 
-      values_from:
+      value_from:
          url: http://foobar.com/mydata
          format: json
          expr: Region."us-east-1"[].ImageId
@@ -133,6 +135,7 @@ class ValuesFrom:
         }
         self.data = format_string_values(data, **config_args)
         self.manager = manager
+        self.cache = manager._cache
         self.resolver = URIResolver(manager.session_factory, manager._cache)
 
     def get_contents(self):
@@ -151,6 +154,21 @@ class ValuesFrom:
         return contents, format
 
     def get_values(self):
+        if self.cache:
+            # use these values as a key to cache the result so if we have
+            # the same filter happening across many resources, we can reuse
+            # the results.
+            key = [self.data.get(i) for i in ('url', 'format', 'expr')]
+            contents = self.cache.get(("value-from", key))
+            if contents is not None:
+                return contents
+
+        contents = self._get_values()
+        if self.cache:
+            self.cache.save(("value-from", key), contents)
+        return contents
+
+    def _get_values(self):
         contents, format = self.get_contents()
 
         if format == 'json':

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -37,6 +37,10 @@ class URIResolver:
         self.cache = cache
 
     def resolve(self, uri):
+        contents = self.cache.get(("uri-resolver", uri))
+        if contents is not None:
+            return contents
+
         if uri.startswith('s3://'):
             contents = self.get_s3_uri(uri)
         else:


### PR DESCRIPTION
this closes #5547 as we were saving the results in the resolver to a cache, but never looking them up.  s3 was being cached because of the generic boto session caching that happens.