### PR TITLE
releng - switch default shell for doc building to bash

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Install Tox
         run: |
           python -m pip install --upgrade pip
-          pip install
+          pip install tox
       - name: Install Build Deps
         run: |
           TOXENV=docs tox --notest

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -26,7 +26,7 @@ jobs:
 
   Tests:
     runs-on: "${{ matrix.os }}"
-    needs: Lint
+    needs: Docs
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
@@ -111,7 +111,7 @@ jobs:
   Docs:
     # todo, figure out how to fast cache the tox directory here.
     runs-on: ubuntu-latest
-    needs: Lint
+#    needs: Lint
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -26,7 +26,7 @@ jobs:
 
   Tests:
     runs-on: "${{ matrix.os }}"
-    needs: Docs
+    needs: Lint
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
@@ -111,7 +111,7 @@ jobs:
   Docs:
     # todo, figure out how to fast cache the tox directory here.
     runs-on: ubuntu-latest
-#    needs: Lint
+    needs: Lint
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -112,9 +112,6 @@ jobs:
     # todo, figure out how to fast cache the tox directory here.
     runs-on: ubuntu-latest
 #    needs: Lint
-    defaults:
-      run:
-        shell: bash
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -128,7 +125,7 @@ jobs:
       - name: Install Tox
         run: |
           python -m pip install --upgrade pip
-          pip install tox==3.14.6
+          pip install
       - name: Install Build Deps
         run: |
           TOXENV=docs tox --notest

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -112,6 +112,9 @@ jobs:
     # todo, figure out how to fast cache the tox directory here.
     runs-on: ubuntu-latest
     needs: Lint
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -127,7 +127,7 @@ jobs:
           key: docs-${{ runner.os }}-${{ 3.8 }}-${{ hashFiles('**/requirement*.txt') }}
       - name: Install Git
         run: |
-          apt-get install -y git
+          sudo apt-get install -y git
       - name: Install Tox
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -125,15 +125,10 @@ jobs:
         with:
           path: "~/.cache/pip"
           key: docs-${{ runner.os }}-${{ 3.8 }}-${{ hashFiles('**/requirement*.txt') }}
-      - name: Install Git
-        run: |
-          sudo apt-get install -y git
-          env
-          which git
       - name: Install Tox
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install tox==3.14.6
       - name: Install Build Deps
         run: |
           TOXENV=docs tox --notest

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -128,6 +128,8 @@ jobs:
       - name: Install Git
         run: |
           sudo apt-get install -y git
+          env
+          which git
       - name: Install Tox
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -125,6 +125,9 @@ jobs:
         with:
           path: "~/.cache/pip"
           key: docs-${{ runner.os }}-${{ 3.8 }}-${{ hashFiles('**/requirement*.txt') }}
+      - name: Install Git
+        run: |
+          apt-get install -y git
       - name: Install Tox
         run: |
           python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ ftest:
 
 sphinx:
 # if this errors either tox -e docs or cd tools/c7n_sphinext && poetry install
-	which c7n-sphinxext
 	make -f docs/Makefile.sphinx html
 
 ghpages:

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ commands = make lint
 whitelist_externals = make
 commands = make sphinx
 setenv =
-   PATH="$PWD/.tox/docs/bin:/opt/hostedtoolcache/Python/3.8.2/x64/bin:/opt/hostedtoolcache/Python/3.8.2/x64:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+   PATH="$PWD/.tox/docs/bin:/opt/hostedtoolcache/Python/3.8.2/x64/bin:/opt/hostedtoolcache/Python/3.8.2/x64:$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
 deps =
   -rrequirements-dev.txt
   -rrequirements-docs.txt

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ commands = make lint
 whitelist_externals = make
 commands = make sphinx
 setenv =
-   PATH="$PWD/.tox/docs/bin:$PATH"
+   PATH="$PWD/.tox/docs/bin:/opt/hostedtoolcache/Python/3.8.2/x64/bin:/opt/hostedtoolcache/Python/3.8.2/x64:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
 deps =
   -rrequirements-dev.txt
   -rrequirements-docs.txt

--- a/tox.ini
+++ b/tox.ini
@@ -84,8 +84,6 @@ commands = make lint
 [testenv:docs]
 whitelist_externals = make
 commands = make sphinx
-setenv =
-   PATH="$PWD/.tox/docs/bin:/opt/hostedtoolcache/Python/3.8.2/x64/bin:/opt/hostedtoolcache/Python/3.8.2/x64:$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
 deps =
   -rrequirements-dev.txt
   -rrequirements-docs.txt


### PR DESCRIPTION

ubuntu-latest appears to have been updated to switch default
shell from bash to dash, which lacks the `which` shell builtin
command. the doc builds use this to verify the install of
c7n-sphinxext﻿
