### PR TITLE
tests - A setup.cfg to help you forget about pytest cli arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[tool:pytest]
+addopts =
+  --cov=c7n --cov-report=term-missing
+  --flakes
+  --pep8
+  -v
+  tests/
+pep8ignore =
+  * E123 E226 E501 W503


### PR DESCRIPTION
Opinionated as can be (I literally should just compare the pep ignores with whatever is in tox.ini I guess), but here's a file that saves me from having to type `tests/` everytime I run tests.  Thanks for your considerations! ;-)