### PR TITLE
AWS - Elasticsearch cross-account filter and remove-statements action

### DIFF
--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -145,7 +145,9 @@ class ElasticSearchCrossAccountAccessFilter(CrossAccountAccessFilter):
                 client.describe_elasticsearch_domain_config,
                 DomainName=r['DomainName'],
                 ignore_err_codes=('ResourceNotFoundException',))
-            r[self.policy_attribute] = json.loads(result['DomainConfig']['AccessPolicies']['Options'])
+            r[self.policy_attribute] = json.loads(
+                result['DomainConfig']['AccessPolicies']['Options']
+            )
         return super().process(resources)
 
 

--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -158,8 +158,8 @@ class RemovePolicyStatement(RemovePolicyBase):
     .. code-block:: yaml
 
         policies:
-          - name: glacier-cross-account
-            resource: glacier
+          - name: elasticsearch-cross-account
+            resource: aws.elasticsearch
             filters:
               - type: cross-account
             actions:

--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -179,8 +179,7 @@ class RemovePolicyStatement(RemovePolicyBase):
             try:
                 results += filter(None, [self.process_resource(client, r)])
             except Exception:
-                self.log.exception(
-                    "Error processing es:%s", r['ARN'])
+                self.log.exception("Error processing es:%s", r['ARN'])
         return results
 
     def process_resource(self, client, resource):

