### PR TITLE
Azure nested management group support

### DIFF
--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -482,7 +482,7 @@ class ManagedGroupHelper:
     class serialize(JSONEncoder):
         def default(self, o):
             return o.__dict__
-    
+
     @staticmethod
     def filter_subscriptions(key, dictionary):
         for k, v in dictionary.items():
@@ -506,6 +506,7 @@ class ManagedGroupHelper:
         subscriptions = ManagedGroupHelper.filter_subscriptions('type', groups)
         subscriptions = [subscription['name'] for subscription in subscriptions]
         return subscriptions
+
 
 def generate_key_vault_url(name):
     return constants.TEMPLATE_KEYVAULT_URL.format(name)

--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -34,6 +34,7 @@ from msrestazure.azure_active_directory import MSIAuthentication
 from msrestazure.azure_exceptions import CloudError
 from msrestazure.tools import parse_resource_id
 from netaddr import IPNetwork, IPRange, IPSet
+from json import JSONEncoder
 
 from c7n.utils import chunks, local_session
 
@@ -478,14 +479,33 @@ class AppInsightsHelper:
 
 
 class ManagedGroupHelper:
+    class serialize(JSONEncoder):
+        def default(self, o):
+            return o.__dict__
+    
+    @staticmethod
+    def filter_subscriptions(key, dictionary):
+        for k, v in dictionary.items():
+            if k == key:
+                if v == '/subscriptions':
+                    yield dictionary
+            elif isinstance(v, dict):
+                for result in ManagedGroupHelper.filter_subscriptions(key, v):
+                    yield result
+            elif isinstance(v, list):
+                for d in v:
+                    for result in ManagedGroupHelper.filter_subscriptions(key, d):
+                        yield result
 
     @staticmethod
     def get_subscriptions_list(managed_resource_group, credentials):
         client = ManagementGroupsAPI(credentials)
-        entities = client.entities.list(filter='name eq \'%s\'' % managed_resource_group)
-
-        return [e.name for e in entities if e.type == '/subscriptions']
-
+        groups = client.management_groups.get(
+            group_id=managed_resource_group, recurse=True,
+            expand="children").serialize()["properties"]
+        subscriptions = ManagedGroupHelper.filter_subscriptions('type', groups)
+        subscriptions = [subscription['name'] for subscription in subscriptions]
+        return subscriptions
 
 def generate_key_vault_url(name):
     return constants.TEMPLATE_KEYVAULT_URL.format(name)


### PR DESCRIPTION
This change allows custodian instances using Azure Functions to access subscriptions inside nested management groups. eg:
- Parent Management Group
    - Management Group 1
        - Subscription 1
    - Management Group 2
        - Management Group 3
            - Subscription 2