### PR TITLE
show filter details to help with debugging

### DIFF
--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -112,9 +112,7 @@ class ResourceManager:
         if event and event.get('debug', False):
             self.log.info(
                 "Filtering resources using %d filters", len(self.filters))
-        c = 0
-        for f in self.filters:
-            c = c + 1
+        for idx, f in enumerate(self.filters):
             if not resources:
                 break
             rcount = len(resources)
@@ -125,7 +123,7 @@ class ResourceManager:
             if event and event.get('debug', False):
                 self.log.debug(
                     "Filter #%d applied %d->%d filter: %s",
-                    c, rcount, len(resources), dumps(f.data, indent=None))
+                    idx + 1, rcount, len(resources), dumps(f.data, indent=None))
         self.log.debug("Filtered from %d to %d %s" % (
             original, len(resources), self.__class__.__name__.lower()))
         return resources

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -111,8 +111,10 @@ class ResourceManager:
         original = len(resources)
         if event and event.get('debug', False):
             self.log.info(
-                "Filtering resources with %s", self.filters)
+                "Filtering resources using %d filters", len(self.filters))
+        c = 0
         for f in self.filters:
+            c = c + 1
             if not resources:
                 break
             rcount = len(resources)
@@ -122,7 +124,8 @@ class ResourceManager:
 
             if event and event.get('debug', False):
                 self.log.debug(
-                    "applied filter %s %d->%d", f.data, rcount, len(resources))
+                    "Filter #%d applied %d->%d filter: %s",
+                    c, rcount, len(resources), dumps(f.data, indent=None))
         self.log.debug("Filtered from %d to %d %s" % (
             original, len(resources), self.__class__.__name__.lower()))
         return resources

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -122,7 +122,7 @@ class ResourceManager:
 
             if event and event.get('debug', False):
                 self.log.debug(
-                    "applied filter %s %d->%d", f, rcount, len(resources))
+                    "applied filter %s %d->%d", f.data, rcount, len(resources))
         self.log.debug("Filtered from %d to %d %s" % (
             original, len(resources), self.__class__.__name__.lower()))
         return resources

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -112,7 +112,7 @@ class ResourceManager:
         if event and event.get('debug', False):
             self.log.info(
                 "Filtering resources using %d filters", len(self.filters))
-        for idx, f in enumerate(self.filters):
+        for idx, f in enumerate(self.filters, start=1):
             if not resources:
                 break
             rcount = len(resources)
@@ -123,7 +123,7 @@ class ResourceManager:
             if event and event.get('debug', False):
                 self.log.debug(
                     "Filter #%d applied %d->%d filter: %s",
-                    idx + 1, rcount, len(resources), dumps(f.data, indent=None))
+                    idx, rcount, len(resources), dumps(f.data, indent=None))
         self.log.debug("Filtered from %d to %d %s" % (
             original, len(resources), self.__class__.__name__.lower()))
         return resources


### PR DESCRIPTION
Rather than just showing the filter type, it's much more useful to show the full filter details.  This is especially true if your top-level is a boolean-style filter as `Not`, `And`, and `Or` are not very useful to debugging.  Any issues with just showing the full payload like this?  Only issue might be if there's some sort of sensitive data in there.