### PR TITLE
AWS - Add Iam Access Analyzer Resource

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -446,13 +446,13 @@ class ServerCertificate(QueryResourceManager):
 class AccessAnalyzer(QueryResourceManager):
 
     class resource_type(TypeInfo):
-        service = 'accessanalyzer'
+        service = 'access-analyzer'
         arn_type = 'access-analyzer'
         enum_spec = ('list_analyzers', 'analyzers', None)
         id = name = 'name'
         arn = 'arn'
         date = 'createdAt'
-        cfn_type = config_type = "AWS::AccessAnalyzer::Analyzer"
+        cfn_type = "AWS::AccessAnalyzer::Analyzer"
 
 
 @AccessAnalyzer.filter_registry.register('marked-for-op')

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -446,7 +446,7 @@ class ServerCertificate(QueryResourceManager):
 class AccessAnalyzer(QueryResourceManager):
 
     class resource_type(TypeInfo):
-        service = 'access-analyzer'
+        service = 'accessanalyzer'
         arn_type = 'access-analyzer'
         enum_spec = ('list_analyzers', 'analyzers', None)
         id = name = 'name'

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -452,6 +452,7 @@ class AccessAnalyzer(QueryResourceManager):
         id = name = 'name'
         arn = 'arn'
         date = 'createdAt'
+        permission_prefix = 'access-analyzer'
         cfn_type = "AWS::AccessAnalyzer::Analyzer"
 
 

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -1,4 +1,5 @@
 ResourceMap = {
+    "aws.access-analyzer": "c7n.resources.iam.AccessAnalyzer",
     "aws.account": "c7n.resources.account.Account",
     "aws.acm-certificate": "c7n.resources.acm.Certificate",
     "aws.alarm": "c7n.resources.cw.Alarm",

--- a/tests/data/placebo/test_access_analyzer_delete/access-analyzer.DeleteAnalyzer_1.json
+++ b/tests/data/placebo/test_access_analyzer_delete/access-analyzer.DeleteAnalyzer_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_access_analyzer_delete/access-analyzer.ListAnalyzers_1.json
+++ b/tests/data/placebo/test_access_analyzer_delete/access-analyzer.ListAnalyzers_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "analyzers": [
+            {
+                "arn": "arn:aws:access-analyzer:us-west-2:0123456789012:analyzer/test-analyzer",
+                "name": "test-analyzer",
+                "tags": {
+                    "Env": "Dev",
+                    "maid_status": "Resource does not meet policy: delete@2020/06/27"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_access_analyzer_delete/access-analyzer.ListAnalyzers_2.json
+++ b/tests/data/placebo/test_access_analyzer_delete/access-analyzer.ListAnalyzers_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "analyzers": []
+    }
+}

--- a/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.ListAnalyzers_1.json
+++ b/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.ListAnalyzers_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "analyzers": [
+            {
+                "arn": "arn:aws:access-analyzer:us-west-2:0123456789012:analyzer/test-analyzer",
+                "name": "test-analyzer",
+                "status": "ACTIVE",
+                "tags": {
+                    "OutdatedTag": "present"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.ListTagsForResource_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "Env": "Dev",
+            "maid_status": "Resource does not meet policy: delete@2020/06/27"
+        }
+    }
+}

--- a/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.TagResource_1.json
+++ b/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.TagResource_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 204,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.TagResource_2.json
+++ b/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.TagResource_2.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 204,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.UntagResource_1.json
+++ b/tests/data/placebo/test_access_analyzer_tag_untag_markforop/access-analyzer.UntagResource_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 204,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}


### PR DESCRIPTION
Add support for the IAM Access Analyzer Resource. I had to manually implement tag, untag, and mark-for-op since  the resourcegroupstaggingapi does not yet support access analyzer. 