### PR TITLE
Do not propagate tags if ASG has no instances

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1215,7 +1215,7 @@ class PropagateTags(Action):
         if self.data.get('trim', False):
             instances = [self.instance_map[i] for i in instance_ids]
             self.prune_instance_tags(client, asg, tag_set, instances)
-        if not self.manager.config.dryrun:
+        if not self.manager.config.dryrun and instances:
             client.create_tags(
                 Resources=instance_ids,
                 Tags=[{'Key': k, 'Value': v} for k, v in tag_map.items()])

--- a/tests/data/placebo/test_asg_propagate_tag_no_instances/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_no_instances/autoscaling.DescribeAutoScalingGroups_1.json
@@ -1,62 +1,62 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "AutoScalingGroups": [
             {
-                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:185106417252:autoScalingGroup:5fd42b45-825e-45c1-b02a-6a97d9512f30:autoScalingGroupName/c7n.asg.ec2.01", 
-                "TargetGroupARNs": [], 
-                "SuspendedProcesses": [], 
-                "DesiredCapacity": 1, 
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:123456789012:autoScalingGroup:5fd42b45-825e-45c1-b02a-6a97d9512f30:autoScalingGroupName/c7n.asg.ec2.01",
+                "TargetGroupARNs": [],
+                "SuspendedProcesses": [],
+                "DesiredCapacity": 1,
                 "Tags": [
                     {
-                        "ResourceType": "auto-scaling-group", 
-                        "ResourceId": "CustodianASG", 
-                        "PropagateAtLaunch": true, 
-                        "Value": "ubuntu", 
+                        "ResourceType": "auto-scaling-group",
+                        "ResourceId": "CustodianASG",
+                        "PropagateAtLaunch": true,
+                        "Value": "ubuntu",
                         "Key": "Platform"
                     }
-                ], 
-                "EnabledMetrics": [], 
-                "LoadBalancerNames": [], 
-                "AutoScalingGroupName": "c7n.asg.ec2.01", 
-                "DefaultCooldown": 300, 
-                "MinSize": 1, 
+                ],
+                "EnabledMetrics": [],
+                "LoadBalancerNames": [],
+                "AutoScalingGroupName": "c7n.asg.ec2.01",
+                "DefaultCooldown": 300,
+                "MinSize": 1,
                 "Instances": [
-                ], 
-                "MaxSize": 1, 
-                "VPCZoneIdentifier": "subnet-ea6429a3,subnet-2c5dcf01", 
-                "HealthCheckGracePeriod": 300, 
+                ],
+                "MaxSize": 1,
+                "VPCZoneIdentifier": "subnet-ea6429a3,subnet-2c5dcf01",
+                "HealthCheckGracePeriod": 300,
                 "TerminationPolicies": [
                     "Default"
-                ], 
-                "LaunchConfigurationName": "c7n.asg.01", 
+                ],
+                "LaunchConfigurationName": "c7n.asg.01",
                 "CreatedTime": {
-                    "hour": 19, 
-                    "__class__": "datetime", 
-                    "month": 2, 
-                    "second": 3, 
-                    "microsecond": 171000, 
-                    "year": 2017, 
-                    "day": 24, 
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 3,
+                    "microsecond": 171000,
+                    "year": 2017,
+                    "day": 24,
                     "minute": 0
-                }, 
+                },
                 "AvailabilityZones": [
-                    "us-east-1a", 
+                    "us-east-1a",
                     "us-east-1b"
-                ], 
-                "HealthCheckType": "EC2", 
+                ],
+                "HealthCheckType": "EC2",
                 "NewInstancesProtectedFromScaleIn": false
-            } 
-        ], 
+            }
+        ],
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "770b2115-fac8-11e6-ac2c-5ff00137fb8b", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "770b2115-fac8-11e6-ac2c-5ff00137fb8b",
             "HTTPHeaders": {
-                "x-amzn-requestid": "770b2115-fac8-11e6-ac2c-5ff00137fb8b", 
-                "vary": "Accept-Encoding", 
-                "content-length": "7006", 
-                "content-type": "text/xml", 
+                "x-amzn-requestid": "770b2115-fac8-11e6-ac2c-5ff00137fb8b",
+                "vary": "Accept-Encoding",
+                "content-length": "7006",
+                "content-type": "text/xml",
                 "date": "Fri, 24 Feb 2017 19:35:57 GMT"
             }
         }

