### PR TITLE
Use set comprehensions directly when creating a set

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -297,7 +297,7 @@ def report(options, policies):
         log.error('Error: must supply at least one policy')
         sys.exit(1)
 
-    resources = set([p.resource_type for p in policies])
+    resources = {p.resource_type for p in policies}
     if len(resources) > 1:
         log.error('Error: Report subcommand can accept multiple policies, '
                   'but they must all be for the same resource.')

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -320,7 +320,7 @@ class Not(BooleanGroupFilter):
                 break
 
         before = set(resource_map.keys())
-        after = set([r[rtype_id] for r in resources])
+        after = {r[rtype_id] for r in resources}
         results = before - after
         sweeper.sweep([])
 

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -63,8 +63,8 @@ log = logging.getLogger('custodian.reports')
 
 def report(policies, start_date, options, output_fh, raw_output_fh=None):
     """Format a policy's extant records into a report."""
-    regions = set([p.options.region for p in policies])
-    policy_names = set([p.name for p in policies])
+    regions = {p.options.region for p in policies}
+    policy_names = {p.name for p in policies}
     formatter = Formatter(
         policies[0].resource_manager.resource_type,
         extra_fields=options.field,

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -597,7 +597,7 @@ class ServiceLimit(Filter):
     # Max wait here is 5 * 10 ~ 50 seconds.
     poll_interval = 5
     poll_max_intervals = 10
-    global_services = set(['IAM'])
+    global_services = {'IAM'}
 
     def validate(self):
         region = self.manager.data.get('region', '')

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -300,7 +300,7 @@ class ImageUnusedFilter(Filter):
 
     def _pull_ec2_images(self):
         ec2_manager = self.manager.get_resource_manager('ec2')
-        return set([i['ImageId'] for i in ec2_manager.resources()])
+        return {i['ImageId'] for i in ec2_manager.resources()}
 
     def process(self, resources, event=None):
         images = self._pull_ec2_images().union(self._pull_asg_images())

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -270,23 +270,23 @@ class ConfigValidFilter(Filter):
 
     def get_subnets(self):
         manager = self.manager.get_resource_manager('subnet')
-        return set([s['SubnetId'] for s in manager.resources()])
+        return {s['SubnetId'] for s in manager.resources()}
 
     def get_security_groups(self):
         manager = self.manager.get_resource_manager('security-group')
-        return set([s['GroupId'] for s in manager.resources()])
+        return {s['GroupId'] for s in manager.resources()}
 
     def get_key_pairs(self):
         manager = self.manager.get_resource_manager('key-pair')
-        return set([k['KeyName'] for k in manager.resources()])
+        return {k['KeyName'] for k in manager.resources()}
 
     def get_elbs(self):
         manager = self.manager.get_resource_manager('elb')
-        return set([e['LoadBalancerName'] for e in manager.resources()])
+        return {e['LoadBalancerName'] for e in manager.resources()}
 
     def get_appelb_target_groups(self):
         manager = self.manager.get_resource_manager('app-elb-target-group')
-        return set([a['TargetGroupArn'] for a in manager.resources()])
+        return {a['TargetGroupArn'] for a in manager.resources()}
 
     def get_images(self):
         images = self.launch_info.get_image_map()
@@ -310,9 +310,8 @@ class ConfigValidFilter(Filter):
                     continue
                 snaps.add(bd['Ebs']['SnapshotId'].strip())
         manager = self.manager.get_resource_manager('ebs-snapshot')
-        return set([
-            s['SnapshotId'] for s in manager.get_resources(
-                list(snaps), cache=False)])
+        return {s['SnapshotId'] for s in manager.get_resources(
+                list(snaps), cache=False)}
 
     def process(self, asgs, event=None):
         self.initialize(asgs)
@@ -1680,9 +1679,8 @@ class UnusedLaunchConfig(Filter):
 
     def process(self, configs, event=None):
         asgs = self.manager.get_resource_manager('asg').resources()
-        used = set([
-            a.get('LaunchConfigurationName', a['AutoScalingGroupName'])
-            for a in asgs if not a.get('LaunchTemplate')])
+        used = {a.get('LaunchConfigurationName', a['AutoScalingGroupName'])
+                for a in asgs if not a.get('LaunchTemplate')}
         return [c for c in configs if c['LaunchConfigurationName'] not in used]
 
 

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -603,12 +603,12 @@ class AWS(Provider):
         service_region_map, resource_service_map = get_service_region_map(
             options.regions, policy_collection.resource_types)
         if 'all' in options.regions:
-            enabled_regions = set([
+            enabled_regions = {
                 r['RegionName'] for r in
                 get_profile_session(options).client('ec2').describe_regions(
                     Filters=[{'Name': 'opt-in-status',
                               'Values': ['opt-in-not-required', 'opted-in']}]
-                ).get('Regions')])
+                ).get('Regions')}
         for p in policy_collection:
             if 'aws.' in p.resource_type:
                 _, resource_type = p.resource_type.split('.', 1)

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1454,9 +1454,8 @@ class UnusedRDSSubnetGroup(Filter):
 
     def process(self, configs, event=None):
         rds = self.manager.get_resource_manager('rds').resources()
