### PR TITLE
aws - core - iam analyzer filter, use a dict getter to account for resource without findings

### DIFF
--- a/c7n/filters/iamanalyzer.py
+++ b/c7n/filters/iamanalyzer.py
@@ -52,7 +52,7 @@ class AccessAnalyzer(ValueFilter):
             client, analyzer_arn,
             [r for r in resources if self.analysis_annotation not in r])
         for r in resources:
-            findings = r[self.analysis_annotation]
+            findings = r.get(self.analysis_annotation, [])
             if not findings:
                 continue
             elif not len(self.data) > 1:


### PR DESCRIPTION
I was getting a KeyError when scanning resources that did not have existing or active findings. Adding this getter to safely handle those conditions.