### PR TITLE
aws - remove resource specific StateTransitionFilter for actions

### DIFF
--- a/c7n/actions/core.py
+++ b/c7n/actions/core.py
@@ -16,8 +16,7 @@ Actions to take on resources
 """
 import logging
 
-import jmespath
-
+from c7n.element import Element
 from c7n.exceptions import PolicyValidationError, ClientError
 from c7n.executor import ThreadPoolExecutor
 from c7n.registry import PluginRegistry
@@ -56,7 +55,7 @@ class ActionRegistry(PluginRegistry):
         return action_class(data, manager)
 
 
-class Action:
+class Action(Element):
 
     permissions = ()
     metrics = ()
@@ -86,26 +85,6 @@ class Action:
     def process(self, resources):
         raise NotImplementedError(
             "Base action class does not implement behavior")
-
-    def filter_resources(self, resources, key_expr, allowed_values=()):
-        # many actions implementing a resource state transition only allow
-        # a given set of starting states, this method will filter resources
-        # and issue a warning log, as implicit filtering in actions means
-        # our policy metrics are off, and they should be added as policy
-        # filters.
-        resource_count = len(resources)
-        search_expr = key_expr
-        if not search_expr.startswith('[].'):
-            search_expr = '[].' + key_expr
-        results = [r for value, r in zip(
-            jmespath.search(search_expr, resources), resources)
-            if value in allowed_values]
-        if resource_count != len(results):
-            self.log.warning(
-                "%s implicitly filtered %d of %d resources key:%s on %s",
-                self.type, len(results), resource_count, key_expr,
-                (', '.join(allowed_values)))
-        return results
 
     def _run_api(self, cmd, *args, **kw):
         try:

--- a/c7n/element.py
+++ b/c7n/element.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Cloud Custodian Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jmespath
+
+
+class Element:
+    """Parent base class for filters and actions.
+    """
+
+    def filter_resources(self, resources, key_expr, allowed_values=()):
+        # many filters implementing a resource state transition only allow
+        # a given set of starting states, this method will filter resources
+        # and issue a warning log, as implicit filtering in filters means
+        # our policy metrics are off, and they should be added as policy
+        # filters.
+        resource_count = len(resources)
+        search_expr = key_expr
+        if not search_expr.startswith('[].'):
+            search_expr = '[].' + key_expr
+        results = [r for value, r in zip(
+            jmespath.search(search_expr, resources), resources)
+            if value in allowed_values]
+        if resource_count != len(results):
+            self.log.warning(
+                "%s implicitly filtered %d of %d resources key:%s on %s",
+                self.type, len(results), resource_count, key_expr,
+                (', '.join(allowed_values)))
+        return results

--- a/c7n/filters/__init__.py
+++ b/c7n/filters/__init__.py
@@ -22,8 +22,7 @@ from .core import (
     Not,
     ValueFilter,
     AgeFilter,
-    EventFilter,
-    StateTransitionFilter,)
+    EventFilter,)
 from .config import ConfigCompliance
 from .health import HealthEventFilter
 from .iamaccess import CrossAccountAccessFilter, PolicyChecker

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -30,6 +30,7 @@ from dateutil.parser import parse
 from distutils import version
 import jmespath
 
+from c7n.element import Element
 from c7n.exceptions import PolicyValidationError
 from c7n.executor import ThreadPoolExecutor
 from c7n.registry import PluginRegistry
@@ -167,7 +168,7 @@ class FilterRegistry(PluginRegistry):
 # Really should be an abstract base class (abc) or
 # zope.interface
 
-class Filter:
+class Filter(Element):
 
     executor_factory = ThreadPoolExecutor
 
@@ -218,26 +219,6 @@ class Filter:
 
         if not values and block_op != 'or':
             return
-
-    def filter_resources(self, resources, key_expr, allowed_values=()):
-        # many filters implementing a resource state transition only allow
-        # a given set of starting states, this method will filter resources
-        # and issue a warning log, as implicit filtering in filters means
-        # our policy metrics are off, and they should be added as policy
-        # filters.
-        resource_count = len(resources)
-        search_expr = key_expr
-        if not search_expr.startswith('[].'):
-            search_expr = '[].' + key_expr
-        results = [r for value, r in zip(
-            jmespath.search(search_expr, resources), resources)
-            if value in allowed_values]
-        if resource_count != len(results):
-            self.log.warning(
-                "%s implicitly filtered %d of %d resources key:%s on %s",
-                self.type, len(results), resource_count, key_expr,
-                (', '.join(allowed_values)))
-        return results
 
 
 def intersect_list(a, b):

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -810,4 +810,3 @@ class ValueRegex:
         if capture is None:  # regex didn't capture anything
             return None
         return capture.group(1)
-

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -219,6 +219,26 @@ class Filter:
         if not values and block_op != 'or':
             return
 
+    def filter_resources(self, resources, key_expr, allowed_values=()):
+        # many filters implementing a resource state transition only allow
+        # a given set of starting states, this method will filter resources
+        # and issue a warning log, as implicit filtering in filters means
+        # our policy metrics are off, and they should be added as policy
+        # filters.
+        resource_count = len(resources)
+        search_expr = key_expr
+        if not search_expr.startswith('[].'):
+            search_expr = '[].' + key_expr
+        results = [r for value, r in zip(
+            jmespath.search(search_expr, resources), resources)
+            if value in allowed_values]
+        if resource_count != len(results):
+            self.log.warning(
+                "%s implicitly filtered %d of %d resources key:%s on %s",
+                self.type, len(results), resource_count, key_expr,
+                (', '.join(allowed_values)))
+        return results
+
 
 def intersect_list(a, b):
     if b is None:
@@ -791,16 +811,3 @@ class ValueRegex:
             return None
         return capture.group(1)
 
-
-class StateTransitionFilter(Filter):
-    valid_origin_states = ()
-
-    def filter_resource_state(self, resources, event=None):
-        state_key = self.manager.get_model().state_key
-        states = self.valid_origin_states
-        orig_length = len(resources)
-        results = [r for r in resources if r[state_key] in states]
-        self.log.info("filtered %d of %d %s resources with  %s states" % (
-            len(results), orig_length, self.__class__.__name__, states))
-
-        return results

--- a/c7n/resources/batch.py
+++ b/c7n/resources/batch.py
@@ -61,31 +61,8 @@ class JobDefinition(QueryResourceManager):
         cfn_type = 'AWS::Batch::JobDefinition'
 
 
-class StateTransitionFilter:
-    """Filter resources by state.
-
-    Try to simplify construction for policy authors by automatically
-    filtering elements (filters or actions) to the resource states
-    they are valid for.
-    """
-    valid_origin_states = ()
-
-    def filter_resource_state(self, resources, key, states=None):
-        states = states or self.valid_origin_states
-        if not states:
-            return resources
-        orig_length = len(resources)
-        results = [r for r in resources if r[key] in states]
-        if orig_length != len(results):
-            self.log.warn(
-                "%s implicitly filtered %d of %d resources with valid %s" % (
-                    self.__class__.__name__,
-                    len(results), orig_length, key.lower()))
-        return results
-
-
 @ComputeEnvironment.action_registry.register('update-environment')
-class UpdateComputeEnvironment(BaseAction, StateTransitionFilter):
+class UpdateComputeEnvironment(BaseAction):
     """Updates an AWS batch compute environment
 
     :example:
