### PR TITLE
add config rule support to policylambda.py

### DIFF
--- a/tools/ops/policylambda.py
+++ b/tools/ops/policylambda.py
@@ -115,7 +115,7 @@ def render_invoke(name):
         "Type": "AWS::Lambda::Permission",
         "Properties": {
             "Action": "lambda:InvokeFunction",
-            "FunctionName": {"Ref": name },
+            "FunctionName": {"Ref": name},
             "Principal": "config.amazonaws.com"
         }
     }

--- a/tools/ops/policylambda.py
+++ b/tools/ops/policylambda.py
@@ -28,6 +28,8 @@ import json
 import os
 import string
 import yaml
+import boto3
+from boto3.session import Session
 
 from c7n.config import Config
 from c7n.policy import load as policy_load
@@ -54,34 +56,79 @@ def render(p):
     if key_arn:
         properties['KmsKeyArn']
 
-    # Event render
-    revents = {}
-    if p.execution_mode == 'periodic':
-        revents = {
-            'PolicySchedule': {
-                'Type': 'Schedule',
-                'Properties': {
-                    'Schedule': p.data.get('mode', {}).get('schedule')}}
-        }
-    else:
-        events = [e for e in policy_lambda.get_events(None)
-                  if isinstance(e, mu.CloudWatchEventSource)]
-        if not events:
-            return
-
+    if p.execution_mode == 'periodic' or p.execution_mode == 'cloudtrail':
+        # Event render
         revents = {}
-        for idx, e in enumerate(events):
-            revents[
-                'PolicyTrigger%s' % string.ascii_uppercase[idx]] = {
-                    'Type': 'CloudWatchEvent',
+        if p.execution_mode == 'periodic':
+            revents = {
+                'PolicySchedule': {
+                    'Type': 'Schedule',
                     'Properties': {
-                        'Pattern': json.loads(e.render_event_pattern())}
+                        'Schedule': p.data.get('mode', {}).get('schedule')}}
             }
+        else:
+            events = [e for e in policy_lambda.get_events(None)
+                    if isinstance(e, mu.CloudWatchEventSource)]
+            if not events:
+                return
 
-    properties['Events'] = revents
+            revents = {}
+            for idx, e in enumerate(events):
+                revents[
+                    'PolicyTrigger%s' % string.ascii_uppercase[idx]] = {
+                        'Type': 'CloudWatchEvent',
+                        'Properties': {
+                            'Pattern': json.loads(e.render_event_pattern())}
+                }
+
+        properties['Events'] = revents
+
+    elif p.execution_mode == 'config-rule':
+        properties.pop('Delay', None)
+
     return {
         'Type': 'AWS::Serverless::Function',
         'Properties': properties}
+
+
+def render_config_rule(p):
+    policy_lambda = mu.PolicyLambda(p)
+    policy_lambda.arn = get_lambda_arn(policy_lambda.name)
+    config_rule = policy_lambda.get_events(Session)
+
+    properties = config_rule[0].get_rule_params(policy_lambda)
+
+    exec_mode_type = p.data.get('mode', {'type': 'pull'}).get('type')
+    if exec_mode_type == 'config-poll-rule':
+        properties.pop('Scope', None)
+
+    attributes = {}
+    attributes['Type'] = 'AWS::Config::ConfigRule'
+    attributes['DependsOn'] = resource_name(p.name) + "Invoke"
+    attributes['Properties'] = properties
+    return attributes
+
+
+def render_invoke(name):
+    return {
+        "DependsOn": name,
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {"Ref": name },
+            "Principal": "config.amazonaws.com"
+        }
+    }
+
+
+def get_lambda_arn(function_name):
+    sts = boto3.client("sts")
+    account_id = sts.get_caller_identity()["Arn"].split(":")[4]
+    region = boto3.session.Session().region_name
+    arn = "arn:aws:lambda:" + str(region) \
+          + ":" + account_id + ":function:" \
+          + function_name
+    return arn
 
 
 def resource_name(policy_name):
@@ -133,6 +180,13 @@ def main():
         sam_func = render(p)
         if sam_func:
             sam['Resources'][resource_name(p.name)] = sam_func
+
+            if exec_mode_type == 'config-rule' or exec_mode_type == 'config-poll-rule':
+                configrule_resource = render_config_rule(p)
+                invoke_resource = render_invoke(resource_name(p.name))
+                sam['Resources'][resource_name(p.name) + "Invoke"] = invoke_resource
+                sam['Resources'][resource_name(p.name) + "ConfigRule"] = configrule_resource
+
             sam_func['Properties']['CodeUri'] = './%s.zip' % p.name
         else:
             print("unable to render sam for policy:%s" % p.name)


### PR DESCRIPTION
Solution for Issue #6051

**Is your feature request related to a problem? Please describe.**
When using cloud-custodian/tools/ops/policylambda.py to convert custodian policy documents into cloudformation templates, there is missing functionality for the modes config-rule and config-poll-rule.

**Describe the solution you'd like**
We would like cloud-custodian/tools/ops/policylambda.py to add support for modes config-rule and config-poll-rule to generate SAM/Cloudformation for Config Rules. We need to convert custodian policies containing AWS Config Rules into cloudformation so that underlying resources can be linted and managed.

