### PR TITLE
rds modify db fix

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1599,7 +1599,7 @@ class ModifyDb(BaseAction):
         required=('update',))
 
     permissions = ('rds:ModifyDBInstance',)
-    shape = 'ModifyDBInstanceMessage'    
+    shape = 'ModifyDBInstanceMessage'
 
     def validate(self):
         if self.data.get('update'):

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1615,9 +1615,8 @@ class ModifyDb(BaseAction):
     def process(self, resources):
         c = local_session(self.manager.session_factory).client('rds')
         for r in resources:
-            param = {}
-            for update in self.data.get('update'):
-                param[update['property']] = update['value']
+            param = {
+                update['property']: update['value'] for update in self.data.get('update')}
             if not param:
                 continue
             param['ApplyImmediately'] = self.data.get('immediate', False)

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1663,8 +1663,8 @@ class ModifyDb(BaseAction):
                     k not in update_dict.get('CloudwatchLogsExportConfiguration')
                     for k in ('EnableLogTypes', 'DisableLogTypes'))):
                 raise PolicyValidationError(
-                    "A EnableLogTypes or DisableLogTypes input list\
-                    is required for setting CloudwatchLogsExportConfiguration")
+                    "A EnableLogTypes or DisableLogTypes input list is required\
+                    for setting CloudwatchLogsExportConfiguration")
         return self
 
     def process(self, resources):

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1617,8 +1617,7 @@ class ModifyDb(BaseAction):
         for r in resources:
             param = {}
             for update in self.data.get('update'):
-                if r.get(update['property'], None) != update['value']:
-                    param[update['property']] = update['value']
+                param[update['property']] = update['value']
             if not param:
                 continue
             param['ApplyImmediately'] = self.data.get('immediate', False)

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1626,8 +1626,11 @@ class ModifyDb(BaseAction):
                         'PerformanceInsightsKMSKeyId',
                         'PerformanceInsightsRetentionPeriod',
                         'CloudwatchLogsExportConfiguration',
+                        'ProcessorFeatures',
                         'UseDefaultProcessorFeatures',
-                        'DeletionProtection']},
+                        'DeletionProtection',
+                        'MaxAllocatedStorage',
+                        'CertificateRotationRestart']},
                     'value': {}
                 },
             },
@@ -1635,6 +1638,17 @@ class ModifyDb(BaseAction):
         required=('update',))
 
     permissions = ('rds:ModifyDBInstance',)
+    conversion_map = {
+        'DBSubnetGroupName': 'DBSubnetGroup.DBSubnetGroupName',
+        'VpcSecurityGroupIds': 'VpcSecurityGroups[].VpcSecurityGroupId',
+        'DBParameterGroupName': 'DBParameterGroups[].DBParameterGroupName',
+        'OptionGroupName': 'OptionGroupMemberships[].OptionGroupName',
+        'NewDBInstanceIdentifier': 'DBInstanceIdentifier',
+        'Domain': 'DomainMemberships[].DomainName',
+        'DBPortNumber': 'Endpoint.Port',
+        'EnablePerformanceInsights': 'PerformanceInsightsEnabled',
+        'CloudwatchLogsExportConfiguration': 'EnabledCloudwatchLogsExports'
+    }
 
     def validate(self):
         if self.data.get('update'):
@@ -1644,13 +1658,25 @@ class ModifyDb(BaseAction):
                 raise PolicyValidationError(
                     "A MonitoringRoleARN value is required \
                     if you specify a MonitoringInterval value other than 0")
+            if ('CloudwatchLogsExportConfiguration' in update_dict
+                and all(
+                    k not in update_dict.get('CloudwatchLogsExportConfiguration')
+                    for k in ('EnableLogTypes', 'DisableLogTypes'))):
+                raise PolicyValidationError(
+                    "A EnableLogTypes or DisableLogTypes input list\
+                    is required for setting CloudwatchLogsExportConfiguration")
         return self
 
     def process(self, resources):
         c = local_session(self.manager.session_factory).client('rds')
         for r in resources:
             param = {
-                update['property']: update['value'] for update in self.data.get('update')}
+                u['property']: u['value'] for u in self.data.get('update')
+                if r.get(
+                    u['property'],
+                    jmespath.search(
+                        self.conversion_map.get(u['property'], 'None'), r))
+                    != u['value']}
             if not param:
                 continue
             param['ApplyImmediately'] = self.data.get('immediate', False)

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -71,7 +71,6 @@ from c7n.utils import (
     local_session, type_schema, get_retry, chunks, snapshot_identifier)
 from c7n.resources.kms import ResourceKmsKeyAlias
 from c7n.resources.securityhub import OtherResourcePostFinding
-from .aws import shape_validate
 
 log = logging.getLogger('custodian.rds')
 
