### PR TITLE
Fixes #5750 - remove inadvertently-added splunk-sdk dependency from c7n-mailer

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/deploy.py
@@ -50,7 +50,6 @@ CORE_DEPS = [
     'requests', 'urllib3', 'idna', 'chardet', 'certifi',
     # used by splunk mailer transport
     'jsonpointer', 'jsonpatch',
-    'splunk-sdk',
     # sendgrid dependencies
     'sendgrid', 'python_http_client']
 

--- a/tools/c7n_mailer/poetry.lock
+++ b/tools/c7n_mailer/poetry.lock
@@ -419,14 +419,6 @@ version = "2.1.0"
 
 [[package]]
 category = "main"
-description = "The Splunk Software Development Kit for Python."
-name = "splunk-sdk"
-optional = false
-python-versions = "*"
-version = "1.6.12"
-
-[[package]]
-category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
 optional = false
@@ -459,7 +451,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "e074b9762446f9fb837c6c3651df313386783751591c019851d899ebfb682dca"
+content-hash = "ada358158de8d1ea8ef245204f06bdd74fa58dad189d0f1fde86006010ea2d2b"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -665,9 +657,6 @@ six = [
 sortedcontainers = [
     {file = "sortedcontainers-2.1.0-py2.py3-none-any.whl", hash = "sha256:d9e96492dd51fae31e60837736b38fe42a187b5404c16606ff7ee7cd582d4c60"},
     {file = "sortedcontainers-2.1.0.tar.gz", hash = "sha256:974e9a32f56b17c1bac2aebd9dcf197f3eb9cd30553c5852a3187ad162e1a03a"},
-]
-splunk-sdk = [
-    {file = "splunk-sdk-1.6.12.tar.gz", hash = "sha256:eb6446227447fe10f4c0a0d830efd91ab57e3cb815f4675a42d522241e9ef3ae"},
 ]
 urllib3 = [
     {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},

--- a/tools/c7n_mailer/pyproject.toml
+++ b/tools/c7n_mailer/pyproject.toml
@@ -28,7 +28,6 @@ sendgrid = "^6.1.1"
 datadog = "^0.34.0"
 ldap3 = "^2.6.1"
 redis = "^3.4.1"
-splunk-sdk = "^1.6.12"
 jsonpointer = "^2.0"
 jsonpatch = "^1.25"
 

--- a/tools/c7n_mailer/requirements.txt
+++ b/tools/c7n_mailer/requirements.txt
@@ -25,6 +25,5 @@ requests==2.23.0
 s3transfer==0.3.3
 sendgrid==6.3.0
 six==1.14.0
-splunk-sdk==1.6.12
 urllib3==1.25.9
 zipp==3.1.0

--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -20,8 +20,7 @@ install_requires = \
  'python-dateutil>=2.8.1,<3.0.0',
  'pyyaml>=5.3,<6.0',
  'redis>=3.4.1,<4.0.0',
- 'sendgrid>=6.1.1,<7.0.0',
- 'splunk-sdk>=1.6.12,<2.0.0']
+ 'sendgrid>=6.1.1,<7.0.0']
 
 entry_points = \
 {'console_scripts': ['c7n-mailer = c7n_mailer.cli:main',

--- a/tools/c7n_mailer/tests/test_misc.py
+++ b/tools/c7n_mailer/tests/test_misc.py
@@ -8,6 +8,8 @@ from c7n_mailer import replay
 from c7n_mailer import handle
 from c7n_mailer import sqs_queue_processor
 from c7n_mailer import cli
+from c7n_mailer import deploy
+from c7n.mu import PythonPackageArchive
 from common import MAILER_CONFIG
 
 
@@ -52,3 +54,13 @@ class AWSMailerTests(unittest.TestCase):
             [session.region_name, session.profile_name],
             ['us-east-1', 'default']
         )
+
+
+class DeployTests(unittest.TestCase):
+
+    def test_get_archive(self):
+        archive = deploy.get_archive({'templates_folders': []})
+        assert isinstance(archive, PythonPackageArchive)
+        # basic sanity checks using random, low values
+        assert archive.size > 10000  # this should really be about 1.5 MB
+        assert len(archive.get_filenames()) > 50  # should be > 500


### PR DESCRIPTION
Per my description in #5750, the ``splunk-sdk`` dependency added to c7n-mailer in #5708 is not needed (the implementation uses pure ``requests``, not the SDK). In addition, ``splunk-sdk`` is the package name but the module name is ``splunklib``, so this is causing ``c7n_mailer.deploy.get_archive()`` to fail as importlib can't find the non-existent ``splunk-sdk`` module.

This PR removes the ``splunk-sdk`` dependency from mailer, as well as removing the ``splunk-sdk`` module from c7n_mailer.deploy.

In addition, to attempt to catch bugs like #5750 and #5707 in the future, I've added a unit test that runs ``c7n_mailer.deploy.get_archive()`` and validates that it returns a PythonPackageArchive that meets a reasonable minimum size and number of files.