### PR TITLE
core - mailer - add mailer replay to entry points

### DIFF
--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -24,7 +24,7 @@ install_requires = \
  'splunk-sdk>=1.6.12,<2.0.0']
 
 entry_points = \
-{'console_scripts': ['c7n-mailer = c7n_mailer.cli:main']}
+{'console_scripts': ['c7n-mailer = c7n_mailer.cli:main', 'c7n-mailer-replay = c7n_mailer.replay:main']}
 
 setup_kwargs = {
     'name': 'c7n-mailer',


### PR DESCRIPTION
For #5711 

Looks like mailer replay was missing from entry_points, this should fix it