### PR TITLE
aws - asg - null launch template

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -121,12 +121,12 @@ class LaunchInfo:
 
         lid = asg.get('LaunchTemplate')
         if lid is not None:
-            return (lid['LaunchTemplateId'], lid['Version'])
+            return (lid['LaunchTemplateId'], lid.get('Version', '$Default'))
 
         if 'MixedInstancesPolicy' in asg:
             mip_spec = asg['MixedInstancesPolicy'][
                 'LaunchTemplate']['LaunchTemplateSpecification']
-            return (mip_spec['LaunchTemplateId'], mip_spec['Version'])
+            return (mip_spec['LaunchTemplateId'], mip_spec.get('Version', '$Default'))
 
         # we've noticed some corner cases where the asg name is the lc name, but not
         # explicitly specified as launchconfiguration attribute.

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -2112,7 +2112,7 @@ class LaunchTemplate(query.QueryResourceManager):
                 continue
             templates.setdefault(
                 (t['LaunchTemplateId'],
-                 t.get('Version', None)), []).append(a['AutoScalingGroupName'])
+                 t.get('Version', '$Default')), []).append(a['AutoScalingGroupName'])
         return templates
 
 


### PR DESCRIPTION
Handle a condition when a launch template version is not configured, it defaults to $Default behind the scenes so adjusting to be accurate locally as per the docs and avoid any KeyErrors.

> The version number, $Latest , or $Default . If the value is $Latest , Amazon EC2 Auto Scaling selects the latest version of the launch template when launching instances. If the value is $Default , Amazon EC2 Auto Scaling selects the default version of the launch template when launching instances. The default value is $Default

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/autoscaling.html