### PR TITLE
releng - docker build pipeline updates

### DIFF
--- a/.azure-pipelines/live-functional.yml
+++ b/.azure-pipelines/live-functional.yml
@@ -110,7 +110,7 @@ stages:
           - script: python -m pip install --upgrade pip && pip install click docker pytest
             displayName: "Install Dependencies"
 
-	  - task: Docker@2
+          - task: Docker@2
             displayName: Login to Docker Hub
             inputs:
               command: login

--- a/.azure-pipelines/live-functional.yml
+++ b/.azure-pipelines/live-functional.yml
@@ -13,7 +13,7 @@ variables:
 
 stages:
   - stage: azure_live_functional
-    displayName: Azure Live Functional Tests
+    displayName: Custodian Live Functional Tests
 
     jobs:
     - job: 'azure_nightly_test_run'
@@ -22,7 +22,7 @@ stages:
       cancelTimeoutInMinutes: 0
 
       pool:
-        vmImage: 'Ubuntu-16.04'
+        vmImage: 'Ubuntu-18.04'
 
       steps:
         - checkout: self
@@ -30,7 +30,7 @@ stages:
 
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.7'
+            versionSpec: '3.8'
             architecture: 'x64'
 
         - script: python -m pip install --upgrade pip && pip install . && pip install -r requirements-dev.txt
@@ -65,7 +65,7 @@ stages:
       cancelTimeoutInMinutes: 0
 
       pool:
-        vmImage: 'Ubuntu-16.04'
+        vmImage: 'Ubuntu-18.04'
 
       steps:
         - checkout: self
@@ -73,7 +73,7 @@ stages:
 
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.7'
+            versionSpec: '3.8'
             architecture: 'x64'
 
         - script: python -m pip install --upgrade pip && pip install . && pip install -r requirements-dev.txt
@@ -99,34 +99,35 @@ stages:
         displayName: 'Push Nightly Docker Image'
 
         pool:
-          vmImage: 'Ubuntu-16.04'
+          vmImage: 'Ubuntu-18.04'
 
         steps:
-          - bash: |
-              printf -v TAG_DATE '%(%Y%m%d)T\n' -1
-              echo "##vso[task.setvariable variable=TAG_DATE]$TAG_DATE"
-
-          # C7N
-          - task: Docker@2
-            displayName: Build and Push C7N Nightly
+          - task: UsePythonVersion@0
             inputs:
-              command: buildAndPush
-              Dockerfile: Dockerfile
-              containerRegistry: dockerServiceConnection
-              repository: cloudcustodian/c7n
-              tags: |
-                nightly
-                $(TAG_DATE)-nightly
+              versionSpec: '3.8'
+              architecture: 'x64'
 
-          # Mailer
-          - task: Docker@2
-            displayName: Build and Push Mailer Nightly
+          - script: python -m pip install --upgrade pip && pip install click docker pytest
+            displayName: "Install Dependencies"
+
+	  - task: Docker@2
+            displayName: Login to Docker Hub
             inputs:
-              command: buildAndPush
-              Dockerfile: tools/c7n_mailer/Dockerfile
-              buildContext: $(Build.Repository.LocalPath)
+              command: login
               containerRegistry: dockerServiceConnection
