### PR TITLE
#6132 AccountId is not part of rule schema in same account

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -285,7 +285,6 @@ class ConfigS3(query.ConfigSource):
                 'Status': r['status'],
                 'Prefix': r['prefix'],
                 'Destination': {
-                    'Account': r['destinationConfig']['Account'],
                     'Bucket': r['destinationConfig']['bucketARN']}
             }
             if r['destinationConfig']['storageClass']:

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -287,6 +287,8 @@ class ConfigS3(query.ConfigSource):
                 'Destination': {
                     'Bucket': r['destinationConfig']['bucketARN']}
             }
+            if 'Account' in r['destinationConfig']:
+                rule['Destination']['Account'] = r['destinationConfig']['Account']
             if r['destinationConfig']['storageClass']:
                 rule['Destination']['StorageClass'] = r['destinationConfig']['storageClass']
             d['Rules'].append(rule)


### PR DESCRIPTION
AccuntId Key isn;t avaiable for s3 buckets replicated in same account and this like ends up in error as notes in #6132 