-        self.used = set([
-            r.get('DBSubnetGroupName', r['DBInstanceIdentifier'])
-            for r in rds])
+        self.used = {r.get('DBSubnetGroupName', r['DBInstanceIdentifier'])
+                     for r in rds}
         return super(UnusedRDSSubnetGroup, self).process(configs)
 
     def __call__(self, config):

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1724,7 +1724,7 @@ class AttachLambdaEncrypt(BucketActionBase):
             None, self.data.get('role', self.manager.config.assume_role),
             account_id=account_id, tags=self.data.get('tags'))
 
-        regions = set([get_region(b) for b in buckets])
+        regions = {get_region(b) for b in buckets}
 
         # session managers by region
         region_sessions = {}
@@ -2393,7 +2393,7 @@ class LogTarget(Filter):
     def get_cloud_trail_locations(self, buckets):
         session = local_session(self.manager.session_factory)
         client = session.client('cloudtrail')
-        names = set([b['Name'] for b in buckets])
+        names = {b['Name'] for b in buckets}
         for t in client.describe_trails().get('trailList', ()):
             if t.get('S3BucketName') in names:
                 yield (t['S3BucketName'], t.get('S3KeyPrefix', ''))

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -834,7 +834,7 @@ class UsedSecurityGroup(SGUsage):
         unused = [
             r for r in resources
             if r['GroupId'] not in used and 'VpcId' in r]
-        unused = set([g['GroupId'] for g in self.filter_peered_refs(unused)])
+        unused = {g['GroupId'] for g in self.filter_peered_refs(unused)}
         return [r for r in resources if r['GroupId'] not in unused]
 
 
@@ -863,7 +863,7 @@ class Stale(Filter):
 
     def process(self, resources, event=None):
         client = local_session(self.manager.session_factory).client('ec2')
-        vpc_ids = set([r['VpcId'] for r in resources if 'VpcId' in r])
+        vpc_ids = {r['VpcId'] for r in resources if 'VpcId' in r}
         group_map = {r['GroupId']: r for r in resources}
         results = []
         self.log.debug("Querying %d vpc for stale refs", len(vpc_ids))

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -286,9 +286,8 @@ def generate(resource_types=()):
                 if not resource_type.type_aliases:
                     continue
                 # atm only azure is using type aliases.
-                elif not set([
-                        "%s.%s" % (cloud_name, ralias) for ralias
-                        in resource_type.type_aliases]).intersection(
+                elif not {"%s.%s" % (cloud_name, ralias) for ralias
+                          in resource_type.type_aliases}.intersection(
                             resource_types):
                     continue
 

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -287,8 +287,8 @@ def generate(resource_types=()):
                     continue
                 # atm only azure is using type aliases.
                 elif not {"%s.%s" % (cloud_name, ralias) for ralias
-                          in resource_type.type_aliases}.intersection(
-                            resource_types):
+                        in resource_type.type_aliases}.intersection(
+                        resource_types):
                     continue
 
             aliases = []

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -1017,7 +1017,7 @@ class CopyRelatedResourceTag(Tag):
         for rrid, r in zip(jmespath.search('[].[%s]' % self.data['key'], resources),
                            resources):
             related_resources.append((rrid[0], r))
