### PR TITLE
Load only AWS resource types

### DIFF
--- a/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
+++ b/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
@@ -763,7 +763,7 @@ def tag(assume, region, db, creator_tag, user_suffix, dryrun,
     """Tag resources with their creator.
     """
     trail_db = TrailDB(db)
-    load_resources()
+    load_resources(resource_types=('aws.*',))
 
     with temp_dir() as output_dir:
         config = ExecConfig.empty(


### PR DESCRIPTION
Without resource_types specified the tool tries to load other cloud provider resources (such as Azure) which doesn't make sense for this tool.