### PR TITLE
cli - schema command - add --outline option

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -173,7 +173,10 @@ def _schema_options(p):
     p.add_argument(
         '--summary', action="store_true",
         help="Summarize counts of available resources, actions and filters")
-    p.add_argument('--json', action="store_true", help=argparse.SUPPRESS)
+    p.add_argument('--json', action="store_true",
+        help="Export custodian's jsonschema")
+    p.add_argument('--outline', action="store_true",
+        help="Print outline of all resources and their actions and filters")
     p.add_argument("-v", "--verbose", action="count", help="Verbose logging")
     p.add_argument("-q", "--quiet", action="count", help=argparse.SUPPRESS)
     p.add_argument("--debug", default=False, help=argparse.SUPPRESS)

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -14,6 +14,7 @@
 from collections import Counter, defaultdict
 from datetime import timedelta, datetime
 from functools import wraps
+import json
 import itertools
 import logging
 import os
@@ -317,6 +318,16 @@ def logs(options, policies):
 def schema_cmd(options):
     """ Print info about the resources, actions and filters available. """
     from c7n import schema
+
+    if options.outline:
+        load_available()
+        outline = schema.resource_outline(options.resource.lower().split('.')[0])
+        if options.json:
+            print(json.dumps(outline, indent=2))
+            return
+        print(yaml_dump(outline))
+        return
+
     if options.json:
         schema.json_dump(options.resource)
         return

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -320,8 +320,9 @@ def schema_cmd(options):
     from c7n import schema
 
     if options.outline:
+        provider = options.resource and options.resource.lower().split('.')[0] or None
         load_available()
-        outline = schema.resource_outline(options.resource.lower().split('.')[0])
+        outline = schema.resource_outline(provider)
         if options.json:
             print(json.dumps(outline, indent=2))
             return

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -433,8 +433,8 @@ def resource_outline(provider=None):
         cresources = outline[cname] = {}
         for rname, rtype in sorted(ctype.resources.items()):
             cresources['%s.%s' % (cname, rname)] = rinfo = {}
-            rinfo['filters'] = list(sorted(rtype.filter_registry.keys()))
-            rinfo['actions'] = list(sorted(rtype.action_registry.keys()))
+            rinfo['filters'] = sorted(rtype.filter_registry.keys())
+            rinfo['actions'] = sorted(rtype.action_registry.keys())
     return outline
 
 

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -425,6 +425,19 @@ def process_resource(
     return {'$ref': '#/definitions/resources/%s/policy' % type_name}
 
 
+def resource_outline(provider=None):
+    outline = {}
+    for cname, ctype in sorted(clouds.items()):
+        if provider and provider != cname:
+            continue
+        cresources = outline[cname] = {}
+        for rname, rtype in sorted(ctype.resources.items()):
+            cresources['%s.%s' % (cname, rname)] = rinfo = {}
+            rinfo['filters'] = list(sorted(rtype.filter_registry.keys()))
+            rinfo['actions'] = list(sorted(rtype.action_registry.keys()))
+    return outline
+
+
 def resource_vocabulary(cloud_name=None, qualify_name=True):
     vocabulary = {}
     resources = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,15 @@ class ValidateTest(CliTest):
 
 class SchemaTest(CliTest):
 
+    def test_schema_outline(self):
+        stdout, stderr = self.run_and_expect_success(["custodian", "schema", "--outline", "--json", "aws"])
+        data = json.loads(stdout)
+        self.assertEqual(list(data.keys()), ["aws"])
+        self.assertTrue(len(data['aws']) > 100)
+        self.assertEqual(
+            sorted(data['aws']['aws.ec2'].keys()), ['actions', 'filters'])
+        self.assertTrue(len(data['aws']['aws.ec2']['actions']) > 10)
+
     def test_schema(self):
 
         # no options

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,7 +169,8 @@ class ValidateTest(CliTest):
 class SchemaTest(CliTest):
 
     def test_schema_outline(self):
-        stdout, stderr = self.run_and_expect_success(["custodian", "schema", "--outline", "--json", "aws"])
+        stdout, stderr = self.run_and_expect_success([
+            "custodian", "schema", "--outline", "--json", "aws"])
         data = json.loads(stdout)
         self.assertEqual(list(data.keys()), ["aws"])
         self.assertTrue(len(data['aws']) > 100)


### PR DESCRIPTION
support getting a yaml or json of all the custodian resources and their actions and filters.

addresses #5743