-        related_ids = set([r[0] for r in related_resources])
+        related_ids = {r[0] for r in related_resources}
         missing = False
         if None in related_ids:
             missing = True
@@ -1170,20 +1170,20 @@ def coalesce_copy_user_tags(resource, copy_tags, user_tags):
 
     if isinstance(copy_tags, list):
         if '*' in copy_tags:
-            copy_keys = set([t['Key'] for t in r_tags])
+            copy_keys = {t['Key'] for t in r_tags}
         else:
             copy_keys = set(copy_tags)
 
     if isinstance(copy_tags, bool):
         if copy_tags is True:
-            copy_keys = set([t['Key'] for t in r_tags])
+            copy_keys = {t['Key'] for t in r_tags}
         else:
             copy_keys = set()
 
     if isinstance(user_tags, dict):
         user_tags = [{'Key': k, 'Value': v} for k, v in user_tags.items()]
 
-    user_keys = set([t['Key'] for t in user_tags])
+    user_keys = {t['Key'] for t in user_tags}
     tags_diff = list(copy_keys.difference(user_keys))
     resource_tags_to_copy = [t for t in r_tags if t['Key'] in tags_diff]
     user_tags.extend(resource_tags_to_copy)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -390,16 +390,16 @@ class AccountTests(BaseTest):
             resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(
-            set([l["service"] for l in resources[0]["c7n:ServiceLimitsExceeded"]]),
-            set(["RDS"]),
+            {l["service"] for l in resources[0]["c7n:ServiceLimitsExceeded"]},
+            {"RDS"},
         )
         self.assertEqual(
-            set([l["region"] for l in resources[0]["c7n:ServiceLimitsExceeded"]]),
-            set(["us-east-1"]),
+            {l["region"] for l in resources[0]["c7n:ServiceLimitsExceeded"]},
+            {"us-east-1"},
         )
         self.assertEqual(
-            set([l["check"] for l in resources[0]["c7n:ServiceLimitsExceeded"]]),
-            set(["DB instances"]),
+            {l["check"] for l in resources[0]["c7n:ServiceLimitsExceeded"]},
+            {"DB instances"},
         )
         self.assertEqual(len(resources[0]["c7n:ServiceLimitsExceeded"]), 1)
 
@@ -421,8 +421,8 @@ class AccountTests(BaseTest):
             resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(
-            set([l["service"] for l in resources[0]["c7n:ServiceLimitsExceeded"]]),
-            set(["IAM"]),
+            {l["service"] for l in resources[0]["c7n:ServiceLimitsExceeded"]},
+            {"IAM"},
         )
         self.assertEqual(len(resources[0]["c7n:ServiceLimitsExceeded"]), 2)
 
@@ -965,7 +965,7 @@ class AccountDataEvents(BaseTest):
     def make_bucket(self, session_factory, name):
         client = session_factory().client("s3")
 
-        buckets = set([b["Name"] for b in client.list_buckets()["Buckets"]])
+        buckets = {b["Name"] for b in client.list_buckets()["Buckets"]}
         if name in buckets:
             self.destroyBucket(client, name)
 

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -645,7 +645,7 @@ class AutoScalingTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
-        s = set([x[0] for x in resources[0]["Invalid"]])
+        s = {x[0] for x in resources[0]["Invalid"]}
         self.assertTrue("invalid-subnet" in s)
         self.assertTrue("invalid-security-group" in s)
 

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -339,7 +339,7 @@ class TestEcsTask(BaseTest):
         self.assertEqual(len(resources), 2)
         client = session_factory().client("ecs")
         tasks = client.list_tasks(cluster=resources[0]["clusterArn"])["taskArns"]
-        self.assertFalse(set([r["taskArn"] for r in resources]).intersection(tasks))
+        self.assertFalse({r["taskArn"] for r in resources}.intersection(tasks))
 
 
 class TestEcsContainerInstance(BaseTest):

