### PR TITLE
Add support for policy tag filtering on mugc.

### DIFF
--- a/tools/ops/README.md
+++ b/tools/ops/README.md
@@ -68,6 +68,8 @@ optional arguments:
                         The policy must match the regex
   -p POLICY_FILTER, --policies POLICY_FILTER
                         Only use named/matched policies
+  -l POLICY_TAGS_FILTER, --policytags POLICY_TAGS_FILTER
+                        Filter policies based on policy tags.
   --assume ASSUME_ROLE  Role to assume
   -v                    toggle verbose logging
 


### PR DESCRIPTION
Mugc by default doesn't filter on policy tags. This becomes an issue if deployments use policy tags to filter which policies to apply, as mugc won't generate the same list of applied policies.

This fixes the issue.