### PR TITLE
aws - rds resources tag support

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -959,7 +959,7 @@ class RDSSubscriptionDelete(BaseAction):
     """
 
     schema = type_schema('delete')
-    permissions = ('rds:DeleteEventSubscriptions',)
+    permissions = ('rds:DeleteEventSubscription',)
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('rds')

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -926,16 +926,47 @@ class RDSSubscription(QueryResourceManager):
 
     class resource_type(TypeInfo):
         service = 'rds'
-        arn_type = 'rds-subscription'
+        arn_type = 'es'
         cfn_type = 'AWS::RDS::EventSubscription'
         enum_spec = (
             'describe_event_subscriptions', 'EventSubscriptionsList', None)
-        name = id = "EventSubscriptionArn"
+        name = id = "CustSubscriptionId"
+        arn = 'EventSubscriptionArn'
         date = "SubscriptionCreateTime"
-        # SubscriptionName isn't part of describe events results?! all the
-        # other subscription apis.
-        # filter_name = 'SubscriptionName'
-        # filter_type = 'scalar'
+        permissions_enum = ('rds:DescribeEventSubscriptions',)
+        universal_taggable = object()
+    
+    augment = universal_augment
+        
+
+@RDSSubscription.action_registry.register('delete')
+class RDSSubscriptionDelete(BaseAction):
+    """Deletes a RDS snapshot resource
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: rds-subscription-delete
+                resource: rds-subscription
+                filters:
+                  - type: value
+                    key: CustSubscriptionId
+                    value: xyz
+                actions:
+                  - delete
+    """
+
+    schema = type_schema('delete')
+    permissions = ('rds:DeleteEventSubscriptions',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('rds')
+        for r in resources:
+            self.manager.retry(client.delete_event_subscription,
+                SubscriptionName=r['CustSubscriptionId'], ignore_err_codes=(
+                'SubscriptionNotFoundFault', 'InvalidEventSubscriptionStateFault'))
 
 
 class DescribeRDSSnapshot(DescribeSource):
@@ -1376,14 +1407,16 @@ class RDSSubnetGroup(QueryResourceManager):
 
     class resource_type(TypeInfo):
         service = 'rds'
-        arn_type = 'rds-subnet-group'
+        arn_type = 'subgrp'
         id = name = 'DBSubnetGroupName'
+        arn_separator = ':'
         enum_spec = (
             'describe_db_subnet_groups', 'DBSubnetGroups', None)
         filter_name = 'DBSubnetGroupName'
         filter_type = 'scalar'
         permissions_enum = ('rds:DescribeDBSubnetGroups',)
         cfn_type = config_type = 'AWS::RDS::DBSubnetGroup'
+        universal_taggable = object()
 
     source_mapping = {
         'config': ConfigSource,
@@ -1698,6 +1731,9 @@ class ReservedRDS(QueryResourceManager):
             'describe_reserved_db_instances', 'ReservedDBInstances', None)
         filter_name = 'ReservedDBInstances'
         filter_type = 'list'
-        arn_type = "reserved-db"
+        arn_type = "ri"
         arn = "ReservedDBInstanceArn"
         permissions_enum = ('rds:DescribeReservedDBInstances',)
+        universal_taggable = object()
+
+    augment = universal_augment

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -935,9 +935,9 @@ class RDSSubscription(QueryResourceManager):
         date = "SubscriptionCreateTime"
         permissions_enum = ('rds:DescribeEventSubscriptions',)
         universal_taggable = object()
-    
+
     augment = universal_augment
-        
+
 
 @RDSSubscription.action_registry.register('delete')
 class RDSSubscriptionDelete(BaseAction):
@@ -964,9 +964,10 @@ class RDSSubscriptionDelete(BaseAction):
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('rds')
         for r in resources:
-            self.manager.retry(client.delete_event_subscription,
-                SubscriptionName=r['CustSubscriptionId'], ignore_err_codes=(
-                'SubscriptionNotFoundFault', 'InvalidEventSubscriptionStateFault'))
+            self.manager.retry(
+                client.delete_event_subscription, SubscriptionName=r['CustSubscriptionId'],
+                ignore_err_codes=('SubscriptionNotFoundFault',
+                'InvalidEventSubscriptionStateFault'))
 
 
 class DescribeRDSSnapshot(DescribeSource):

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -401,7 +401,7 @@ class RDSClusterSnapshot(QueryResourceManager):
             'describe_db_cluster_snapshots', 'DBClusterSnapshots', None)
         name = id = 'DBClusterSnapshotIdentifier'
         date = 'SnapshotCreateTime'
-        universal_tagging = object()
+        universal_taggable = object()
         config_type = 'AWS::RDS::DBClusterSnapshot'
         permissions_enum = ('rds:DescribeDBClusterSnapshots',)
 

--- a/c7n/resources/rdsparamgroup.py
+++ b/c7n/resources/rdsparamgroup.py
@@ -20,6 +20,7 @@ from c7n.filters import FilterRegistry
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
 from c7n.utils import (type_schema, local_session, chunks)
+from c7n.tags import universal_augment
 
 log = logging.getLogger('custodian.rds-param-group')
 
@@ -38,9 +39,13 @@ class RDSParamGroup(QueryResourceManager):
         arn_type = 'pg'
         enum_spec = ('describe_db_parameter_groups', 'DBParameterGroups', None)
         name = id = 'DBParameterGroupName'
+        arn = 'DBParameterGroupArn'
         dimension = 'DBParameterGroupName'
         permissions_enum = ('rds:DescribeDBParameterGroups',)
         cfn_type = 'AWS::RDS::DBParameterGroup'
+        universal_taggable = object()
+
+    augment = universal_augment
 
     filter_registry = pg_filters
     action_registry = pg_actions
@@ -59,11 +64,15 @@ class RDSClusterParamGroup(QueryResourceManager):
 
         service = 'rds'
         arn_type = 'cluster-pg'
+        arn = 'DBClusterParameterGroupArn'
         enum_spec = ('describe_db_cluster_parameter_groups', 'DBClusterParameterGroups', None)
         name = id = 'DBClusterParameterGroupName'
         dimension = 'DBClusterParameterGroupName'
         permissions_enum = ('rds:DescribeDBClusterParameterGroups',)
         cfn_type = 'AWS::RDS::DBClusterParameterGroup'
+        universal_taggable = object()
+
+    augment = universal_augment
 
     filter_registry = pg_cluster_filters
     action_registry = pg_cluster_actions

--- a/tests/data/placebo/test_rds_event_subscription_delete/rds.DeleteEventSubscription_1.json
+++ b/tests/data/placebo/test_rds_event_subscription_delete/rds.DeleteEventSubscription_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "EventSubscription": {
+            "CustomerAwsId": "644160558196",
+            "CustSubscriptionId": "c7n-test-pratyush",
+            "SnsTopicArn": "arn:aws:sns:us-east-1:644160558196:c7n-pratyush",
+            "Status": "deleting",
+            "SubscriptionCreationTime": "2020-07-16 04:08:23.406",
+            "SourceType": "db-instance",
+            "Enabled": true,
+            "EventSubscriptionArn": "arn:aws:rds:us-east-1:644160558196:es:c7n-test-pratyush"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_event_subscription_delete/rds.DescribeEventSubscriptions_1.json
+++ b/tests/data/placebo/test_rds_event_subscription_delete/rds.DescribeEventSubscriptions_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "EventSubscriptionsList": [
+            {
+                "CustomerAwsId": "644160558196",
+                "CustSubscriptionId": "c7n-test-pratyush",
+                "SnsTopicArn": "arn:aws:sns:us-east-1:644160558196:c7n-pratyush",
+                "Status": "active",
+                "SubscriptionCreationTime": "2020-07-16 04:08:23.406",
+                "SourceType": "db-instance",
+                "Enabled": true,
+                "EventSubscriptionArn": "arn:aws:rds:us-east-1:644160558196:es:c7n-test-pratyush"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_event_subscription_delete/rds.DescribeEventSubscriptions_2.json
+++ b/tests/data/placebo/test_rds_event_subscription_delete/rds.DescribeEventSubscriptions_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "EventSubscriptionsList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_event_subscription_delete/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rds_event_subscription_delete/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:es:c7n-test-pratyush",
+                "Tags": [
+                    {
+                        "Key": "name",
+                        "Value": "pratyush"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsclusterparamgroup_copy/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdsclusterparamgroup_copy/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-pg:default.aurora-mysql5.7",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsclusterparamgroup_delete/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdsclusterparamgroup_delete/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-pg:default.aurora-mysql5.7",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsclusterparamgroup_modify/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdsclusterparamgroup_modify/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:cluster-pg:default.aurora-mysql5.7",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsparamgroup_copy/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdsparamgroup_copy/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:pg:rds-pg-group-a",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsparamgroup_delete/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdsparamgroup_delete/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:pg:rds-pg-group-a",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsparamgroup_modify/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdsparamgroup_modify/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:pg:rds-pg-group-a",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_reserved_rds_instance_query/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_reserved_rds_instance_query/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:ri:ri-2019-05-06-14-19-06-332",
+                "Tags": [
+                    {
+                        "Key": "c7n",
+                        "Value": "test"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1633,3 +1633,23 @@ class TestReservedRDSInstance(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["ReservedDBInstanceId"], "ri-2019-05-06-14-19-06-332")
+
+
+class RDSEventSubscription(BaseTest):
+    def test_rds_event_subscription_delete(self):
+        session_factory = self.replay_flight_data("test_rds_event_subscription_delete")
+        p = self.load_policy(
+            {
+                "name": "rds-event-subscription-delete",
+                "resource": "aws.rds-subscription",
+                "filters": [{"type": "value", "key": "tag:name", "value": "pratyush"}],
+                "actions": [{"type": "delete"}]
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["CustSubscriptionId"], "c7n-test-pratyush")
+        client = session_factory().client("rds")
+        response = client.describe_event_subscriptions()
+        self.assertEqual(len(response.get('EventSubscriptionsList')), 0)


### PR DESCRIPTION
This PR adds tagging support for:
1. rds-cluster-snapshot - tag
2. rds-reserved - tag 
3. rds-param-group - tag 
4. rds-cluster-param-group - tag
5. rds-subnet-group - tag
6. rds-subscription - tag + delete

FYI, I have tested these tagging actions manually