### PR TITLE
aws - account access-analyzer filter

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -380,7 +380,7 @@ class AccessAnalyzer(ValueFilter):
           resource: account
           filters:
             - type: access-analyzer
-              key: [].status
+              key: '[].status'
               value: ACTIVE
               op: contains
     """

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -395,11 +395,12 @@ class AccessAnalyzer(ValueFilter):
             client = local_session(self.manager.session_factory).client('accessanalyzer')
             analyzers = self.manager.retry(
                 client.list_analyzers)['analyzers']
-            account['c7n:matched_analyzers'] = []
-        for analyzer in analyzers:
-            if self.match(analyzer):
-                account['c7n:matched_analyzers'].append(analyzer)
-        if account['c7n:matched_analyzers']:
+            matched_analyzers = []
+            for analyzer in analyzers:
+                if self.match(analyzer):
+                    matched_analyzers.append(analyzer)
+            account['c7n:matched_analyzers'] = matched_analyzers
+        if account.get('c7n:matched_analyzers', []):
             return resources
         return []
 

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -404,9 +404,11 @@ class AccessAnalyzer(Filter):
                 if analyzer['status'].lower() == status and analyzer['type'].lower() == trust:
                     account['c7n:AccessAnalyzer'] = analyzer
                     return resources
-        except ClientError as e:
-            if e.response['Error']['Code'] != 'ResourceNotFoundException':
-                raise
+        except Exception as e:
+            self.log.warning(
+                "Exception trying to list analyzers in account: %s error: %s",
+                self.manager.config.account_id, e)
+            raise e
         return []
 
 

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -394,14 +394,15 @@ class AccessAnalyzer(Filter):
     def process(self, resources, event=None):
         account = resources[0]
         status = self.data.get('status', 'active')
-        trust = self.data.get('trust', 'account')
+        trust = self.data.get('trust', '')
 
         client = local_session(self.manager.session_factory).client('accessanalyzer')
 
         try:
             analyzers = self.manager.retry(client.list_analyzers)['analyzers']
             for analyzer in analyzers:
-                if analyzer['status'].lower() == status and analyzer['type'].lower() == trust:
+                if (not trust and analyzer['status'].lower() == status) or \
+                   (analyzer['type'].lower() == trust and analyzer['status'].lower()):
                     account['c7n:AccessAnalyzer'] = analyzer
                     return resources
         except Exception as e:

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -375,15 +375,14 @@ class AccessAnalyzer(ValueFilter):
 
     .. code-block:: yaml
 
-            policies:
-              - name: account-access-analyzer
-                resource: account
-                region: us-east-1
-                filters:
-                  - type: access-analyzer
-                    key: [].status
-                    value: ACTIVE
-                    op: contains
+      policies:
+        - name: account-access-analyzer
+          resource: account
+          filters:
+            - type: access-analyzer
+              key: [].status
+              value: ACTIVE
+              op: contains
     """
 
     schema = type_schema('access-analyzer', rinherit=ValueFilter.schema)

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -381,7 +381,7 @@ class AccessAnalyzer(ValueFilter):
                 region: us-east-1
                 filters:
                   - type: access-analyzer
