### PR TITLE
[c7n-org] AWS Service Region availability check

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -42,6 +42,7 @@ from c7n.provider import get_resource_class
 from c7n.reports.csvout import Formatter, fs_record_set
 from c7n.resources import load_available
 from c7n.utils import CONN_CACHE, dumps
+from c7n.provider import clouds
 
 from c7n_org.utils import environ, account_tags
 
@@ -553,6 +554,12 @@ def run_account(account, region, policies_config, output_path,
             # Variable expansion and non schema validation (not optional)
             p.expand_variables(p.get_variables(account.get('vars', {})))
             p.validate()
+            aws_resource = clouds['aws'].resources.get(p.resource_type.replace('aws.','')).resource_type.service
+            if region not in boto3.session.Session().get_available_regions(aws_resource):
+                log.warning(
+                    "Resource:%s not available in %s",
+                            p.resource_type, region)
+                continue  
             log.debug(
                 "Running policy:%s account:%s region:%s",
                 p.name, account['name'], region)


### PR DESCRIPTION
Checks if the AWS service is supported in the targeted region before to run the policy. Log a warning if not.
Related to https://github.com/cloud-custodian/cloud-custodian/issues/5718