### PR TITLE
Fix the intermittent test failure by explicitly setting rand seed.

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -5,6 +5,7 @@ import calendar
 from datetime import datetime, timedelta
 from dateutil import tz
 from dateutil.parser import parse as parse_date
+import random
 import unittest
 import os
 
@@ -1225,6 +1226,9 @@ class TestReduceFilter(BaseFilterTest):
                 "order": "randomize",
             }
         )
+        # Set the rand seed to ensure that the random sets aren't accidentally
+        # the same.
+        random.seed(1234)
         rs1 = f.process(resources)
         rs2 = f.process(resources)
         self.assertEqual(len(rs1), len(resources))


### PR DESCRIPTION
The test_randomize function would intermittently fail when the random function ends up selecting the list in the same way twice.

By specifying the random seed explicitly in the test we can ensure that the randomness that is created for test will not generate two identical lists.

Addresses issue #6039