### PR TITLE
aws - appelb - allow is-not-logging filter for network ELBs

### DIFF
--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -614,12 +614,11 @@ class IsNotLoggingFilter(Filter, AppELBAttributeFilterBase):
         bucket_prefix = self.data.get('prefix', None)
 
         return [alb for alb in resources
-                if alb['Type'] == 'application' and (
-                    not alb['Attributes']['access_logs.s3.enabled'] or (
+                if not alb['Attributes']['access_logs.s3.enabled'] or (
                         bucket_name and bucket_name != alb['Attributes'].get(
                             'access_logs.s3.bucket', None)) or (
                         bucket_prefix and bucket_prefix != alb['Attributes'].get(
-                            'access_logs.s3.prefix', None)))]
+                            'access_logs.s3.prefix', None))]
 
 
 class AppELBTargetGroupFilterBase:

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -614,11 +614,11 @@ class IsNotLoggingFilter(Filter, AppELBAttributeFilterBase):
         bucket_prefix = self.data.get('prefix', None)
 
         return [alb for alb in resources
-                if not alb['Attributes']['access_logs.s3.enabled'] or (
-                        bucket_name and bucket_name != alb['Attributes'].get(
-                            'access_logs.s3.bucket', None)) or (
-                        bucket_prefix and bucket_prefix != alb['Attributes'].get(
-                            'access_logs.s3.prefix', None))]
+                if not alb['Attributes']['access_logs.s3.enabled'] or
+                (bucket_name and bucket_name != alb['Attributes'].get(
+                    'access_logs.s3.bucket', None)) or
+                (bucket_prefix and bucket_prefix != alb['Attributes'].get(
+                    'access_logs.s3.prefix', None))]
 
 
 class AppELBTargetGroupFilterBase:


### PR DESCRIPTION
Fixes #5322.

Change `is-not-logging` to be similar to `is-logging`. 