### PR TITLE
gcp - storage output, register log output

### DIFF
--- a/c7n/ctx.py
+++ b/c7n/ctx.py
@@ -41,6 +41,7 @@ class ExecutionContext:
         self.start_time = None
         self.execution_id = None
         self.output = None
+        self.logs = None
         self.api_stats = None
         self.sys_stats = None
 

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -34,9 +34,12 @@ import zipfile
 # that support service side building.
 # Its also used for release engineering on our pypi uploads
 try:
-    import importlib_metadata as pkgmd
-except (ImportError, FileNotFoundError):
-    pkgmd = None
+    from importlib import metadata as pkgmd
+except ImportError:
+    try:
+        import importlib_metadata as pkgmd
+    except (ImportError, FileNotFoundError):
+        pkgmd = None
 
 
 # Static event mapping to help simplify cwe rules creation

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -278,7 +278,7 @@ def get_exec_options(options):
         if options[k]:
             d[k] = options[k]
     # ignore local fs/dir output paths
-    if 'output_dir' in d and not '://' in d['output_dir']:
+    if 'output_dir' in d and '://' not in d['output_dir']:
         d.pop('output_dir')
     return d
 

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -502,7 +502,7 @@ class BlobOutput(DirectoryOutput):
             date_path = datetime.datetime.utcnow().strftime('%Y/%m/%d/%H')
             return "/".join([s.strip('/') for s in [
                 output_url, self.ctx.policy.name, date_path]])
-        return output_url.format(**self.get_output_vars())
+        return output_url.format(**self.get_output_vars()).rstrip('/')
 
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
         self.log.debug("%s: uploading policy logs", self.type)

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -480,6 +480,8 @@ class DirectoryOutput:
 
 class BlobOutput(DirectoryOutput):
 
+    log = logging.getLogger('custodian.output.blob')
+
     def __init__(self, ctx, config):
         self.ctx = ctx
         # we allow format strings in output urls so reparse config
@@ -503,11 +505,11 @@ class BlobOutput(DirectoryOutput):
         return output_url.format(**self.get_output_vars())
 
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
-        self.log.debug("Uploading policy logs")
+        self.log.debug("%s: uploading policy logs", self.type)
         self.compress()
         self.upload()
         shutil.rmtree(self.root_dir)
-        self.log.debug("Policy Logs uploaded")
+        self.log.debug("%s: policy logs uploaded", self.type)
 
     def upload(self):
         for root, dirs, files in os.walk(self.root_dir):

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -20,7 +20,6 @@ See docs/usage/outputs.rst
 """
 import contextlib
 import datetime
-import json
 import gzip
 import logging
 import os

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -463,20 +463,6 @@ class DirectoryOutput:
             'uuid': str(uuid.uuid4())}
         return data
 
-    def get_resource_set(self):
-        record_path = os.path.join(self.root_dir, 'resources.json')
-
-        if not os.path.exists(record_path):
-            return []
-
-        mdate = datetime.datetime.fromtimestamp(
-            os.stat(record_path).st_ctime)
-
-        with open(record_path) as fh:
-            records = json.load(fh)
-            [r.__setitem__('CustodianDate', mdate) for r in records]
-            return records
-
 
 class BlobOutput(DirectoryOutput):
 

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -53,7 +53,9 @@ class OutputRegistry(PluginRegistry):
     def select(self, selector, ctx):
         if not selector:
             return self['default'](ctx, {'url': selector})
-        if self.default_protocol and '://' not in selector:
+        if '://' not in selector and selector in self:
+            selector = "{}://".format(selector)
+        elif self.default_protocol and '://' not in selector:
             selector = "{}://{}".format(
                 self.default_protocol, selector)
         for k in self.keys():

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -507,9 +507,7 @@ class S3Output(BlobOutput):
 
     def __init__(self, ctx, config):
         super().__init__(ctx, config)
-        # Lazy import
-        # can't use a local session as we dont want an unassumed session
-        # cached.
+        # can't use a local session as we dont want an unassumed session cached.
         self.transfer = S3Transfer(
             self.ctx.session_factory(assume=False).client('s3'))
 

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -22,9 +22,7 @@ import itertools
 import logging
 import os
 import operator
-import shutil
 import sys
-import tempfile
 import time
 import threading
 import traceback
@@ -32,6 +30,7 @@ import traceback
 import boto3
 
 from botocore.validate import ParamValidator
+from boto3.s3.transfer import S3Transfer
 
 from c7n.credentials import SessionFactory
 from c7n.config import Bag
@@ -53,7 +52,7 @@ from c7n.output import (
 from c7n.output import (
     Metrics,
     DeltaStats,
-    DirectoryOutput,
+    BlobOutput,
     LogOutput,
 )
 
@@ -493,7 +492,7 @@ class ApiStats(DeltaStats):
 
 
 @blob_outputs.register('s3')
-class S3Output(DirectoryOutput):
+class S3Output(BlobOutput):
     """
     Usage:
 
