### PR TITLE
aws - log-group last-write timestamp is sometimes wrong

### DIFF
--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from c7n.actions import BaseAction
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import Filter, MetricsFilter
+from c7n.filters.core import parse_date
 from c7n.filters.iamaccess import CrossAccountAccessFilter
 from c7n.query import QueryResourceManager, ChildResourceManager, TypeInfo
 from c7n.manager import resources
@@ -154,12 +155,6 @@ class LogGroup(QueryResourceManager):
         universal_taggable = True
         cfn_type = 'AWS::Logs::LogGroup'
 
-    def augment(self, resources):
-        resources = universal_augment(self, resources)
-        for r in resources:
-            r['creationTime'] = r['creationTime'] / 1000.0
-        return resources
-
     def get_arns(self, resources):
         # log group arn in resource describe has ':*' suffix, not all
         # apis can use that form, so normalize to standard arn.
@@ -255,7 +250,7 @@ class LastWriteDays(Filter):
 
     def process(self, resources, event=None):
         client = local_session(self.manager.session_factory).client('logs')
-        self.date_threshold = datetime.utcnow() - timedelta(
+        self.date_threshold = parse_date(datetime.utcnow()) - timedelta(
             days=self.data['days'])
         return [r for r in resources if self.check_group(client, r)]
 
@@ -274,7 +269,7 @@ class LastWriteDays(Filter):
         else:
             last_timestamp = streams[0]['creationTime']
 
-        last_write = datetime.fromtimestamp(last_timestamp / 1000.0)
+        last_write = parse_date(last_timestamp)
         group['lastWrite'] = last_write
         return self.date_threshold > last_write
 

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -37,7 +37,7 @@ class LogGroupTest(BaseTest):
             session_factory=factory, config={'region': 'us-west-2'})
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]['creationTime'], 1548368507.441)
+        self.assertEqual(resources[0]['creationTime'], 1548368507441)
 
     def test_last_write(self):
         log_group = "test-log-group"
@@ -85,6 +85,7 @@ class LogGroupTest(BaseTest):
             resources[0]["lastWrite"].timestamp() * 1000,
             float(resources[0]["creationTime"])
         )
+        self.assertGreater(resources[0]["lastWrite"].year, 2019)
 
     def test_last_write_no_streams(self):
         log_group = "test-log-group"
@@ -113,6 +114,7 @@ class LogGroupTest(BaseTest):
             resources[0]["lastWrite"].timestamp() * 1000,
             float(resources[0]["creationTime"])
         )
+        self.assertGreater(resources[0]["lastWrite"].year, 2019)
 
     def test_last_write_empty_streams(self):
         log_group = "test-log-group"
@@ -148,6 +150,7 @@ class LogGroupTest(BaseTest):
             resources[0]["lastWrite"].timestamp() * 1000,
             float(resources[0]["creationTime"])
         )
+        self.assertGreater(resources[0]["lastWrite"].year, 2019)
 
     @functional
     def test_retention(self):


### PR DESCRIPTION
Discovered that the log group `last-write` filter is wrong when it uses the log group creation time instead of a stream time.  There's an augment mechanism to change the creationTime of the group to seconds (from milliseconds) and then when the last-write time is parsed it also divides by 1000.  This causes creation times some number of days into 1970 as the time, incorrectly.  So, this change instead uses our `parse_date` filter function that knows how to parse both second and millisecond epoch timestamps and removes the augment bits.  I've also updated the tests to make sure that the parsed timestamp is greater than the year 2019 to make sure this doesn't recur.