### PR TITLE
security hub resource and filters

### DIFF
--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -147,6 +147,7 @@ ResourceMap = {
     "aws.sagemaker-transform-job": "c7n.resources.sagemaker.SagemakerTransformJob",
     "aws.secrets-manager": "c7n.resources.secretsmanager.SecretsManager",
     "aws.security-group": "c7n.resources.vpc.SecurityGroup",
+    "aws.security-hub": "c7n.resources.securityhub.SecurityHubMember",
     "aws.serverless-app": "c7n.resources.sar.ServerlessApp",
     "aws.shield-attack": "c7n.resources.shield.ShieldAttack",
     "aws.shield-protection": "c7n.resources.shield.ShieldProtection",

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -111,8 +111,7 @@ class SecurityHubMember(QueryResourceManager):
         id = name = 'HubArn'
         arn_type = 'hub'
         cfn_type = 'AWS::SecurityHub::Hub'
-
-    permissions = ('securityhub:DescribeHub',)
+        enum_spec = ("describe_hub", None, None)
 
     def resources(self):
         return self.filter_resources(get_security_hub(self.session_factory, self.retry))

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -232,7 +232,7 @@ class SecurityHub(LambdaMode):
     """
 
     schema = type_schema(
-        'hub-finding', aliases=('hub-action'),
+        'hub-finding', aliases=('hub-action',),
         rinherit=LambdaMode.schema)
 
     ActionFinding = 'Security Hub Findings - Custom Action'

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -173,7 +173,7 @@ class SecurityHubProductsFilter(Filter):
         products={'type': 'array', 'items': {'type': 'string'}})
     permissions = ("securityhub:ListEnabledProductsForImport",)
 
-    def process(self, balancers, event=None):
+    def process(self, resources, event=None):
         client = local_session(self.manager.session_factory).client('securityhub')
         resp = client.list_enabled_products_for_import()
         product_subscriptions = resp.get('ProductSubscriptions', [])
@@ -182,7 +182,7 @@ class SecurityHubProductsFilter(Filter):
         for p in self.data["products"]:
             if p not in product_subscriptions:
                 return []
-        return balancers
+        return resources
 
 
 @execution.register('hub-finding')

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -110,7 +110,7 @@ class SecurityHubMember(ResourceManager):
     class resource_type(TypeInfo):
         service = 'securityhub'
         id = name = 'HubArn'
-        arn_type = 'HubArn'
+        arn_type = 'hub'
         cfn_type = 'AWS::SecurityHub::Hub'
 
     @classmethod

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -109,8 +109,9 @@ class SecurityHubMember(ResourceManager):
 
     class resource_type(TypeInfo):
         service = 'securityhub'
-        id = 'HubArn'
-        filter_name = 'security-hub'
+        id = name = 'HubArn'
+        arn_type = 'HubArn'
+        cfn_type = 'AWS::SecurityHub::Hub'
 
     @classmethod
     def get_permissions(cls):
@@ -140,6 +141,7 @@ class SecurityHubValidMasterFilter(Filter):
     :example:
 
     .. code-block:: yaml
+
             policies:
             - name: security-hub-valid-master
                 resource: security-hub
@@ -149,7 +151,7 @@ class SecurityHubValidMasterFilter(Filter):
                     - 123456789
     """
     schema = type_schema('valid-master', accounts={'type': 'array', 'items': {'type': 'string'}})
-    permissions = ("securityhub:GetMasterAccount")
+    permissions = ("securityhub:GetMasterAccount",)
 
     def process(self, balancers, event=None):
         client = local_session(self.manager.session_factory).client('securityhub')
@@ -171,6 +173,7 @@ class SecurityHubEnabledProductsFilter(Filter):
     :example:
 
     .. code-block:: yaml
+
             policies:
             - name: security-hub-enabled-products
                 resource: security-hub

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -129,13 +129,13 @@ class SecurityHubValidMasterFilter(Filter):
 
     .. code-block:: yaml
 
-            policies:
-            - name: security-hub-valid-master
-              resource: security-hub
-              filters:
-                - type: valid-master
-                  accounts:
-                    - "123456789"
+        policies:
+          - name: security-hub-valid-master
+            resource: security-hub
+            filters:
+              - type: valid-master
+                accounts:
+                  - "123456789"
     """
     schema = type_schema('valid-master', accounts={'type': 'array', 'items': {'type': 'string'}})
     permissions = ("securityhub:GetMasterAccount",)
@@ -161,14 +161,14 @@ class SecurityHubEnabledProductsFilter(Filter):
 
     .. code-block:: yaml
 
-            policies:
-            - name: security-hub-enabled-products
-              resource: security-hub
-              filters:
-                - type: enabled-products
-                  products:
-                    - "aws/guardduty"
-                    - "cloud-custodian/cloud-custodian"
+        policies:
+          - name: security-hub-enabled-products
+            resource: security-hub
+            filters:
+              - type: enabled-products
+                products:
+                  - "aws/guardduty"
+                  - "cloud-custodian/cloud-custodian"
     """
     schema = type_schema('enabled-products',
         products={'type': 'array', 'items': {'type': 'string'}})

--- a/tests/data/placebo/test_securityhub_enabled_products/securityhub.DescribeHub_1.json
+++ b/tests/data/placebo/test_securityhub_enabled_products/securityhub.DescribeHub_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "HubArn": "arn:aws:securityhub:us-east-1:644160558196:hub/default",
+        "SubscribedAt": "2018-11-28T22:14:06.771Z"
+    }
+}

