### PR TITLE
c7n - tests - replace recorded data account ids with the test account id

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -21,16 +21,12 @@ from c7n.config import Bag
 
 from c7n.testing import TestUtils, TextTestIO, functional # NOQA
 
-from .zpill import PillTest
+from .zpill import PillTest, ACCOUNT_ID
 
 
 logging.getLogger("placebo.pill").setLevel(logging.DEBUG)
 logging.getLogger("botocore").setLevel(logging.WARNING)
 
-
-# Custodian Test Account. This is used only for testing.
-# Access is available for community project maintainers.
-ACCOUNT_ID = "644160558196"
 
 C7N_VALIDATE = bool(os.environ.get("C7N_VALIDATE", ""))
 

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -28,6 +28,10 @@ from six import StringIO
 
 from c7n.testing import CustodianTestCore
 
+# Custodian Test Account. This is used only for testing.
+# Access is available for community project maintainers.
+ACCOUNT_ID = "644160558196"
+
 ###########################################################################
 # BEGIN PLACEBO MONKEY PATCH
 #
@@ -268,7 +272,7 @@ class RedPill(pill.Pill):
             response_data['ResponseMetadata'] = {}
 
         response_data = json.dumps(response_data, default=self.datetime_converter)
-        response_data = re.sub("\d{12}", "644160558196", response_data)  # noqa
+        response_data = re.sub("\d{12}", ACCOUNT_ID, response_data)  # noqa
         response_data = json.loads(response_data)
 
         super(RedPill, self).save_response(service, operation, response_data,

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -268,7 +268,7 @@ class RedPill(pill.Pill):
             response_data['ResponseMetadata'] = {}
 
         response_data = json.dumps(response_data, default=self.datetime_converter)
-        response_data = re.sub("\d{12}", "123456789123", response_data)  # noqa
+        response_data = re.sub("\d{12}", "644160558196", response_data)  # noqa
         response_data = json.loads(response_data)
 
         super(RedPill, self).save_response(service, operation, response_data,


### PR DESCRIPTION
helps to cover an issue when comparing arns against it