### PR TITLE
releng - dockerpkg -t option

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -48,5 +48,5 @@ jobs:
       pip install docker click pytest pyyaml
   # build a docker image and sanity test
   - script: |
-      python tools/dev/dockerpkg.py build --verbose --test -i cli-distroless
+      python tools/dev/dockerpkg.py build -t build --verbose --test -i cli-distroless
 

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -269,7 +269,7 @@ def cli():
 @click.option(
     "-r", "--registry", multiple=True, help="Registries for image repo on tag and push"
 )
-@click.option("--tag", help="Static tag for the image")
+@click.option("-t", "--tag", help="Static tag for the image")
 @click.option("--push", is_flag=True, help="Push images to registries")
 @click.option(
     "--test", help="Run lightweight functional tests with image", is_flag=True


### PR DESCRIPTION
oops.. updated builds to use -t short form tag option, but twas missing in dockerpkg cli.