### PR TITLE
aws - elasticip - use allocation id for filtering

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1866,7 +1866,7 @@ class NetworkAddress(query.QueryResourceManager):
         enum_spec = ('describe_addresses', 'Addresses', None)
         name = 'PublicIp'
         id = 'AllocationId'
-        filter_name = 'PublicIps'
+        filter_name = 'AllocationId'
         filter_type = 'list'
         config_type = "AWS::EC2::EIP"
 


### PR DESCRIPTION
closes #5069
﻿
