### PR TITLE
Add pending as a valid state for EC2 stop instances

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1360,7 +1360,7 @@ class Stop(BaseAction):
     Note when using hiberate, instances not configured for hiberation
     will just be stopped.
     """
-    valid_origin_states = ('running',)
+    valid_origin_states = ('running', 'pending')
 
     schema = type_schema(
         'stop',


### PR DESCRIPTION
Verified with AWS pending is a valid state to receive a stop request. Added pending as a state only.