### PR TITLE
aws.glue-crawler | update glue crawlers

### DIFF
--- a/tests/data/placebo/test_crawlers_update/glue.GetCrawlers_1.json
+++ b/tests/data/placebo/test_crawlers_update/glue.GetCrawlers_1.json
@@ -1,0 +1,56 @@
+{
+    "status_code": 200,
+    "data": {
+        "Crawlers": [
+            {
+                "Name": "test-filter-crawler",
+                "Role": "c7n-glue-test",
+                "Targets": {
+                    "S3Targets": [
+                        {
+                            "Path": "s3://cof-c7n-sandbox-dev/horizontal-dev/us-east-1/policies/account-service-limits-notify/2019/08/08/22",
+                            "Exclusions": []
+                        },
+                        {
+                            "Path": "s3://cof-c7n-sandbox-dev/public-cloud-dev/us-east-1/policies/account-service-limits-notify/2019/08/01/22",
+                            "Exclusions": []
+                        }
+                    ],
+                    "JdbcTargets": [],
+                    "DynamoDBTargets": [],
+                    "CatalogTargets": []
+                },
+                "DatabaseName": "central-logs-poc",
+                "Classifiers": [],
+                "SchemaChangePolicy": {
+                    "UpdateBehavior": "UPDATE_IN_DATABASE",
+                    "DeleteBehavior": "DEPRECATE_IN_DATABASE"
+                },
+                "State": "READY",
+                "CrawlElapsedTime": 0,
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 3,
+                    "day": 18,
+                    "hour": 10,
+                    "minute": 55,
+                    "second": 51,
+                    "microsecond": 0
+                },
+                "LastUpdated": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 4,
+                    "day": 30,
+                    "hour": 21,
+                    "minute": 17,
+                    "second": 19,
+                    "microsecond": 0
+                },
+                "Version": 6
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_crawlers_update/glue.GetCrawlers_2.json
+++ b/tests/data/placebo/test_crawlers_update/glue.GetCrawlers_2.json
@@ -1,0 +1,57 @@
+{
+    "status_code": 200,
+    "data": {
+        "Crawlers": [
+            {
+                "Name": "test-filter-crawler",
+                "Role": "c7n-glue-test",
+                "Targets": {
+                    "S3Targets": [
+                        {
+                            "Path": "s3://cof-c7n-sandbox-dev/horizontal-dev/us-east-1/policies/account-service-limits-notify/2019/08/08/22",
+                            "Exclusions": []
+                        },
+                        {
+                            "Path": "s3://cof-c7n-sandbox-dev/public-cloud-dev/us-east-1/policies/account-service-limits-notify/2019/08/01/22",
+                            "Exclusions": []
+                        }
+                    ],
+                    "JdbcTargets": [],
+                    "DynamoDBTargets": [],
+                    "CatalogTargets": []
+                },
+                "DatabaseName": "central-logs-poc",
+                "Classifiers": [],
+                "SchemaChangePolicy": {
+                    "UpdateBehavior": "UPDATE_IN_DATABASE",
+                    "DeleteBehavior": "DEPRECATE_IN_DATABASE"
+                },
+                "State": "READY",
+                "CrawlElapsedTime": 0,
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 3,
+                    "day": 18,
+                    "hour": 10,
+                    "minute": 55,
+                    "second": 51,
+                    "microsecond": 0
+                },
+                "LastUpdated": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 4,
+                    "day": 30,
+                    "hour": 21,
+                    "minute": 17,
+                    "second": 32,
+                    "microsecond": 0
+                },
+                "Version": 7,
+                "CrawlerSecurityConfiguration": "glue-test"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_crawlers_update/glue.UpdateCrawler_1.json
+++ b/tests/data/placebo/test_crawlers_update/glue.UpdateCrawler_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_crawlers_update/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_crawlers_update/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -343,6 +343,28 @@ class TestGlueCrawlers(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['Name'], 'test-filter-crawler')
 
+    def test_crawlers_update(self):
+        session_factory = self.replay_flight_data("test_crawlers_update")
+        p = self.load_policy(
+            {
+                "name": "glue-crawler-update",
+                "resource": "glue-crawler",
+                "filters": [{"type": "value", "key": "CrawlerSecurityConfiguration",
+                    "value": "glue-test", "op": "ne"}],
+                "actions": [{
+                    "type": "update-crawler",
+                    "attributes": {
+                        "CrawlerSecurityConfiguration": "glue-test"}
+                }]
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = session_factory().client("glue")
+        response = client.get_crawlers().get('Crawlers')
+        self.assertEqual(len(response), 1)
+        self.assertTrue(response[0].get('CrawlerSecurityConfiguration'), 'glue-test')
 
 class TestGlueTables(BaseTest):
     def test_tables_delete(self):


### PR DESCRIPTION
This PR adds a feature to update glue-crawler resources to make them compliant. API used: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.update_crawler
Sample Policy:
```
policies:
  - name: glue-crawler-update
    resource: aws.glue-crawler
    filters:
      - type: value
        key: CrawlerSecurityConfiguration
        value: null
    actions:
      - type: update-crawler
        attributes:
            CrawlerSecurityConfiguration: glue-test
```