--- a/tests/data/placebo/test_securityhub_enabled_products/securityhub.ListEnabledProductsForImport_1.json
+++ b/tests/data/placebo/test_securityhub_enabled_products/securityhub.ListEnabledProductsForImport_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ProductSubscriptions": [
+            "arn:aws:securityhub:us-east-1:644160558196:product-subscription/aws/access-analyzer",
+            "arn:aws:securityhub:us-east-1:644160558196:product-subscription/aws/firewall-manager",
+            "arn:aws:securityhub:us-east-1:644160558196:product-subscription/aws/guardduty",
+            "arn:aws:securityhub:us-east-1:644160558196:product-subscription/aws/macie",
+            "arn:aws:securityhub:us-east-1:644160558196:product-subscription/aws/securityhub",
+            "arn:aws:securityhub:us-east-1:644160558196:product-subscription/cloud-custodian/cloud-custodian"
+        ]
+    }
+}

--- a/tests/data/placebo/test_securityhub_valid_master/securityhub.DescribeHub_1.json
+++ b/tests/data/placebo/test_securityhub_valid_master/securityhub.DescribeHub_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "HubArn": "arn:aws:securityhub:us-east-1:644160558196:hub/default",
+        "SubscribedAt": "2018-11-28T22:14:06.771Z"
+    }
+}

--- a/tests/data/placebo/test_securityhub_valid_master/securityhub.GetMasterAccount_1.json
+++ b/tests/data/placebo/test_securityhub_valid_master/securityhub.GetMasterAccount_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Master": {
+            "AccountId": "519413311747",
+            "InvitationId": "e6b4f9ecc1cc37ea35814559a2a3f09b",
+            "InvitedAt": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 4,
+                "day": 6,
+                "hour": 18,
+                "minute": 11,
+                "second": 52,
+                "microsecond": 344000
+            },
+            "MemberStatus": "Associated"
+        }
+    }
+}

