### PR TITLE
reduce chance of hitting s3 rate limits

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1393,7 +1393,7 @@ class FilterPublicBlock(Filter):
 
     def process(self, buckets, event=None):
         results = []
-        with self.executor_factory(max_workers=2) as w:
+        with self.executor_factory(max_workers=1) as w:
             futures = {w.submit(self.process_bucket, bucket): bucket for bucket in buckets}
             for f in as_completed(futures):
                 if f.result():


### PR DESCRIPTION
I found that while there are more than 100 buckets per region, the s3 API will return a weird error `No Such Bucket Exists`.
After some testing I found that reducing the max_workers on this method, the API works fine, even though the real solution would be a client-based throttling mechanism.