### PR TITLE
aws - enablement of shield on streaming distribution

### DIFF
--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -661,6 +661,10 @@ class DistributionUpdateAction(BaseUpdateAction):
             raise e
 
 
+StreamingDistribution.filter_registry.register('shield-enabled', IsShieldProtected)
+StreamingDistribution.action_registry.register('set-shield', SetShieldProtection)
+
+
 @StreamingDistribution.action_registry.register('set-attributes')
 class StreamingDistributionUpdateAction(BaseUpdateAction):
     """Action to update the attributes of a distribution


### PR DESCRIPTION
Closes #5923 

Extends enablement of shield on `resource: aws.streaming-distribution`