### PR TITLE
aws - credential report - Include inactive keys w/ create dates

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1377,7 +1377,7 @@ class CredentialReport(Filter):
         for p, t in cls.list_sub_objects:
             obj = dict([(k[len(p):], info.pop(k))
                         for k in keys if k.startswith(p)])
-            if obj.get('active', False) or obj.get('last_rotated', None):
+            if obj.get('active', False) or obj.get('last_rotated', False):
                 info.setdefault(t, []).append(obj)
         return info
 

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1377,7 +1377,7 @@ class CredentialReport(Filter):
         for p, t in cls.list_sub_objects:
             obj = dict([(k[len(p):], info.pop(k))
                         for k in keys if k.startswith(p)])
-            if obj.get('active', False):
+            if obj.get('active', False) or obj.get('last_rotated', None):
                 info.setdefault(t, []).append(obj)
         return info
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -217,6 +217,54 @@ class UserCredentialReportTest(BaseTest):
             },
         )
 
+    def test_record_transform_with_keys(self):
+        info = {
+            "access_key_2_active": "false",
+            "password_next_rotation": "2017-01-24T13:15:33+00:00",
+            "access_key_2_last_rotated": "N/A",
+            "mfa_active": "true",
+            "cert_1_active": "false",
+            "cert_1_last_rotated": "N/A",
+            "access_key_1_last_used_date": "N/A",
+            "arn": "arn:aws:iam::644160558196:user/anthony",
+            "cert_2_active": "false",
+            "password_enabled": "true",
+            "access_key_2_last_used_region": "N/A",
+            "password_last_changed": "2016-10-26T13:15:33+00:00",
+            "access_key_1_last_rotated": "2019-12-04T13:22:47+00:00",
+            "user_creation_time": "2016-10-06T16:11:27+00:00",
+            "access_key_1_last_used_service": "N/A",
+            "user": "anthony",
+            "password_last_used": "2016-10-26T13:14:37+00:00",
+            "cert_2_last_rotated": "N/A",
+            "access_key_2_last_used_date": "N/A",
+            "access_key_2_last_used_service": "N/A",
+            "access_key_1_last_used_region": "N/A",
+            "access_key_1_active": "false",
+        }
+        credential = UserCredentialReport({}, None)
+        credential.process_user_record(info)
+        self.assertEqual(
+            info,
+            {
+                "access_keys": [{
+                    "active": False,
+                    "last_rotated": "2019-12-04T13:22:47+00:00",
+                    "last_used_date": None,
+                    "last_used_region": None,
+                    "last_used_service": None
+                }],
+                "arn": "arn:aws:iam::644160558196:user/anthony",
+                "mfa_active": True,
+                "password_enabled": True,
+                "password_last_changed": "2016-10-26T13:15:33+00:00",
+                "password_last_used": "2016-10-26T13:14:37+00:00",
+                "password_next_rotation": "2017-01-24T13:15:33+00:00",
+                "user": "anthony",
+                "user_creation_time": "2016-10-06T16:11:27+00:00",
+            },
+        )
+
 
 class IamUserTag(BaseTest):
 


### PR DESCRIPTION
Prior to this change, all keys that were inactive in the credential report were skipped and not added to the user object.

The credential report always has entries for two keys. If these keys don't exist, active is false, and the `last_rotated` field is "N/A".  Without checking the `last_rotated` field, keys that exist but are inactive are not available to use in the `credential` filter.

Added a test to confirm that such keys are added to the report.