### PR TITLE
aws - config workaround broken select resource api and normalize rds cluster snapshot

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -16,6 +16,7 @@ Query capability built on skew metamodel
 
 tags_spec -> s3, elb, rds
 """
+from concurrent.futures import as_completed
 import functools
 import itertools
 import json
@@ -353,6 +354,35 @@ class ConfigSource:
             item_config = item['configuration']
         return camelResource(item_config)
 
+    def get_listed_resources(self, client):
+        # fallback for when config decides to arbitrarily break select
+        # resource for a given resource type.
+        paginator = client.get_paginator('list_discovered_resources')
+        paginator.PAGE_ITERATOR_CLS = RetryPageIterator
+        pages = paginator.paginate(
+            resourceType=self.manager.get_model().config_type)
+        results = []
+
+        with self.manager.executor_factory(max_workers=2) as w:
+            ridents = pages.build_full_result()
+            resource_ids = [
+                r['resourceId'] for r in ridents.get('resourceIdentifiers', ())]
+            self.manager.log.debug(
+                "querying %d %s resources",
+                len(resource_ids),
+                self.manager.__class__.__name__.lower())
+
+            for resource_set in chunks(resource_ids, 50):
+                futures = []
+                futures.append(w.submit(self.get_resources, resource_set))
+                for f in as_completed(futures):
+                    if f.exception():
+                        self.manager.log.error(
+                            "Exception getting resources from config \n %s" % (
+                                f.exception()))
+                    results.extend(f.result())
+        return results
+
     def resources(self, query=None):
         client = local_session(self.manager.session_factory).client('config')
         query = self.get_query_params(query)
@@ -367,6 +397,12 @@ class ConfigSource:
         for page in pager.paginate(Expression=query['expr']):
             results.extend([
                 self.load_resource(json.loads(r)) for r in page['Results']])
+
+        # Config arbitrarily breaks which resource types its supports for query/select
+        # on any given day, if we don't have a user defined query, then fallback
+        # to iteration mode.
+        if not results and query == self.get_query_params({}):
+            results = self.get_listed_resources(client)
         return results
 
     def augment(self, resources):

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -19,6 +19,7 @@ tags_spec -> s3, elb, rds
 from concurrent.futures import as_completed
 import functools
 import itertools
+import json
 
 import jmespath
 import os

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -19,7 +19,6 @@ tags_spec -> s3, elb, rds
 from concurrent.futures import as_completed
 import functools
 import itertools
-import json
 
 import jmespath
 import os

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import logging
 
 from concurrent.futures import as_completed

--- a/tests/data/placebo/test_rdscluster_snapshot_config/config.GetResourceConfigHistory_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_config/config.GetResourceConfigHistory_1.json
@@ -1,0 +1,63 @@
+{
+    "status_code": 200,
+    "data": {
+        "configurationItems": [
+            {
+                "version": "1.3",
+                "accountId": "644160558196",
+                "configurationItemCaptureTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 19,
+                    "hour": 8,
+                    "minute": 28,
+                    "second": 14,
+                    "microsecond": 760000
+                },
+                "configurationItemStatus": "ResourceDiscovered",
+                "configurationStateId": "6441605581960",
+                "configurationItemMD5Hash": "",
+                "arn": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-19-05-58",
+                "resourceType": "AWS::RDS::DBClusterSnapshot",
+                "resourceId": "rds:database-1-2020-05-19-05-58",
+                "resourceName": "rds:database-1-2020-05-19-05-58",
+                "awsRegion": "us-east-1",
+                "availabilityZone": "Multiple Availability Zones",
+                "resourceCreationTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 19,
+                    "hour": 1,
+                    "minute": 58,
+                    "second": 37,
+                    "microsecond": 785000
+                },
+                "tags": {
+                    "Owner": "kapil"
+                },
+                "relatedEvents": [],
+                "relationships": [
+                    {
+                        "resourceType": "AWS::EC2::VPC",
+                        "resourceId": "vpc-d2d616b5",
+                        "relationshipName": "Is associated with "
+                    },
+                    {
+                        "resourceType": "AWS::RDS::DBCluster",
+                        "resourceName": "database-1",
+                        "relationshipName": "Is associated with "
+                    }
+                ],
+                "configuration": "{\"availabilityZones\":[\"us-east-1a\",\"us-east-1b\",\"us-east-1d\"],\"snapshotCreateTime\":6441605581965,\"engine\":\"aurora-postgresql\",\"allocatedStorage\":0,\"status\":\"available\",\"port\":0,\"vpcId\":\"vpc-d2d616b5\",\"clusterCreateTime\":6441605581960,\"masterUsername\":\"postgres\",\"engineVersion\":\"10.serverless_7\",\"licenseModel\":\"postgresql-license\",\"snapshotType\":\"automated\",\"percentProgress\":100,\"storageEncrypted\":true,\"kmsKeyId\":\"arn:aws:kms:us-east-1:644160558196:key/b10f842a-feb7-4318-92d5-0640a75b7688\",\"dbclusterIdentifier\":\"database-1\",\"dbclusterSnapshotIdentifier\":\"rds:database-1-2020-05-19-05-58\",\"iamdatabaseAuthenticationEnabled\":false,\"dbclusterSnapshotArn\":\"arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-19-05-58\"}",
+                "supplementaryConfiguration": {
+                    "DBClusterSnapshotAttributes": "[{\"attributeName\":\"restore\",\"attributeValues\":[]}]",
+                    "Tags": "[{\"key\":\"Owner\",\"value\":\"kapil\"}]"
+                }
+            }
+        ],
+        "nextToken": "eyJlbmNyeXB0ZWREYXRhIjpbMTIwLDYzLDg2LDk2LC0xMjAsNzMsMTE2LC0xMjAsLTcwLDEzLC05NiwtMjIsMTI3LC0zMCwxMjQsLTYxLDExOSwxMTUsMTI3LC03MywtNTMsLTUwLC0yMSwxMjYsNDQsNTYsNDMsLTQ0LC0xMTcsNjMsLTg2LC05OSw2Nyw5OSw2OSwxNiw0OCw2MSwxMDksMTE5LC03NiwtNTAsLTExNCwtMTI1LC0xMjMsLTU3LDg0LC0xMDcsMTEyLDE4LDUxLC01LC05NiwtMTI0LDMxLDY5LC0xMjEsNDEsNDYsLTEyLC00MywtMTAxLC04LC00MywtOTYsODgsLTI4LDgwLC0xMjMsLTI1LC0xMSw4NSwtOCwtNTcsMzgsMjUsLTExNywtNTUsLTEwMywyNyw4LDU2LDU0LC02MywtODcsMTI2LDUsLTYxLDEyMCwtODUsNjEsLTEyNiwtMTIwLC0xMjEsODgsLTQ2LC05Myw4MCw5NCwwLDYyLDUsODgsNzMsLTk2LC03NiwtNDUsLTM0LDk2LDcxLC02LC03OSw4NiwtMTE2LC0xMSwtNjgsMzcsLTU1LC0xNSwtNDIsLTEwOCwtMTI3LDUwLC0xMjgsLTE1LDgyLDc5LC0yOSw3NSwtMTEzLC0zMiw4MywtOTEsLTc3LDY2LDMsMjMsMjksODIsNDMsLTk3LC03MSwyMiwtNTYsMjAsMTIwLC04MCwtMzgsLTI2LC0xNywyLC00OCw0Nyw3OCwtMTEsLTkzLDQzLDEwMywzNCwzMCwtMTI2LDIxLDExNCwxMjMsNzgsMzRdLCJtYXRlcmlhbFNldFNlcmlhbE51bWJlciI6MSwiaXZQYXJhbWV0ZXJTcGVjIjp7Iml2IjpbMTE0LDMsLTQ1LDQ4LDYyLDM1LDExMSwxMSwtNzUsLTM3LC03LC0yMSwyMSwtNzAsMTIsLTEwMF19fQ==",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_config/config.GetResourceConfigHistory_2.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_config/config.GetResourceConfigHistory_2.json
@@ -1,0 +1,63 @@
+{
+    "status_code": 200,
+    "data": {
+        "configurationItems": [
+            {
+                "version": "1.3",
+                "accountId": "644160558196",
+                "configurationItemCaptureTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 10,
+                    "day": 23,
+                    "hour": 12,
+                    "minute": 46,
+                    "second": 53,
+                    "microsecond": 279000
+                },
+                "configurationItemStatus": "ResourceDiscovered",
+                "configurationStateId": "6441605581969",
+                "configurationItemMD5Hash": "",
+                "arn": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:verify",
+                "resourceType": "AWS::RDS::DBClusterSnapshot",
+                "resourceId": "verify",
+                "resourceName": "verify",
+                "awsRegion": "us-east-1",
+                "availabilityZone": "Multiple Availability Zones",
+                "resourceCreationTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 10,
+                    "day": 23,
+                    "hour": 12,
+                    "minute": 44,
+                    "second": 39,
+                    "microsecond": 790000
+                },
+                "tags": {
+                    "Owner": "kapil"
+                },
+                "relatedEvents": [],
+                "relationships": [
+                    {
+                        "resourceType": "AWS::RDS::DBCluster",
+                        "resourceName": "database-1",
+                        "relationshipName": "Is associated with "
+                    },
+                    {
+                        "resourceType": "AWS::EC2::VPC",
+                        "resourceId": "vpc-d2d616b5",
+                        "relationshipName": "Is associated with "
+                    }
+                ],
+                "configuration": "{\"availabilityZones\":[\"us-east-1a\",\"us-east-1b\",\"us-east-1d\"],\"snapshotCreateTime\":6441605581960,\"engine\":\"aurora-postgresql\",\"allocatedStorage\":0,\"status\":\"available\",\"port\":0,\"vpcId\":\"vpc-d2d616b5\",\"clusterCreateTime\":6441605581960,\"masterUsername\":\"postgres\",\"engineVersion\":\"10.serverless_7\",\"licenseModel\":\"postgresql-license\",\"snapshotType\":\"manual\",\"percentProgress\":100,\"storageEncrypted\":true,\"kmsKeyId\":\"arn:aws:kms:us-east-1:644160558196:key/b10f842a-feb7-4318-92d5-0640a75b7688\",\"dbclusterSnapshotIdentifier\":\"verify\",\"dbclusterIdentifier\":\"database-1\",\"iamdatabaseAuthenticationEnabled\":false,\"dbclusterSnapshotArn\":\"arn:aws:rds:us-east-1:644160558196:cluster-snapshot:verify\"}",
+                "supplementaryConfiguration": {
+                    "DBClusterSnapshotAttributes": "[{\"attributeName\":\"restore\",\"attributeValues\":[]}]",
+                    "Tags": "[{\"key\":\"Owner\",\"value\":\"kapil\"}]"
+                }
+            }
+        ],
+        "nextToken": "eyJlbmNyeXB0ZWREYXRhIjpbLTM4LC01NywtMjAsNTIsLTEwNiwxMTksOTEsNzMsODYsLTExLC0zNywxMDYsMzAsMTE1LC0xMTAsMTA1LDc3LC00NywtMjksLTE2LC0xMTAsLTEwOSw0OSwtNDgsLTkxLC00NiwtMTAwLC0xMjcsNzEsLTY5LDEyNywtMTI3LDQ3LDY2LC05MiwtMTE0LDczLDM1LC0xNiwxMjQsMzksLTI1LC04NCw5Miw1MywtOTksLTcyLDkwLC0zLDg5LC01OSwxMTMsMSwtMTEwLDE3LDcxLC0zNywtMjQsLTEwMywxNSwtNiwtOTUsLTM0LDM2LC0xMCwtOSwtNTAsMTE3LC05MCwzMywtODAsNTgsLTEyNywtOTAsLTUyLC0xMiwxMjAsLTUzLDEwNywtMTEzLC01NywtOSwtMTExLC0xMDgsLTEyNCwtMTMsLTY2LC0xMTIsMTksLTEyNSwtNjEsLTExLDEwOCw1Nyw1OCwtNDksNzYsLTEyNCwtOTEsNzYsLTcsLTg2LDQ4LC03OCwtMSwxMTQsOCwtNjYsNDEsLTc0LC0zNCw5Myw2MiwtMTMsNTIsLTksLTExOSw0MCw5Miw5NiwtMTE5LDU1LDg4LDgxLDM1LC04NiwxMTYsLTExNSwyNCwtMTksLTgsNCwtMTExLC03MSwtOTgsLTM0LDY1LC01OCw1NiwtODksOTMsMzksLTk2LDUzLDU4LDEwLC04NCwtOTYsLTMzLC03LC03MiwxMDIsLTQ0LDMzLC0zNywtNjgsMywxMjMsMzAsLTExNiwtNzgsLTYzLDI3LC0zNCwtMTAyLC0zXSwibWF0ZXJpYWxTZXRTZXJpYWxOdW1iZXIiOjEsIml2UGFyYW1ldGVyU3BlYyI6eyJpdiI6WzEwMSwyNCw4MSw5NiwtNDgsLTkwLDU4LDM5LDQyLDU1LC04MSwtMTMsNzUsLTExNiw5NSwtMTddfX0=",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_config/config.ListDiscoveredResources_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_config/config.ListDiscoveredResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "resourceIdentifiers": [
+            {
+                "resourceType": "AWS::RDS::DBClusterSnapshot",
+                "resourceId": "rds:database-1-2020-05-19-05-58",
+                "resourceName": "rds:database-1-2020-05-19-05-58"
+            },
+            {
+                "resourceType": "AWS::RDS::DBClusterSnapshot",
+                "resourceId": "verify",
+                "resourceName": "verify"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_config/config.SelectResourceConfig_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_config/config.SelectResourceConfig_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "Results": [],
+        "QueryInfo": {
+            "SelectFields": [
+                {
+                    "Name": "configuration"
+                },
+                {
+                    "Name": "supplementaryConfiguration"
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_config/rds.DescribeDBClusterSnapshots_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_config/rds.DescribeDBClusterSnapshots_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshots": [
+            {
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1d"
+                ],
+                "DBClusterSnapshotIdentifier": "verify",
+                "DBClusterIdentifier": "database-1",
+                "SnapshotCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 10,
+                    "day": 23,
+                    "hour": 16,
+                    "minute": 44,
+                    "second": 39,
+                    "microsecond": 790000
+                },
+                "Engine": "aurora-postgresql",
+                "AllocatedStorage": 0,
+                "Status": "available",
+                "Port": 0,
+                "VpcId": "vpc-d2d616b5",
+                "ClusterCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 10,
+                    "day": 20,
+                    "hour": 10,
+                    "minute": 53,
+                    "second": 28,
+                    "microsecond": 740000
+                },
+                "MasterUsername": "postgres",
+                "EngineVersion": "10.serverless_7",
+                "LicenseModel": "postgresql-license",
+                "SnapshotType": "manual",
+                "PercentProgress": 100,
+                "StorageEncrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/b10f842a-feb7-4318-92d5-0640a75b7688",
+                "DBClusterSnapshotArn": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:verify",
+                "IAMDatabaseAuthenticationEnabled": false
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_config/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_config/tagging.GetResources_1.json
@@ -1,0 +1,81 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-26-05-58",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "kapil"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-21-05-59",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "kapil"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-25-05-58",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "kapil"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-24-05-58",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "kapil"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-23-05-58",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "kapil"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:verify",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "kapil"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-27-05-58",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "kapil"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-snapshot:rds:database-1-2020-05-22-05-58",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "kapil"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_rdscluster.py
+++ b/tests/test_rdscluster.py
@@ -371,6 +371,30 @@ class RDSClusterTest(BaseTest):
 
 class RDSClusterSnapshotTest(BaseTest):
 
+    def test_rdscluster_snapshot_config(self):
+        session_factory = self.replay_flight_data("test_rdscluster_snapshot_config")
+        p = self.load_policy(
+            {"name": "rdscluster-snapshot-simple",
+             "source": "config",
+             "resource": "rds-cluster-snapshot"},
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+        p2 = self.load_policy(
+            {"name": "rdscluster-snapshot-descr",
+             "resource": "rds-cluster-snapshot"},
+            session_factory=session_factory)
+        rm = p2.resource_manager
+        resources2 = rm.get_resources([resources[-1][rm.resource_type.id]])
+        self.maxDiff = None
+        # placebo mangles the utc tz with its own class, also our account rewriter
+        # mangles the timestamp string :-(
+        for k in ('ClusterCreateTime', 'SnapshotCreateTime'):
+            for r in (resources[-1], resources2[0]):
+                r.pop(k)
+        self.assertEqual(resources[-1], resources2[0])
+
     def test_rdscluster_snapshot_simple(self):
         session_factory = self.replay_flight_data("test_rdscluster_snapshot_simple")
         p = self.load_policy(


### PR DESCRIPTION
closes #5780﻿

as noted in #5408 config is fairly arbitrary with regard to what it supports for a given resource type. for many resource type that it **documents** as supporting, it doesn't actually support resource select api, how arbitrary it is on being broken is unclear (ie. does it vary just by type or also include other mystery variations by account, region, time of day). fallback to our old way of handling this pre select resources api, of just iterating ids and fetching fo resource types where we're not able to get results via select resources. on empty sets this does involve an extra api query per region.

also handle the particularly mangled db cluster snapshot identifiers, and normalize them back to describe format.
