### PR TITLE
Fixit snskms documentation

### DIFF
--- a/c7n/filters/kms.py
+++ b/c7n/filters/kms.py
@@ -19,7 +19,7 @@ from c7n.utils import local_session, type_schema
 
 class KmsRelatedFilter(RelatedResourceFilter):
     """
-    Filter a resource by its associcated kms key and optionally the aliasname
+    Filter a resource by its associated kms key and optionally the aliasname
     of the kms key by using 'c7n:AliasName'
 
     :example:

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -333,7 +333,6 @@ class ModifyPolicyStatement(ModifyPolicyBase):
 
 @SNS.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-
     """
     Filters SNS topic by kms key and optionally the aliasname
     of the kms key by using 'c7n:AliasName'

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -334,6 +334,23 @@ class ModifyPolicyStatement(ModifyPolicyBase):
 @SNS.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
 
+    """
+    Filters SNS topic by kms key and optionally the aliasname
+    of the kms key by using 'c7n:AliasName'
+
+    :example:
+
+        .. code-block:: yaml
+
+            policies:
+                - name: sns-encrypt-key-check
+                  resource: sns
+                  filters:
+                    - type: kms-key
+                      key: c7n:AliasName
+                      value: alias/aws/sns
+    """
+
     RelatedIdsExpression = 'KmsMasterKeyId'
 
 


### PR DESCRIPTION
Noticed a minor issue in the documentation where the SNS KMS filter was showing a policy that referenced DMS resources. Updated that to show a more pertinent example in the docs plus a minor spelling error. 