### PR TITLE
support for C7N_VAR_ environment variables

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -1102,6 +1102,10 @@ class Policy:
             'target_prefix': '{target_prefix}',
             'LoadBalancerName': '{LoadBalancerName}'
         })
+
+        c7n_env_vars = {k:os.environ[k] for k in os.environ if k.startswith('C7N_VAR_')}
+        variables.update(c7n_env_vars)
+
         return variables
 
     def expand_variables(self, variables):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -643,7 +643,8 @@ class TestPolicy(BaseTest):
         self.assertEqual(p.data['mode']['role'], 'arn:aws:iam::12312311:role/FooBar')
 
     def test_policy_variable_interpolation(self):
-
+        import os
+        os.environ['C7N_VAR_token'] = 'token'
         p = self.load_policy({
             'name': 'compute',
             'resource': 'aws.ec2',
@@ -661,6 +662,12 @@ class TestPolicy(BaseTest):
                      'topic': 'arn:::::',
                  },
                  'subject': "S3 - Cross-Account -[custodian {{ account }} - {{ region }}]"},
+                {'type':'webhook',
+                 'url':"test.com",
+                 'headers':{
+                     'auth':'{C7N_VAR_token}'
+                 }
+                }
             ]}, config={'account_id': '12312311', 'region': 'zanzibar'})
 
         ivalue = 'bad monkey 12312311 zanzibar %s' % (
@@ -673,6 +680,7 @@ class TestPolicy(BaseTest):
         self.assertEqual(p.data['mode']['role'], 'arn:aws:iam::12312311:role/FooBar')
         self.assertEqual(p.data['mode']['member-role'], 'arn:aws:iam::{account_id}:role/BarFoo')
         self.assertEqual(p.resource_manager.actions[0].data['value'], ivalue)
+        self.assertEqual(p.data['actions'][2]['headers']['auth'],'token')
 
     def test_child_resource_trail_validation(self):
         self.assertRaises(


### PR DESCRIPTION
#5895 Allows the ability to inject environment variables into a policy. 
for example

```
 policies:
  - name: cw-events
    resource: event-rule
    actions:
      - type: webhook
        url: "{C7N_VAR_webhook_url}" 
        headers:{
         auth_token: "{C7N_VAR_token}"
```

