### PR TITLE
AWS - Emr security-configuration resource

### DIFF
--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -301,7 +301,7 @@ class EMRSecurityConfiguration(QueryResourceManager):
         id = name = 'Name'
 
     permissions = ('elasticmapreduce:ListSecurityConfigurations',
-                  'elasticmapreduce:DescirbeSecurityConfiguration',)
+                  'elasticmapreduce:DescribeSecurityConfiguration',)
 
     def augment(self, resources):
 
@@ -319,7 +319,7 @@ class EMRSecurityConfiguration(QueryResourceManager):
 class DeleteEMRSecurityConfiguration(BaseAction):
 
     schema = type_schema('delete')
-    permissions = ('emr:DeleteSecurityConfiguration',)
+    permissions = ('elasticmapreduce:DeleteSecurityConfiguration',)
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('emr')

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -295,6 +295,7 @@ class EMRSecurityConfiguration(QueryResourceManager):
     class resource_type(TypeInfo):
         service = 'emr'
         arn_type = 'emr'
+        permission_prefix = 'elasticmapreduce'
         enum_spec = ('list_security_configurations', 'SecurityConfigurations', None)
         detail_spec = ('describe_security_configuration', 'Name', 'Name', None)
         id = name = 'Name'

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -299,7 +299,7 @@ class EMRSecurityConfiguration(QueryResourceManager):
         detail_spec = ('describe_security_configuration', 'Name', 'Name', None)
         id = name = 'Name'
 
-    permissions = ('emr:ListSecurityConfigurations','emr:DescirbeSecurityConfiguration')
+    permissions = ('emr:ListSecurityConfigurations', 'emr:DescirbeSecurityConfiguration',)
 
     def augment(self, resources):
 

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -311,7 +311,7 @@ class EMRSecurityConfiguration(QueryResourceManager):
             return r
 
         # Describe notebook-instance & then list tags
-        resources = super(EMRSecurityConfiguration, self).augment(resources)
+        resources = super().augment(resources)
         return list(map(_augment, resources))
 
 

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -284,3 +284,43 @@ class QueryFilter:
             value = [self.value]
 
         return {'Name': self.key, 'Values': value}
