### PR TITLE
Add schema diff to script that generates changelogs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,6 @@
 -r tools/c7n_kube/requirements.txt
 -r tools/c7n_mailer/requirements.txt
 -r tools/c7n_org/requirements.txt
--r tools/dev/requirements.txt
 
 # Setup source directories as editable/development distributions
 -e .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@
 -r tools/c7n_kube/requirements.txt
 -r tools/c7n_mailer/requirements.txt
 -r tools/c7n_org/requirements.txt
+-r tools/dev/requirements.txt
 
 # Setup source directories as editable/development distributions
 -e .

--- a/tools/dev/changelog.py
+++ b/tools/dev/changelog.py
@@ -41,6 +41,7 @@ aliases = {
     'sechub': 'aws',
     'sns': 'aws',
     'actions': 'aws',
+    'chore': 'core',
     'serverless': 'core',
     'packaging': 'tests',
     '0': 'release',
@@ -247,7 +248,7 @@ def main(path, output, since, end, user):
                 print(" - %s" % c.strip(), file=fh)
             print("\n", file=fh)
         if diff_md.strip():
-            print("# schema diff", file=fh)
+            print("# schema changes", file=fh)
             print(diff_md, file=fh)
 
 

--- a/tools/dev/changelog.py
+++ b/tools/dev/changelog.py
@@ -233,7 +233,7 @@ def main(path, output, since, end, user):
     pprint.pprint(dict([(k, len(groups[k])) for k in groups]))
 
     diff_md = ""
-    if since and not end:
+    if since and not end and since.count('.') > 2:
         schema_old = schema_outline_from_docker(since)
         load_available()
         schema_new = resource_outline()

--- a/tools/dev/requirements.txt
+++ b/tools/dev/requirements.txt
@@ -1,0 +1,2 @@
+docker
+pygit2

--- a/tools/dev/tests/data/diff.md
+++ b/tools/dev/tests/data/diff.md
@@ -1,0 +1,7 @@
+- `provider1.resource1`
+  - actions added: `action2`
+  - actions removed: `action1`
+  - filters added: `filter3`, `filter4`
+  - filters removed: `filter2`
+- `provider1.resource2` removed
+- `provider1.resource3` added

--- a/tools/dev/tests/data/diff.md
+++ b/tools/dev/tests/data/diff.md
@@ -1,7 +1,8 @@
-- `provider1.resource1`
-  - actions added: `action2`
-  - actions removed: `action1`
-  - filters added: `filter3`, `filter4`
-  - filters removed: `filter2`
 - `provider1.resource2` removed
 - `provider1.resource3` added
+- added global actions: `action3`
+- `provider1.resource1`
+  - added actions: `action2`
+  - removed actions: `action1`
+  - added filters: `filter3`, `filter4`
+  - removed filters: `filter2`

--- a/tools/dev/tests/data/diff.md
+++ b/tools/dev/tests/data/diff.md
@@ -1,8 +1,8 @@
 - `provider1.resource2` removed
-- `provider1.resource3` added
-- added global actions: `action3`
+- [`provider1.resource3`](https://cloudcustodian.io/docs/provider1/resources/resource3.html) added
+- added common actions: [`action3`](https://cloudcustodian.io/docs/aws/resources/aws-common-actions.html#aws-common-actions-action3)
 - `provider1.resource1`
-  - added actions: `action2`
+  - added actions: [`action2`](https://cloudcustodian.io/docs/provider1/resources/resource1.html#provider1-resource1-actions-action2)
   - removed actions: `action1`
-  - added filters: `filter3`, `filter4`
+  - added filters: [`filter3`](https://cloudcustodian.io/docs/provider1/resources/resource1.html#provider1-resource1-filters-filter3), [`filter4`](https://cloudcustodian.io/docs/provider1/resources/resource1.html#provider1-resource1-filters-filter4)
   - removed filters: `filter2`

--- a/tools/dev/tests/data/schema-new.json
+++ b/tools/dev/tests/data/schema-new.json
@@ -1,0 +1,16 @@
+{
+  "provider1": {
+    "provider1.resource1": {
+      "filters": ["filter1", "filter3", "filter4"],
+      "actions": ["action2"]
+    },
+    "provider1.resource3": {
+      "filters": ["filter2"],
+      "actions": ["action2"]
+    },
+    "provider1.resource4": {
+      "filters": ["filter1"],
+      "actions": ["action1"]
+    }
+  }
+}

--- a/tools/dev/tests/data/schema-new.json
+++ b/tools/dev/tests/data/schema-new.json
@@ -2,15 +2,15 @@
   "provider1": {
     "provider1.resource1": {
       "filters": ["filter1", "filter3", "filter4"],
-      "actions": ["action2"]
+      "actions": ["action2", "action3"]
     },
     "provider1.resource3": {
       "filters": ["filter2"],
-      "actions": ["action2"]
+      "actions": ["action2", "action3"]
     },
     "provider1.resource4": {
       "filters": ["filter1"],
-      "actions": ["action1"]
+      "actions": ["action1", "action3"]
     }
   }
 }

--- a/tools/dev/tests/data/schema-old.json
+++ b/tools/dev/tests/data/schema-old.json
@@ -1,0 +1,16 @@
+{
+  "provider1": {
+    "provider1.resource1": {
+      "filters": ["filter1", "filter2"],
+      "actions": ["action1"]
+    },
+    "provider1.resource2": {
+      "filters": ["filter1"],
+      "actions": ["action1"]
+    },
+    "provider1.resource4": {
+      "filters": ["filter1"],
+      "actions": ["action1"]
+    }
+  }
+}

--- a/tools/dev/tests/test_changelog.py
+++ b/tools/dev/tests/test_changelog.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+
+schema_diff = Path(__file__).parent.parent / "changelog.py"
+with open(schema_diff, encoding='utf-8') as f:
+    exec(f.read())
+
+
+def test_schema_diff():
+    data_dir = Path(__file__).parent / "data"
+    with open(data_dir / "schema-old.json") as f:
+        schema_old = json.load(f)
+    with open(data_dir / "schema-new.json") as f:
+        schema_new = json.load(f)
+    with open(data_dir / "diff.md", encoding='utf-8') as f:
+        expected = f.read()
+
+    result = schema_diff(schema_old, schema_new)  # noqa
+    assert result == expected

--- a/tools/dev/tests/test_changelog.py
+++ b/tools/dev/tests/test_changelog.py
@@ -1,10 +1,32 @@
 import json
 from pathlib import Path
 
+import pytest
+
 
 schema_diff = Path(__file__).parent.parent / "changelog.py"
 with open(schema_diff, encoding='utf-8') as f:
     exec(f.read())
+
+
+@pytest.mark.parametrize('provider, resource, category, element, expected', [
+    ('aws', 'firehose', 'filters', 'kms-key',
+     '[`kms-key`](https://cloudcustodian.io/docs/aws/resources/firehose.html#aws-firehose-filters-kms-key)'),  # noqa
+    (None, 'gcp.pubsub-topic', 'actions', 'delete',
+     '[`delete`](https://cloudcustodian.io/docs/gcp/resources/pubsub-topic.html#gcp-pubsub-topic-actions-delete)'),  # noqa
+    ('aws', 'elasticsearch', None, None,
+     '[`aws.elasticsearch`](https://cloudcustodian.io/docs/aws/resources/elasticsearch.html)'),
+    ('aws', None, 'filters', 'reduce',
+     '[`reduce`](https://cloudcustodian.io/docs/aws/resources/aws-common-filters.html#aws-common-filters-reduce)'),  # noqa
+])
+def test_link(provider, resource, category, element, expected):
+    got = link(  # noqa
+        provider=provider,
+        resource=resource,
+        category=category,
+        element=element,
+    )
+    assert got == expected
 
 
 def test_schema_diff():

--- a/tools/dev/tests/test_changelog.py
+++ b/tools/dev/tests/test_changelog.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 
 
+pytest.importorskip('pygit2')
+
 schema_diff = Path(__file__).parent.parent / "changelog.py"
 with open(schema_diff, encoding='utf-8') as f:
     exec(f.read())

--- a/tools/utils/README.md
+++ b/tools/utils/README.md
@@ -1,0 +1,14 @@
+# schema_diff.py
+
+Use this utility to display the list of providers, filters, and
+actions that have been added or removed between two given versions.
+Here's the command that writes out the differences between Custodian
+version 0.9.2.0 and the latest version to a file called `diff.md`:
+
+```
+python schema_diff.py 0.9.2.0 latest --only-changes --out=diff.md
+```
+
+This assumes that `custodian-cask` is available in your environment.
+If you want to display a list of all filters and actions, regardless
+of whether they changes or not, omit the `--only-changes` flag.


### PR DESCRIPTION
This is based on work of @jtroberts83 in #5743.

I'm attaching an output of the command when diffing between `0.9.2.0` and `latest` (in `diff.zip`).  Another dummy example can be found in this PR as `diff-only-changes.md`.  I'd like to hear your ideas on how to make this prettier or more useful.

[diff.zip](https://github.com/cloud-custodian/cloud-custodian/files/5187502/diff.zip)