--- a/tests/test_elb.py
+++ b/tests/test_elb.py
@@ -170,7 +170,7 @@ class HealthCheckProtocolMismatchTest(BaseTest):
         self.assertEqual(len(resources), 3)
 
         # make sure we matched the right load balcners
-        elb_names = set([elb["LoadBalancerName"] for elb in resources])
+        elb_names = {elb["LoadBalancerName"] for elb in resources}
         self.assertEqual(
             elb_names,
             set(

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1525,14 +1525,14 @@ class CrossAccountChecker(TestCase):
             ],
         }
 
-        checker = PolicyChecker({"allowed_accounts": set(["221800032964"])})
+        checker = PolicyChecker({"allowed_accounts": {"221800032964"}})
 
         self.assertTrue(bool(checker.check(policy)))
 
     def test_sqs_policies(self):
         policies = load_data("iam/sqs-policies.json")
 
-        checker = PolicyChecker({"allowed_accounts": set(["221800032964"])})
+        checker = PolicyChecker({"allowed_accounts": {"221800032964"}})
         for p, expected in zip(
             policies, [False, True, True, False, False, False, False, False]
         ):
@@ -1543,9 +1543,9 @@ class CrossAccountChecker(TestCase):
         policies = load_data("iam/s3-policies.json")
         checker = PolicyChecker(
             {
-                "allowed_accounts": set(["123456789012"]),
-                "allowed_vpc": set(["vpc-12345678"]),
-                "allowed_vpce": set(["vpce-12345678", "vpce-87654321"]),
+                "allowed_accounts": {"123456789012"},
+                "allowed_vpc": {"vpc-12345678"},
+                "allowed_vpce": {"vpce-12345678", "vpce-87654321"},
             }
         )
         for p, expected in zip(
@@ -1572,7 +1572,7 @@ class CrossAccountChecker(TestCase):
 
     def test_s3_policies_vpc(self):
         policies = load_data("iam/s3-policies.json")
-        checker = PolicyChecker({"allowed_accounts": set(["123456789012"])})
+        checker = PolicyChecker({"allowed_accounts": {"123456789012"}})
         for p, expected in zip(
             policies,
             [
@@ -1599,8 +1599,8 @@ class CrossAccountChecker(TestCase):
         policies = load_data("iam/s3-conditions.json")
         checker = PolicyChecker(
             {
-                "allowed_accounts": set(["123456789012"]),
-                "allowed_vpc": set(["vpc-12345678"]),
+                "allowed_accounts": {"123456789012"},
+                "allowed_vpc": {"vpc-12345678"},
             }
         )
         for p, expected in zip(policies, [False, True]):
@@ -1618,7 +1618,7 @@ class CrossAccountChecker(TestCase):
         policies = load_data("iam/s3-orgid.json")
         checker = PolicyChecker(
             {
-                "allowed_orgid": set(["o-goodorg"])
+                "allowed_orgid": {"o-goodorg"}
             }
         )
         for p, expected in zip(policies, [False, True]):

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -300,7 +300,7 @@ class LambdaTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 2)
         self.assertEqual(
-            {r["c7n:EventSources"][0] for r in resources}, set(["iot.amazonaws.com"])
+            {r["c7n:EventSources"][0] for r in resources}, {"iot.amazonaws.com"}
         )
 
     def test_sg_filter(self):

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -54,8 +54,7 @@ def test_generate_requirements():
     for l in lines.split('\n'):
         pkg_name, version = l.split('==')
         packages.append(pkg_name)
-    assert set(packages) == set([
-        'botocore', 'jmespath', 'python-dateutil'])
+    assert set(packages) == {'botocore', 'jmespath', 'python-dateutil'}
 
 
 class Publish(BaseTest):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -545,7 +545,7 @@ class BucketDelete(BaseTest):
 
         session = session_factory()
         client = session.client("s3")
-        buckets = set([b["Name"] for b in client.list_buckets()["Buckets"]])
+        buckets = {b["Name"] for b in client.list_buckets()["Buckets"]}
         self.assertFalse(bname in buckets)
 
     @functional
@@ -595,7 +595,7 @@ class BucketDelete(BaseTest):
         if self.recording:
             time.sleep(60)
         self.assertEqual(len(resources), 1)
-        buckets = set([b["Name"] for b in client.list_buckets()["Buckets"]])
+        buckets = {b["Name"] for b in client.list_buckets()["Buckets"]}
         self.assertFalse(bname in buckets)
 
     @functional
@@ -626,7 +626,7 @@ class BucketDelete(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        buckets = set([b["Name"] for b in client.list_buckets()["Buckets"]])
+        buckets = {b["Name"] for b in client.list_buckets()["Buckets"]}
         self.assertFalse(bname in buckets)
 
     def test_delete_bucket_with_failure(self):
@@ -669,7 +669,7 @@ class BucketDelete(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        buckets = set([b["Name"] for b in client.list_buckets()["Buckets"]])
+        buckets = {b["Name"] for b in client.list_buckets()["Buckets"]}
         self.assertIn(bname, buckets)
 
         # Make sure file got written
@@ -681,7 +681,7 @@ class BucketDelete(BaseTest):
         client.delete_bucket_policy(Bucket=bname)
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        buckets = set([b["Name"] for b in client.list_buckets()["Buckets"]])
+        buckets = {b["Name"] for b in client.list_buckets()["Buckets"]}
         self.assertFalse(bname in buckets)
 
 
@@ -3558,7 +3558,7 @@ class S3LifecycleTest(BaseTest):
         # Make a bucket
         client.create_bucket(Bucket=bname)
         self.addCleanup(destroyBucket, client, bname)
-        buckets = set([b["Name"] for b in client.list_buckets()["Buckets"]])
+        buckets = {b["Name"] for b in client.list_buckets()["Buckets"]}
         self.assertIn(bname, buckets)
 
         def get_policy(**kwargs):
@@ -3605,8 +3605,8 @@ class S3LifecycleTest(BaseTest):
         lifecycle = client.get_bucket_lifecycle_configuration(Bucket=bname)
         self.assertEqual(len(lifecycle["Rules"]), 2)
         self.assertSetEqual(
-            set([x["ID"] for x in lifecycle["Rules"]]),
-            set([lifecycle_id1, lifecycle_id2]),
+            {x["ID"] for x in lifecycle["Rules"]},
+            {lifecycle_id1, lifecycle_id2},
         )
 
         #
@@ -3619,8 +3619,8 @@ class S3LifecycleTest(BaseTest):
         lifecycle = client.get_bucket_lifecycle_configuration(Bucket=bname)
         self.assertEqual(len(lifecycle["Rules"]), 2)
         self.assertSetEqual(
-            set([x["ID"] for x in lifecycle["Rules"]]),
-            set([lifecycle_id1, lifecycle_id2]),
+            {x["ID"] for x in lifecycle["Rules"]},
+            {lifecycle_id1, lifecycle_id2},
         )
 
         for rule in lifecycle["Rules"]:

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1122,8 +1122,8 @@ class SecurityGroupTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 3)
         self.assertEqual(
-            set(["sg-f9cc4d9f", "sg-13de8f75", "sg-ce548cb7"]),
-            set([r["GroupId"] for r in resources]),
+            {"sg-f9cc4d9f", "sg-13de8f75", "sg-ce548cb7"},
+            {r["GroupId"] for r in resources},
         )
 
     def test_unused_ecs(self):

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -165,7 +165,7 @@ class ZippedPill(pill.Pill):
         self.archive = zipfile.ZipFile(self.path, "a", zipfile.ZIP_DEFLATED)
         self._files = set()
 
-        files = set([n for n in self.archive.namelist() if n.startswith(self.prefix)])
+        files = {n for n in self.archive.namelist() if n.startswith(self.prefix)}
 
         if not files:
             return super(ZippedPill, self).record()

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -240,8 +240,8 @@ class WhiteListFilter(Filter):
                     # If user_permissions is not empty, but allowed permissions is empty -- Failed.
                     return False
                 # User lowercase to compare sets
-                lower_user_perm = set([x.lower() for x in user_permissions[v]])
-                lower_perm = set([x.lower() for x in permissions[v]])
+                lower_user_perm = {x.lower() for x in user_permissions[v]}
+                lower_perm = {x.lower() for x in permissions[v]}
                 if lower_user_perm.difference(lower_perm):
                     # If user has more permissions than allowed -- Failed
                     return False

--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -333,7 +333,7 @@ class PortsRangeHelper:
         """ Converts array of port ranges to the set of integers
             Example: [(10-12), (20,20)] -> {10, 11, 12, 20}
         """
-        return set([i for r in ranges for i in range(r.start, r.end + 1)])
+        return {i for r in ranges for i in range(r.start, r.end + 1)}
 
     @staticmethod
     def validate_ports_string(ports):

--- a/tools/c7n_azure/tests_azure/tests_resources/test_cosmos_db.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_cosmos_db.py
@@ -519,8 +519,8 @@ class CosmosDBFirewallActionTest(BaseTest):
             set(kwargs['create_update_parameters']['properties']['ipRangeFilter'].split(',')))
         self.assertEqual(
             {'id1', 'id2'},
-            set([r.id for r in
-                 kwargs['create_update_parameters']['properties']['virtualNetworkRules']]))
+            {r.id for r in
+             kwargs['create_update_parameters']['properties']['virtualNetworkRules']})
 
 
 class CosmosDBThroughputActionsTest(BaseTest):

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqlserver.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqlserver.py
@@ -371,7 +371,7 @@ class SQLServerFirewallActionTest(BaseTest):
         self.assertEqual(IPSet(expected_add), added)
 
         # Removed IP's
-        self.assertEqual(set(expected_remove), set([args[2] for _, args, _ in delete.mock_calls]))
+        self.assertEqual(set(expected_remove), {args[2] for _, args, _ in delete.mock_calls})
 
     @patch('azure.mgmt.sql.operations._firewall_rules_operations.'
            'FirewallRulesOperations.create_or_update')

--- a/tools/c7n_azure/tests_azure/tests_resources/test_storage_container.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_storage_container.py
@@ -51,7 +51,7 @@ class StorageContainerTest(BaseTest):
         })
         resources = p.run()
         self.assertEqual(2, len(resources))