+
+@resources.register('emr-security-configuration')
+class EMRSecurityConfiguration(QueryResourceManager):
+    """Resource manager for Elastic MapReduce clusters
+    """
+
+    class resource_type(TypeInfo):
+        service = 'emr'
+        arn_type = 'emr'
+        enum_spec = ('list_security_configurations', 'SecurityConfigurations', None)
+        detail_spec = ('describe_security_confgiration', 'Name', None, None)
+        id = name = 'Name'
+
+@EMRSecurityConfiguration.action_registry.register('delete')
+class DeleteEMRSecurityConfiguration(BaseAction):
+
+    schema = type_schema('delete')
+    permissions = ('emr:DeleteSecurityConfiguration',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('emr')
+        for r in resources:
+            try:
+                client.delete_security_configuration(Name=r['Name'])
+            except client.exceptions.EntityNotFoundException:
+                continue
+
+@EMRSecurityConfiguration.action_registry.register('delete')
+class DeleteEMRSecurityConfiguration(BaseAction):
+
+    schema = type_schema('delete')
+    permissions = ('emr:DeleteSecurityConfiguration',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('emr')
+        for r in resources:
+            try:
+                client.delete_security_configuration(Name=r['Name'])
+            except client.exceptions.EntityNotFoundException:
+                continue

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -299,7 +299,8 @@ class EMRSecurityConfiguration(QueryResourceManager):
         detail_spec = ('describe_security_configuration', 'Name', 'Name', None)
         id = name = 'Name'
 
-    permissions = ('elasticmapreduce:ListSecurityConfigurations', 'elasticmapreduce:DescirbeSecurityConfiguration',)
+    permissions = ('elasticmapreduce:ListSecurityConfigurations',
+                  'elasticmapreduce:DescirbeSecurityConfiguration',)
 
     def augment(self, resources):
 

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -299,7 +299,7 @@ class EMRSecurityConfiguration(QueryResourceManager):
         detail_spec = ('describe_security_configuration', 'Name', 'Name', None)
         id = name = 'Name'
 
-    permissions = ('emr:ListSecurityConfigurations', 'emr:DescirbeSecurityConfiguration',)
+    permissions = ('elasticmapreduce:ListSecurityConfigurations', 'elasticmapreduce:DescirbeSecurityConfiguration',)
 
     def augment(self, resources):
 

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -286,6 +286,7 @@ class QueryFilter:
 
         return {'Name': self.key, 'Values': value}
 
+
 @resources.register('emr-security-configuration')
 class EMRSecurityConfiguration(QueryResourceManager):
     """Resource manager for Elastic MapReduce clusters
@@ -308,6 +309,7 @@ class EMRSecurityConfiguration(QueryResourceManager):
         # Describe notebook-instance & then list tags
         resources = super(EMRSecurityConfiguration, self).augment(resources)
         return list(map(_augment, resources))
+
 
 @EMRSecurityConfiguration.action_registry.register('delete')
 class DeleteEMRSecurityConfiguration(BaseAction):

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -289,7 +289,7 @@ class QueryFilter:
 
 @resources.register('emr-security-configuration')
 class EMRSecurityConfiguration(QueryResourceManager):
-    """Resource manager for Elastic MapReduce clusters
+    """Resource manager for EMR Security Configuration
     """
 
     class resource_type(TypeInfo):
@@ -298,6 +298,8 @@ class EMRSecurityConfiguration(QueryResourceManager):
         enum_spec = ('list_security_configurations', 'SecurityConfigurations', None)
         detail_spec = ('describe_security_configuration', 'Name', 'Name', None)
         id = name = 'Name'
+
+    permissions = ('emr:ListSecurityConfigurations','emr:DescirbeSecurityConfiguration')
 
     def augment(self, resources):
 

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -304,15 +304,10 @@ class EMRSecurityConfiguration(QueryResourceManager):
                   'elasticmapreduce:DescribeSecurityConfiguration',)
 
     def augment(self, resources):
-
-        def _augment(r):
-            # Convert the json string to dict
-            r['SecurityConfiguration'] = json.loads(r['SecurityConfiguration'])
-            return r
-
-        # Describe notebook-instance & then list tags
         resources = super().augment(resources)
-        return list(map(_augment, resources))
+        for r in resources:
+            r['SecurityConfiguration'] = json.loads(r['SecurityConfiguration'])
+        return resources
 
 
 @EMRSecurityConfiguration.action_registry.register('delete')

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -55,6 +55,7 @@ ResourceMap = {
     "aws.elasticsearch": "c7n.resources.elasticsearch.ElasticSearchDomain",
     "aws.elb": "c7n.resources.elb.ELB",
     "aws.emr": "c7n.resources.emr.EMRCluster",
+    "aws.emr-security-configuration": "c7n.resources.emr.EMRSecurityConfiguration",
     "aws.eni": "c7n.resources.vpc.NetworkInterface",
     "aws.event-rule": "c7n.resources.cw.EventRule",
     "aws.event-rule-target": "c7n.resources.cw.EventRuleTarget",

--- a/tests/data/placebo/test_emr_security_configuration/elasticmapreduce.DescribeSecurityConfiguration_1.json
+++ b/tests/data/placebo/test_emr_security_configuration/elasticmapreduce.DescribeSecurityConfiguration_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "Name": "test",
+        "SecurityConfiguration": "{\"EncryptionConfiguration\":{\"EnableInTransitEncryption\":false,\"EnableAtRestEncryption\":false}}",
+        "CreationDateTime": "2020-04-21T00:26:08.759000-04:00",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration/elasticmapreduce.ListSecurityConfigurations_1.json
+++ b/tests/data/placebo/test_emr_security_configuration/elasticmapreduce.ListSecurityConfigurations_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityConfigurations": [
+            {
+                "Name": "test",
+                "CreationDateTime": "2020-04-21T00:26:08.759000-04:00"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_delete/elasticmapreduce.DeleteSecurityConfiguration_1.json
+++ b/tests/data/placebo/test_emr_security_configuration_delete/elasticmapreduce.DeleteSecurityConfiguration_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_delete/elasticmapreduce.DescribeSecurityConfiguration_1.json
+++ b/tests/data/placebo/test_emr_security_configuration_delete/elasticmapreduce.DescribeSecurityConfiguration_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "Name": "test",
+        "SecurityConfiguration": "{\"EncryptionConfiguration\":{\"EnableInTransitEncryption\":false,\"EnableAtRestEncryption\":false}}",
+        "CreationDateTime": "2020-04-21T00:26:08.759000-04:00",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_delete/elasticmapreduce.ListSecurityConfigurations_1.json
+++ b/tests/data/placebo/test_emr_security_configuration_delete/elasticmapreduce.ListSecurityConfigurations_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityConfigurations": [
+            {
+                "Name": "test",
+                "CreationDateTime": "2020-04-21T00:26:08.759000-04:00"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_delete/elasticmapreduce.ListSecurityConfigurations_2.json
+++ b/tests/data/placebo/test_emr_security_configuration_delete/elasticmapreduce.ListSecurityConfigurations_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityConfigurations": [],
+        "ResponseMetadata": {}
+    }
+}


### PR DESCRIPTION
Create a new EMR security configuration resource to filter for EMR security configurations, for example to check ones that do not have encryption fields enabled. 