### PR TITLE
aws - rds snapshot delete raise on unknown error

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1315,9 +1315,10 @@ class RDSSnapshotDelete(BaseAction):
         error = None
         with self.executor_factory(max_workers=2) as w:
             futures = []
+            client = local_session(self.manager.session_factory).client('rds')
             for snapshot_set in chunks(reversed(snapshots), size=50):
                 futures.append(
-                    w.submit(self.process_snapshot_set, snapshot_set))
+                    w.submit(self.process_snapshot_set, client, snapshot_set))
             for f in as_completed(futures):
                 if f.exception():
                     self.log.error(
@@ -1328,12 +1329,15 @@ class RDSSnapshotDelete(BaseAction):
             raise error
         return snapshots
 
-    def process_snapshot_set(self, snapshots_set):
-        c = local_session(self.manager.session_factory).client('rds')
+    def process_snapshot_set(self, client, snapshots_set):
         for s in snapshots_set:
-            self.manager.retry(
-                c.delete_db_snapshot,
-                DBSnapshotIdentifier=s['DBSnapshotIdentifier'])
+            try:
+                self.manager.retry(
+                    client.delete_db_snapshot,
+                    DBSnapshotIdentifier=s['DBSnapshotIdentifier'])
+            except (client.exceptions.DBSnapshotNotFoundFault,
+                    client.exceptions.InvalidDBSnapshotStateFault):
+                continue
 
 
 @actions.register('modify-security-groups')


### PR DESCRIPTION
closes #5794

- aws - rds snapshot delete action raise if err on any snapshot delete
- client construction in main thread, exempt known exceptions
