### PR TITLE
cli - fix schema output with no args, remove argcompletion around schema

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -31,7 +31,6 @@ except ImportError:
     def setproctitle(t):
         return None
 
-from c7n.commands import schema_completer
 from c7n.config import Config
 
 DEFAULT_REGION = 'us-east-1'
@@ -166,20 +165,11 @@ def _logs_options(p):
     )
 
 
-def _schema_tab_completer(prefix, parsed_args, **kwargs):
-    # If we are printing the summary we discard the resource
-    if parsed_args.summary:
-        return []
-
-    return schema_completer(prefix)
-
-
 def _schema_options(p):
     """ Add options specific to schema subcommand. """
 
     p.add_argument(
-        'resource', metavar='selector', nargs='?',
-        default=None).completer = _schema_tab_completer
+        'resource', metavar='selector', nargs='?', default=None)
     p.add_argument(
         '--summary', action="store_true",
         help="Summarize counts of available resources, actions and filters")

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -14,7 +14,7 @@
 from collections import Counter, defaultdict
 from datetime import timedelta, datetime
 from functools import wraps
-import inspect
+import itertools
 import logging
 import os
 import sys
@@ -29,7 +29,6 @@ from c7n.policy import Policy, PolicyCollection, load as policy_load
 from c7n.schema import ElementSchema, StructureParser, generate
 from c7n.utils import load_file, local_session, SafeLoader, yaml_dump
 from c7n.config import Bag, Config
-from c7n import provider
 from c7n.resources import (
     load_resources, load_available, load_providers, PROVIDER_NAMES)
 
@@ -316,63 +315,6 @@ def logs(options, policies):
     sys.exit(1)
 
 
-def _schema_get_docstring(starting_class):
-    """ Given a class, return its docstring.
-
-    If no docstring is present for the class, search base classes in MRO for a
-    docstring.
-    """
-    for cls in inspect.getmro(starting_class):
-        if inspect.getdoc(cls):
-            return inspect.getdoc(cls)
-
-
-def schema_completer(prefix):
-    """ For tab-completion via argcomplete, return completion options.
-
-    For the given prefix so far, return the possible options.  Note that
-    filtering via startswith happens after this list is returned.
-    """
-    from c7n import schema
-    load_available()
-    components = prefix.split('.')
-
-    if components[0] in provider.clouds.keys():
-        cloud_provider = components.pop(0)
-        provider_resources = provider.resources(cloud_provider)
-    else:
-        cloud_provider = 'aws'
-        provider_resources = provider.resources('aws')
-        components[0] = "aws.%s" % components[0]
-
-    # Completions for resource
-    if len(components) == 1:
-        choices = [r for r in provider.resources().keys()
-                   if r.startswith(components[0])]
-        if len(choices) == 1:
-            choices += ['{}{}'.format(choices[0], '.')]
-        return choices
-
-    if components[0] not in provider_resources.keys():
-        return []
-
-    # Completions for category
-    if len(components) == 2:
-        choices = ['{}.{}'.format(components[0], x)
-                   for x in ('actions', 'filters') if x.startswith(components[1])]
-        if len(choices) == 1:
-            choices += ['{}{}'.format(choices[0], '.')]
-        return choices
-
-    # Completions for item
-    elif len(components) == 3:
-        resource_mapping = schema.resource_vocabulary(cloud_provider)
-        return ['{}.{}.{}'.format(components[0], components[1], x)
-                for x in resource_mapping[components[0]][components[1]]]
-
-    return []
-
-
 def schema_cmd(options):
     """ Print info about the resources, actions and filters available. """
     from c7n import schema
@@ -405,7 +347,9 @@ def schema_cmd(options):
     #   - Show class doc string and schema for supplied filter
 
     if not options.resource:
-        resource_list = {'resources': sorted(provider.resources().keys())}
+        load_available(resources=False)
+        resource_list = {'resources': sorted(itertools.chain(
+            *[clouds[p].resource_map.keys() for p in PROVIDER_NAMES]))}
         print(yaml_dump(resource_list))
         return
 
@@ -463,7 +407,7 @@ def schema_cmd(options):
         sys.exit(1)
 
     if len(components) == 1:
-        docstring = _schema_get_docstring(
+        docstring = ElementSchema.doc(
             resource_mapping[resource]['classes']['resource'])
         del(resource_mapping[resource]['classes'])
         if docstring:
@@ -511,7 +455,7 @@ def schema_cmd(options):
 
 def _print_cls_schema(cls):
     # Print docstring
-    docstring = _schema_get_docstring(cls)
+    docstring = ElementSchema.doc(cls)
     print("\nHelp\n----\n")
     if docstring:
         print(docstring)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ from c7n import cli, version, commands
 from c7n.resolver import ValuesFrom
 from c7n.resources import aws
 from c7n.schema import ElementSchema, generate
-from c7n.utils import yaml_dump
+from c7n.utils import yaml_dump, yaml_load
 
 from .common import BaseTest, TextTestIO
 
@@ -171,7 +171,9 @@ class SchemaTest(CliTest):
     def test_schema(self):
 
         # no options
-        self.run_and_expect_success(["custodian", "schema"])
+        stdout, stderr = self.run_and_expect_success(["custodian", "schema"])
+        data = yaml_load(stdout)
+        assert data['resources']
 
         # summary option
         self.run_and_expect_success(["custodian", "schema", "--summary"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -425,30 +425,6 @@ class LogsTest(CliTest):
         self.run_and_expect_failure(["custodian", "logs", "-s", output_dir, yaml_file], 1)
 
 
-class TabCompletionTest(CliTest):
-    """ Tests for argcomplete tab completion. """
-
-    def test_schema_completer(self):
-        self.assertIn("aws.rds", cli.schema_completer("rd"))
-        self.assertIn("aws.s3.", cli.schema_completer("s3"))
-        self.assertListEqual([], cli.schema_completer("invalidResource."))
-        self.assertIn("aws.rds.actions", cli.schema_completer("rds."))
-        self.assertIn("aws.s3.filters.", cli.schema_completer("s3.filters"))
-        self.assertIn("aws.s3.filters.event", cli.schema_completer("s3.filters.eve"))
-        self.assertListEqual([], cli.schema_completer("rds.actions.foo.bar"))
-
-    def test_schema_completer_wrapper(self):
-
-        class MockArgs:
-            summary = False
-
-        args = MockArgs()
-        self.assertIn("aws.rds", cli._schema_tab_completer("rd", args))
-
-        args.summary = True
-        self.assertListEqual([], cli._schema_tab_completer("rd", args))
-
-
 class RunTest(CliTest):
 
     def test_ec2(self):


### PR DESCRIPTION
#5599 had a regression for the no arg case which was being caught by the docker image testing.

argcompletion around schema command, was also bitrotted so removing for now, we can do better with a shell in the future.