--- a/tests/data/placebo/test_elasticsearch_cross_account/es.DescribeElasticsearchDomainConfig_1.json
+++ b/tests/data/placebo/test_elasticsearch_cross_account/es.DescribeElasticsearchDomainConfig_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainConfig": {
+            "AccessPolicies": {
+                "Options": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"},{\"Sid\":\"CrossAccount\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"es:ESHttpGet\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"}]}"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_cross_account/es.DescribeElasticsearchDomains_1.json
+++ b/tests/data/placebo/test_elasticsearch_cross_account/es.DescribeElasticsearchDomains_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainStatusList": [
+            {
+                "DomainId": "644160558196/test-es",
+                "DomainName": "test-es",
+                "ARN": "arn:aws:es:us-east-1:644160558196:domain/test-es",
+                "Created": true,
+                "Deleted": false,
+                "AccessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"},{\"Sid\":\"CrossAccount\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"es:ESHttpGet\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"}]}"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_cross_account/es.ListDomainNames_1.json
+++ b/tests/data/placebo/test_elasticsearch_cross_account/es.ListDomainNames_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainNames": [
+            {
+                "DomainName": "test-es"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_cross_account/es.ListTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_cross_account/es.ListTags_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "TagList": []
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_matched/es.DescribeElasticsearchDomainConfig_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_matched/es.DescribeElasticsearchDomainConfig_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainConfig": {
+            "AccessPolicies": {
+                "Options": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"},{\"Sid\":\"CrossAccount\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"es:ESHttpGet\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"}]}"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_matched/es.DescribeElasticsearchDomainConfig_2.json
+++ b/tests/data/placebo/test_elasticsearch_remove_matched/es.DescribeElasticsearchDomainConfig_2.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainConfig": {
+            "AccessPolicies": {
+                "Options": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"}]}"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_matched/es.DescribeElasticsearchDomains_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_matched/es.DescribeElasticsearchDomains_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainStatusList": [
+            {
+                "DomainId": "644160558196/test-es",
+                "DomainName": "test-es",
+                "ARN": "arn:aws:es:us-east-1:644160558196:domain/test-es",
+                "Created": true,
+                "Deleted": false,
+                "AccessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"},{\"Sid\":\"CrossAccount\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"es:ESHttpGet\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"}]}"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_matched/es.ListDomainNames_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_matched/es.ListDomainNames_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainNames": [
+            {
+                "DomainName": "test-es"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_matched/es.ListTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_matched/es.ListTags_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "TagList": []
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_matched/es.UpdateElasticsearchDomainConfig_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_matched/es.UpdateElasticsearchDomainConfig_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainConfig": {
+            "AccessPolicies": {
+                "Options": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"},{\"Sid\":\"CrossAccount\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"es:ESHttpGet\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"}]}"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_matched/es.UpdateElasticsearchDomainConfig_2.json
+++ b/tests/data/placebo/test_elasticsearch_remove_matched/es.UpdateElasticsearchDomainConfig_2.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DomainConfig": {
+            "AccessPolicies": {
+                "Options": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/test-es/*\"}]}"
+            }
+        }
+    }
+}

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -294,6 +294,9 @@ class ElasticSearch(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        print(resources[0])
+        access_policy = json.loads(resources[0]['AccessPolicies'])
+        self.assertIn("*", [s['Principal'] for s in access_policy.get('Statement')])
 
     def test_elasticsearch_remove_matched(self):
         session_factory = self.replay_flight_data("test_elasticsearch_remove_matched")

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -296,6 +296,13 @@ class ElasticSearch(BaseTest):
         self.assertEqual(len(resources), 1)
         access_policy = json.loads(resources[0]['AccessPolicies'])
         self.assertEqual(resources[0]['c7n:Policy'], access_policy)
+        assert resources[0]['CrossAccountViolations'] == [
+            {'Action': 'es:ESHttpGet',
+             'Effect': 'Allow',
+             'Principal': '*',
+             'Resource': 'arn:aws:es:us-east-1:644160558196:domain/test-es/*',
+             'Sid': 'CrossAccount'}]
+
         self.assertIn("*", [s['Principal'] for s in access_policy.get('Statement')])
 
     def test_elasticsearch_remove_matched(self):

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -294,7 +294,6 @@ class ElasticSearch(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        print(resources[0])
         access_policy = json.loads(resources[0]['AccessPolicies'])
         self.assertIn("*", [s['Principal'] for s in access_policy.get('Statement')])
 

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest
 import json
-from c7n.exceptions import PolicyValidationError
 
 from c7n.resources.aws import shape_validate
 

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest
 import json
-
+from c7n.exceptions import PolicyValidationError
 from c7n.resources.aws import shape_validate
 
 
@@ -333,6 +333,17 @@ class ElasticSearch(BaseTest):
         access_policy = json.loads(data['DomainConfig']['AccessPolicies']['Options'])
         self.assertEqual(len(access_policy.get('Statement')), 1)
         self.assertEqual([s['Sid'] for s in access_policy.get('Statement')], ["SpecificAllow"])
+
+    def test_remove_statements_validation_error(self):
+        self.assertRaises(
+            PolicyValidationError,
+            self.load_policy,
+            {
+                "name": "elasticsearch-remove-matched",
+                "resource": "elasticsearch",
+                "actions": [{"type": "remove-statements", "statement_ids": "matched"}],
+            }
+        )
 
 
 class TestReservedInstances(BaseTest):

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -2,6 +2,8 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest
+import json
+from c7n.exceptions import PolicyValidationError
 
 from c7n.resources.aws import shape_validate
 
@@ -280,6 +282,58 @@ class ElasticSearch(BaseTest):
         self.assertTrue(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['EncryptionAtRestOptions']['KmsKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/aws/es')
+
+    def test_elasticsearch_cross_account(self):
+        session_factory = self.replay_flight_data("test_elasticsearch_cross_account")
+        p = self.load_policy(
+            {
+                "name": "elasticsearch-cross-account",
+                "resource": "elasticsearch",
+                "filters": [{"type": "cross-account"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_elasticsearch_remove_matched(self):
+        session_factory = self.replay_flight_data("test_elasticsearch_remove_matched")
+        client = session_factory().client("es")
+        client.update_elasticsearch_domain_config(DomainName='test-es', AccessPolicies=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "SpecificAllow",
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "arn:aws:iam::644160558196:root"},
+                        "Action": "es:*",
+                        "Resource": "arn:aws:es:us-east-1:644160558196:domain/test-es/*"
+                    },
+                    {
+                        "Sid": "CrossAccount",
+                        "Effect": "Allow",
+                        "Principal": "*",
+                        "Action": "es:ESHttpGet",
+                        "Resource": "arn:aws:es:us-east-1:644160558196:domain/test-es/*"
+                    },
+                ]
+            }))
+        p = self.load_policy(
+            {
+                "name": "elasticsearch-rm-matched",
+                "resource": "elasticsearch",
+                "filters": [{"type": "cross-account"}],
+                "actions": [{"type": "remove-statements", "statement_ids": "matched"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        data = client.describe_elasticsearch_domain_config(DomainName=resources[0]['DomainName'])
+        access_policy = json.loads(data['DomainConfig']['AccessPolicies']['Options'])
+        self.assertEqual(len(access_policy.get('Statement')), 1)
+        self.assertEqual([s['Sid'] for s in access_policy.get('Statement')], ["SpecificAllow"])
 
 
 class TestReservedInstances(BaseTest):

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -295,6 +295,7 @@ class ElasticSearch(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         access_policy = json.loads(resources[0]['AccessPolicies'])
+        self.assertEqual(resources[0]['c7n:Policy'], access_policy)
         self.assertIn("*", [s['Principal'] for s in access_policy.get('Statement')])
 
     def test_elasticsearch_remove_matched(self):


### PR DESCRIPTION
Addresses https://github.com/cloud-custodian/cloud-custodian/issues/5070. Add a cross-account filter and remove-statements action for the elasticsearch access policies