### PR TITLE
aws - sns - modify policy, change logical OR to AND to avoid early exit

### DIFF
--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -338,7 +338,7 @@ class ModifyPolicyStatement(ModifyPolicyBase):
                 new_policy = policy_statements
             new_policy, added = self.add_statements(new_policy)
 
-            if not removed or not added:
+            if not removed and not added:
                 continue
 
             results += {


### PR DESCRIPTION
When performing a modify policy op on SNS, it will exit early if there are no `remove or add statements`. It should instead only exit if there are no `remove and add statements` similar to what is done with SQS. In the current state, this action will only update the policy if there are both remove and add statements, which does not allow the policy author the control to only add or remove exclusively.