@@ -125,8 +102,7 @@ class UpdateComputeEnvironment(BaseAction, StateTransitionFilter):
     valid_origin_status = ('VALID', 'INVALID')
 
     def process(self, resources):
-        resources = self.filter_resource_state(
-            resources, 'status', self.valid_origin_status)
+        resources = self.filter_resources(resources, 'status', self.valid_origin_status)
         client = local_session(self.manager.session_factory).client('batch')
         params = dict(self.data)
         params.pop('type')
@@ -136,7 +112,7 @@ class UpdateComputeEnvironment(BaseAction, StateTransitionFilter):
 
 
 @ComputeEnvironment.action_registry.register('delete')
-class DeleteComputeEnvironment(BaseAction, StateTransitionFilter):
+class DeleteComputeEnvironment(BaseAction):
     """Delete an AWS batch compute environment
 
     :example:
@@ -161,8 +137,8 @@ class DeleteComputeEnvironment(BaseAction, StateTransitionFilter):
             computeEnvironment=r['computeEnvironmentName'])
 
     def process(self, resources):
-        resources = self.filter_resource_state(
-            self.filter_resource_state(
+        resources = self.filter_resources(
+            self.filter_resources(
                 resources, 'state', self.valid_origin_states),
             'status', self.valid_origin_status)
         client = local_session(self.manager.session_factory).client('batch')
@@ -171,7 +147,7 @@ class DeleteComputeEnvironment(BaseAction, StateTransitionFilter):
 
 
 @JobDefinition.action_registry.register('deregister')
-class DefinitionDeregister(BaseAction, StateTransitionFilter):
+class DefinitionDeregister(BaseAction):
     """Deregisters a batch definition
 
     :example:
