### PR TITLE
S3 policy condition add absent/present support

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -851,7 +851,11 @@ class HasStatementFilter(BucketFilterBase):
             for statement in statements:
                 found = 0
                 for key, value in required_statement.items():
-                    if key in statement and value == statement[key]:
+                    if value == "absent" and key not in statement:
+                        found += 1
+                    elif value == "present" and key in statement:
+                        found += 1
+                    elif key in statement and value == statement[key]:
                         found += 1
                 if found and found == len(required_statement):
                     required_statements.remove(required_statement)


### PR DESCRIPTION
We want to use `has-statement` to filter aws public bucket by aws principal(the value is *), but if the bucket policy has condition to limit source ip, the bucket shouldn't treat as public, aws console doesn't highlight `public` as well.  

Currently c7n `has-statement` condition only support value compare, we maybe need add present/absent support to filter public bucket as follows:

```
policies:
  - name: check_s3_public_bucket
    resource: s3
    filters:
     - type: has-statement
       statements:
         - Effect: Allow
           Principal: '*'
           Condition: absent
```