### PR TITLE
aws - emr expose subnet ids and sgs, master/member nodes

### DIFF
--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -14,6 +14,7 @@
 import logging
 import time
 import json
+import jmespath
 
 from c7n.actions import ActionRegistry, BaseAction
 from c7n.exceptions import PolicyValidationError
@@ -24,6 +25,7 @@ from c7n.utils import (
     local_session, type_schema, get_retry)
 from c7n.tags import (
     TagDelayedAction, RemoveTag, TagActionFilter, Tag)
+import c7n.filters.vpc as net_filters
 
 filters = FilterRegistry('emr.filters')
 actions = ActionRegistry('emr.actions')
@@ -284,6 +286,34 @@ class QueryFilter:
             value = [self.value]
 
         return {'Name': self.key, 'Values': value}
+
+
+@filters.register('subnet')
+class SubnetFilter(net_filters.SubnetFilter):
+
+    RelatedIdsExpression = "Ec2InstanceAttributes.RequestedEc2SubnetIds[]"
+
+
+@filters.register('security-group')
+class SecurityGroupFilter(net_filters.SecurityGroupFilter):
+
+    RelatedIdsExpression = ""
+    expressions = ('Ec2InstanceAttributes.EmrManagedMasterSecurityGroup',
+                'Ec2InstanceAttributes.EmrManagedSlaveSecurityGroup',
+                'Ec2InstanceAttributes.ServiceAccessSecurityGroup',
+                'Ec2InstanceAttributes.AdditionalMasterSecurityGroups[]',
+                'Ec2InstanceAttributes.AdditionalSlaveSecurityGroups[]')
+
+    def get_related_ids(self, resources):
+        sg_ids = set()
+        for r in resources:
+            for exp in self.expressions:
+                ids = jmespath.search(exp, r)
+                if isinstance(ids, list):
+                    sg_ids.update(tuple(ids))
+                elif isinstance(ids, str):
+                    sg_ids.add(ids)
+        return list(sg_ids)
 
 
 @resources.register('emr-security-configuration')

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -316,6 +316,9 @@ class SecurityGroupFilter(net_filters.SecurityGroupFilter):
         return list(sg_ids)
 
 
