### PR TITLE
azure - function app ssl/cert only

### DIFF
--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -30,7 +30,11 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
 
     def _provision(self, params):
         site_config = SiteConfig(app_settings=[])
-        functionapp_def = Site(location=params['location'], site_config=site_config)
+        functionapp_def = Site(
+            https_only=True,
+            client_cert_enabled=True,
+            location=params['location'],
+            site_config=site_config)
 
         # common function app settings
         functionapp_def.server_farm_id = params['app_service_plan_id']


### PR DESCRIPTION
custodian doesn't use any of the inbound https that is hard-wired into the azure serverless implementation, so just make it unusable (ssl only and require client certs).

this addresses a cis benchmark issue with custodian provisioning of azure functions.