@@ -196,8 +172,7 @@ class DefinitionDeregister(BaseAction, StateTransitionFilter):
                                      r['revision']))
 
     def process(self, resources):
-        resources = self.filter_resource_state(
-            resources, 'status', self.valid_origin_states)
+        resources = self.filter_resources(resources, 'status', self.valid_origin_states)
         self.client = local_session(
             self.manager.session_factory).client('batch')
         with self.executor_factory(max_workers=2) as w:

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1022,7 +1022,7 @@ class SsmCompliance(Filter):
 
 
 @actions.register('set-monitoring')
-class MonitorInstances(BaseAction, StateTransitionFilter):
+class MonitorInstances(BaseAction):
     """Action on EC2 Instances to enable/disable detailed monitoring
 
     The different states of detailed monitoring status are :
@@ -1121,7 +1121,7 @@ class InstanceFinding(PostFinding):
 
 
 @actions.register('start')
-class Start(BaseAction, StateTransitionFilter):
+class Start(BaseAction):
     """Starts a previously stopped EC2 instance.
 
     :Example:
@@ -1150,7 +1150,7 @@ class Start(BaseAction, StateTransitionFilter):
 
     def process(self, instances):
         instances = self._filter_ec2_with_volumes(
-            self.filter_instance_state(instances))
+            self.filter_resources(instances, 'State.Name', self.valid_origin_states))
         if not len(instances):
             return
 
@@ -1206,7 +1206,7 @@ def extract_instance_id(state_error):
 
 
 @actions.register('resize')
-class Resize(BaseAction, StateTransitionFilter):
+class Resize(BaseAction):
     """Change an instance's size.
 
     An instance can only be resized when its stopped, this action
@@ -1236,10 +1236,8 @@ class Resize(BaseAction, StateTransitionFilter):
         return perms
 
     def process(self, resources):
-        stopped_instances = self.filter_instance_state(
-            resources, ('stopped',))
-        running_instances = self.filter_instance_state(
-            resources, ('running',))
+        stopped_instances = self.filter_resources(resources, 'State.Name', ('stopped',))
+        running_instances = self.filter_resources(resources, 'State.Name', ('running',))
 
         if self.data.get('restart') and running_instances:
             Stop({'terminate-ephemeral': False},
@@ -1287,7 +1285,7 @@ class Resize(BaseAction, StateTransitionFilter):
 
 
 @actions.register('stop')
-class Stop(BaseAction, StateTransitionFilter):
+class Stop(BaseAction):
     """Stops or hibernates a running EC2 instances
 
     :Example:
@@ -1349,7 +1347,7 @@ class Stop(BaseAction, StateTransitionFilter):
         return enabled, disabled
 
     def process(self, instances):