-              repository: cloudcustodian/mailer
-              tags: |
-                nightly
-                $(TAG_DATE)-nightly
+
+          # cli
+          - script: python tools/dev/dockerpkg --test --push --tag nightly -r cloudcustodian -i cli -i cli-distroless 
+            displayName: build, test, push custodian cli nightlies
+
+          # cli-org
+          - script: python tools/dev/dockerpkg --test --push --tag nightly -r cloudcustodian -i org -i org-distroless 
+            displayName: build, test, push custodian org nightlies
+
+          # mailer
+          - script: python tools/dev/dockerpkg --test --push --tag nightly -r cloudcustodian -i mailer -i mailer-distroless 
+            displayName: build, test, push custodian mailer nightlies
+
+          # mailer
+          - script: python tools/dev/dockerpkg --test --push --tag nightly -r cloudcustodian -i policystream -i policystream-distroless
+            displayName: build, test, push custodian policystream nightlies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,25 +93,25 @@ jobs:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --test --scan --push  -r cloudcustodian -i cli-distroless
+          python tools/dev/dockerpkg.py build --test --scan --push -t dev -r cloudcustodian -i cli-distroless
 
       - name: org - distroless
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --test --scan --push -r cloudcustodian -i org-distroless
+          python tools/dev/dockerpkg.py build --test --scan --push -t dev -r cloudcustodian -i org-distroless
 
       - name: mailer - distroless
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --test --scan --push -r cloudcustodian -i mailer-distroless
+          python tools/dev/dockerpkg.py build --test --scan --push -t dev -r cloudcustodian -i mailer-distroless
 
       - name: policystream - distroless
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --test --scan --push -r cloudcustodian -i policystream-distroless
+          python tools/dev/dockerpkg.py build --test --scan --push -t dev -r cloudcustodian -i policystream-distroless

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    tags:
+      # todo: update for 1.0
+      - 0.*
 
 jobs:
 
@@ -38,28 +41,28 @@ jobs:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --scan --test -r cloudcustodian -i cli
+          python tools/dev/dockerpkg.py build --test --scan --push -t auto -r cloudcustodian -i cli
 
       - name: org
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --scan --test -r cloudcustodian -i org
+          python tools/dev/dockerpkg.py build --test --scan --push -t auto -r cloudcustodian -i org
 
       - name: mailer
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --scan --test -r cloudcustodian -i mailer
+          python tools/dev/dockerpkg.py build --test --scan --push -t auto -r cloudcustodian -i mailer
 
       - name: policystream
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --scan --test -r cloudcustodian -i policystream
+          python tools/dev/dockerpkg.py build --test --scan --push -t auto -r cloudcustodian -i policystream
 
 
   "Publish_Distroless":
@@ -93,25 +96,25 @@ jobs:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --test --scan --push -t dev -r cloudcustodian -i cli-distroless
+          python tools/dev/dockerpkg.py build --test --scan --push -t auto -r cloudcustodian -i cli-distroless
 
       - name: org - distroless
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --test --scan --push -t dev -r cloudcustodian -i org-distroless
+          python tools/dev/dockerpkg.py build --test --scan --push -t auto -r cloudcustodian -i org-distroless
 
       - name: mailer - distroless
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --test --scan --push -t dev -r cloudcustodian -i mailer-distroless
+          python tools/dev/dockerpkg.py build --test --scan --push -t auto -r cloudcustodian -i mailer-distroless
 
       - name: policystream - distroless
         env:
           HUB_USER: c7nbuild
           HUB_TOKEN: ${{ secrets.DOCKER_CI_HUB_TOKEN }}
         run: |
-          python tools/dev/dockerpkg.py build --test --scan --push -t dev -r cloudcustodian -i policystream-distroless
+          python tools/dev/dockerpkg.py build --test --scan --push -t auto -r cloudcustodian -i policystream-distroless

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@
 -e tools/c7n_org
 
 # we don't export dev requirements of subpackages (due to editable/distribution above)
-# so explicitly list them here.
+# so explicitly list them here..
 vcrpy-unittest==0.1.7
 parameterized==0.7.1
 fakeredis==1.2.1

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -364,7 +364,7 @@ def get_github_env():
 
 
 def get_git_env():
-    return {'sha': subprocess.check_output(['git', 'rev-parse', 'HEAD'])}
+    return {'sha': subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf8')}
 
 
 def get_image_repo_tags(image, registries, tags):

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -364,8 +364,10 @@ def get_github_env():
 
 
 def get_git_env():
-    return {"sha": subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf8"),
-            "repository": "https://github.com/cloud-custodian/cloud-custodian"}
+    return {
+        "sha": subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf8"),
+        "repository": "https://github.com/cloud-custodian/cloud-custodian",
+    }
 
 
 def get_image_repo_tags(image, registries, tags):

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -362,8 +362,9 @@ def get_github_env():
         if v
     }
 
