### PR TITLE
c7n-mailer - add support for additional, arbitrary email headers

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -41,9 +41,7 @@ CONFIG_SCHEMA = {
         'queue_url': {'type': 'string'},
         'endpoint_url': {'type': 'string'},
         'from_address': {'type': 'string'},
-        'additional_email_headers': {
-            'type': 'array', 'items': {'type': 'string'}
-        },
+        'additional_email_headers': {'type': 'object'},
         'contact_tags': {'type': 'array', 'items': {'type': 'string'}},
         'org_domain': {'type': 'string'},
 

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -41,6 +41,9 @@ CONFIG_SCHEMA = {
         'queue_url': {'type': 'string'},
         'endpoint_url': {'type': 'string'},
         'from_address': {'type': 'string'},
+        'additional_email_headers': {
+            'type': 'array', 'items': {'type': 'string'}
+        },
         'contact_tags': {'type': 'array', 'items': {'type': 'string'}},
         'org_domain': {'type': 'string'},
 

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -41,7 +41,12 @@ CONFIG_SCHEMA = {
         'queue_url': {'type': 'string'},
         'endpoint_url': {'type': 'string'},
         'from_address': {'type': 'string'},
-        'additional_email_headers': {'type': 'object'},
+        'additional_email_headers': {
+            'type': 'object',
+            'patternProperties': {
+                '': {'type': 'string'},
+            }
+        },
         'contact_tags': {'type': 'array', 'items': {'type': 'string'}},
         'org_domain': {'type': 'string'},
 

--- a/tools/c7n_mailer/c7n_mailer/utils_email.py
+++ b/tools/c7n_mailer/c7n_mailer/utils_email.py
@@ -80,7 +80,10 @@ def priority_header_is_valid(priority_header, logger):
         return False
 
 
-def set_mimetext_headers(message, subject, from_addr, to_addrs, cc_addrs, additional_headers, priority, logger):
+def set_mimetext_headers(
+    message, subject, from_addr, to_addrs, cc_addrs, additional_headers,
+    priority, logger
+):
     """Sets headers on Mimetext message"""
 
     message['Subject'] = subject

--- a/tools/c7n_mailer/c7n_mailer/utils_email.py
+++ b/tools/c7n_mailer/c7n_mailer/utils_email.py
@@ -80,7 +80,7 @@ def priority_header_is_valid(priority_header, logger):
         return False
 
 
-def set_mimetext_headers(message, subject, from_addr, to_addrs, cc_addrs, priority, logger):
+def set_mimetext_headers(message, subject, from_addr, to_addrs, cc_addrs, additional_headers, priority, logger):
     """Sets headers on Mimetext message"""
 
     message['Subject'] = subject
@@ -88,6 +88,9 @@ def set_mimetext_headers(message, subject, from_addr, to_addrs, cc_addrs, priori
     message['To'] = ', '.join(to_addrs)
     if cc_addrs:
         message['Cc'] = ', '.join(cc_addrs)
+    if additional_headers:
+        for k, v in additional_headers.items():
+            message[k] = v
 
     if priority and priority_header_is_valid(priority, logger):
         priority = PRIORITIES[str(priority)].copy()
@@ -113,6 +116,7 @@ def get_mimetext_message(config, logger, message, resources, to_addrs):
         from_addr=message['action'].get('from', config['from_address']),
         to_addrs=to_addrs,
         cc_addrs=message['action'].get('cc', []),
+        additional_headers=config.get('additional_email_headers', {}),
         priority=message['action'].get('priority_header', None),
         logger=logger
     )


### PR DESCRIPTION
This PR adds support in the c7n-mailer config for specifying a dictionary of ``additional_email_headers`` to be added to outgoing MIME email messages. Our specific need is to set ``Reply-To`` and ``Return-Path``, but it seemed to me like it's best to leave this generic in case there are other things that people need for their specific purposes (such as X- headers for specific use cases).

We have this running currently in one of our test accounts, and it's working as expected when setting Reply-To and Return-Path.