### PR TITLE
add config_type variable for glue job resource

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -146,6 +146,7 @@ class GlueJob(QueryResourceManager):
         date = 'CreatedOn'
         arn_type = 'job'
         universal_taggable = True
+        config_type = "AWS::Glue::Job"
 
     permissions = ('glue:GetJobs',)
     augment = universal_augment


### PR DESCRIPTION
I have a custom aws config rule which returns glue job resources. I noticed that my policy: 

```
policies:
  - name: glue-job-encryption-rule
    resource: aws.glue-job
    filters:
      - type: config-compliance
        rules: ['Glue-JobEncryptionRule']
        states:
          - NON_COMPLIANT

```

would always filter to zero even though my rule returned results. After some exploring I 
discovered custodian makes a call to https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/config.html#ConfigService.Client.get_compliance_details_by_config_rule
at https://github.com/cloud-custodian/cloud-custodian/blob/e21823f0b94dd23bc9bbac88424e5be2256acfd9/c7n/filters/config.py#L75
Part of the boto API call returns 'AWS::Glue::Job' in the 'ResourceType' part of the response data structure. This is what config_type matches against to make the filter work. 
