### PR TITLE
fixed log group dimension

### DIFF
--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -159,7 +159,7 @@ class LogGroup(QueryResourceManager):
         id = 'arn'
         filter_name = 'logGroupNamePrefix'
         filter_type = 'scalar'
-        dimension = 'LogGroupName'
+        dimension = 'logGroupName'
         date = 'creationTime'
         universal_taggable = True
         cfn_type = 'AWS::Logs::LogGroup'

--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -159,7 +159,7 @@ class LogGroup(QueryResourceManager):
         id = 'arn'
         filter_name = 'logGroupNamePrefix'
         filter_type = 'scalar'
-        dimension = 'logGroupName'
+        dimension = 'LogGroupName'
         date = 'creationTime'
         universal_taggable = True
         cfn_type = 'AWS::Logs::LogGroup'
@@ -174,6 +174,13 @@ class LogGroup(QueryResourceManager):
         # log group arn in resource describe has ':*' suffix, not all
         # apis can use that form, so normalize to standard arn.
         return [r['arn'][:-2] for r in resources]
+
+
+@LogGroup.filter_registry.register('metrics')
+class LogGroupMetrics(MetricsFilter):
+
+    def get_dimensions(self, resource):
+        return [{'Name': 'LogGroupName', 'Value': resource['logGroupName']}]
 
 
 @LogGroup.action_registry.register('retention')

--- a/tests/data/placebo/test_log_group_metric/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_log_group_metric/logs.DescribeLogGroups_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/myIOTFunction",
+                "creationTime": 6441605581965,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-west-2:644160558196:log-group:/aws/lambda/myIOTFunction:*",
+                "storedBytes": 857324
+            },
+            {
+                "logGroupName": "devlog",
+                "creationTime": 6441605581968,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-west-2:644160558196:log-group:devlog:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_log_group_metric/monitoring.GetMetricStatistics_1.json
+++ b/tests/data/placebo/test_log_group_metric/monitoring.GetMetricStatistics_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "IncomingBytes",
+        "Datapoints": [
+            {
+                "Timestamp": {
+                    "hour": 11, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 8, 
+                    "minute": 46
+                }, 
+                "Average": 107.0, 
+                "Unit": "Bytes"
+            }  
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_log_group_metric/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_log_group_metric/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -161,3 +161,20 @@ class LogGroupTest(BaseTest):
         self.assertEqual(
             results[0]['kmsKeyId'],
             'arn:aws:kms:us-west-2:644160558196:key/6f13fc53-8da0-46f2-9c69-c1f9fbf471d7')
+
+    def test_metrics(self):
+        session_factory = self.replay_flight_data('test_log_group_metric')
+        p = self.load_policy(
+            {'name': 'metric-log-group',
+             'resource': 'log-group',
+             'filters': [
+                 {"logGroupName": "/aws/lambda/myIOTFunction"},
+                 {"type": "metrics",
+                  "name": "IncomingBytes",
+                  "value": 1,
+                  "op": "greater-than"}]},
+            config={'region': 'us-west-2'},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertIn('c7n.metrics', resources[0])

--- a/tools/c7n_gcp/c7n_gcp/resources/network.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/network.py
@@ -28,7 +28,7 @@ class Network(QueryResourceManager):
         service = 'compute'
         version = 'v1'
         component = 'networks'
-        scope_template = "projects/{}/global/networks"
+        scope_template = "{}"
         name = id = "name"
         default_report_fields = [
             "name", "description", "creationTimestamp",


### PR DESCRIPTION
fixes #5938. 
the dimension key was previously `LogGroupName`, but the resource contains the key `logGroupName`.