### PR TITLE
Fix the date generation for tomorrow.

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1205,7 +1205,7 @@ class PullModeTest(BaseTest):
             session_factory=None)
         self.assertEqual(p.is_runnable(), True)
 
-        tomorrow_date = str(datetime.date(datetime.utcnow()) + timedelta(days=1))
+        tomorrow_date = str(datetime.date(datetime.now()) + timedelta(days=1))
         p = self.load_policy(
             {'name': 'bad-start-date',
              'resource': 'ec2',


### PR DESCRIPTION
Since the date string is parsed as a local time, and we don't want
to change that behaviour, the better approach is to generate
the tomorrow date based on local time, not UTC.

Addresses test issue #6062.