### PR TITLE
aws - backup vault cross account filter

### DIFF
--- a/c7n/resources/backup.py
+++ b/c7n/resources/backup.py
@@ -106,7 +106,8 @@ class BackupVaultCrossAccount(CrossAccountAccessFilter):
         for r in resources:
             if self.policy_attribute not in r:
                 get_policy = self.manager.retry(client.get_backup_vault_access_policy,
-                    BackupVaultName=r['BackupVaultName'], ignore_err_codes=('ResourceNotFoundException',))
+                    BackupVaultName=r['BackupVaultName'], ignore_err_codes=(
+                        'ResourceNotFoundException',))
                 if get_policy:
                     policy = get_policy.get('Policy')
                 r[self.policy_attribute] = policy

--- a/c7n/resources/backup.py
+++ b/c7n/resources/backup.py
@@ -97,7 +97,7 @@ class BackupVaultCrossAccount(CrossAccountAccessFilter):
             - type: cross-account
 
     """
-    permissions = ('glue:GetResourcePolicy',)
+    permissions = ('backup:GetBackupVaultAccessPolicy',)
     policy_annotation = "c7n:Policy"
 
     def process(self, resources, event=None):

--- a/tests/data/placebo/test_backup_vault_cross_account/backup.GetBackupVaultAccessPolicy_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account/backup.GetBackupVaultAccessPolicy_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BackupVaultName": "Default",
+        "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:Default",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowBackupDeletion\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:role/c7n-pratyush-test\"},\"Action\":[\"backup:DeleteBackupVault\",\"backup:DeleteBackupVaultAccessPolicy\",\"backup:DeleteBackupVaultNotifications\"],\"Resource\":\"*\"}]}"
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account/backup.GetBackupVaultAccessPolicy_2.json
+++ b/tests/data/placebo/test_backup_vault_cross_account/backup.GetBackupVaultAccessPolicy_2.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BackupVaultName": "test_backup_vault_policy_statement_filter",
+        "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:test_backup_vault_policy_statement_filter",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowBackupDeletion\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::890123456789:role/aws-service-role/cloud9.amazonaws.com/AWSServiceRoleForAWSCloud9\"},\"Action\":[\"backup:DeleteBackupVault\",\"backup:DeleteBackupVaultAccessPolicy\",\"backup:DeleteBackupVaultNotifications\"],\"Resource\":\"*\"}]}"
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account/backup.ListBackupVaults_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account/backup.ListBackupVaults_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BackupVaultList": [
+            {
+                "BackupVaultName": "Default",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:Default",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 8,
+                    "minute": 59,
+                    "second": 50,
+                    "microsecond": 374000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "CreatorRequestId": "Default",
+                "NumberOfRecoveryPoints": 1
+            },
+            {
+                "BackupVaultName": "test_backup_vault_policy_statement_filter",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:test_backup_vault_policy_statement_filter",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 20,
+                    "hour": 15,
+                    "minute": 45,
+                    "second": 1,
+                    "microsecond": 491000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "NumberOfRecoveryPoints": 0
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -100,3 +100,17 @@ class BackupVaultTest(BaseTest):
         self.assertTrue(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['EncryptionKeyArn'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/aws/backup')
+
+    def test_backup_vault_cross_account(self):
+        factory = self.replay_flight_data("test_backup_vault_cross_account")
+        p = self.load_policy(
+            {
+                "name": "backup-vault-cross-account",
+                "resource": "backup-vault",
+                "filters": [{"type": "cross-account"}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0].get('BackupVaultName'), 'test_backup_vault_policy_statement_filter')

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -113,4 +113,5 @@ class BackupVaultTest(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0].get('BackupVaultName'), 'test_backup_vault_policy_statement_filter')
+        self.assertEqual(resources[0].get(
+            'BackupVaultName'), 'test_backup_vault_policy_statement_filter')


### PR DESCRIPTION
Adding cross-account filter support for backup vaults

Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/backup.html#Backup.Client.get_backup_vault_access_policy