### PR TITLE
Refactor base Action and Filter classes to remove duplication.

### DIFF
--- a/c7n/actions/core.py
+++ b/c7n/actions/core.py
@@ -8,7 +8,6 @@ import logging
 
 from c7n.element import Element
 from c7n.exceptions import PolicyValidationError, ClientError
-from c7n.executor import ThreadPoolExecutor
 from c7n.registry import PluginRegistry
 
 
@@ -47,26 +46,12 @@ class ActionRegistry(PluginRegistry):
 
 class Action(Element):
 
-    permissions = ()
-    metrics = ()
-
     log = logging.getLogger("custodian.actions")
-
-    executor_factory = ThreadPoolExecutor
-    permissions = ()
-    schema = {'type': 'object'}
-    schema_alias = None
 
     def __init__(self, data=None, manager=None, log_dir=None):
         self.data = data or {}
         self.manager = manager
         self.log_dir = log_dir
-
-    def get_permissions(self):
-        return self.permissions
-
-    def validate(self):
-        return self
 
     @property
     def name(self):

--- a/c7n/element.py
+++ b/c7n/element.py
@@ -25,7 +25,13 @@ class Element:
         return self.permissions
 
     def validate(self):
-        return self
+        """Validate the current element's configuration.
+
+        Should raise a validation error if there are any configuration issues.
+
+        This method will always be called prior to element execution/process() method
+        being called and thus can act as a point of lazy initialization.
+        """
 
     def filter_resources(self, resources, key_expr, allowed_values=()):
         # many filters implementing a resource state transition only allow

--- a/c7n/element.py
+++ b/c7n/element.py
@@ -4,10 +4,28 @@
 
 import jmespath
 
+from c7n.executor import ThreadPoolExecutor
+
 
 class Element:
     """Parent base class for filters and actions.
     """
+
+    permissions = ()
+    metrics = ()
+
+    executor_factory = ThreadPoolExecutor
+
+    schema = {'type': 'object'}
+    # schema aliases get hoisted into a jsonschema definition
+    # location, and then referenced inline.
+    schema_alias = None
+
+    def get_permissions(self):
+        return self.permissions
+
+    def validate(self):
+        return self
 
     def filter_resources(self, resources, key_expr, allowed_values=()):
         # many filters implementing a resource state transition only allow

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -22,7 +22,6 @@ import jmespath
 
 from c7n.element import Element
 from c7n.exceptions import PolicyValidationError
-from c7n.executor import ThreadPoolExecutor
 from c7n.registry import PluginRegistry
 from c7n.resolver import ValuesFrom
 from c7n.utils import set_annotation, type_schema, parse_cidr
@@ -182,27 +181,11 @@ def trim_runtime(filters):
 
 class Filter(Element):
 
-    executor_factory = ThreadPoolExecutor
-
     log = logging.getLogger('custodian.filters')
-
-    metrics = ()
-    permissions = ()
-    schema = {'type': 'object'}
-    # schema aliases get hoisted into a jsonschema definition
-    # location, and then referenced inline.
-    schema_alias = None
 
     def __init__(self, data, manager=None):
         self.data = data
         self.manager = manager
-
-    def get_permissions(self):
-        return self.permissions
-
-    def validate(self):
-        """validate filter config, return validation error or self"""
-        return self
 
     def process(self, resources, event=None):
         """ Bulk process resources and return filtered set."""


### PR DESCRIPTION
Both the Action and Filter class defined a common set of public attributes
along with a default implementation for get_permission and validate.

This common functionality is extracted up to the Element class, which
is a common base class for both Action and Filter.

This extraction up also removed the duplicate `permissions` that somehow
crept into the Action base class.