### PR TITLE
Azure - VM - action to resize vm

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/vm.py
+++ b/tools/c7n_azure/c7n_azure/resources/vm.py
@@ -62,7 +62,7 @@ class VirtualMachine(ArmResourceManager):
     .. code-block:: yaml
 
         policies:
-          - name: stop-running-vms
+          - name: delete-vm
             resource: azure.vm
             filters:
               - type: value

--- a/tools/c7n_azure/c7n_azure/resources/vm.py
+++ b/tools/c7n_azure/c7n_azure/resources/vm.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+from azure.mgmt.compute.models import HardwareProfile, VirtualMachineUpdate
 from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
@@ -54,6 +55,25 @@ class VirtualMachine(ArmResourceManager):
             resource: azure.vm
             actions:
               - type: restart
+
+    :example:
+
+    Resize specific VM by name
+
+    .. code-block:: yaml
+
+        policies:
+          - name: resize-vm
+            resource: azure.vm
+            filters:
+              - type: value
+                key: name
+                op: eq
+                value_type: normalize
+                value: fake_vm_name
+            actions:
+              - type: resize
+                vmSize: Standard_A2_v2
 
     :example:
 
@@ -217,3 +237,52 @@ class VmRestartAction(AzureBaseAction):
 
     def _process_resource(self, resource):
         self.client.virtual_machines.restart(resource['resourceGroup'], resource['name'])
+
+
+@VirtualMachine.action_registry.register('resize')
+class VmResizeAction(AzureBaseAction):
+
+    """Change a VM's size
+
+    :example:
+
+    Resize specific VM by name
+
+    .. code-block:: yaml
+
+        policies:
+          - name: resize-vm
+            resource: azure.vm
+            filters:
+              - type: value
+                key: name
+                op: eq
+                value_type: normalize
+                value: fake_vm_name
+            actions:
+              - type: resize
+                vmSize: Standard_A2_v2
+    """
+
+    schema = type_schema(
+        'resize',
+        required=['vmSize'],
+        **{
+            'vmSize': {'type': 'string'}
+        })
+
+    def __init__(self, data, manager=None):
+        super(VmResizeAction, self).__init__(data, manager)
+        self.vm_size = self.data['vmSize']
+
+    def _prepare_processing(self):
+        self.client = self.manager.get_client()
+
+    def _process_resource(self, resource):
+        hardware_profile = HardwareProfile(vm_size=self.vm_size)
+
+        self.client.virtual_machines.update(
+            resource['resourceGroup'],
+            resource['name'],
+            VirtualMachineUpdate(hardware_profile=hardware_profile)
+        )