@@ -507,56 +506,19 @@ class S3Output(DirectoryOutput):
     permissions = ('S3:PutObject',)
 
     def __init__(self, ctx, config):
-        self.ctx = ctx
-        self.config = config
-        self.output_path = self.get_output_path(self.config['url'])
-        self.s3_path, self.bucket, self.key_prefix = utils.parse_s3(
-            self.output_path)
-        self.root_dir = tempfile.mkdtemp()
-        self.transfer = None
-
-    def __repr__(self):
-        return "<%s to bucket:%s prefix:%s>" % (
-            self.__class__.__name__,
-            self.bucket,
-            self.key_prefix)
-
-    def get_output_path(self, output_url):
-        if '{' not in output_url:
-            date_path = datetime.datetime.utcnow().strftime('%Y/%m/%d/%H')
-            return self.join(
-                output_url, self.ctx.policy.name, date_path)
-        return output_url.format(**self.get_output_vars())
-
-    @staticmethod
-    def join(*parts):
-        return "/".join([s.strip('/') for s in parts])
-
-    def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
-        from boto3.s3.transfer import S3Transfer
-        if exc_type is not None:
-            log.exception("Error while executing policy")
-        log.debug("Uploading policy logs")
-        self.compress()
+        super().__init__(ctx, config)
+        # Lazy import
+        # can't use a local session as we dont want an unassumed session
+        # cached.
         self.transfer = S3Transfer(
             self.ctx.session_factory(assume=False).client('s3'))
-        self.upload()
-        shutil.rmtree(self.root_dir)
-        log.debug("Policy Logs uploaded")
 
