### PR TITLE
azure - fix logic app json schema for vscode completion

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -142,6 +142,10 @@ def type_schema(
         s['additionalProperties'] = False
 
     s['properties'].update(props)
+
+    for k, v in props.items():
+        if v is None:
+            del s['properties'][k]
     if not required:
         required = []
     if isinstance(required, list):

--- a/tools/c7n_azure/tests_azure/test_logic_app.py
+++ b/tools/c7n_azure/tests_azure/test_logic_app.py
@@ -15,6 +15,9 @@ from c7n.utils import local_session
 
 class LogicAppTest(BaseTest):
 
+    def test_valid_schema(self):
+        assert 'url' not in LogicAppAction.schema['properties']
+
     def test_valid_policy(self):
         policy = {
             "name": "logic-app",


### PR DESCRIPTION
closes #6211
﻿
previously there was  a url: null in the properties which caused ref'd issue error with vscode processing the jsonschema for completion.