### PR TITLE
releng - dockerpkg retry image push to handle transient hub errors

### DIFF
--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -319,7 +319,7 @@ def build(provider, registry, tag, image, quiet, push, test, scan, verbose):
         if scan:
             scan_image(":".join(image_refs[0]))
         if push:
-            retry(3, RuntimeException, push_image, client, image_id, image_refs)
+            retry(3, RuntimeError, push_image, client, image_id, image_refs)
 
 
 def get_labels(image):

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -351,6 +351,7 @@ def retry(retry_count, exceptions, func, *args, **kw):
         try:
             func(*args, **kw)
         except tuple(exceptions):
+            log.warn('retrying on %s' % func)
             attempts += 1
             time.sleep(5)
 

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -25,6 +25,7 @@ We also support running functional tests and image cve scanning before pushing.
 
 import logging
 import os
+import time
 import subprocess
 import sys
 from datetime import datetime
@@ -351,6 +352,7 @@ def retry(retry_count, exceptions, func, *args, **kw):
             func(*args, **kw)
         except tuple(exceptions):
             attempts += 1
+            time.sleep(5)
 
 
 def get_github_env():

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -319,7 +319,7 @@ def build(provider, registry, tag, image, quiet, push, test, scan, verbose):
         if scan:
             scan_image(":".join(image_refs[0]))
         if push:
-            push_image(client, image_id, image_refs)
+            retry(3, RuntimeException, push_image, client, image_id, image_refs)
 
 
 def get_labels(image):
@@ -342,6 +342,15 @@ def get_labels(image):
     if hub_env.get("sha"):
         labels["org.opencontainers.image.revision"] = hub_env["sha"]
     return labels
+
+
+def retry(retry_count, exceptions, func, *args, **kw):
+    attempts = 1
+    while attempts <= retry_count:
+        try:
+            func(*args, **kw)
+        except tuple(exceptions):
+            attempts += 1
 
 
 def get_github_env():

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -320,7 +320,7 @@ def build(provider, registry, tag, image, quiet, push, test, scan, verbose):
         if scan:
             scan_image(":".join(image_refs[0]))
         if push:
-            retry(3, RuntimeError, push_image, client, image_id, image_refs)
+            retry(3, (RuntimeError,), push_image, client, image_id, image_refs)
 
 
 def get_labels(image):
@@ -350,11 +350,12 @@ def retry(retry_count, exceptions, func, *args, **kw):
     while attempts <= retry_count:
         try:
             func(*args, **kw)
-        except tuple(exceptions):
+        except exceptions:
             log.warn('retrying on %s' % func)
             attempts += 1
             time.sleep(5)
-
+            if attempts > retry_count:
+                raise
 
 def get_github_env():
     envget = os.environ.get

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -357,6 +357,7 @@ def retry(retry_count, exceptions, func, *args, **kw):
             if attempts > retry_count:
                 raise
 
+
 def get_github_env():
     envget = os.environ.get
     return {


### PR DESCRIPTION
we have a few commits on master, where ci fails on pushing docker images to the image registry, this seems to be a transient issue, so just doing a retry loop here seems appropriate. would also worthwhile to look at docker client source to compare and see what its doing.