### PR TITLE
 releng - configure away pytest implicit magic for test speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ pkg-publish-wheel:
 	for pkg in $(PKG_SET); do cd $$pkg && twine upload -r testpypi dist/* && cd ../..; done
 
 test-poetry:
-	. test.env && poetry run pytest -n auto tests tools
+	. $(PWD)/test.env && poetry run pytest -n auto tests tools
 
 test:
 	./bin/tox -e py38

--- a/tox.ini
+++ b/tox.ini
@@ -95,3 +95,5 @@ addopts= --tb=native --durations 50
 markers =
   functional
   skiplive
+python_files = test_*.py
+norecursedirs = data cassettes templates


### PR DESCRIPTION
so pytest does a bunch of implicit magic, and wastes quite a bit of time looking at non python files, so ignore the non python data files. on a no-op test collection this drops time from 6s down to 1s, and with xdist from 15s to 5s (16 hw threads) since xdist duplicates test collection for each worker process.