### PR TITLE
adding value_from docstrings to value filter docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ import sys
 import os
 import shlex
 import sphinx_rtd_theme
+from sphinx.ext import autodoc
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -37,6 +38,17 @@ extensions = [
     'recommonmark',
     'sphinx_markdown_tables'
 ]
+
+# Extract only a classes docstrings
+class DocsonlyMethodDocumenter(autodoc.MethodDocumenter):
+  objtype = "doconly"
+  content_indent = ""
+
+  def format_signature(self, **kwargs):
+    return ""
+
+  def add_directive_header(self, sig: str):
+    return None
 
 # Add any paths that contain templates here, relative to this directory.
 #templates_path = ['_templates']
@@ -303,3 +315,4 @@ texinfo_documents = [
 def setup(app):
     app.add_javascript('js/expand.js')
     app.add_stylesheet('css/expand.css')
+    app.add_autodocumenter(DocsonlyMethodDocumenter)

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -279,6 +279,11 @@ There are several ways to get a list of possible keys for each resource.
       op: less-than
       value: 0
 
+- Value From:
+
+  ``value_from`` allows the use of external values in the Value Filter
+
+  .. autodoconly:: c7n.resolver.ValuesFrom
 
 Event Filter
 -------------


### PR DESCRIPTION
adding `value_from` docstring to the Value Filter docs which includes examples

closes #5509 