### PR TITLE
Update the metavar for the metrics CLI help.

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -228,7 +228,7 @@ def setup_parser():
             "https://cloudcustodian.io/docs/aws/usage.html#metrics")
 
     run.add_argument(
-        "-m", "--metrics-enabled",
+        "-m", "--metrics-enabled", metavar="PROVIDER",
         default=None, nargs="?", const="aws",
         help=metrics_help)
     run.add_argument(


### PR DESCRIPTION
Changes the help output from:
```
  -m [METRICS_ENABLED], --metrics-enabled [METRICS_ENABLED]
                        Emit metrics to provider metrics. Specify 'aws', 'gcp', or 'azure'. For more details on aws metrics options, see: https://cloudcustodian.io/docs/aws/usage.html#metrics
```
to:
```
  -m [PROVIDER], --metrics-enabled [PROVIDER]
                        Emit metrics to provider metrics. Specify 'aws', 'gcp', or 'azure'. For more details on aws metrics options, see: https://cloudcustodian.io/docs/aws/usage.html#metrics
```