### PR TITLE
aws - don't cache unaugmented resources

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -500,7 +500,8 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
             if augment:
                 with self.ctx.tracer.subsegment('resource-augment'):
                     resources = self.augment(resources)
-            self._cache.save(cache_key, resources)
+                # Don't pollute cache unuaugmented resources
+                self._cache.save(cache_key, resources)
 
         resource_count = len(resources)
         with self.ctx.tracer.subsegment('filter'):


### PR DESCRIPTION
reported via dm on gitter.

an unaugmented resource retrieval could pollute the cache with entries
sans tags. instead only cache if we're fetching augmented resources.

alternatively we could add unaugmented as a cache key, and refill the
cache, but we'd be getting additional cache entries.

