### PR TITLE
AWS - Route53 dangling dns filter

### DIFF
--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -407,3 +407,89 @@ class IsQueryLoggingEnabled(Filter):
             elif not logging and not state:
                 results.append(r)
         return results
+
+
+@HostedZone.action_registry.register('dangling-records')
+class GetDanglingRecords(BaseAction):
+    """Enables query logging on a hosted zone.
+
+    By default this enables a log group per route53 domain, alternatively
+    a log group name can be specified for a unified log across domains.
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: enablednsquerylogging
+            resource: hostedzone
+            region: us-east-1
+            filters:
+              - type: query-logging-enabled
+                state: false
+            actions:
+              - type: set-query-logging
+                state: true
+
+    """
+
+    permissions = (
+        'route53:GetQueryLoggingConfig',
+        'route53:CreateQueryLoggingConfig',
+        'route53:DeleteQueryLoggingConfig',
+        'logs:DescribeLogGroups',
+        'logs:CreateLogGroup',
+        'logs:GetResourcePolicy',
+        'logs:PutResourcePolicy')
+
+    schema = type_schema(
+        'set-query-logging', **{
+            'set-permissions': {'type': 'boolean'},
+            'log-group-prefix': {'type': 'string', 'default': '/aws/route53'},
+            'log-group': {'type': 'string', 'default': 'auto'},
+            'state': {'type': 'boolean'}})
+
+    def validate(self):
+        if not self.data.get('state', True):
+            # By forcing use of a filter we ensure both getting to right set of
+            # resources as well avoiding an extra api call here, as we'll reuse
+            # the annotation from the filter for logging config.
+            if not [f for f in self.manager.iter_filters() if isinstance(
+                    f, IsQueryLoggingEnabled)]:
+                raise ValueError(
+                    "set-query-logging when deleting requires "
+                    "use of query-logging-enabled filter in policy")
+        return self
+
+    def process(self, resources):
+        if self.manager.config.region != 'us-east-1':
+            self.log.warning("set-query-logging should be only be performed region: us-east-1")
+
+        client = local_session(self.manager.session_factory).client('route53')
+        state = self.data.get('state', True)
+
+        zone_log_names = {z['Id']: self.get_zone_log_name(z) for z in resources}
+        if state:
+            self.ensure_log_groups(set(zone_log_names.values()))
+
+        for r in resources:
+            if not state:
+                try:
+                    client.delete_query_logging_config(Id=r['c7n:log-config']['Id'])
+                except client.exceptions.NoSuchQueryLoggingConfig:
+                    pass
+                continue
+            log_arn = "arn:aws:logs:us-east-1:{}:log-group:{}".format(
+                self.manager.account_id, zone_log_names[r['Id']])
+            client.create_query_logging_config(
+                HostedZoneId=r['Id'],
+                CloudWatchLogsLogGroupArn=log_arn)
+
+    def get_zone_log_name(self, zone):
+        if self.data.get('log-group', 'auto') == 'auto':
+            log_group_name = "%s/%s" % (
+                self.data.get('log-group-prefix', '/aws/route53').rstrip('/'),
+                zone['Name'][:-1])
+        else:
+            log_group_name = self.data['log-group']
+        return log_group_name

--- a/tests/data/placebo/test_hosted_zone_dangling_record/ec2.DescribeAddresses_1.json
+++ b/tests/data/placebo/test_hosted_zone_dangling_record/ec2.DescribeAddresses_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Addresses": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_hosted_zone_dangling_record/route53.ListHostedZones_1.json
+++ b/tests/data/placebo/test_hosted_zone_dangling_record/route53.ListHostedZones_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "HostedZones": [
+            {
+                "Id": "/hostedzone/Z20H1474487I0O",
+                "Name": "cloudcustodian.io.",
+                "CallerReference": "82155185-1D01-4ED0-8F5E-490E8715D384",
+                "Config": {
+                    "PrivateZone": false
+                },
+                "ResourceRecordSetCount": 3
+            }
+        ],
+        "IsTruncated": false,
+        "MaxItems": "100"
+    }
+}

--- a/tests/data/placebo/test_hosted_zone_dangling_record/route53.ListResourceRecordSets_1.json
+++ b/tests/data/placebo/test_hosted_zone_dangling_record/route53.ListResourceRecordSets_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ResourceRecordSets": [
+            {
+                "Name": "test.cloudcustodian.io.",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [
+                    {
+                        "Value": "3.83.0.194"
+                    }
+                ]
+            }
+        ],
+        "IsTruncated": false,
+        "MaxItems": "100"
+    }
+}

--- a/tests/data/placebo/test_hosted_zone_dangling_record/route53.ListTagsForResources_1.json
+++ b/tests/data/placebo/test_hosted_zone_dangling_record/route53.ListTagsForResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ResourceTagSets": [
+            {
+                "ResourceType": "hostedzone",
+                "ResourceId": "Z20H1474487I0O",
+                "Tags": []
+            }
+        ]
+    }
+}

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -243,6 +243,19 @@ class Route53DomainTest(BaseTest):
         ]
         self.assertEqual(len(tags), 0)
 
+    def test_hostedzone_dangling_record(self):
+        session_factory = self.replay_flight_data(
+            'test_hosted_zone_dangling_record')
+        p = self.load_policy({
+            'name': 'dangling-records',
+            'resource': 'hostedzone',
+            'filters': [{'type': 'dangling-records'}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['Id'], "/hostedzone/Z20H1474487I0O")
+        self.assertEqual(resources[0]['c7n:dangling-records'][0]['Name'], "test.cloudcustodian.io.")
+
 
 class Route53EnableDNSQueryLoggingTest(BaseTest):
 


### PR DESCRIPTION
Trying to start https://github.com/cloud-custodian/cloud-custodian/issues/5988, I basically followed the audit section of this  https://www.cloudconformity.com/knowledge-base/aws/Route53/dangling-dns-records.html as requested. This is more niche as it will only find include route 53 A records that point to unavailable EIPs.