### PR TITLE
aws - config - more aws config garbage unmangling

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -842,7 +842,7 @@ class ConfigRuleMode(LambdaMode):
         resources = []
 
         # TODO config resource type matches policy check
-        if event['eventLeftScope'] or cfg_item['configurationItemStatus'] in (
+        if event.get('eventLeftScope') or cfg_item['configurationItemStatus'] in (
                 "ResourceDeleted",
                 "ResourceNotRecorded",
                 "ResourceDeletedNotRecorded"):

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -342,7 +342,23 @@ class ConfigSource:
             item_config = json.loads(item['configuration'])
         else:
             item_config = item['configuration']
-        return camelResource(item_config, implicitDate=True)
+        resource = camelResource(item_config, implicitDate=True)
+        # normalized tag loading across the many variants of config's inconsistencies.
+        if ((item.get('tags') or item['supplementaryConfiguration'].get('Tags'))
+                and 'Tags' not in resource):
+            if item.get('tags'):
+                resource['Tags'] = [
+                    {u'Key': k, u'Value': v} for k, v in item['tags'].items()]
+            else:
+                # config has a bit more variation on tags (serialized json, list, dict, etc)
+                stags = item['supplementaryConfiguration']['Tags']
+                if isinstance(stags, str):
+                    stags = json.loads(stags)
+                if isinstance(stags, list):
+                    resource['Tags'] = [{u'Key': t['key'], u'Value': t['value']} for t in stags]
+                elif isinstance(stags, dict):
+                    resource['Tags'] = [{u'Key': k, u'Value': v} for k, v in stags.items()]
+        return resource
 
     def get_listed_resources(self, client):
         # fallback for when config decides to arbitrarily break select

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -51,15 +51,6 @@ class ConfigAppElb(ConfigSource):
 
     def load_resource(self, item):
         resource = super(ConfigAppElb, self).load_resource(item)
-        item_tags = item['supplementaryConfiguration']['Tags']
-
-        # Config originally stored supplementaryconfig on elbv2 as json
-        # strings. Support that format for historical queries.
-        if isinstance(item_tags, str):
-            item_tags = json.loads(item_tags)
-        resource['Tags'] = [
-            {'Key': t['key'], 'Value': t['value']} for t in item_tags]
-
         item_attrs = item['supplementaryConfiguration'][
             'LoadBalancerAttributes']
         if isinstance(item_attrs, str):

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -153,6 +153,9 @@ class Arn(namedtuple('_Arn', (
         elif ':' in parts[-1]:
             parts.extend(reversed(parts.pop(-1).split(':', 1)))
             parts.append(':')
+        elif len(parts) == 6:
+            parts.append('')
+            parts.append('')
         return cls(*parts)
 
 

--- a/c7n/resources/awslambda.py
+++ b/c7n/resources/awslambda.py
@@ -51,9 +51,6 @@ class ConfigLambda(query.ConfigSource):
 
     def load_resource(self, item):
         resource = super(ConfigLambda, self).load_resource(item)
-        resource['Tags'] = [
-            {u'Key': k, u'Value': v} for k, v in item[
-                'supplementaryConfiguration'].get('Tags', {}).items()]
         resource['c7n:Policy'] = item[
             'supplementaryConfiguration'].get('Policy')
         return resource

--- a/c7n/resources/code.py
+++ b/c7n/resources/code.py
@@ -75,6 +75,36 @@ class DescribeBuild(DescribeSource):
             super(DescribeBuild, self).augment(resources))
 
 
+class ConfigBuild(ConfigSource):
+
+    def load_resource(self, item):
+        item_config = item['configuration']
+        item_config['Tags'] = [
+            {'Key': t['key'], 'Value': t['value']} for t in item_config.get('tags')]
+
+        # AWS Config garbage mangle undo.
+
+        if 'queuedtimeoutInMinutes' in item_config:
+            item_config['queuedTimeoutInMinutes'] = int(item_config.pop('queuedtimeoutInMinutes'))
+
+        artifacts = item_config.pop('artifacts')
+        item_config['artifacts'] = artifacts.pop(0)
+        if artifacts:
+            item_config['secondaryArtifacts'] = artifacts
+        sources = item_config['source']
+        item_config['source'] = sources.pop(0)
+        if sources:
+            item_config['secondarySources'] = sources
+
+        if 'vpcConfig' in item_config and 'subnets' in item_config['vpcConfig']:
+            item_config['vpcConfig']['subnets'] = [
+                s['subnet'] for s in item_config['vpcConfig']['subnets']]
+
+        item_config['arn'] = 'arn:aws:codebuild:{}:{}:project/{}'.format(
+            self.manager.config.region, self.manager.config.account_id, item_config['name'])
+        return item_config
+
+
 @resources.register('codebuild')
 class CodeBuildProject(QueryResourceManager):
 
@@ -93,7 +123,7 @@ class CodeBuildProject(QueryResourceManager):
 
     source_mapping = {
         'describe': DescribeBuild,
-        'config': ConfigSource
+        'config': ConfigBuild
     }
 
 

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -75,15 +75,6 @@ class DescribeRDS(DescribeSource):
             self.manager, super(DescribeRDS, self).augment(dbs))
 
 
-class ConfigRDS(ConfigSource):
-
-    def load_resource(self, item):
-        resource = super(ConfigRDS, self).load_resource(item)
-        resource['Tags'] = [{u'Key': t['key'], u'Value': t['value']}
-          for t in item['supplementaryConfiguration']['Tags']]
-        return resource
-
-
 @resources.register('rds')
 class RDS(QueryResourceManager):
     """Resource manager for RDS DB instances.
@@ -121,7 +112,7 @@ class RDS(QueryResourceManager):
 
     source_mapping = {
         'describe': DescribeRDS,
-        'config': ConfigRDS
+        'config': ConfigSource
     }
 
 
@@ -967,16 +958,6 @@ class DescribeRDSSnapshot(DescribeSource):
             self.manager, super(DescribeRDSSnapshot, self).augment(snaps))
 
 
-class ConfigRDSSnapshot(ConfigSource):
-
-    def load_resource(self, item):
-        resource = super(ConfigRDSSnapshot, self).load_resource(item)
-        resource['Tags'] = [{u'Key': t['key'], u'Value': t['value']}
-          for t in item['supplementaryConfiguration']['Tags']]
-        # TODO: Load DBSnapshotAttributes into annotation
-        return resource
-
-
 @resources.register('rds-snapshot')
 class RDSSnapshot(QueryResourceManager):
     """Resource manager for RDS DB snapshots.
@@ -996,7 +977,7 @@ class RDSSnapshot(QueryResourceManager):
 
     source_mapping = {
         'describe': DescribeRDSSnapshot,
-        'config': ConfigRDSSnapshot
+        'config': ConfigSource
     }
 
 

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -31,15 +31,6 @@ class DescribeTopic(DescribeSource):
             return list(w.map(_augment, resources))
 
 
-class ConfigSNS(ConfigSource):
-
-    def load_resource(self, item):
-        resource = super().load_resource(item)
-        resource['Tags'] = [{'Key': t['key'], 'Value': t['value']}
-          for t in item['supplementaryConfiguration']['Tags']]
-        return resource
-
-
 @resources.register('sns')
 class SNS(QueryResourceManager):
 
@@ -64,7 +55,7 @@ class SNS(QueryResourceManager):
     permissions = ('sns:ListTagsForResource',)
     source_mapping = {
         'describe': DescribeTopic,
-        'config': ConfigSNS
+        'config': ConfigSource
     }
 
 

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -15,7 +15,6 @@ from c7n.actions import BaseAction
 from c7n.utils import type_schema
 from c7n.tags import universal_augment
 
-from c7n.resources.aws import Arn
 from c7n.resources.securityhub import PostFinding
 
 
@@ -49,8 +48,7 @@ class QueueConfigSource(ConfigSource):
 
     def load_resource(self, item):
         resource = super().load_resource(item)
-        resource['QueueUrl'] = "https://sqs.{region}.amazonaws.com/{account_id}/{resource}".format(
-            **Arn.parse(resource['QueueArn'])._asdict())
+        resource['QueueUrl'] = item['resourceId']
         return resource
 
 

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -15,7 +15,6 @@ from c7n.actions import BaseAction
 from c7n.utils import type_schema
 from c7n.tags import universal_augment
 
-from c7n.resources.aws import Arn
 from c7n.resources.securityhub import PostFinding
 
 

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -15,6 +15,7 @@ from c7n.actions import BaseAction
 from c7n.utils import type_schema
 from c7n.tags import universal_augment
 
+from c7n.resources.aws import Arn
 from c7n.resources.securityhub import PostFinding
 
 
@@ -44,6 +45,15 @@ class DescribeQueue(DescribeSource):
                 self.manager, list(filter(None, w.map(_augment, resources))))
 
 
+class QueueConfigSource(ConfigSource):
+
+    def load_resource(self, item):
+        resource = super().load_resource(item)
+        resource['QueueUrl'] = "https://sqs.{region}.amazonaws.com/{account_id}/{resource}".format(
+            **Arn.parse(resource['QueueArn'])._asdict())
+        return resource
+
+
 @resources.register('sqs')
 class SQS(QueryResourceManager):
 
@@ -69,7 +79,7 @@ class SQS(QueryResourceManager):
 
     source_mapping = {
         'describe': DescribeQueue,
-        'config': ConfigSource
+        'config': QueueConfigSource
     }
 
     def get_permissions(self):

--- a/tests/common.py
+++ b/tests/common.py
@@ -59,7 +59,7 @@ class ConfigTest(BaseTest):
        with the queue url and the resource id.
     """
 
-    def wait_for_config(self, session, queue_url, resource_id):
+    def wait_for_config(self, session, queue_url, resource_id=None):
         # lazy import to avoid circular
         from c7n.sqsexec import MessageIterator
 
@@ -71,7 +71,7 @@ class ConfigTest(BaseTest):
                 msg = json.loads(m["Body"])
                 change = json.loads(msg["Message"])
                 messages.ack(m)
-                if change["configurationItem"]["resourceId"] != resource_id:
+                if resource_id and change["configurationItem"]["resourceId"] != resource_id:
                     continue
                 results.append(change["configurationItem"])
                 break

--- a/tests/data/cwe/sqs-discover.json
+++ b/tests/data/cwe/sqs-discover.json
@@ -1,0 +1,53 @@
+{
+  "version": "0",
+  "id": "47a37318-9c13-1eb8-33a6-607f6b881a9c",
+  "detail-type": "Config Configuration Item Change",
+  "source": "aws.config",
+  "account": "662108712480",
+  "time": "2020-10-06T22:39:24Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:sqs:us-east-1:644160558196:config-changes"
+  ],
+  "detail": {
+    "recordVersion": "1.3",
+    "messageType": "ConfigurationItemChangeNotification",
+    "configurationItemDiff": {
+      "changedProperties": {},
+      "changeType": "CREATE"
+    },
+    "notificationCreationTime": "2020-10-06T22:39:24.385Z",
+    "configurationItem": {
+      "relatedEvents": [],
+      "relationships": [],
+      "configuration": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"sqs:SendMessage\",\"Resource\":\"arn:aws:sqs:us-east-1:644160558196:config-changes\"}]}",
+        "ReceiveMessageWaitTimeSeconds": "0",
+        "CreatedTimestamp": "1602023249",
+        "DelaySeconds": "0",
+        "MessageRetentionPeriod": "345600",
+        "MaximumMessageSize": "262144",
+        "VisibilityTimeout": "30",
+        "LastModifiedTimestamp": "1602023249",
+        "QueueArn": "arn:aws:sqs:us-east-1:644160558196:config-changes"
+      },
+      "supplementaryConfiguration": {
+        "Tags": {}
+      },
+      "tags": {},
+      "configurationItemVersion": "1.3",
+      "configurationItemCaptureTime": "2020-10-06T22:39:22.579Z",
+      "configurationStateId": 1602023962579,
+      "awsAccountId": "662108712480",
+      "configurationItemStatus": "ResourceDiscovered",
+      "resourceType": "AWS::SQS::Queue",
+      "resourceId": "https://sqs.us-east-1.amazonaws.com/644160558196/config-changes",
+      "resourceName": "config-changes",
+      "ARN": "arn:aws:sqs:us-east-1:662108712480:config-changes",
+      "awsRegion": "us-east-1",
+      "availabilityZone": "Not Applicable",
+      "configurationStateMd5Hash": "",
+      "resourceCreationTime": "2020-10-06T22:27:29.000Z"
+    }
+  }
+}

--- a/tests/data/placebo/test_codebuild_config/codebuild.BatchGetProjects_1.json
+++ b/tests/data/placebo/test_codebuild_config/codebuild.BatchGetProjects_1.json
@@ -1,0 +1,105 @@
+{
+    "status_code": 200,
+    "data": {
+        "projects": [
+            {
+                "name": "test-project",
+                "arn": "arn:aws:codebuild:us-east-1:644160558196:project/test-project",
+                "description": "test_codebuild_project",
+                "source": {
+                    "type": "GITHUB",
+                    "location": "https://github.com/mitchellh/packer.git",
+                    "gitCloneDepth": 1,
+                    "gitSubmodulesConfig": {
+                        "fetchSubmodules": true
+                    },
+                    "buildspec": "",
+                    "reportBuildStatus": false,
+                    "insecureSsl": false
+                },
+                "sourceVersion": "master",
+                "artifacts": {
+                    "type": "NO_ARTIFACTS",
+                    "overrideArtifactName": false
+                },
+                "cache": {
+                    "type": "NO_CACHE"
+                },
+                "environment": {
+                    "type": "LINUX_CONTAINER",
+                    "image": "aws/codebuild/standard:1.0",
+                    "computeType": "BUILD_GENERAL1_SMALL",
+                    "environmentVariables": [
+                        {
+                            "name": "SOME_KEY1",
+                            "value": "SOME_VALUE1",
+                            "type": "PLAINTEXT"
+                        },
+                        {
+                            "name": "SOME_KEY2",
+                            "value": "SOME_VALUE2",
+                            "type": "PARAMETER_STORE"
+                        }
+                    ],
+                    "privilegedMode": false,
+                    "imagePullCredentialsType": "CODEBUILD"
+                },
+                "serviceRole": "arn:aws:iam::644160558196:role/example",
+                "timeoutInMinutes": 5,
+                "queuedTimeoutInMinutes": 480,
+                "encryptionKey": "arn:aws:kms:us-east-1:644160558196:alias/aws/s3",
+                "tags": [
+                    {
+                        "key": "Environment",
+                        "value": "Test"
+                    }
+                ],
+                "created": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 10,
+                    "day": 7,
+                    "hour": 10,
+                    "minute": 39,
+                    "second": 35,
+                    "microsecond": 814000
+                },
+                "lastModified": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 10,
+                    "day": 7,
+                    "hour": 10,
+                    "minute": 39,
+                    "second": 35,
+                    "microsecond": 814000
+                },
+                "vpcConfig": {
+                    "vpcId": "vpc-0ef5a04184aee6026",
+                    "subnets": [
+                        "subnet-06a50bc476820b18c"
+                    ],
+                    "securityGroupIds": [
+                        "sg-0d4546977e35db448"
+                    ]
+                },
+                "badge": {
+                    "badgeEnabled": false
+                },
+                "logsConfig": {
+                    "cloudWatchLogs": {
+                        "status": "ENABLED",
+                        "groupName": "log-group",
+                        "streamName": "log-stream"
+                    },
+                    "s3Logs": {
+                        "status": "DISABLED",
+                        "encryptionDisabled": false
+                    }
+                }
+            }
+        ],
+        "projectsNotFound": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_codebuild_config/codebuild.ListProjects_1.json
+++ b/tests/data/placebo/test_codebuild_config/codebuild.ListProjects_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "projects": [
+            "test-project"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_codebuild_config/config.SelectResourceConfig_1.json
+++ b/tests/data/placebo/test_codebuild_config/config.SelectResourceConfig_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Results": [
+            "{\"configuration\":{\"logsConfig\":{\"cloudWatchLogs\":{\"groupName\":\"log-group\",\"streamName\":\"log-stream\",\"status\":\"ENABLED\"},\"s3Logs\":{\"status\":\"DISABLED\"}},\"cache\":{\"type\":\"NO_CACHE\"},\"sourceVersion\":\"master\",\"serviceRole\":\"arn:aws:iam::644160558196:role/example\",\"description\":\"test_codebuild_project\",\"source\":[{\"buildSpec\":\"\",\"reportBuildStatus\":false,\"gitSubmodulesConfig\":{\"fetchSubmodules\":true},\"location\":\"https://github.com/mitchellh/packer.git\",\"type\":\"GITHUB\",\"gitCloneDepth\":1.0}],\"encryptionKey\":\"arn:aws:kms:us-east-1:644160558196:alias/aws/s3\",\"tags\":[{\"value\":\"Test\",\"key\":\"Environment\"}],\"environment\":{\"image\":\"aws/codebuild/standard:1.0\",\"computeType\":\"BUILD_GENERAL1_SMALL\",\"imagePullCredentialsType\":\"CODEBUILD\",\"environmentVariables\":[{\"name\":\"SOME_KEY1\",\"type\":\"PLAINTEXT\",\"value\":\"******\"},{\"name\":\"SOME_KEY2\",\"type\":\"PARAMETER_STORE\",\"value\":\"SOME_VALUE2\"}],\"privilegedMode\":false,\"type\":\"LINUX_CONTAINER\"},\"vpcConfig\":{\"securityGroupIds\":[\"sg-0d4546977e35db448\"],\"vpcId\":\"vpc-0ef5a04184aee6026\",\"subnets\":[{\"buildFleetAZ\":\"us-east-1a\",\"subnet\":\"subnet-06a50bc476820b18c\",\"customerAZ\":\"us-east-1d\"}]},\"name\":\"test-project\",\"timeoutInMinutes\":5.0,\"queuedtimeoutInMinutes\":480.0,\"artifacts\":[{\"type\":\"NO_ARTIFACTS\",\"overrideArtifactName\":false}]},\"supplementaryConfiguration\":{}}"
+        ],
+        "QueryInfo": {
+            "SelectFields": [
+                {
+                    "Name": "configuration"
+                },
+                {
+                    "Name": "supplementaryConfiguration"
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_codebuild_config/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_codebuild_config/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:codebuild:us-east-1:644160558196:project/test-project",
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Test"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_appelb.py
+++ b/tests/test_appelb.py
@@ -42,16 +42,14 @@ class AppELBTest(BaseTest):
         source = p.resource_manager.get_source("config")
         resource = source.load_resource(event)
         self.maxDiff = None
-        self.assertEqual(
-            resource["Tags"],
-            [
-                {"Key": "App", "Value": "ARTIFACTPLATFORM"},
-                {"Key": "OwnerContact", "Value": "me@example.com"},
-                {"Key": "TeamName", "Value": "Frogger"},
-                {"Key": "Env", "Value": "QA"},
-                {"Key": "Name", "Value": "Artifact ELB"},
-            ],
-        )
+
+        assert resource["Tags"] == [
+            {"Key": "App", "Value": "ARTIFACTPLATFORM"},
+            {"Key": "Env", "Value": "QA"},
+            {"Key": "Name", "Value": "Artifactory ELB"},
+            {"Key": "OwnerContact", "Value": "me@example.com"},
+            {"Key": "TeamName", "Value": "Frogger"},
+        ]
 
     def test_appelb_simple(self):
         self.patch(AppELB, "executor_factory", MainThreadExecutor)

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -91,6 +91,17 @@ class CodeCommit(BaseTest):
 
 class CodeBuild(BaseTest):
 
+    def test_config_source(self):
+        factory = self.replay_flight_data('test_codebuild_config')
+        config_resources = self.load_policy({
+            'name': 'builders', 'resource': 'aws.codebuild', 'source': 'config'},
+            session_factory=factory).run()
+        resources = self.load_policy({
+            'name': 'dbuilders', 'resource': 'aws.codebuild'},
+            session_factory=factory).run()
+        assert set(config_resources[0].keys()) == (
+            set(resources[0].keys()).difference(('created', 'lastModified', 'badge')))
+        
     def test_query_builds(self):
         factory = self.replay_flight_data("test_codebuild")
         p = self.load_policy(

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -101,7 +101,7 @@ class CodeBuild(BaseTest):
             session_factory=factory).run()
         assert set(config_resources[0].keys()) == (
             set(resources[0].keys()).difference(('created', 'lastModified', 'badge')))
-        
+
     def test_query_builds(self):
         factory = self.replay_flight_data("test_codebuild")
         p = self.load_policy(

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from .common import BaseTest, functional
+from .common import BaseTest, functional, event_data
 from pytest_terraform import terraform
 from botocore.exceptions import ClientError
 
@@ -10,6 +10,30 @@ import pytest
 import time
 
 from c7n.resources.aws import shape_validate
+
+
+def test_sqs_config_translate(test):
+    # we're using a cwe event as a config, so have to mangle to
+    # config's inane format (json strings in json)
+    event = event_data('sqs-discover.json')
+    p = test.load_policy({
+        'name': 'sqs-check',
+        'resource': 'aws.sqs',
+        'mode': {'type': 'config-rule'}})
+    config = p.resource_manager.get_source('config')
+    resource = config.load_resource(event['detail']['configurationItem'])
+    assert resource == {
+        'CreatedTimestamp': '1602023249',
+        'DelaySeconds': '0',
+        'LastModifiedTimestamp': '1602023249',
+        'MaximumMessageSize': '262144',
+        'MessageRetentionPeriod': '345600',
+        'Policy': '{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"events.amazonaws.com"},"Action":"sqs:SendMessage","Resource":"arn:aws:sqs:us-east-1:644160558196:config-changes"}]}',
+        'QueueArn': 'arn:aws:sqs:us-east-1:644160558196:config-changes',
+        'QueueUrl': 'https://sqs.us-east-1.amazonaws.com/644160558196/config-changes',
+        'ReceiveMessageWaitTimeSeconds': '0',
+        'VisibilityTimeout': '30',
+    }
 
 
 @terraform('sqs_delete', teardown=terraform.TEARDOWN_IGNORE)

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -28,7 +28,7 @@ def test_sqs_config_translate(test):
         'LastModifiedTimestamp': '1602023249',
         'MaximumMessageSize': '262144',
         'MessageRetentionPeriod': '345600',
-        'Policy': '{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"events.amazonaws.com"},"Action":"sqs:SendMessage","Resource":"arn:aws:sqs:us-east-1:644160558196:config-changes"}]}',
+        'Policy': '{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"events.amazonaws.com"},"Action":"sqs:SendMessage","Resource":"arn:aws:sqs:us-east-1:644160558196:config-changes"}]}', # noqa
         'QueueArn': 'arn:aws:sqs:us-east-1:644160558196:config-changes',
         'QueueUrl': 'https://sqs.us-east-1.amazonaws.com/644160558196/config-changes',
         'ReceiveMessageWaitTimeSeconds': '0',

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -9,7 +9,7 @@ import json
 import pytest
 import time
 
-from c7n.resources.aws import shape_validate
+from c7n.resources.aws import shape_validate, Arn
 
 
 def test_sqs_config_translate(test):
@@ -22,6 +22,7 @@ def test_sqs_config_translate(test):
         'mode': {'type': 'config-rule'}})
     config = p.resource_manager.get_source('config')
     resource = config.load_resource(event['detail']['configurationItem'])
+    Arn.parse(resource['QueueArn']).resource == 'config-changes'
     assert resource == {
         'CreatedTimestamp': '1602023249',
         'DelaySeconds': '0',


### PR DESCRIPTION
- unify tag loading across the dozen of inconsistent variants that aws config uses
- normalize codebuild across config's garbage mangling
- handle sqs config item missing queue url

closes #6176﻿
closes #6184 