--- a/tools/c7n_azure/tests_azure/cassettes/VMTest.test_resize.json
+++ b/tools/c7n_azure/tests_azure/cassettes/VMTest.test_resize.json
@@ -1,0 +1,231 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2019-07-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-length": [
+                        "13321"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "9d1f3d02-c6c7-4156-9fd2-bdbb42171d84",
+                        "e8840802-e918-4be7-b93f-7088f446009a",
+                        "3d275fd1-b8fa-4566-a6f7-fdca4c173438",
+                        "523d9744-2a32-418b-879c-ce20780f3a17"
+                    ],
+                    "date": [
+                        "Mon, 26 Oct 2020 18:12:58 GMT"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "cctestvm",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm",
+                                "type": "Microsoft.Compute/virtualMachines",
+                                "location": "southcentralus",
+                                "tags": {
+                                    "testtag": "testvalue",
+                                    "schedule": "on=(M-U,8);off=(M-U,18);tz=pt"
+                                },
+                                "properties": {
+                                    "vmId": "d565866c-9aaa-4ff1-a8ee-17bdc9ce4675",
+                                    "hardwareProfile": {
+                                        "vmSize": "Standard_A1_v2"
+                                    },
+                                    "storageProfile": {
+                                        "imageReference": {
+                                            "publisher": "Canonical",
+                                            "offer": "UbuntuServer",
+                                            "sku": "16.04.0-LTS",
+                                            "version": "latest",
+                                            "exactVersion": "16.04.202010140"
+                                        },
+                                        "osDisk": {
+                                            "osType": "Linux",
+                                            "name": "cctestvm_OsDisk_1_358aa817f747420abc4dd5794a268a7b",
+                                            "createOption": "FromImage",
+                                            "caching": "ReadWrite",
+                                            "managedDisk": {
+                                                "storageAccountType": "Standard_LRS",
+                                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/disks/cctestvm_OsDisk_1_358aa817f747420abc4dd5794a268a7b"
+                                            },
+                                            "diskSizeGB": 30
+                                        },
+                                        "dataDisks": [
+                                            {
+                                                "lun": 0,
+                                                "name": "cctestvm_disk2_880671278cbd4b5b8083bfe176d35dee",
+                                                "createOption": "Empty",
+                                                "caching": "None",
+                                                "managedDisk": {
+                                                    "storageAccountType": "Standard_LRS",
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/disks/cctestvm_disk2_880671278cbd4b5b8083bfe176d35dee"
+                                                },
+                                                "diskSizeGB": 1023,
+                                                "toBeDetached": false
+                                            }
+                                        ]
+                                    },
+                                    "osProfile": {
+                                        "computerName": "vmyd3b22k4ef27q",
+                                        "adminUsername": "testuser",
+                                        "linuxConfiguration": {
+                                            "disablePasswordAuthentication": false
+                                        },
+                                        "secrets": []
+                                    },
+                                    "networkProfile": {
+                                        "networkInterfaces": [
+                                            {
+                                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Network/networkInterfaces/myVMNic"
+                                            }
+                                        ]
+                                    },
+                                    "diagnosticsProfile": {
+                                        "bootDiagnostics": {
+                                            "enabled": true,
+                                            "storageUri": "https://yd3b22k4ef27qsalinuxvm.blob.core.windows.net/"
+                                        }
+                                    },
+                                    "provisioningState": "Succeeded"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "PATCH",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm?api-version=2019-07-01",
+                "body": "mock_body",
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-ms-ratelimit-remaining-resource": [
+                        "Microsoft.Compute/PutVM3Min;239,Microsoft.Compute/PutVM30Min;1198"
+                    ],
+                    "date": [
+                        "Mon, 26 Oct 2020 18:13:02 GMT"
+                    ],
+                    "azure-asyncnotification": [
+                        "Enabled"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "azure-asyncoperation": [
+                        "https://management.azure.com/subscriptions/27847cfa-1b12-462a-9672-6dfb0f85e28c/providers/Microsoft.Compute/locations/southcentralus/operations/63039941-1414-44af-90c0-d3d90e4697c8?api-version=2019-07-01"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-writes": [
+                        "1198"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "2387"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "name": "cctestvm",
+                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm",
+                        "type": "Microsoft.Compute/virtualMachines",
+                        "location": "southcentralus",
+                        "tags": {
+                            "testtag": "testvalue",
+                            "schedule": "on=(M-U,8);off=(M-U,18);tz=pt"
+                        },
+                        "properties": {
+                            "vmId": "d565866c-9aaa-4ff1-a8ee-17bdc9ce4675",
+                            "hardwareProfile": {
+                                "vmSize": "Standard_A2_v2"
+                            },
+                            "storageProfile": {
+                                "imageReference": {
+                                    "publisher": "Canonical",
+                                    "offer": "UbuntuServer",
+                                    "sku": "16.04.0-LTS",
+                                    "version": "latest",
+                                    "exactVersion": "16.04.202010140"
+                                },
+                                "osDisk": {
+                                    "osType": "Linux",
+                                    "name": "cctestvm_OsDisk_1_358aa817f747420abc4dd5794a268a7b",
+                                    "createOption": "FromImage",
+                                    "caching": "ReadWrite",
+                                    "managedDisk": {
+                                        "storageAccountType": "Standard_LRS",
+                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/disks/cctestvm_OsDisk_1_358aa817f747420abc4dd5794a268a7b"
+                                    },
+                                    "diskSizeGB": 30
+                                },
+                                "dataDisks": [
+                                    {
+                                        "lun": 0,
+                                        "name": "cctestvm_disk2_880671278cbd4b5b8083bfe176d35dee",
+                                        "createOption": "Empty",
+                                        "caching": "None",
+                                        "managedDisk": {
+                                            "storageAccountType": "Standard_LRS",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Compute/disks/cctestvm_disk2_880671278cbd4b5b8083bfe176d35dee"
+                                        },
+                                        "diskSizeGB": 1023,
+                                        "toBeDetached": false
+                                    }
+                                ]
+                            },
+                            "osProfile": {
+                                "computerName": "vmyd3b22k4ef27q",
+                                "adminUsername": "testuser",
+                                "linuxConfiguration": {
+                                    "disablePasswordAuthentication": false
+                                },
+                                "secrets": []
+                            },
+                            "networkProfile": {
+                                "networkInterfaces": [
+                                    {
+                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/providers/Microsoft.Network/networkInterfaces/myVMNic"
+                                    }
+                                ]
+                            },
+                            "diagnosticsProfile": {
+                                "bootDiagnostics": {
+                                    "enabled": true,
+                                    "storageUri": "https://yd3b22k4ef27qsalinuxvm.blob.core.windows.net/"
+                                }
+                            },
+                            "provisioningState": "Updating"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/templates/provision.sh
+++ b/tools/c7n_azure/tests_azure/templates/provision.sh
@@ -51,7 +51,7 @@ deploy_resource() {
         fi
 
         azureAdUserObjectId=$(az ad signed-in-user show --query objectId --output tsv)
-        az group deployment create --resource-group $rgName --template-file $file \
+        az deployment group create --resource-group $rgName --template-file $file \
             --parameters "userObjectId=$azureAdUserObjectId" --output None
 
         vault_name=$(az keyvault list --resource-group $rgName --query [0].name --output tsv)
@@ -70,7 +70,7 @@ deploy_resource() {
 
     elif [[ "$fileName" == "aks.json" ]]; then
 
-        az group deployment create --resource-group $rgName --template-file $file --parameters client_id=$AZURE_CLIENT_ID client_secret=$AZURE_CLIENT_SECRET --mode Complete --output None
+        az deployment group create --resource-group $rgName --template-file $file --parameters client_id=$AZURE_CLIENT_ID client_secret=$AZURE_CLIENT_SECRET --mode Complete --output None
 
     elif [[ "$fileName" == "cost-management-export.json" ]]; then
 
@@ -80,7 +80,7 @@ deploy_resource() {
         fi
 
         # Deploy storage account required for the export
-        az group deployment create --resource-group $rgName --template-file $file --mode Complete --output None
+        az deployment group create --resource-group $rgName --template-file $file --mode Complete --output None
 
         token=$(az account get-access-token --query accessToken --output tsv)
         storage_id=$(az storage account list --resource-group $rgName --query [0].id --output tsv)
@@ -94,7 +94,7 @@ deploy_resource() {
         rm -f cost-management.body
 
     else
-        az group deployment create --resource-group $rgName --template-file $file --mode Complete --output None
+        az deployment group create --resource-group $rgName --template-file $file --mode Complete --output None
     fi
 
     echo "Deployment for ${filenameNoExtension} complete"

--- a/tools/c7n_azure/tests_azure/templates/vm.json
+++ b/tools/c7n_azure/tests_azure/templates/vm.json
@@ -15,7 +15,7 @@
     "publicIPAddressName": "myPublicIP",
     "publicIPAddressType": "Dynamic",
     "vmName": "cctestvm",
-    "vmSize": "Standard_A1",
+    "vmSize": "Standard_A1_v2",
     "virtualNetworkName": "MyVNET",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
@@ -106,7 +106,7 @@
       ],
       "properties": {
         "hardwareProfile": {
-          "vmSize": "Basic_A0"
+          "vmSize": "[variables('vmSize')]"
         },
         "osProfile": {
           "computerName": "[concat('vm', uniqueString(resourceGroup().id))]",


### PR DESCRIPTION
This PR adds the `azure.vm.actions.resize` action.

It is my first contribution and python is not my first language so suggestions are very welcome.

Trying to run the test suite I found a couple of other minor things:
- Deprecation warning in `provision.sh` script
- The vm.json template was not using the variable and was hardcoded to a non supported size
- The example for the `azure.vm.actions.delete` had a misleading name

Not sure if they are ok to be merged like this or you prefer separate PRs, they are in different commits so easily done if needed.