@@ -1591,7 +1590,44 @@ class ModifyDb(BaseAction):
             'items': {
                 'type': 'object',
                 'properties': {
-                    'property': {'type': 'string'},
+                    'property': {'type': 'string', 'enum': [
+                        'AllocatedStorage',
+                        'DBInstanceClass',
+                        'DBSubnetGroupName',
+                        'DBSecurityGroups',
+                        'VpcSecurityGroupIds',
+                        'MasterUserPassword',
+                        'DBParameterGroupName',
+                        'BackupRetentionPeriod',
+                        'PreferredBackupWindow',
+                        'PreferredMaintenanceWindow',
+                        'MultiAZ',
+                        'EngineVersion',
+                        'AllowMajorVersionUpgrade',
+                        'AutoMinorVersionUpgrade',
+                        'LicenseModel',
+                        'Iops',
+                        'OptionGroupName',
+                        'NewDBInstanceIdentifier',
+                        'StorageType',
+                        'TdeCredentialArn',
+                        'TdeCredentialPassword',
+                        'CACertificateIdentifier',
+                        'Domain',
+                        'CopyTagsToSnapshot',
+                        'MonitoringInterval',
+                        'MonitoringRoleARN',
+                        'DBPortNumber',
+                        'PubliclyAccessible',
+                        'DomainIAMRoleName',
+                        'PromotionTier',
+                        'EnableIAMDatabaseAuthentication',
+                        'EnablePerformanceInsights',
+                        'PerformanceInsightsKMSKeyId',
+                        'PerformanceInsightsRetentionPeriod',
+                        'CloudwatchLogsExportConfiguration',
+                        'UseDefaultProcessorFeatures',
+                        'DeletionProtection']},
                     'value': {}
                 },
             },
@@ -1599,7 +1635,6 @@ class ModifyDb(BaseAction):
         required=('update',))
 
     permissions = ('rds:ModifyDBInstance',)
-    shape = 'ModifyDBInstanceMessage'
 
     def validate(self):
         if self.data.get('update'):
@@ -1609,8 +1644,7 @@ class ModifyDb(BaseAction):
                 raise PolicyValidationError(
                     "A MonitoringRoleARN value is required \
                     if you specify a MonitoringInterval value other than 0")
-        update_dict['DBInstanceIdentifier'] = 'PolicyValidation'
-        return shape_validate(update_dict, self.shape, 'rds')
+        return self
 
     def process(self, resources):
         c = local_session(self.manager.session_factory).client('rds')

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1609,6 +1609,7 @@ class ModifyDb(BaseAction):
                 raise PolicyValidationError(
                     "A MonitoringRoleARN value is required \
                     if you specify a MonitoringInterval value other than 0")
+        update_dict['DBInstanceIdentifier'] = 'PolicyValidation'
         return shape_validate(update_dict, self.shape, 'rds')
 
     def process(self, resources):

--- a/tests/data/placebo/test_rds_modify_db_enable_cloudwatch/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_modify_db_enable_cloudwatch/rds.DescribeDBInstances_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "database-2",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:database-2",                
+                "Engine": "mysql",
+                "EnabledCloudwatchLogsExports": [
+                    "general",
+                    "slowquery"
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_modify_db_enable_cloudwatch/rds.DescribeDBInstances_2.json
+++ b/tests/data/placebo/test_rds_modify_db_enable_cloudwatch/rds.DescribeDBInstances_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "database-2",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:database-2",
+                "Engine": "mysql",
+                "EnabledCloudwatchLogsExports": [
+                    "error",                    
+                    "general",
+                    "slowquery"
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_modify_db_enable_cloudwatch/rds.ModifyDBInstance_1.json
+++ b/tests/data/placebo/test_rds_modify_db_enable_cloudwatch/rds.ModifyDBInstance_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBInstance": {
+            "DBInstanceIdentifier": "database-2",
+            "Engine": "mysql",
+            "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:database-2"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_modify_db_enable_cloudwatch/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rds_modify_db_enable_cloudwatch/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_modify_db_enable_perfinsights/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_modify_db_enable_perfinsights/rds.DescribeDBInstances_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "database-4",
+                "Engine": "postgres",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:database-4",
+                "PerformanceInsightsEnabled": false
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_modify_db_enable_perfinsights/rds.DescribeDBInstances_2.json
+++ b/tests/data/placebo/test_rds_modify_db_enable_perfinsights/rds.DescribeDBInstances_2.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "database-4",
+                "Engine": "postgres",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:database-4",
+                "PerformanceInsightsEnabled": true
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_modify_db_enable_perfinsights/rds.ModifyDBInstance_1.json
+++ b/tests/data/placebo/test_rds_modify_db_enable_perfinsights/rds.ModifyDBInstance_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBInstance": {
+            "DBInstanceIdentifier": "database-4",
+            "Engine": "postgres",
+            "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:database-4"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_modify_db_enable_perfinsights/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rds_modify_db_enable_perfinsights/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -829,8 +829,6 @@ class RDSTest(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        if self.recording:
-            time.sleep(60)
         client = session_factory().client("rds")
         db_info = client.describe_db_instances(DBInstanceIdentifier="database-4")
         self.assertTrue(db_info["DBInstances"][0]["PerformanceInsightsEnabled"])

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -30,7 +30,11 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
 
     def _provision(self, params):
         site_config = SiteConfig(app_settings=[])
-        functionapp_def = Site(location=params['location'], site_config=site_config)
+        functionapp_def = Site(
+            https_only=True,
+            client_cert_enabled=True,
+            location=params['location'],
+            site_config=site_config)
 
         # common function app settings
         functionapp_def.server_farm_id = params['app_service_plan_id']


### PR DESCRIPTION
Removes some redtape restriction on enums and makes use of shape validate for params. Also makes use of a dict getter instead of using the index to retrieve the update key. Overall, this helps improve the action to accept proper keys for db instance modifications. Closes #5861 