### PR TITLE
c7n_guardian --all-regions

### DIFF
--- a/tools/c7n_guardian/c7n_guardian/cli.py
+++ b/tools/c7n_guardian/c7n_guardian/cli.py
@@ -210,7 +210,7 @@ def get_session(role, session_name, profile, region):
 
 def expand_regions(regions, partition='aws'):
     if 'all' in regions:
-        regions = boto3.Session().get_available_regions('ec2')
+        regions = boto3.Session().get_available_regions('guardduty')
     return regions
 
 


### PR DESCRIPTION
Add cmdline flag --all-regions
If specified

- Ignores --region (default=us-east-1)
- Use supplied ProcessPoolExecutor to query accounts in each region, in parallel
- Add 'region' column to output