--- a/tests/data/placebo/test_asg_propagate_tag_no_instances/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_no_instances/autoscaling.DescribeAutoScalingGroups_1.json
@@ -1,0 +1,64 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:185106417252:autoScalingGroup:5fd42b45-825e-45c1-b02a-6a97d9512f30:autoScalingGroupName/c7n.asg.ec2.01", 
+                "TargetGroupARNs": [], 
+                "SuspendedProcesses": [], 
+                "DesiredCapacity": 1, 
+                "Tags": [
+                    {
+                        "ResourceType": "auto-scaling-group", 
+                        "ResourceId": "CustodianASG", 
+                        "PropagateAtLaunch": true, 
+                        "Value": "ubuntu", 
+                        "Key": "Platform"
+                    }
+                ], 
+                "EnabledMetrics": [], 
+                "LoadBalancerNames": [], 
+                "AutoScalingGroupName": "c7n.asg.ec2.01", 
+                "DefaultCooldown": 300, 
+                "MinSize": 1, 
+                "Instances": [
+                ], 
+                "MaxSize": 1, 
+                "VPCZoneIdentifier": "subnet-ea6429a3,subnet-2c5dcf01", 
+                "HealthCheckGracePeriod": 300, 
+                "TerminationPolicies": [
+                    "Default"
+                ], 
+                "LaunchConfigurationName": "c7n.asg.01", 
+                "CreatedTime": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 3, 
+                    "microsecond": 171000, 
+                    "year": 2017, 
+                    "day": 24, 
+                    "minute": 0
+                }, 
+                "AvailabilityZones": [
+                    "us-east-1a", 
+                    "us-east-1b"
+                ], 
+                "HealthCheckType": "EC2", 
+                "NewInstancesProtectedFromScaleIn": false
+            } 
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "770b2115-fac8-11e6-ac2c-5ff00137fb8b", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "770b2115-fac8-11e6-ac2c-5ff00137fb8b", 
+                "vary": "Accept-Encoding", 
+                "content-length": "7006", 
+                "content-type": "text/xml", 
+                "date": "Fri, 24 Feb 2017 19:35:57 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_propagate_tag_no_instances/ec2.CreateTags_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_no_instances/ec2.CreateTags_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Code": "MissingParameter",
+            "Message": "The request must contain the parameter resourceIdSet"
+        },
+        "ResponseMetadata": {
+            "RequestId": "f229a23a-def5-4288-8ee0-f754ea63eda2",
+            "HTTPStatusCode": 400,
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "date": "Thu, 21 Nov 2019 18:49:02 GMT",
+                "connection": "close",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_propagate_tag_no_instances/ec2.DeleteTags_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_no_instances/ec2.DeleteTags_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "1b312937-e532-443a-99bd-1dab530b4a84"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_propagate_tag_no_instances/ec2.DeleteTags_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_no_instances/ec2.DeleteTags_1.json
@@ -1,8 +1,8 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "HTTPStatusCode": 200, 
+            "HTTPStatusCode": 200,
             "RequestId": "1b312937-e532-443a-99bd-1dab530b4a84"
         }
     }

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -819,6 +819,28 @@ class AutoScalingTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["AutoScalingGroupName"], "c7n-asg-np-missing")
 
+    def test_asg_propagate_tag_no_instances(self):
+        factory = self.replay_flight_data("test_asg_propagate_tag_no_instances")
+        p = self.load_policy(
+            {
+                "name": "asg-tag",
+                "resource": "asg",
+                "filters": [{"tag:Platform": "ubuntu"}],
+                "actions": [
+                    {
+                        "type": "propagate-tags",
+                        "trim": True,
+                        "tags": ["CustomerId", "Platform"],
+                    },
+                ],
+            },
+            session_factory=factory,
+        )
+
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["AutoScalingGroupName"], "c7n.asg.ec2.01")
+
     def test_asg_filter_capacity_delta_match(self):
         factory = self.replay_flight_data("test_asg_filter_capacity_delta_match")
         p = self.load_policy(


### PR DESCRIPTION
Closes #5086

If an ASG does not have any instances, a `propagate_tags` policy will cause a `boto3` EC2 `create_tags` request with an empty payload. This PR aborts the request prior to this call.

I believe this was already tackled in #5057 , but this PR only addresses the 'Missing Parameter' AWS response, and does not retry the request.