+filters.register('network-location', net_filters.NetworkLocation)
+
+
 @resources.register('emr-security-configuration')
 class EMRSecurityConfiguration(QueryResourceManager):
     """Resource manager for EMR Security Configuration

--- a/tests/data/placebo/test_emr_sg/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/test_emr_sg/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "Description": "Member group for Elastic MapReduce",
+                "GroupName": "ElasticMapReduce-Member-Private",
+                "IpPermissions": [],
+                "OwnerId": "644160558196",
+                "GroupId": "sg-cfcf69c3",
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": []
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "NetworkLocation",
+                        "Value": "CustFacing,EntFacing"
+                    }
+                ],
+                "VpcId": "vpc-xxxxxxxx"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_sg/elasticmapreduce.DescribeCluster_1.json
+++ b/tests/data/placebo/test_emr_sg/elasticmapreduce.DescribeCluster_1.json
@@ -1,0 +1,83 @@
+{
+    "status_code": 200,
+    "data": {
+        "Cluster": {
+            "Id": "j-2OMWOHFEP8XA9",
+            "Name": "pratyush-emr-test",
+            "Status": {
+                "State": "WAITING",
+                "StateChangeReason": {
+                    "Message": "Cluster ready after last step completed."
+                },
+                "Timeline": {
+                    "CreationDateTime": {
+                        "__class__": "datetime",
+                        "year": 2019,
+                        "month": 9,
+                        "day": 27,
+                        "hour": 10,
+                        "minute": 36,
+                        "second": 12,
+                        "microsecond": 558000
+                    },
+                    "ReadyDateTime": {
+                        "__class__": "datetime",
+                        "year": 2019,
+                        "month": 9,
+                        "day": 27,
+                        "hour": 10,
+                        "minute": 42,
+                        "second": 52,
+                        "microsecond": 754000
+                    }
+                }
+            },
+            "Ec2InstanceAttributes": {
+                "Ec2KeyName": "pratyush-key",
+                "Ec2SubnetId": "subnet-028c2369",
+                "RequestedEc2SubnetIds": [
+                    "subnet-028c2369"
+                ],
+                "Ec2AvailabilityZone": "us-east-1c",
+                "RequestedEc2AvailabilityZones": [],
+                "IamInstanceProfile": "EMR_EC2_DefaultRole",
+                "EmrManagedMasterSecurityGroup": "sg-cecf69c2",
+                "EmrManagedSlaveSecurityGroup": "sg-cfcf69c3",
+                "ServiceAccessSecurityGroup": "sg-8cbc29c0",
+                "AdditionalMasterSecurityGroups": [],
+                "AdditionalSlaveSecurityGroups": []
+            },
+            "InstanceCollectionType": "INSTANCE_GROUP",
+            "LogUri": "s3n://aws-logs-644160558196-us-east-1/elasticmapreduce/",
+            "ReleaseLabel": "emr-5.23.0",
+            "AutoTerminate": false,
+            "TerminationProtected": false,
+            "VisibleToAllUsers": true,
+            "Applications": [
+                {
+                    "Name": "Hadoop",
+                    "Version": "2.8.5"
+                },
+                {
+                    "Name": "Ganglia",
+                    "Version": "3.7.2"
+                }
+            ],
+            "Tags": [],         
+            "ServiceRole": "EMR_DefaultRole",
+            "NormalizedInstanceHours": 106000,
+            "MasterPublicDnsName": "ip-X-X-X-X.ec2.internal",
+            "Configurations": [],
+            "SecurityConfiguration": "Encrypted",
+            "AutoScalingRole": "EMR_AutoScaling_DefaultRole",
+            "ScaleDownBehavior": "TERMINATE_AT_TASK_COMPLETION",
+            "CustomAmiId": "ami-0xxxxxxx89dc50e2b",
+            "EbsRootVolumeSize": 20,
+            "RepoUpgradeOnBoot": "SECURITY",
+            "KerberosAttributes": {},
+            "ClusterArn": "arn:aws:elasticmapreduce:us-east-1:644160558196:cluster/j-2OMWOHFEP8XA",
+            "StepConcurrencyLevel": 1
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_sg/elasticmapreduce.DescribeCluster_1.json
+++ b/tests/data/placebo/test_emr_sg/elasticmapreduce.DescribeCluster_1.json
@@ -63,9 +63,9 @@
                     "Version": "3.7.2"
                 }
             ],
-            "Tags": [],         
+            "Tags": [],
             "ServiceRole": "EMR_DefaultRole",
-            "NormalizedInstanceHours": 106000,
+            "NormalizedInstanceHours": 106352,
             "MasterPublicDnsName": "ip-X-X-X-X.ec2.internal",
             "Configurations": [],
             "SecurityConfiguration": "Encrypted",
@@ -75,7 +75,7 @@
             "EbsRootVolumeSize": 20,
             "RepoUpgradeOnBoot": "SECURITY",
             "KerberosAttributes": {},
-            "ClusterArn": "arn:aws:elasticmapreduce:us-east-1:644160558196:cluster/j-2OMWOHFEP8XA",
+            "ClusterArn": "arn:aws:elasticmapreduce:us-east-1:644160558196:cluster/j-2OMWOHFEP8XA9",
             "StepConcurrencyLevel": 1
         },
         "ResponseMetadata": {}

--- a/tests/data/placebo/test_emr_sg/elasticmapreduce.ListClusters_1.json
+++ b/tests/data/placebo/test_emr_sg/elasticmapreduce.ListClusters_1.json
@@ -33,7 +33,7 @@
                         }
                     }
                 },
-                "NormalizedInstanceHours": 106000,
+                "NormalizedInstanceHours": 106352,
                 "ClusterArn": "arn:aws:elasticmapreduce:us-east-1:644160558196:cluster/j-2OMWOHFEP8XA9"
             }
         ],

--- a/tests/data/placebo/test_emr_sg/elasticmapreduce.ListClusters_1.json
+++ b/tests/data/placebo/test_emr_sg/elasticmapreduce.ListClusters_1.json
@@ -8,7 +8,7 @@
                 "Status": {
                     "State": "WAITING",
                     "StateChangeReason": {
-                        "Message": "Cluster ready after last step completed."
+                        "Message": "Cluster ready after last step completed"
                     },
                     "Timeline": {
                         "CreationDateTime": {

--- a/tests/data/placebo/test_emr_sg/elasticmapreduce.ListClusters_1.json
+++ b/tests/data/placebo/test_emr_sg/elasticmapreduce.ListClusters_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "Id": "j-2OMWOHFEP8XA9",
+                "Name": "pratyush-emr-test",
+                "Status": {
+                    "State": "WAITING",
+                    "StateChangeReason": {
+                        "Message": "Cluster ready after last step completed."
+                    },
+                    "Timeline": {
+                        "CreationDateTime": {
+                            "__class__": "datetime",
+                            "year": 2019,
+                            "month": 9,
+                            "day": 27,
+                            "hour": 10,
+                            "minute": 36,
+                            "second": 12,
+                            "microsecond": 558000
+                        },
+                        "ReadyDateTime": {
+                            "__class__": "datetime",
+                            "year": 2019,
+                            "month": 9,
+                            "day": 27,
+                            "hour": 10,
+                            "minute": 42,
+                            "second": 52,
+                            "microsecond": 754000
+                        }
+                    }
+                },
+                "NormalizedInstanceHours": 106000,
+                "ClusterArn": "arn:aws:elasticmapreduce:us-east-1:644160558196:cluster/j-2OMWOHFEP8XA9"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -175,6 +175,7 @@ class TestEMR(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["Name"], "pratyush-emr-test")
 
 
 class TestEMRQueryFilter(unittest.TestCase):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -157,6 +157,25 @@ class TestEMR(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertFalse("test_tag" in old_tags)
 
+    def test_emr_sg(self):
+        session_factory = self.replay_flight_data("test_emr_sg")
+        p = self.load_policy(
+            {
+                "name": "emr-sg-tag",
+                "resource": "emr",
+                "filters": [
+                    {
+                        "type": "security-group",
+                        "key": "tag:NetworkLocation",
+                        "value": "CustFacing,EntFacing"
+                    }
+                ],
+            },
+            session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
 
 class TestEMRQueryFilter(unittest.TestCase):
 


### PR DESCRIPTION
Closes #5905 
This PR exposes the following:

1. SubnetIds for the cluster
2. Sgs in the cluster which includes:         
           'EmrManagedMasterSecurityGroup': 'string',
            'EmrManagedSlaveSecurityGroup': 'string',
            'ServiceAccessSecurityGroup': 'string',
            'AdditionalMasterSecurityGroups': ['string',],
            'AdditionalSlaveSecurityGroups': ['string',]
3. Adds `network-location` filter

Doc ref: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.describe_cluster
