### PR TITLE
aws - cfn delete and set-protection retries

### DIFF
--- a/c7n/resources/cfn.py
+++ b/c7n/resources/cfn.py
@@ -62,13 +62,15 @@ class Delete(BaseAction):
     permissions = ("cloudformation:DeleteStack",)
 
     def process(self, stacks):
-        with self.executor_factory(max_workers=10) as w:
+        with self.executor_factory(max_workers=3) as w:
             list(w.map(self.process_stacks, stacks))
 
     def process_stacks(self, stack):
         client = local_session(
             self.manager.session_factory).client('cloudformation')
-        client.delete_stack(StackName=stack['StackName'])
+        self.manager.retry(
+            client.delete_stack,
+            StackName=stack['StackName'])
 
 
 @CloudFormation.action_registry.register('set-protection')
@@ -112,7 +114,8 @@ class SetProtection(BaseAction):
                         s['StackName'], f.exception())
 
     def process_stacks(self, client, stack):
-        client.update_termination_protection(
+        self.manager.retry(
+            client.update_termination_protection,
             EnableTerminationProtection=self.data.get('state', False),
             StackName=stack['StackName'])
 


### PR DESCRIPTION
cloudformation has notoriously low api rates before it throttles... so these need some retry help.