### PR TITLE
support for multiple resources in one policy

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -27,7 +27,7 @@ from c7n.exceptions import ClientError, PolicyValidationError
 from c7n.provider import clouds
 from c7n.policy import Policy, PolicyCollection, load as policy_load
 from c7n.schema import ElementSchema, StructureParser, generate
-from c7n.utils import load_file, local_session, SafeLoader, yaml_dump
+from c7n.utils import load_file, local_session, SafeLoader, yaml_dump, split_policies
 from c7n.config import Bag, Config
 from c7n.resources import (
     load_resources, load_available, load_providers, PROVIDER_NAMES)
@@ -223,6 +223,7 @@ def validate(options):
 
         try:
             structure.validate(data)
+            data["policies"] = split_policies(data["policies"])
         except PolicyValidationError as e:
             log.error("Configuration invalid: {}".format(config_file))
             log.error("%s" % e)

--- a/c7n/loader.py
+++ b/c7n/loader.py
@@ -29,7 +29,7 @@ except ImportError:
     # serverless execution doesn't use jsonschema
     schema = None
 from c7n.structure import StructureParser
-from c7n.utils import load_file
+from c7n.utils import load_file, split_policies
 
 
 class SchemaValidator:
@@ -119,6 +119,7 @@ class PolicyLoader:
     def load_data(self, policy_data, file_uri, validate=None,
                   session_factory=None, config=None):
         self.structure.validate(policy_data)
+        policy_data["policies"] = split_policies(policy_data["policies"])
 
         # Use passed in policy exec configuration or default on loader
         config = config or self.policy_config

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -47,6 +47,8 @@ def load(options, path, format=None, validate=True, vars=None):
 
     structure = StructureParser()
     structure.validate(data)
+    data["policies"] = utils.split_policies(data["policies"])
+    
     load_resources(structure.get_resource_types(data))
 
     if isinstance(data, list):

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -684,3 +684,21 @@ def select_keys(d, keys):
     for k in keys:
         result[k] = d.get(k)
     return result
+
+def split_policies(policy_list):
+    """splits policies that contain a list of resources 
+    into individual policies for each resource
+    """
+    policies = []
+    for p in policy_list:
+        if isinstance(p["resource"],list):
+            for r in p["resource"]:
+                resource_policy= copy.copy(p)
+                resource_policy.update({
+                    "name": "{}[{}]".format(p["name"],r),
+                    "resource":r
+                })
+                policies.append(resource_policy)
+        else:
+            policies.append(p)
+    return policies  

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -695,7 +695,7 @@ def split_policies(policy_list):
             for r in p["resource"]:
                 resource_policy= copy.copy(p)
                 resource_policy.update({
-                    "name": "{}[{}]".format(p["name"],r),
+                    "name": "{}[{}]".format(p["name"],r.replace(".","-")),
                     "resource":r
                 })
                 policies.append(resource_policy)

--- a/tests/data/test_policies/multi-resource.yml
+++ b/tests/data/test_policies/multi-resource.yml
@@ -1,0 +1,3 @@
+policies:
+  - name: multi-resources
+    resource: ["ec2","ebs"]

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -990,6 +990,25 @@ class TestPolicy(BaseTest):
         result = p.validate_policy_start_stop()
         self.assertEqual(result, None)
 
+    def test_multiple_resources(self):
+        policy = self.load_policy(
+            {
+                "name": "combined-resource-tagging",
+                "resource": ["ebs","ec2"],
+                "tags": ["abc"],
+                "filters": [
+                    {
+                        "tag:App":"absent"
+                    }
+                ],
+                "actions": [{"type": "tag", "key": "App", "value:": "Tag"}],
+            }
+        )
+        policy.validate()
+        self.assertEqual(policy.data["name"],'combined-resource-tagging[ebs]')
+        self.assertEqual(policy.data["resource"],'ebs')
+
+
 
 class PolicyConditionsTest(BaseTest):
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -70,3 +70,14 @@ class CommandsValidateTest(BaseTest):
         )
         # if there are only good policy, it should exit none
         self.assertIsNone(validate_yaml_policies(yaml_validate_options))
+
+    def test_multiple_resource(self):
+        yaml_validate_options = argparse.Namespace(
+            command="c7n.commands.validate",
+            config=None,
+            configs=[
+                "tests/data/test_policies/multi-resource.yml"],
+            debug=False,
+            subparser="validate",
+            verbose=False)
+        self.assertIsNone(validate_yaml_policies(yaml_validate_options))


### PR DESCRIPTION
based on #5258 and would allow for multiple resources to be added in one policy. Behind the scenes these policies will be split into individual policies by resource with the resource name appended to the policy name.

For example based on the policy below the new policies would be named `multi-resource-tagging[ec2]` and  `multi-resource-tagging[ebs]` and would have the corresponding resource. They would be validated and executed separately as any other policy. 
```
policies:
  - name: multi-resource-tagging
     resource: ["ec2", "ebs"]
     filters: 
      - "tag:Tag": absent
    actions:
     - type: tag
       key: Tag
       value: tagged
```

note: resources such as `"aws.ebs"` would change to `aws-ebs` in the policy name to correctly pass regex validation. 