--- a/tests/data/placebo/test_securityhub_valid_master/securityhub.GetMasterAccount_1.json
+++ b/tests/data/placebo/test_securityhub_valid_master/securityhub.GetMasterAccount_1.json
@@ -3,7 +3,7 @@
     "data": {
         "ResponseMetadata": {},
         "Master": {
-            "AccountId": "519413311747",
+            "AccountId": "111111111",
             "InvitationId": "e6b4f9ecc1cc37ea35814559a2a3f09b",
             "InvitedAt": {
                 "__class__": "datetime",

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -624,3 +624,57 @@ class SecurityHubTest(BaseTest):
                 "Tags": {
                     "workload-type": "other"}
             })
+
+class SecurityHubResourceTest(BaseTest):
+
+    def test_valid_master(self):
+        session_factory = self.replay_flight_data(
+            'test_securityhub_valid_master')
+        p = self.load_policy({
+            'name': 'valid-master',
+            'resource': 'aws.security-hub',
+            'filters': [{
+                'type': 'valid-master',
+                'accounts':['519413311747']
+            }]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_invalid_master(self):
+        session_factory = self.replay_flight_data(
+            'test_securityhub_valid_master')
+        p = self.load_policy({
+            'name': 'valid-master',
+            'resource': 'aws.security-hub',
+            'filters': [{
+                'type': 'valid-master',
+                'accounts':['12345678']
+            }]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    def test_enabled_products(self):
+        session_factory = self.replay_flight_data(
+            'test_securityhub_enabled_products')
+        p = self.load_policy({
+            'name': 'enabled-products',
+            'resource': 'aws.security-hub',
+            'filters': [{
+                'type': 'enabled-products',
+                'products':['aws/guardduty','cloud-custodian/cloud-custodian']
+            }]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_not_enabled_products(self):
+        session_factory = self.replay_flight_data(
+            'test_securityhub_enabled_products')
+        p = self.load_policy({
+            'name': 'enabled-products',
+            'resource': 'aws.security-hub',
+            'filters': [{
+                'type': 'enabled-products',
+                'products':['aws/guardduty','aws/detective']
+            }]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 0)

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -625,6 +625,7 @@ class SecurityHubTest(BaseTest):
                     "workload-type": "other"}
             })
 
+
 class SecurityHubResourceTest(BaseTest):
 
     def test_valid_master(self):
@@ -635,7 +636,7 @@ class SecurityHubResourceTest(BaseTest):
             'resource': 'aws.security-hub',
             'filters': [{
                 'type': 'valid-master',
-                'accounts':['519413311747']
+                'accounts': ['111111111']
             }]}, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
@@ -648,7 +649,7 @@ class SecurityHubResourceTest(BaseTest):
             'resource': 'aws.security-hub',
             'filters': [{
                 'type': 'valid-master',
-                'accounts':['12345678']
+                'accounts': ['12345678']
             }]}, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 0)
@@ -661,7 +662,7 @@ class SecurityHubResourceTest(BaseTest):
             'resource': 'aws.security-hub',
             'filters': [{
                 'type': 'enabled-products',
-                'products':['aws/guardduty','cloud-custodian/cloud-custodian']
+                'products': ['aws/guardduty', 'cloud-custodian/cloud-custodian']
             }]}, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
@@ -674,7 +675,7 @@ class SecurityHubResourceTest(BaseTest):
             'resource': 'aws.security-hub',
             'filters': [{
                 'type': 'enabled-products',
-                'products':['aws/guardduty','aws/detective']
+                'products': ['aws/guardduty', 'aws/detective']
             }]}, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 0)

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -626,7 +626,7 @@ class SecurityHubTest(BaseTest):
             })
 
 
-class SecurityHubResourceTest(BaseTest):
+class SecurityHubMemberTest(BaseTest):
 
     def test_valid_master(self):
         session_factory = self.replay_flight_data(

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -632,11 +632,12 @@ class SecurityHubMemberTest(BaseTest):
         session_factory = self.replay_flight_data(
             'test_securityhub_valid_master')
         p = self.load_policy({
-            'name': 'valid-master',
+            'name': 'master',
             'resource': 'aws.security-hub',
             'filters': [{
-                'type': 'valid-master',
-                'accounts': ['111111111']
+                'type': 'master',
+                'key': 'AccountId',
+                'value': '111111111'
             }]}, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
@@ -645,11 +646,12 @@ class SecurityHubMemberTest(BaseTest):
         session_factory = self.replay_flight_data(
             'test_securityhub_valid_master')
         p = self.load_policy({
-            'name': 'valid-master',
+            'name': 'master',
             'resource': 'aws.security-hub',
             'filters': [{
-                'type': 'valid-master',
-                'accounts': ['12345678']
+                'type': 'master',
+                'key': 'AccountId',
+                'value': '12345678'
             }]}, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 0)
@@ -658,10 +660,10 @@ class SecurityHubMemberTest(BaseTest):
         session_factory = self.replay_flight_data(
             'test_securityhub_enabled_products')
         p = self.load_policy({
-            'name': 'enabled-products',
+            'name': 'products',
             'resource': 'aws.security-hub',
             'filters': [{
-                'type': 'enabled-products',
+                'type': 'products',
                 'products': ['aws/guardduty', 'cloud-custodian/cloud-custodian']
             }]}, session_factory=session_factory)
         resources = p.run()
@@ -671,10 +673,10 @@ class SecurityHubMemberTest(BaseTest):
         session_factory = self.replay_flight_data(
             'test_securityhub_enabled_products')
         p = self.load_policy({
-            'name': 'enabled-products',
+            'name': 'products',
             'resource': 'aws.security-hub',
             'filters': [{
-                'type': 'enabled-products',
+                'type': 'products',
                 'products': ['aws/guardduty', 'aws/detective']
             }]}, session_factory=session_factory)
         resources = p.run()


### PR DESCRIPTION
This closes #5891  by adding a new `security-hub` resource as well as adding a `valid-master` filter and a `enabled-products` filter.

the `valid-master` checks if security hub is linked to a master account in a provided list of `accounts`

the `enabled-products` checks if security hub contains all of the products in a provided list of `products`