### PR TITLE
aws - cloudtrail mode support for event-rule-target

### DIFF
--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -110,6 +110,7 @@ class EventRuleTarget(ChildResourceManager):
         arn_type = 'event-rule-target'
         enum_spec = ('list_targets_by_rule', 'Targets', None)
         parent_spec = ('event-rule', 'Rule', True)
+        supports_trailevents = True
         name = id = 'Id'
 
 


### PR DESCRIPTION
Closes #5984 