### PR TITLE
aws.glue-catalog | cross-account filter

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -20,7 +20,7 @@ from c7n.utils import local_session, chunks, type_schema
 from c7n.actions import BaseAction, ActionRegistry
 from c7n.filters.vpc import SubnetFilter, SecurityGroupFilter
 from c7n.tags import universal_augment
-from c7n.filters import StateTransitionFilter, FilterRegistry
+from c7n.filters import StateTransitionFilter, FilterRegistry, CrossAccountAccessFilter
 from c7n import query, utils
 from c7n.resources.account import GlueCatalogEncryptionEnabled
 
@@ -516,3 +516,37 @@ class GlueCatalogEncryptionFilter(GlueCatalogEncryptionEnabled):
               SseAwsKmsKeyId: alias/aws/glue
 
     """
+
+
+@GlueDataCatalog.filter_registry.register('cross-account')
+class GlueCatalogCrossAccount(CrossAccountAccessFilter):
+    """Filter glue catalog if its has cross account permissions
+
+    :example:
+
+    .. code-block:: yaml
+
+      policies:
+        - name: catalog-cross-account
+          resource: aws.glue-catalog
+          filters:
+            - type: cross-account
+
+    """
+    permissions = ('glue:GetResourcePolicy',)
+    policy_annotation = "c7n:AccessPolicy"
+
+    def get_resource_policy(self, r):
+        client = local_session(self.manager.session_factory).client('glue')
+        if self.policy_annotation in r:
+            return r[self.policy_annotation]
+        try:
+            policy = client.get_resource_policy().get('PolicyInJson')
+        except client.exceptions.EntityNotFoundException:
+            policy = {}
+        r[self.policy_annotation] = policy
+        return policy
+
+    def __call__(self, r):
+        if self.get_resource_policy(r):
+            return True

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -520,7 +520,7 @@ class GlueCatalogEncryptionFilter(GlueCatalogEncryptionEnabled):
 
 @GlueDataCatalog.filter_registry.register('cross-account')
 class GlueCatalogCrossAccount(CrossAccountAccessFilter):
-    """Filter glue catalog if its has cross account permissions
+    """Filter glue catalog if it has cross account permissions
 
     :example:
 

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -546,7 +546,3 @@ class GlueCatalogCrossAccount(CrossAccountAccessFilter):
             policy = {}
         r[self.policy_annotation] = policy
         return policy
-
-    def __call__(self, r):
-        if self.get_resource_policy(r):
-            return True

--- a/tests/data/placebo/test_glue_catalog_cross_account/glue.GetDataCatalogEncryptionSettings_1.json
+++ b/tests/data/placebo/test_glue_catalog_cross_account/glue.GetDataCatalogEncryptionSettings_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "DataCatalogEncryptionSettings": {
+            "EncryptionAtRest": {
+                "CatalogEncryptionMode": "DISABLED"
+            },
+            "ConnectionPasswordEncryption": {
+                "ReturnConnectionPasswordEncrypted": false
+            }
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_catalog_cross_account/glue.GetResourcePolicy_1.json
+++ b/tests/data/placebo/test_glue_catalog_cross_account/glue.GetResourcePolicy_1.json
@@ -1,27 +1,27 @@
 {
     "status_code": 200,
     "data": {
-        "PolicyInJson": "{\n  \"Version\" : \"2012-10-17\",\n  \"Statement\" : [ {\n    \"Effect\" : \"Allow\",\n    \"Principal\" : {\n      \"AWS\" : \"arn:aws:iam::644160558196:root\"\n    },\n    \"Action\" : \"glue:CreateTable\",\n    \"Resource\" : \"arn:aws:glue:us-east-1:644160558196:catalog\"\n  } ]\n}",
-        "PolicyHash": "aJFpcO9vM7z/blt/6znr+Q==",
+        "PolicyInJson": "{\n  \"Version\" : \"2012-10-17\",\n  \"Statement\" : [ {\n    \"Effect\" : \"Allow\",\n    \"Principal\" : {\n      \"AWS\" : \"arn:aws:iam::123123456789:root\"\n    },\n    \"Action\" : \"glue:CreateTable\",\n    \"Resource\" : \"arn:aws:glue:us-east-1:644160558196:catalog\"\n  } ]\n}",
+        "PolicyHash": "AhFmtdamgfkG6spl26TP2w==",
         "CreateTime": {
             "__class__": "datetime",
             "year": 2020,
             "month": 4,
             "day": 20,
             "hour": 12,
-            "minute": 21,
-            "second": 11,
-            "microsecond": 592000
+            "minute": 55,
+            "second": 36,
+            "microsecond": 887000
         },
         "UpdateTime": {
             "__class__": "datetime",
             "year": 2020,
             "month": 4,
             "day": 20,
-            "hour": 12,
-            "minute": 27,
-            "second": 26,
-            "microsecond": 109000
+            "hour": 14,
+            "minute": 30,
+            "second": 7,
+            "microsecond": 111000
         },
         "ResponseMetadata": {}
     }

--- a/tests/data/placebo/test_glue_catalog_cross_account/glue.GetResourcePolicy_1.json
+++ b/tests/data/placebo/test_glue_catalog_cross_account/glue.GetResourcePolicy_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "PolicyInJson": "{\n  \"Version\" : \"2012-10-17\",\n  \"Statement\" : [ {\n    \"Effect\" : \"Allow\",\n    \"Principal\" : {\n      \"AWS\" : \"arn:aws:iam::644160558196:root\"\n    },\n    \"Action\" : \"glue:CreateTable\",\n    \"Resource\" : \"arn:aws:glue:us-east-1:644160558196:catalog\"\n  } ]\n}",
+        "PolicyHash": "aJFpcO9vM7z/blt/6znr+Q==",
+        "CreateTime": {
+            "__class__": "datetime",
+            "year": 2020,
+            "month": 4,
+            "day": 20,
+            "hour": 12,
+            "minute": 21,
+            "second": 11,
+            "microsecond": 592000
+        },
+        "UpdateTime": {
+            "__class__": "datetime",
+            "year": 2020,
+            "month": 4,
+            "day": 20,
+            "hour": 12,
+            "minute": 27,
+            "second": 26,
+            "microsecond": 109000
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -484,3 +484,16 @@ class TestGlueDataCatalog(BaseTest):
         self.assertEqual(datacatlog.get('DataCatalogEncryptionSettings').get(
             'EncryptionAtRest'),
             {'CatalogEncryptionMode': 'SSE-KMS', 'SseAwsKmsKeyId': 'alias/skunk/glue/encrypted'})
+
+    def test_glue_catalog_cross_account(self):
+        session_factory = self.replay_flight_data("test_glue_catalog_cross_account")
+        p = self.load_policy(
+            {
+                "name": "glue-catalog-cross-account",
+                "resource": "glue-catalog",
+                "filters": [{"type": "cross-account"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
This PR adds supports for cross-account filter for glue-catalog resource

Gets resource policy using get_resource_policy() and uses `CrossAccountAccessFilter` to evaluate the policy