-        self.assertEqual({'containerone', 'containertwo'}, set([c['name'] for c in resources]))
+        self.assertEqual({'containerone', 'containertwo'}, {c['name'] for c in resources})
 
     @arm_template('storage.json')
     @cassette_name('containers')

--- a/tools/c7n_kube/c7n_kube/query.py
+++ b/tools/c7n_kube/c7n_kube/query.py
@@ -133,7 +133,7 @@ class CustomResourceQueryManager(QueryResourceManager):
         }
 
     def validate(self):
-        required_keys = set(['group', 'version', 'plural'])
+        required_keys = {'group', 'version', 'plural'}
         if 'query' not in self.data:
             raise PolicyValidationError(
                 "Custom resources require query in policy with only " +

--- a/tools/c7n_sentry/c7n_sentry/c7nsentry.py
+++ b/tools/c7n_sentry/c7n_sentry/c7nsentry.py
@@ -374,8 +374,8 @@ def orgreplay(options):
         "@" in dsn.netloc and dsn.netloc.rsplit('@', 1)[1] or dsn.netloc)
 
     log.info("sentry endpoint: %s", endpoint)
-    teams = set([t['slug'] for t in sget(
-        endpoint + "organizations/%s/teams/" % options.sentry_org).json()])
+    teams = {t['slug'] for t in sget(
+             endpoint + "organizations/%s/teams/" % options.sentry_org).json()}
     projects = {p['name']: p for p in sget(endpoint + "projects/").json()}
 
     def process_account(a):


### PR DESCRIPTION
Not sure if you accept PRs for tech debt, but this is to use set comprehensions directly instead of converting list comprehensions to a set in order to save overhead and be more Pythonic.