+
 def get_git_env():
-    return {'sha': subprocess.check_output(['git', 'rev-parse', 'head'])}
+    return {'sha': subprocess.check_output(['git', 'rev-parse', 'HEAD'])}
 
 
 def get_image_repo_tags(image, registries, tags):

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -422,6 +422,7 @@ def get_env_tags(cli_tag):
             image_tags.append(rvalue)
 
     if cli_tag == 'nightly':
+        image_tags.append(cli_tag)
         image_tags.append(datetime.utcnow().strftime("%Y-%m-%d"))
 
     if cli_tag not in ('nightly', 'auto'):

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -385,8 +385,9 @@ def get_env_tags():
     image_tags = []
     hub_env = get_github_env()
 
-    if "sha" in hub_env:
-        image_tags.append("sha-{}".format(hub_env["sha"][:7]))
+    # sha alias are overkill
+    # if "sha" in hub_env:
+    #    image_tags.append("sha-{}".format(hub_env["sha"][:7]))
 
     image_tags.append(datetime.utcnow().strftime("%Y-%m-%d"))
 

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -411,21 +411,21 @@ def get_env_tags(cli_tag):
     image_tags = []
     hub_env = get_github_env()
 
-    if "ref" in hub_env and cli_tag == 'auto':
+    if "ref" in hub_env and cli_tag == "auto":
         _, rtype, rvalue = hub_env["ref"].split("/", 2)
         if rtype == "tags":
             image_tags.append("latest")
             image_tags.append(rvalue)
         elif rtype == "heads" and rvalue == "master":
             image_tags.append("dev")
-        elif rtype == "heads": # branch
+        elif rtype == "heads":  # branch
             image_tags.append(rvalue)
 
-    if cli_tag == 'nightly':
+    if cli_tag == "nightly":
         image_tags.append(cli_tag)
         image_tags.append(datetime.utcnow().strftime("%Y-%m-%d"))
 
-    if cli_tag not in ('nightly', 'auto'):
+    if cli_tag not in ("nightly", "auto"):
         image_tags = [cli_tag]
 
     return list(filter(None, image_tags))

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -248,7 +248,7 @@ def cli():
     slices, dices, and blends :-)
     """
     logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s:%(name)s:%(levelname)s %(message)s"
+        level=logging.INFO, format="%(asctime)s:%(levelname)s %(message)s"
     )
     logging.getLogger("docker").setLevel(logging.INFO)
     logging.getLogger("urllib3").setLevel(logging.INFO)


### PR DESCRIPTION
so the intent is that after this, and disabling the docker hub builds we'll end up with this publishing matrix

|name|label|frequency|mutability|testing|
|----|-----|---------|----------|-------|
|c7n |latest|release|mutable|light-functional|
|c7n |0.9.1|release|immutable|light-functional|
|c7n |nightly|daily|mutable|functional|
|c7n |2020-04-01|daily|immutable|functional|
|c7n |dev|per-commit|mutable|light-functional|
|c7n |distroless-dev|per-commit|mutable|light-functional|
|c7n |distroless-latest|release|mutable|functional|
|c7n |distroless-2020-04-01|daily|immutable|functional|
|c7n |distroless-0.9.1|release|immutable|light-functional|


its a bit odd that we're not able to do full functional testing on the the release images, but their currently triggered from azure-pipelines on a schedule, I'm going to leave that as a followup to explore.

wrt to changes in this pr

dockerpkg
- will use env vars for login if present
- use git cli for sha sans github env vars
- fail on errors to login or push
- no more per commit sha image tags, advice to users is to use the last daily or dev.
- [x] given -t nightly append daily format, else omit date tag.

test_docker
- check for standard image labels present

azure pipeline functional
 - refactor to use dockerpkg to publish

GitHub action docker workflow
 - [x] publish dev builds on distro based images
 - publish only dev builds on distroless images 
 - [x] trigger on tag push for release images
