### PR TITLE
Account for potentially missing keys

### DIFF
--- a/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
+++ b/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
@@ -296,10 +296,14 @@ def process_athena_query(athena, workgroup, athena_db, table, athena_output,
     while True:
         qexec = athena.get_query_execution(QueryExecutionId=query_id).get('QueryExecution')
         if qexec.get('Statistics'):
-            stats['QueryExecutionTime'] = qexec['Statistics'][
-                'EngineExecutionTimeInMillis'] / 1000.0
-            stats['DataScannedInBytes'] = qexec['Statistics'][
-                'DataScannedInBytes']
+            stats['QueryExecutionTime'] = qexec['Statistics'].get(
+                    'EngineExecutionTimeInMillis',
+                    qexec['Statistics'].get(
+                        'TotalExecutionTimeInMillis',
+                        1000
+                        )
+                    )/ 1000.0
+            stats['DataScannedInBytes'] = qexec['Statistics'].get('DataScannedInBytes', 1)
             log.info(
                 "Polling athena query progress scanned:%s qexec:%0.2fs",
                 format_bytes(

--- a/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
+++ b/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
@@ -294,16 +294,15 @@ def process_athena_query(athena, workgroup, athena_db, table, athena_output,
     log.info("Athena query:%s", query_id)
 
     while True:
-        qexec = athena.get_query_execution(
-            QueryExecutionId=query_id).get('QueryExecution')
+        qexec = athena.get_query_execution(QueryExecutionId=query_id).get('QueryExecution')
         if qexec.get('Statistics'):
             stats['QueryExecutionTime'] = qexec['Statistics'].get(
-                    'EngineExecutionTimeInMillis',
-                    qexec['Statistics'].get(
-                        'TotalExecutionTimeInMillis',
-                        1000
-                        )
-                    )/1000.0
+                'EngineExecutionTimeInMillis',
+                qexec['Statistics'].get(
+                    'TotalExecutionTimeInMillis',
+                    1000
+                )
+            ) / 1000.0
             stats['DataScannedInBytes'] = qexec['Statistics'].get('DataScannedInBytes', 1)
             log.info(
                 "Polling athena query progress scanned:%s qexec:%0.2fs",

--- a/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
+++ b/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
@@ -294,7 +294,8 @@ def process_athena_query(athena, workgroup, athena_db, table, athena_output,
     log.info("Athena query:%s", query_id)
 
     while True:
-        qexec = athena.get_query_execution(QueryExecutionId=query_id).get('QueryExecution')
+        qexec = athena.get_query_execution(
+            QueryExecutionId=query_id).get('QueryExecution')
         if qexec.get('Statistics'):
             stats['QueryExecutionTime'] = qexec['Statistics'].get(
                     'EngineExecutionTimeInMillis',
@@ -302,7 +303,7 @@ def process_athena_query(athena, workgroup, athena_db, table, athena_output,
                         'TotalExecutionTimeInMillis',
                         1000
                         )
-                    )/ 1000.0
+                    )/1000.0
             stats['DataScannedInBytes'] = qexec['Statistics'].get('DataScannedInBytes', 1)
             log.info(
                 "Polling athena query progress scanned:%s qexec:%0.2fs",


### PR DESCRIPTION
Some responses from Athena may not include EngineExecutionTimeInMillis or DataScannedInBytes, this patch accounts for these missing keys.