### PR TITLE
Add retries for ThrottledException in QueryResourceManager

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -426,6 +426,7 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
             'ThrottlingException',
             'RequestLimitExceeded',
             'Throttled',
+            'ThrottledException',
             'Throttling',
             'Client.RequestLimitExceeded')))
 


### PR DESCRIPTION
I saw a cluster of throttling errors recently while testing an SQS policy. For context, this was in us-east-1 of an account with high resource counts. Peeking at the CloudWatch details, it looked like the specific error code (`ThrottledException`) wasn't included in the retry list for `QueryResourceManager`. Adding it here.

**More Detail**

 Recurring Error:

```
event ids not resolved: ['<queue name>'] error:An error occurred (ThrottledException) when calling the GetResources operation (reached max retries: 4): Rate exceeded]
```

Reference for the Resource Groups Tagging APIs [get_resources](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/resourcegroupstaggingapi.html?highlight=throttledexception#ResourceGroupsTaggingAPI.Client.get_resources) method, mentioning `ThrottledException`.