-                    key: [*].status
+                    key: [].status
                     value: ACTIVE
                     op: contains
     """

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -391,14 +391,16 @@ class AccessAnalyzer(ValueFilter):
 
     def process(self, resources, event=None):
         account = resources[0]
-        if not account.get('c7n:access_analyzers'):
+        if not account.get('c7n:matched_analyzers'):
             client = local_session(self.manager.session_factory).client('accessanalyzer')
             analyzers = self.manager.retry(
                 client.list_analyzers)['analyzers']
+            account['c7n:matched_analyzers'] = []
         for analyzer in analyzers:
             if self.match(analyzer):
-                account['c7n:access_analyzer'] = analyzer
-                return resources
+                account['c7n:matched_analyzers'].append(analyzer)
+        if account['c7n:matched_analyzers']:
+            return resources
         return []
 
 

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -399,7 +399,7 @@ class AccessAnalyzer(Filter):
         client = local_session(self.manager.session_factory).client('accessanalyzer')
 
         try:
-            analyzers = client.list_analyzers()['analyzers']
+            analyzers = self.manager.retry(client.list_analyzers)['analyzers']
             for analyzer in analyzers:
                 if analyzer['status'].lower() == status and analyzer['type'].lower() == trust:
                     account['c7n:AccessAnalyzer'] = analyzer

--- a/tests/data/placebo/test_account_access_analyzer_filter/access-analyzer.ListAnalyzers_1.json
+++ b/tests/data/placebo/test_account_access_analyzer_filter/access-analyzer.ListAnalyzers_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "analyzers": [
+            {
+                "arn": "arn:aws:access-analyzer:us-east-1:0123456789012:analyzer/ConsoleAnalyzer-d534345f-499c-43bd-bbcc-dd637ab352d2",
+                "name": "ConsoleAnalyzer-d534345f-499c-43bd-bbcc-dd637ab352d2",
+                "status": "ACTIVE",
+                "tags": {},
+                "type": "ACCOUNT"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_account_access_analyzer_filter/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_access_analyzer_filter/iam.ListAccountAliases_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountAliases": [
+            "test-account"
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_account_access_analyzer_filter/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_access_analyzer_filter/iam.ListAccountAliases_1.json
@@ -2,7 +2,7 @@
     "status_code": 200,
     "data": {
         "AccountAliases": [
-            "test-account"
+            "custodian-skunk-works"
         ],
         "IsTruncated": false,
         "ResponseMetadata": {}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -13,7 +13,6 @@ import datetime
 from dateutil import parser
 import json
 import mock
-from unittest.mock import MagicMock
 import time
 
 from .common import functional
@@ -866,39 +865,15 @@ class AccountTests(BaseTest):
             {
                 "name": "account-access-analyzer",
                 "resource": "account",
-                "filters": ["access-analyzer"],
+                "filters": [{"type": "access-analyzer",
+                             "key": "[*].status",
+                             "value": "ACTIVE",
+                             "op": "contains"}],
             },
             session_factory=session_factory,
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-
-    def test_account_access_analyzer_filter_error(self):
-        session_factory = self.replay_flight_data("test_account_access_analyzer_filter")
-        client = session_factory().client("accessanalyzer")
-        mock_factory = MagicMock()
-        mock_factory.region = 'us-east-1'
-        mock_factory().client(
-            'accessanalyzer').exceptions.InternalServerException = (
-                client.exceptions.InternalServerException)
-
-        mock_factory().client('accessanalyzer').list_analyzers.side_effect = (
-            client.exceptions.InternalServerException(
-                {'Error': {'Code': 'InternalServerException'}},
-                operation_name='list_analyzers'))
-
-        p = self.load_policy(
-            {
-                "name": "account-access-analyzer",
-                "resource": "account",
-                "filters": ["access-analyzer"],
-            },
-            session_factory=mock_factory,
-        )
-        try:
-            p.run()
-        except client.exceptions.InternalServerException:
-            mock_factory().client('accessanalyzer').list_analyzers.assert_called_once()
 
     def test_account_shield_filter(self):
         session_factory = self.replay_flight_data("test_account_shield_advanced_filter")

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -866,9 +866,9 @@ class AccountTests(BaseTest):
                 "name": "account-access-analyzer",
                 "resource": "account",
                 "filters": [{"type": "access-analyzer",
-                             "key": "[].status",
+                             "key": "status",
                              "value": "ACTIVE",
-                             "op": "contains"}],
+                             "op": "eq"}],
             },
             session_factory=session_factory,
         )

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -13,6 +13,7 @@ import datetime
 from dateutil import parser
 import json
 import mock
+from unittest.mock import MagicMock
 import time
 
 from .common import functional
@@ -871,6 +872,33 @@ class AccountTests(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_account_access_analyzer_filter_error(self):
+        session_factory = self.replay_flight_data("test_account_access_analyzer_filter")
+        client = session_factory().client("accessanalyzer")
+        mock_factory = MagicMock()
+        mock_factory.region = 'us-east-1'
+        mock_factory().client(
+            'accessanalyzer').exceptions.InternalServerException = (
+                client.exceptions.InternalServerException)
+
+        mock_factory().client('accessanalyzer').list_analyzers.side_effect = (
+            client.exceptions.InternalServerException(
+                {'Error': {'Code': 'InternalServerException'}},
+                operation_name='list_analyzers'))
+
+        p = self.load_policy(
+            {
+                "name": "account-access-analyzer",
+                "resource": "account",
+                "filters": ["access-analyzer"],
+            },
+            session_factory=mock_factory,
+        )
+        try:
+            p.run()
+        except client.exceptions.InternalServerException:
+            mock_factory().client('accessanalyzer').list_analyzers.assert_called_once()
 
     def test_account_shield_filter(self):
         session_factory = self.replay_flight_data("test_account_shield_advanced_filter")

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -859,6 +859,19 @@ class AccountTests(BaseTest):
         status = client.get_trail_status(Name=arn)
         self.assertTrue(status["IsLogging"])
 
+    def test_account_access_analyzer_filter(self):
+        session_factory = self.replay_flight_data("test_account_access_analyzer_filter")
+        p = self.load_policy(
+            {
+                "name": "account-access-analyzer",
+                "resource": "account",
+                "filters": ["access-analyzer"],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_account_shield_filter(self):
         session_factory = self.replay_flight_data("test_account_shield_advanced_filter")
         p = self.load_policy(

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -866,7 +866,7 @@ class AccountTests(BaseTest):
                 "name": "account-access-analyzer",
                 "resource": "account",
                 "filters": [{"type": "access-analyzer",
-                             "key": "[*].status",
+                             "key": "[].status",
                              "value": "ACTIVE",
                              "op": "contains"}],
             },


### PR DESCRIPTION
Addresses #6054. 

I'm unsure what the status and trust values should default to if they are not provided, or whether they should be made to be required. Let me know what you think. 