-        instances = self.filter_instance_state(instances)
+        instances = self.filter_resources(instances, 'State.Name', self.valid_origin_states)
         if not len(instances):
             return
         client = utils.local_session(
@@ -1384,7 +1382,7 @@ class Stop(BaseAction, StateTransitionFilter):
 
 
 @actions.register('reboot')
-class Reboot(BaseAction, StateTransitionFilter):
+class Reboot(BaseAction):
     """Reboots a previously running EC2 instance.
 
     :Example:
@@ -1413,7 +1411,7 @@ class Reboot(BaseAction, StateTransitionFilter):
 
     def process(self, instances):
         instances = self._filter_ec2_with_volumes(
-            self.filter_instance_state(instances))
+            self.filter_resources(instances, 'State.Name', self.valid_origin_states))
         if not len(instances):
             return
 
@@ -1448,7 +1446,7 @@ class Reboot(BaseAction, StateTransitionFilter):
 
 
 @actions.register('terminate')
-class Terminate(BaseAction, StateTransitionFilter):
+class Terminate(BaseAction):
     """ Terminate a set of instances.
 
     While ec2 offers a bulk delete api, any given instance can be configured
@@ -1482,7 +1480,7 @@ class Terminate(BaseAction, StateTransitionFilter):
         return permissions
 
     def process(self, instances):
-        instances = self.filter_instance_state(instances)
+        instances = self.filter_resources(instances, 'State.Name', self.valid_origin_states)
         if not len(instances):
             return
         client = utils.local_session(
@@ -1646,7 +1644,7 @@ class EC2ModifyVpcSecurityGroups(ModifyVpcSecurityGroupsAction):
 
 
 @actions.register('autorecover-alarm')
-class AutorecoverAlarm(BaseAction, StateTransitionFilter):
+class AutorecoverAlarm(BaseAction):
     """Adds a cloudwatch metric alarm to recover an EC2 instance.
 
     This action takes effect on instances that are NOT part
@@ -1676,7 +1674,7 @@ class AutorecoverAlarm(BaseAction, StateTransitionFilter):
 
     def process(self, instances):
         instances = self.filter_asg_membership.process(
-            self.filter_instance_state(instances))
+            self.filter_resources(instances, 'State.Name', self.valid_origin_states))
         if not len(instances):
             return
         client = utils.local_session(
@@ -1709,7 +1707,7 @@ class AutorecoverAlarm(BaseAction, StateTransitionFilter):
 
 
 @actions.register('set-instance-profile')
-class SetInstanceProfile(BaseAction, StateTransitionFilter):
+class SetInstanceProfile(BaseAction):
     """Sets (add, modify, remove) the instance profile for a running EC2 instance.
 
     :Example:
@@ -1741,7 +1739,7 @@ class SetInstanceProfile(BaseAction, StateTransitionFilter):
     valid_origin_states = ('running', 'pending', 'stopped', 'stopping')
 
     def process(self, instances):
-        instances = self.filter_instance_state(instances)
+        instances = self.filter_resources(instances, 'State.Name', self.valid_origin_states)
         if not len(instances):
             return
         client = utils.local_session(self.manager.session_factory).client('ec2')

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -20,7 +20,7 @@ from c7n.actions import BaseAction, ActionRegistry
 from c7n.filters.vpc import SubnetFilter, SecurityGroupFilter
 from c7n.filters.related import RelatedResourceFilter
 from c7n.tags import universal_augment
-from c7n.filters import StateTransitionFilter, ValueFilter, FilterRegistry, CrossAccountAccessFilter
+from c7n.filters import ValueFilter, FilterRegistry, CrossAccountAccessFilter
 from c7n import query, utils
 from c7n.resources.account import GlueCatalogEncryptionEnabled
 
@@ -246,14 +246,14 @@ class GlueCrawlerSecurityConfigFilter(SecurityConfigFilter):
 
 
 @GlueCrawler.action_registry.register('delete')
-class DeleteCrawler(BaseAction, StateTransitionFilter):
+class DeleteCrawler(BaseAction):
 
     schema = type_schema('delete')
     permissions = ('glue:DeleteCrawler',)
     valid_origin_states = ('READY', 'FAILED')
 
     def process(self, resources):
-        resources = self.filter_resource_state(resources)
+        resources = self.filter_resources(resources, 'State', self.valid_origin_states)
 
         client = local_session(self.manager.session_factory).client('glue')
         for r in resources:

--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -297,26 +297,6 @@ class Model(QueryResourceManager):
 Model.filter_registry.register('marked-for-op', TagActionFilter)
 
 
-class StateTransitionFilter:
-    """Filter instances by state.
-
-    Try to simplify construction for policy authors by automatically
-    filtering elements (filters or actions) to the instances states
-    they are valid for.
-
-    """
-    valid_origin_states = ()
-
-    def filter_instance_state(self, instances, states=None):
-        states = states or self.valid_origin_states
-        orig_length = len(instances)
-        results = [i for i in instances
-                   if i['NotebookInstanceStatus'] in states]
-        self.log.info("state filter %s %d of %d notebook instances" % (
-            self.__class__.__name__, len(results), orig_length))
-        return results
-
-
 @SagemakerEndpoint.action_registry.register('tag')
 @SagemakerEndpointConfig.action_registry.register('tag')
 @NotebookInstance.action_registry.register('tag')
@@ -476,7 +456,7 @@ class MarkNotebookInstanceForOp(TagDelayedAction):
 
 
 @NotebookInstance.action_registry.register('start')
-class StartNotebookInstance(BaseAction, StateTransitionFilter):
+class StartNotebookInstance(BaseAction):
     """Start sagemaker-notebook(s)
 
     :example:
@@ -494,7 +474,8 @@ class StartNotebookInstance(BaseAction, StateTransitionFilter):
     valid_origin_states = ('Stopped',)
 
     def process(self, resources):
-        resources = self.filter_instance_state(resources)
+        resources = self.filter_resources(resources, 'NotebookInstanceStatus',
+                                          self.valid_origin_states)
         if not len(resources):
             return
 
@@ -509,7 +490,7 @@ class StartNotebookInstance(BaseAction, StateTransitionFilter):
 
 
 @NotebookInstance.action_registry.register('stop')
-class StopNotebookInstance(BaseAction, StateTransitionFilter):
+class StopNotebookInstance(BaseAction):
     """Stop sagemaker-notebook(s)
 
     :example:
@@ -529,7 +510,8 @@ class StopNotebookInstance(BaseAction, StateTransitionFilter):
     valid_origin_states = ('InService',)
 
     def process(self, resources):
-        resources = self.filter_instance_state(resources)
+        resources = self.filter_resources(resources, 'NotebookInstanceStatus',
+                                          self.valid_origin_states)
         if not len(resources):
             return
 
@@ -544,7 +526,7 @@ class StopNotebookInstance(BaseAction, StateTransitionFilter):
 
 
 @NotebookInstance.action_registry.register('delete')
-class DeleteNotebookInstance(BaseAction, StateTransitionFilter):
+class DeleteNotebookInstance(BaseAction):
     """Deletes sagemaker-notebook(s)
 
     :example:
@@ -564,7 +546,8 @@ class DeleteNotebookInstance(BaseAction, StateTransitionFilter):
     valid_origin_states = ('Stopped', 'Failed',)
 
     def process(self, resources):
-        resources = self.filter_instance_state(resources)
+        resources = self.filter_resources(resources, 'NotebookInstanceStatus',
+                                          self.valid_origin_states)
         if not len(resources):
             return
 
@@ -621,7 +604,7 @@ class NotebookKmsFilter(KmsRelatedFilter):
 
 
 @Model.action_registry.register('delete')
-class DeleteModel(BaseAction, StateTransitionFilter):
+class DeleteModel(BaseAction):
     """Deletes sagemaker-model(s)
 
     :example:


### PR DESCRIPTION
Replace resource specific `StateTransitionFilter` on actions with core action function `filter_resources`.