### PR TITLE
aws - s3 - CreationDate not available in event-based policies

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -97,9 +97,6 @@ class DescribeS3(query.DescribeSource):
             results = list(filter(None, results))
             return results
 
-    def get_resources(self, bucket_names):
-        return [{'Name': b} for b in bucket_names]
-
 
 class ConfigS3(query.ConfigSource):
 

--- a/tests/data/placebo/test_s3_get_resources/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_get_resources/s3.ListBuckets_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Buckets": [
+            {
+                "Name": "c7n-codebuild",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 12,
+                    "day": 20,
+                    "hour": 23,
+                    "minute": 0,
+                    "second": 14,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "Owner": {
+            "DisplayName": "custodian-skunkworks",
+            "ID": "631e4e145c2211ed2e31307ba841b1862307d16de5eab6f5399a23bbbecc26e2"
+        }
+    }
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1272,6 +1272,7 @@ class S3Test(BaseTest):
             tags, {
                 'Application': 'test', 'Env': 'Dev', 'Owner': 'nicholase',
                 'Retention': '2', 'Retention2': '3', 'test': 'test'})
+        self.assertTrue("CreationDate" in resources[0])
 
     def test_multipart_large_file(self):
         self.patch(s3.S3, "executor_factory", MainThreadExecutor)


### PR DESCRIPTION
This closes #5763 