-    def upload(self):
-        for root, dirs, files in os.walk(self.root_dir):
-            for f in files:
-                key = "%s%s" % (
-                    self.key_prefix,
-                    "%s/%s" % (
-                        root[len(self.root_dir):], f))
-                key = key.strip('/')
-                self.transfer.upload_file(
-                    os.path.join(root, f), self.bucket, key,
-                    extra_args={
-                        'ACL': 'bucket-owner-full-control',
-                        'ServerSideEncryption': 'AES256'})
+    def upload_file(self, path, key):
+        self.transfer.upload_file(
+            path, self.bucket, key,
+            extra_args={
+                'ACL': 'bucket-owner-full-control',
+                'ServerSideEncryption': 'AES256'})
 
 
 @clouds.register('aws')

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -154,13 +154,13 @@ def generate(resource_types=()):
         'string_dict': {
             "type": "object",
             "patternProperties": {
-                "*": {"type": "string"},
+                "": {"type": "string"},
             },
         },
         'basic_dict': {
             "type": "object",
             "patternProperties": {
-                "*": {
+                "": {
                     'oneOf': [
                         {"type": "string"},
                         {"type": "boolean"},

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -27,9 +27,11 @@ import zipfile
 
 import mock
 
+from c7n.config import Config
 from c7n.mu import (
     custodian_archive,
     generate_requirements,
+    get_exec_options,
     LambdaFunction,
     LambdaManager,
     PolicyLambda,
@@ -45,6 +47,18 @@ from .data import helloworld
 
 
 ROLE = "arn:aws:iam::644160558196:role/custodian-mu"
+
+
+def test_get_exec_options():
+
+    assert get_exec_options(Config().empty()) == {'tracer': 'default'}
+    assert get_exec_options(Config().empty(output_dir='/tmp/xyz')) == {
+        'tracer': 'default'}
+    assert get_exec_options(
+        Config().empty(log_group='gcp', output_dir='gs://mybucket/myprefix')) == {
+            'tracer': 'default',
+            'output_dir': 'gs://mybucket/myprefix',
+            'log_group': 'gcp'}
 
 
 def test_generate_requirements():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -56,7 +56,7 @@ class DirOutputTest(BaseTest):
 
 class S3OutputTest(TestUtils):
 
-    def test_path_join(self):
+    def xtest_path_join(self):
 
         self.assertEqual(S3Output.join("s3://xyz/", "/bar/"), "s3://xyz/bar")
 
@@ -68,7 +68,7 @@ class S3OutputTest(TestUtils):
         output_dir = "s3://cloud-custodian/policies"
         output = S3Output(
             ExecutionContext(
-                None,
+                lambda assume=False: mock.MagicMock(),
                 Bag(name="xyz", provider_name="ostack"),
                 Config.empty(output_dir=output_dir)),
             {'url': output_dir})
@@ -88,6 +88,7 @@ class S3OutputTest(TestUtils):
     def test_join_leave_log(self):
         temp_dir = self.get_temp_dir()
         output = LogFile(Bag(log_dir=temp_dir), {})
+        logging.getLogger('custodian').setLevel(logging.INFO)
         output.join_log()
 
         l = logging.getLogger("custodian.s3") # NOQA
@@ -129,7 +130,7 @@ class S3OutputTest(TestUtils):
 
         with mock_datetime_now(date_parse('2018/09/01 13:00'), datetime):
             output = self.get_s3_output()
-            self.assertEqual(output.key_prefix, "/policies/xyz/2018/09/01/13")
+            self.assertEqual(output.key_prefix, "policies/xyz/2018/09/01/13")
 
         with open(os.path.join(output.root_dir, "foo.txt"), "w") as fh:
             fh.write("abc")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -59,7 +59,7 @@ class S3OutputTest(TestUtils):
     def get_s3_output(self, output_url=None, cleanup=True, klass=S3Output):
         if output_url is None:
             output_url = "s3://cloud-custodian/policies"
-        output = S3Output(
+        output = klass(
             ExecutionContext(
                 lambda assume=False: mock.MagicMock(),
                 Bag(name="xyz", provider_name="ostack"),

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -22,7 +22,7 @@ from dateutil.parser import parse as date_parse
 
 from c7n.ctx import ExecutionContext
 from c7n.config import Config
-from c7n.output import DirectoryOutput, LogFile, metrics_outputs
+from c7n.output import DirectoryOutput, BlobOutput, LogFile, metrics_outputs
 from c7n.resources.aws import S3Output, MetricsOutput
 from c7n.testing import mock_datetime_now, TestUtils
 
@@ -56,7 +56,7 @@ class DirOutputTest(BaseTest):
 
 class S3OutputTest(TestUtils):
 
-    def get_s3_output(self, output_url=None, cleanup=True):
+    def get_s3_output(self, output_url=None, cleanup=True, klass=S3Output):
         if output_url is None:
             output_url = "s3://cloud-custodian/policies"
         output = S3Output(
@@ -70,6 +70,10 @@ class S3OutputTest(TestUtils):
             self.addCleanup(shutil.rmtree, output.root_dir)
 
         return output
+
+    def test_blob_output(self):
+        blob_output = self.get_s3_output(klass=BlobOutput)
+        self.assertRaises(blob_output.upload_file, 'xyz', '/prefix/xyz')
 
     def test_output_path(self):
         with mock_datetime_now(date_parse('2020/06/10 13:00'), datetime):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -73,7 +73,8 @@ class S3OutputTest(TestUtils):
 
     def test_blob_output(self):
         blob_output = self.get_s3_output(klass=BlobOutput)
-        self.assertRaises(blob_output.upload_file, 'xyz', '/prefix/xyz')
+        self.assertRaises(NotImplementedError,
+                          blob_output.upload_file, 'xyz', '/prefix/xyz')
 
     def test_output_path(self):
         with mock_datetime_now(date_parse('2020/06/10 13:00'), datetime):

--- a/tools/c7n_gcp/c7n_gcp/handler.py
+++ b/tools/c7n_gcp/c7n_gcp/handler.py
@@ -38,17 +38,15 @@ def run(event, context=None):
         log.error('Invalid policy config')
         return False
 
-    options_overrides = \
-        policy_config['policies'][0].get('mode', {}).get('execution-options', {})
-
+    # setup execution options
+    options = Config.empty(**policy_config.pop('execution-options', {}))
+    options.update(
+        policy_config['policies'][0].get('mode', {}).get('execution-options', {}))
     # if output_dir specified use that, otherwise make a temp directory
-    if 'output_dir' not in options_overrides:
-        options_overrides['output_dir'] = get_tmp_output_dir()
+    if not options.output_dir:
+        options['output_dir'] = get_tmp_output_dir()
 
-    # merge all our options in
-    options = Config.empty(**options_overrides)
     loader = PolicyLoader(options)
-
     policies = loader.load_data(policy_config, 'config.json', validate=False)
     if policies:
         for p in policies:

--- a/tools/c7n_gcp/c7n_gcp/mu.py
+++ b/tools/c7n_gcp/c7n_gcp/mu.py
@@ -326,18 +326,19 @@ class PolicyFunction(CloudFunction):
 
     def get_output_deps(self):
         deps = []
+        self.policy.ctx.initialize()
+
         outputs = (
-            ('metrics', self.policy.ctx.api_stats),
+            ('metrics', self.policy.ctx.metrics),
             ('blob', self.policy.ctx.output),
             ('log', self.policy.ctx.logs)
         )
-
         for (output_type, instance) in outputs:
             if not instance:
                 continue
-            if f"{output_type}.{instance}" not in OUTPUT_PACKAGE_MAP:
+            if f"{output_type}.{instance.type}" not in OUTPUT_PACKAGE_MAP:
                 continue
-            deps.append(OUTPUT_PACKAGE_MAP[f"{output_type}.{instance}"])
+            deps.append(OUTPUT_PACKAGE_MAP[f"{output_type}.{instance.type}"])
         return deps
 
     @property

--- a/tools/c7n_gcp/c7n_gcp/mu.py
+++ b/tools/c7n_gcp/c7n_gcp/mu.py
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import base64
+import base64
 from collections import namedtuple
 import json
 import logging
 import hashlib
 
 from c7n_gcp.client import errors
-from c7n.mu import generate_requirements, custodian_archive as base_archive
+from c7n.mu import generate_requirements, get_exec_options, custodian_archive as base_archive
 from c7n.utils import local_session
 
 from googleapiclient.errors import HttpError
 
 log = logging.getLogger('c7n_gcp.mu')
+
 
 OUTPUT_PACKAGE_MAP = {
     'metrics.gcp': 'google-cloud-monitoring',
@@ -356,8 +357,10 @@ class PolicyFunction(CloudFunction):
     def get_archive(self):
         self.archive.add_contents('main.py', PolicyHandlerTemplate)
         self.archive.add_contents(
-            'config.json', json.dumps(
-                {'policies': [self.policy.data]}, indent=2))
+            'config.json', json.dumps({
+                'execution-options': get_exec_options(self.policy.options),
+                'policies': [self.policy.data]},
+                indent=2))
         self.archive.close()
         return self.archive
 

--- a/tools/c7n_gcp/c7n_gcp/mu.py
+++ b/tools/c7n_gcp/c7n_gcp/mu.py
@@ -327,9 +327,9 @@ class PolicyFunction(CloudFunction):
     def get_output_deps(self):
         deps = []
         outputs = (
-            ('metrics', self.ctx.api_stats),
-            ('blob', self.ctx.output),
-            ('log', self.ctx.logs)
+            ('metrics', self.policy.ctx.api_stats),
+            ('blob', self.policy.ctx.output),
+            ('log', self.policy.ctx.logs)
         )
 
         for (output_type, instance) in outputs:
@@ -338,9 +338,7 @@ class PolicyFunction(CloudFunction):
             if f"{output_type}.{instance}" not in OUTPUT_PACKAGE_MAP:
                 continue
             deps.append(OUTPUT_PACKAGE_MAP[f"{output_type}.{instance}"])
-        return [
-            "{dep}=={dep_version}".format(
-                dep, version(dep)) for dep in deps]
+        return deps
 
     @property
     def name(self):

--- a/tools/c7n_gcp/c7n_gcp/mu.py
+++ b/tools/c7n_gcp/c7n_gcp/mu.py
@@ -43,6 +43,7 @@ def custodian_archive(packages=None, deps=()):
     # but for pure python packages, if we have a local install and its
     # relatively small, it might be faster to just upload.
     #
+    # note we pin requirements to the same versions installed locally.
     requirements = set()
     requirements.update((
         'jmespath',
@@ -53,7 +54,9 @@ def custodian_archive(packages=None, deps=()):
         'google-auth-httplib2',
         'google-api-python-client'))
     requirements.update(deps)
-    archive.add_contents('requirements.txt', generate_requirements(requirements))
+    archive.add_contents(
+        'requirements.txt',
+        generate_requirements(requirements, include_self=True))
     return archive
 
 
@@ -321,7 +324,8 @@ class PolicyFunction(CloudFunction):
     def __init__(self, policy, archive=None, events=()):
         self.policy = policy
         self.func_data = self.policy.data['mode']
-        self.archive = archive or custodian_archive(self.get_output_deps())
+        self.archive = archive or custodian_archive(
+            deps=self.get_output_deps())
         self._events = events
 
     def get_output_deps(self):

--- a/tools/c7n_gcp/c7n_gcp/mu.py
+++ b/tools/c7n_gcp/c7n_gcp/mu.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 from collections import namedtuple
 import json
 import logging

--- a/tools/c7n_gcp/c7n_gcp/output.py
+++ b/tools/c7n_gcp/c7n_gcp/output.py
@@ -152,20 +152,19 @@ class StackDriverMetrics(Metrics):
 @log_outputs.register('gcp', condition=bool(LogClient))
 class StackDriverLogging(LogOutput):
 
-    def get_handler(self):
-        # gcp has three independent implementation of api bindings for python.
-        # The one used by logging is not yet supported by our test recording.
-
-        # TODO drop these grpc variants for the REST versions, and we can drop
-        # protobuf/grpc deps, and also so we can record tests..
-        # gcp has three different python sdks all independently maintained .. hmmm...
-        # and random monkey shims on top of those :-(
+    def get_log_group(self):
         log_group = self.config.netloc
         if log_group:
             log_group = "custodian-%s-%s" % (log_group, self.ctx.policy.name)
         else:
             log_group = "custodian-%s" % self.ctx.policy.name
+        return log_group
 
+    def get_handler(self):
+        # TODO drop these grpc variants for the REST versions, and we can drop
+        # protobuf/grpc deps, and also so we can record tests.
+
+        log_group = self.get_log_group()
         project_id = local_session(self.ctx.session_factory).get_default_project()
         client = LogClient(project_id)
         return CloudLoggingHandler(

--- a/tools/c7n_gcp/c7n_gcp/output.py
+++ b/tools/c7n_gcp/c7n_gcp/output.py
@@ -168,7 +168,6 @@ class StackDriverLogging(LogOutput):
 
         project_id = local_session(self.ctx.session_factory).get_default_project()
         client = LogClient(project_id)
-
         return CloudLoggingHandler(
             client,
             log_group,

--- a/tools/c7n_gcp/c7n_gcp/output.py
+++ b/tools/c7n_gcp/c7n_gcp/output.py
@@ -222,7 +222,7 @@ class GCPStorageOutput(DirectoryOutput):
     def upload(self):
         for root, dirs, files in os.walk(self.root_dir):
             for f in files:
-                key = "/".join(filter(None, [self.key_prefix, root[len(self.root_dir)+1:], f]))
+                key = "/".join(filter(None, [self.key_prefix, root[len(self.root_dir):], f]))
                 blob = self.bucket.blob(key)
                 blob.upload_from_filename(os.path.join(root, f))
 

--- a/tools/c7n_gcp/c7n_gcp/output.py
+++ b/tools/c7n_gcp/c7n_gcp/output.py
@@ -187,8 +187,6 @@ class StackDriverLogging(LogOutput):
 @blob_outputs.register('gs', condition=bool(StorageClient))
 class GCPStorageOutput(BlobOutput):
 
-    log = logging.getLogger('c7n_gcp.output')
-
     def __init__(self, ctx, config=None):
         super().__init__(ctx, config)
         self.bucket = Bucket(StorageClient(), self.bucket)

--- a/tools/c7n_gcp/c7n_gcp/output.py
+++ b/tools/c7n_gcp/c7n_gcp/output.py
@@ -24,7 +24,7 @@ import time
 try:
     from google.cloud.storage import Bucket, Client as StorageClient
 except ImportError:
-    StorageClient = None
+    Bucket, StorageClient = None, None
 
 try:
     from google.cloud.logging import Client as LogClient

--- a/tools/c7n_gcp/c7n_gcp/output.py
+++ b/tools/c7n_gcp/c7n_gcp/output.py
@@ -165,7 +165,7 @@ class StackDriverLogging(LogOutput):
         # gcp has three different python sdks all independently maintained .. hmmm...
         # and random monkey shims on top of those :-(
         log_group = self.config.netloc
-        if log_group:gi
+        if log_group:
             log_group = "custodian-%s-%s" % (log_group, self.ctx.policy.name)
         else:
             log_group = "custodian-%s" % self.ctx.policy.name

--- a/tools/c7n_gcp/c7n_gcp/policy.py
+++ b/tools/c7n_gcp/c7n_gcp/policy.py
@@ -28,14 +28,15 @@ class FunctionMode(ServerlessExecutionMode):
 
     schema = type_schema(
         'gcp',
-        **{'execution-options': {'type': 'object'},
+        **{'execution-options': {'$ref': '#/definitions/basic_dict'},
            'timeout': {'type': 'string'},
            'memory-size': {'type': 'integer'},
-           'labels': {'type': 'object'},
+           'labels': {'$ref': '#/definitions/string_dict'},
            'network': {'type': 'string'},
            'max-instances': {'type': 'integer'},
            'service-account': {'type': 'string'},
-           'environment': {'type': 'object'}})
+           'environment': {'type': '#/definitions/string_dict'}}
+    )
 
     def __init__(self, policy):
         self.policy = policy

--- a/tools/c7n_gcp/c7n_gcp/policy.py
+++ b/tools/c7n_gcp/c7n_gcp/policy.py
@@ -35,7 +35,7 @@ class FunctionMode(ServerlessExecutionMode):
            'network': {'type': 'string'},
            'max-instances': {'type': 'integer'},
            'service-account': {'type': 'string'},
-           'environment': {'type': '#/definitions/string_dict'}}
+           'environment': {'$ref': '#/definitions/string_dict'}}
     )
 
     def __init__(self, policy):

--- a/tools/c7n_gcp/poetry.lock
+++ b/tools/c7n_gcp/poetry.lock
@@ -243,6 +243,33 @@ pandas = ["pandas (>=0.17.1)"]
 
 [[package]]
 category = "main"
+description = "Google Cloud Storage API client library"
+name = "google-cloud-storage"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.28.1"
+
+[package.dependencies]
+google-auth = ">=1.11.0,<2.0dev"
+google-cloud-core = ">=1.2.0,<2.0dev"
+google-resumable-media = ">=0.5.0,<0.6dev"
+
+[[package]]
+category = "main"
+description = "Utilities for Google Media Downloads and Resumable Uploads"
+name = "google-resumable-media"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "0.5.0"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+requests = ["requests (>=2.18.0,<3.0.0dev)"]
+
+[[package]]
+category = "main"
 description = "Common protobufs used in Google APIs"
 name = "googleapis-common-protos"
 optional = false
@@ -586,7 +613,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "5f83fc0e6b37c8c8293246d60946eb7ff1ea975e3cebf938d9ea1b3a0c6a9971"
+content-hash = "6c05c5363f47931e05080a9e517b4aee5dca8a442581850e49d85e1ec28245e0"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -659,6 +686,14 @@ google-cloud-logging = [
 google-cloud-monitoring = [
     {file = "google-cloud-monitoring-0.34.0.tar.gz", hash = "sha256:75370af645dd815c234561e7b356fa5d99b0ee6448c0e5d013455c72af961d0b"},
     {file = "google_cloud_monitoring-0.34.0-py2.py3-none-any.whl", hash = "sha256:0f9dea65e4b82c426dc9700cb6011ab4eac43394b38c4fd0b7045735ddb4a760"},
+]
+google-cloud-storage = [
+    {file = "google-cloud-storage-1.28.1.tar.gz", hash = "sha256:a7b5c326e7307a83fa1f1f0ef71aba9ad1f3a2bc6a768401e13fc02369fd8612"},
+    {file = "google_cloud_storage-1.28.1-py2.py3-none-any.whl", hash = "sha256:0b28536acab1d7e856a7a89bbfcad41f26f40b46af59786ca874ff0f94bbc0f9"},
+]
+google-resumable-media = [
+    {file = "google-resumable-media-0.5.0.tar.gz", hash = "sha256:2a8fd188afe1cbfd5998bf20602f76b0336aa892de88fe842a806b9a3ed78d2a"},
+    {file = "google_resumable_media-0.5.0-py2.py3-none-any.whl", hash = "sha256:b86140d5a0b6d290084b11bde90ee9aecad357ba0e0d67388d016b8340320927"},
 ]
 googleapis-common-protos = [
     {file = "googleapis-common-protos-1.52.0.tar.gz", hash = "sha256:560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351"},

--- a/tools/c7n_gcp/pyproject.toml
+++ b/tools/c7n_gcp/pyproject.toml
@@ -21,6 +21,7 @@ google-cloud-logging = "^1.14"
 google-auth = "^1.11.0"
 ratelimiter = "^1.2.0"
 google-cloud-monitoring = "^0.34.0"
+google-cloud-storage = "^1.28.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "~5.3.5"

--- a/tools/c7n_gcp/requirements.txt
+++ b/tools/c7n_gcp/requirements.txt
@@ -9,6 +9,8 @@ google-cloud-core==1.3.0
 google-cloud-logging==1.15.0
 google-cloud-monitoring==0.34.0
 googleapis-common-protos==1.52.0
+google-cloud-storage==1.28.1
+google-resumable-media==0.5.0
 httplib2==0.18.1
 idna==2.9
 protobuf==3.12.2

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -105,6 +105,23 @@ class FunctionTest(BaseTest):
         self.assertRaises(NotImplementedError, exec_mode.provision)
         self.assertEqual(None, exec_mode.validate())
 
+    def test_policy_context_deps(self):
+        p = self.load_policy({
+            'name': 'check',
+            'resource': 'gcp.instance',
+            'mode': {
+                'type': 'gcp-periodic',
+                'schedule': 'every 2 hours'}},
+            output_dir='gs://somebucket/some-prefix',
+            log_group='gcp',
+            config={'metrics': 'gcp'})
+        pf = mu.PolicyFunction(p, archive=True)
+        self.assertEqual(
+            pf.get_output_deps(),
+            ['google-cloud-monitoring',
+             'google-cloud-storage',
+             'google-cloud-logging'])
+
     def test_periodic_validate_tz(self):
         self.assertRaises(
             PolicyValidationError,

--- a/tools/c7n_gcp/tests/test_output_gcp.py
+++ b/tools/c7n_gcp/tests/test_output_gcp.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, timedelta
+import datetime
+from dateutil.parser import parse as date_parse
+from unittest import mock
+import shutil
 import time
 
-from c7n.config import Bag
+from c7n.ctx import ExecutionContext
+from c7n.config import Bag, Config
+from c7n.testing import mock_datetime_now
 from c7n.output import metrics_outputs
-from c7n_gcp.output import StackDriverMetrics
+from c7n.utils import parse_url_config
+
+from c7n_gcp.output import (
+    GCPStorageOutput, StackDriverLogging, StackDriverMetrics)
 
 from gcp_common import BaseTest
 
@@ -50,8 +58,9 @@ class MetricsOutputTest(BaseTest):
                 'filter': 'metric.type="custom.googleapis.com/custodian/policy/resourcecount"',
                 'pageSize': 3,
                 'interval_startTime': (
-                    datetime.utcnow() - timedelta(minutes=5)).isoformat('T') + 'Z',
-                'interval_endTime': datetime.utcnow().isoformat('T') + 'Z'
+                    datetime.datetime.utcnow() - datetime.timedelta(minutes=5)
+                ).isoformat('T') + 'Z',
+                'interval_endTime': datetime.datetime.utcnow().isoformat('T') + 'Z'
             })
         self.assertEqual(
             results['timeSeries'],
@@ -81,3 +90,53 @@ class MetricsOutputTest(BaseTest):
         metrics = StackDriverMetrics(ctx, conf)
         metrics.put_metric('ResourceCount', 43, 'Count', Scope='Policy')
         metrics.flush()
+
+
+def get_log_output(output_url):
+    log = StackDriverLogging(
+        ExecutionContext(
+            lambda assume=False: mock.MagicMock(),
+            Bag(name="xyz", provider_name="gcp", resource_type='gcp.function'),
+            Config.empty(account_id='custodian-test')),
+        parse_url_config(output_url)
+    )
+    return log
+
+
+def get_blob_output(request, output_url=None, cleanup=True):
+    if output_url is None:
+        output_url = "gs://cloud-custodian/policies"
+    output = GCPStorageOutput(
+        ExecutionContext(
+            lambda assume=False: mock.MagicMock(),
+            Bag(name="xyz", provider_name="gcp"),
+            Config.empty(output_dir=output_url, account_id='custodian-test')),
+        parse_url_config(output_url)
+    )
+
+    if cleanup:
+        request.addfinalizer(lambda : shutil.rmtree(output.root_dir)) # noqa
+
+    return output
+
+
+@mock.patch('c7n_gcp.output.LogClient')
+@mock.patch('c7n_gcp.output.CloudLoggingHandler')
+def test_gcp_logging(handler, client):
+    output = get_log_output('gcp://')
+    with output:
+        assert 1
+
+    handler().transport.flush.assert_called_once()
+    handler().transport.worker.stop.assert_called_once()
+
+
+@mock.patch('c7n_gcp.output.StorageClient')
+@mock.patch('c7n_gcp.output.Bucket')
+def test_output(bucket, client, request):
+    bucket().blob.return_value = key = mock.MagicMock()
+    with mock_datetime_now(date_parse('2020/06/10 13:00'), datetime):
+        output = get_blob_output(request)
+        assert output.key_prefix == 'policies/xyz/2020/06/10/13'
+        output.upload_file('resources.json', f"{output.key_prefix}/resources.json")
+        key.upload_from_filename.assert_called_once()


### PR DESCRIPTION
blob store artifacts, logging wasn't registered to avoid a grpc dep, but using any of the 'official' python sdk libraries makes that unavoidable.