### PR TITLE
c7n-org fix config parsing error with AWS profile

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -487,9 +487,10 @@ def run_script(config, output_dir, accounts, tags, region, echo, serial, script_
 
 def accounts_iterator(config):
     for a in config.get('accounts', ()):
-        if isinstance(a['role'], str) and not a['role'].startswith('arn'):
-            a['role'] = "arn:aws:iam::{}:role/{}".format(
-                a['account_id'], a['role'])
+        if 'role' in a:
+            if isinstance(a['role'], str) and not a['role'].startswith('arn'):
+                a['role'] = "arn:aws:iam::{}:role/{}".format(
+                    a['account_id'], a['role'])
         yield {**a, **{'provider': 'aws'}}
     for a in config.get('subscriptions', ()):
         d = {'account_id': a['subscription_id'],


### PR DESCRIPTION
PR to avoid to get an error(KeyError: 'role') when an account configuration uses an AWS profile.