### PR TITLE
aws - security hub - increase findings batch size limit from 10 to 100

### DIFF
--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -331,7 +331,7 @@ class PostFinding(Action):
         recommendation={"type": "string"},
         recommendation_url={"type": "string"},
         fields={"type": "object"},
-        batch_size={'type': 'integer', 'minimum': 1, 'maximum': 10, 'default': 1},
+        batch_size={'type': 'integer', 'minimum': 1, 'maximum': 100, 'default': 1},
         types={
             "type": "array",
             "minItems": 1,


### PR DESCRIPTION
## Sets Security Hub max batch_size to 100 as per docs

Looks like the maximum per call is now 100 according to boto3 docs 
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/securityhub.html#SecurityHub.Client.batch_import_findings

@FireballDWF was it previously 10?