### PR TITLE
azure - support events for storage containers

### DIFF
--- a/docs/source/azure/examples/index.rst
+++ b/docs/source/azure/examples/index.rst
@@ -25,8 +25,8 @@ Compute
 
   ./*compute*
 
-Databases
----------
+Storage and Databases
+---------------------
 
 .. toctree::
   :maxdepth: 2

--- a/docs/source/azure/examples/storagecontainerevent-databases.rst
+++ b/docs/source/azure/examples/storagecontainerevent-databases.rst
@@ -1,0 +1,31 @@
+.. _azure_examples_storage_container_event:
+
+Storage - Monitor newly created Containers for public access
+============================================================
+
+Deploy an Azure Function to monitor real-time Blob Storage Container events.
+- Filter incoming container events on the ``publicAccess`` property.
+- Provides a way to act quickly on any changes to existing containers or creation of new containers.
+- Add your own ``actions`` to notify or mitigate as needed.
+
+.. code-block:: yaml
+
+    policies:
+      - name: storage_container_public_access_event
+        description: 'Identity containers with public access'
+        mode:
+          type: azure-event-grid
+          events:
+            - StorageContainerWrite
+          provision-options:
+            identity:
+              type: UserAssigned
+              id: custodian_identity
+          execution-options:
+            output_dir: azure://<storage_account>.blob.core.windows.net/custodian
+        resource: azure.storage-container
+        filters:
+          - type: value
+            key: properties.publicAccess
+            op: not-equal
+            value: None   # Possible values: Blob, Container, None

--- a/tools/c7n_azure/c7n_azure/azure_events.py
+++ b/tools/c7n_azure/c7n_azure/azure_events.py
@@ -7,7 +7,8 @@ from c7n.utils import local_session
 
 
 class AzureEvents:
-    """A mapping of resource types to events."""
+    """A mapping of resource types to events.
+       Provides user friendly event names for common events."""
 
     azure_events = {
 
@@ -85,6 +86,10 @@ class AzureEvents:
 
         'StorageWrite': {
             'resource_provider': 'Microsoft.Storage/storageAccounts',
+            'event': 'write'},
+
+        'StorageContainerWrite': {
+            'resource_provider': 'Microsoft.Storage/storageAccounts/blobServices/containers',
             'event': 'write'},
 
         'VmWrite': {

--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -2,14 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from c7n_azure.provider import resources
-from c7n_azure.query import ChildTypeInfo, ChildResourceManager
+from c7n_azure.query import ChildTypeInfo
 from c7n_azure.actions.base import AzureBaseAction
+from c7n_azure.resources.arm import ChildArmResourceManager
 from c7n.filters.core import type_schema
 from c7n_azure.utils import ResourceIdParser
+from msrestazure.tools import parse_resource_id
 
 
 @resources.register('storage-container')
-class StorageContainer(ChildResourceManager):
+class StorageContainer(ChildArmResourceManager):
     """Storage Container Resource
 
     :example:
@@ -50,6 +52,20 @@ class StorageContainer(ChildResourceManager):
         def extra_args(cls, parent_resource):
             return {'resource_group_name': parent_resource['resourceGroup'],
                     'account_name': parent_resource['name']}
+
+    def get_resources(self, resource_ids):
+        client = self.get_client()
+        data = [
+            self.get_storage_container(rid, client)
+            for rid in resource_ids
+        ]
+        return self.augment([r.serialize(True) for r in data])
+
+    def get_storage_container(self, resource_id, client):
+        parsed = parse_resource_id(resource_id)
+        return client.blob_containers.get(parsed.get('resource_group'),
+                                          parsed.get('name'),             # Account name
+                                          parsed.get('resource_name'))    # Container name
 
 
 @StorageContainer.action_registry.register('set-public-access')

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -60,6 +60,7 @@ install_requires = \
  'azure-mgmt-storage>=7.1.0,<8.0.0',
  'azure-mgmt-subscription>=0.5.0,<0.6.0',
  'azure-mgmt-web>=0.44.0,<0.45.0',
+ 'azure-mgmt-msi>=1.0.0',
  'azure-storage-blob>=2.1,<2.2',
  'azure-storage-file>=2.1.0,<3.0.0',
  'azure-storage-queue>=2.1,<2.2',

--- a/tools/c7n_azure/tests_azure/cassettes/StorageContainerTest.test_event.json
+++ b/tools/c7n_azure/tests_azure/cassettes/StorageContainerTest.test_event.json
@@ -1,0 +1,147 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Thu, 21 Jan 2021 15:02:33 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "12174"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "9b256834-1504-42cb-b5f8-5fe478cf9b0a",
+                        "8ab61285-d0d3-4764-887b-15861b354959",
+                        "0620e2eb-304a-49f2-90bf-53725ff7f053",
+                        "ddb9df54-47c7-409a-a8e4-52c570019aa3"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "kind": "Storage",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragevbnu36vrszu5c",
+                                "name": "cctstoragevbnu36vrszu5c",
+                                "type": "Microsoft.Storage/storageAccounts",
+                                "location": "southcentralus",
+                                "tags": {},
+                                "properties": {
+                                    "privateEndpointConnections": [],
+                                    "networkAcls": {
+                                        "bypass": "AzureServices",
+                                        "virtualNetworkRules": [],
+                                        "ipRules": [],
+                                        "defaultAction": "Allow"
+                                    },
+                                    "supportsHttpsTrafficOnly": false,
+                                    "encryption": {
+                                        "services": {
+                                            "file": {
+                                                "keyType": "Account",
+                                                "enabled": true,
+                                                "lastEnabledTime": "2021-01-21T15:00:15.9211981Z"
+                                            },
+                                            "blob": {
+                                                "keyType": "Account",
+                                                "enabled": true,
+                                                "lastEnabledTime": "2021-01-21T15:00:15.9211981Z"
+                                            }
+                                        },
+                                        "keySource": "Microsoft.Storage"
+                                    },
+                                    "provisioningState": "Succeeded",
+                                    "creationTime": "2021-01-21T15:00:15.8261975Z",
+                                    "primaryEndpoints": {
+                                        "blob": "https://cctstoragevbnu36vrszu5c.blob.core.windows.net/",
+                                        "queue": "https://cctstoragevbnu36vrszu5c.queue.core.windows.net/",
+                                        "table": "https://cctstoragevbnu36vrszu5c.table.core.windows.net/",
+                                        "file": "https://cctstoragevbnu36vrszu5c.file.core.windows.net/"
+                                    },
+                                    "primaryLocation": "southcentralus",
+                                    "statusOfPrimary": "available"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragevbnu36vrszu5c/blobServices/default/containers/containerone?api-version=2019-06-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Thu, 21 Jan 2021 15:02:33 GMT"
+                    ],
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "etag": [
+                        "\"0x8D8BE1D525A6958\""
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "689"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragevbnu36vrszu5c/blobServices/default/containers/containerone",
+                        "name": "containerone",
+                        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+                        "etag": "\"0x8D8BE1D525A6958\"",
+                        "properties": {
+                            "deleted": false,
+                            "remainingRetentionDays": 0,
+                            "defaultEncryptionScope": "$account-encryption-key",
+                            "denyEncryptionScopeOverride": false,
+                            "publicAccess": "Container",
+                            "leaseStatus": "Unlocked",
+                            "leaseState": "Available",
+                            "lastModifiedTime": "2021-01-21T15:00:41.0000000Z",
+                            "legalHold": {
+                                "hasLegalHold": false,
+                                "tags": []
+                            },
+                            "hasImmutabilityPolicy": false,
+                            "hasLegalHold": false
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
related to #5559  and #4617 

Each of the child resources is a bit of a special case in terms of lookups - just overriding the `get_resources` for container here to make it work with events.

This seems to work well.  I'll get a test added if you think it makes sense to do it this way @logachev?