### PR TITLE
releng - uniform copyright/license headers

### DIFF
--- a/c7n/__init__.py
+++ b/c7n/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/c7n/actions/__init__.py
+++ b/c7n/actions/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/actions/autotag.py
+++ b/c7n/actions/autotag.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/actions/core.py
+++ b/c7n/actions/core.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/actions/invoke.py
+++ b/c7n/actions/invoke.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/actions/metric.py
+++ b/c7n/actions/metric.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime

--- a/c7n/actions/network.py
+++ b/c7n/actions/network.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import itertools

--- a/c7n/actions/notify.py
+++ b/c7n/actions/notify.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/actions/policy.py
+++ b/c7n/actions/policy.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/actions/webhook.py
+++ b/c7n/actions/webhook.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/cache.py
+++ b/c7n/cache.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Provide basic caching services to avoid extraneous queries over

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from collections import Counter, defaultdict

--- a/c7n/config.py
+++ b/c7n/config.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import os

--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/ctx.py
+++ b/c7n/ctx.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/c7n/cwe.py
+++ b/c7n/cwe.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/c7n/exceptions.py
+++ b/c7n/exceptions.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/executor.py
+++ b/c7n/executor.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from concurrent.futures import (ProcessPoolExecutor, ThreadPoolExecutor)  # noqa

--- a/c7n/filters/__init__.py
+++ b/c7n/filters/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .core import (

--- a/c7n/filters/config.py
+++ b/c7n/filters/config.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.filters import ValueFilter

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/filters/health.py
+++ b/c7n/filters/health.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import itertools

--- a/c7n/filters/iamaccess.py
+++ b/c7n/filters/iamaccess.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/filters/iamanalyzer.py
+++ b/c7n/filters/iamanalyzer.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Kapil Thangavelu
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/filters/kms.py
+++ b/c7n/filters/kms.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/filters/missing.py
+++ b/c7n/filters/missing.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/filters/multiattr.py
+++ b/c7n/filters/multiattr.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/filters/related.py
+++ b/c7n/filters/related.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import importlib

--- a/c7n/filters/revisions.py
+++ b/c7n/filters/revisions.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.exceptions import PolicyValidationError

--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/loader.py
+++ b/c7n/loader.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/log.py
+++ b/c7n/log.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/lookup.py
+++ b/c7n/lookup.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from collections import deque

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime

--- a/c7n/provider.py
+++ b/c7n/provider.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/registry.py
+++ b/c7n/registry.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/reports/__init__.py
+++ b/c7n/reports/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .csvout import report

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import csv

--- a/c7n/resources/__init__.py
+++ b/c7n/resources/__init__.py
@@ -1,5 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """AWS Account as a custodian resource.

--- a/c7n/resources/acm.py
+++ b/c7n/resources/acm.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import BaseAction

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import itertools

--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import functools

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/resources/artifact.py
+++ b/c7n/resources/artifact.py
@@ -1,4 +1,4 @@
-# Copyright Cloud Custodian Authors.
+# Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import Action
 from c7n.filters.iamaccess import CrossAccountAccessFilter

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.client import ClientError

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/resources/awslambda.py
+++ b/c7n/resources/awslambda.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/c7n/resources/backup.py
+++ b/c7n/resources/backup.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/batch.py
+++ b/c7n/resources/batch.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import BaseAction

--- a/c7n/resources/cfn.py
+++ b/c7n/resources/cfn.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import re

--- a/c7n/resources/cloudsearch.py
+++ b/c7n/resources/cloudsearch.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import Action

--- a/c7n/resources/cloudtrail.py
+++ b/c7n/resources/cloudtrail.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/c7n/resources/code.py
+++ b/c7n/resources/code.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/cognito.py
+++ b/c7n/resources/cognito.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/config.py
+++ b/c7n/resources/config.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import BaseAction

--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from concurrent.futures import as_completed

--- a/c7n/resources/datapipeline.py
+++ b/c7n/resources/datapipeline.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Data Pipeline

--- a/c7n/resources/directconnect.py
+++ b/c7n/resources/directconnect.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/directory.py
+++ b/c7n/resources/directory.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/dlm.py
+++ b/c7n/resources/dlm.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/dms.py
+++ b/c7n/resources/dms.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from collections import Counter

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import base64

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/efs.py
+++ b/c7n/resources/efs.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import Action, BaseAction

--- a/c7n/resources/eks.py
+++ b/c7n/resources/eks.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import Action

--- a/c7n/resources/elasticache.py
+++ b/c7n/resources/elasticache.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime

--- a/c7n/resources/elasticbeanstalk.py
+++ b/c7n/resources/elasticbeanstalk.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/c7n/resources/elb.py
+++ b/c7n/resources/elb.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/c7n/resources/fsx.py
+++ b/c7n/resources/fsx.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/resources/gamelift.py
+++ b/c7n/resources/gamelift.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/glacier.py
+++ b/c7n/resources/glacier.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/c7n/resources/health.py
+++ b/c7n/resources/health.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import itertools

--- a/c7n/resources/hsm.py
+++ b/c7n/resources/hsm.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from collections import OrderedDict

--- a/c7n/resources/iot.py
+++ b/c7n/resources/iot.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/resources/kafka.py
+++ b/c7n/resources/kafka.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import Action

--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/lightsail.py
+++ b/c7n/resources/lightsail.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/ml.py
+++ b/c7n/resources/ml.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/mq.py
+++ b/c7n/resources/mq.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import Action

--- a/c7n/resources/opsworks.py
+++ b/c7n/resources/opsworks.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/c7n/resources/rdsparamgroup.py
+++ b/c7n/resources/rdsparamgroup.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/c7n/resources/redshift.py
+++ b/c7n/resources/redshift.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 ResourceMap = {
     "aws.account": "c7n.resources.account.Account",
     "aws.acm-certificate": "c7n.resources.acm.Certificate",

--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import functools

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """S3 Resource Manager

--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/resources/sar.py
+++ b/c7n/resources/sar.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Kapil Thangavelu
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/resources/secretsmanager.py
+++ b/c7n/resources/secretsmanager.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Amazon.com, Inc. or its affiliates.
 # All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/c7n/resources/sfn.py
+++ b/c7n/resources/sfn.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/resources/shield.py
+++ b/c7n/resources/shield.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/simpledb.py
+++ b/c7n/resources/simpledb.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import itertools

--- a/c7n/resources/snowball.py
+++ b/c7n/resources/snowball.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/c7n/resources/storagegw.py
+++ b/c7n/resources/storagegw.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/support.py
+++ b/c7n/resources/support.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import itertools

--- a/c7n/resources/waf.py
+++ b/c7n/resources/waf.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources

--- a/c7n/resources/workspaces.py
+++ b/c7n/resources/workspaces.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import functools

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/sqsexec.py
+++ b/c7n/sqsexec.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/structure.py
+++ b/c7n/structure.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/c7n/ufuncs/__init__.py
+++ b/c7n/ufuncs/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/c7n/ufuncs/s3crypt.py
+++ b/c7n/ufuncs/s3crypt.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import copy

--- a/c7n/version.py
+++ b/c7n/version.py
@@ -1,2 +1,4 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Generated via tools/dev/poetrypkg.py
 version = "0.9.8"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import gzip

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/data/helloworld.py
+++ b/tests/data/helloworld.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Hello world Lambda function for mu testing.

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_acm.py
+++ b/tests/test_acm.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/tests/test_apigw.py
+++ b/tests/test_apigw.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError

--- a/tests/test_appelb.py
+++ b/tests/test_appelb.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime

--- a/tests/test_autotag.py
+++ b/tests/test_autotag.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.exceptions import PolicyValidationError

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/tests/test_cloudsearch.py
+++ b/tests/test_cloudsearch.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_cloudtrail.py
+++ b/tests/test_cloudtrail.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.exceptions import PolicyValidationError

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import os

--- a/tests/test_cwa.py
+++ b/tests/test_cwa.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_cwe.py
+++ b/tests/test_cwe.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/tests/test_cwi.py
+++ b/tests/test_cwi.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Kapil Thangavelu
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_datapipeline.py
+++ b/tests/test_datapipeline.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest, functional

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_dlm.py
+++ b/tests/test_dlm.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_dms.py
+++ b/tests/test_dms.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import itertools

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Kapil Thangavelu
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Functional Tests for the Docker

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_efs.py
+++ b/tests/test_efs.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.exceptions import PolicyValidationError

--- a/tests/test_eks.py
+++ b/tests/test_eks.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tests/test_elasticache.py
+++ b/tests/test_elasticache.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.resources.elasticache import _cluster_eligible_for_snapshot

--- a/tests/test_elasticbeanstalk.py
+++ b/tests/test_elasticbeanstalk.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_elb.py
+++ b/tests/test_elb.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import unittest

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n import executor

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import calendar

--- a/tests/test_fsx.py
+++ b/tests/test_fsx.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_glacier.py
+++ b/tests/test_glacier.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_iamgen.py
+++ b/tests/test_iamgen.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import time
 
 from .common import BaseTest, load_data

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from copy import deepcopy

--- a/tests/test_mlmodel.py
+++ b/tests/test_mlmodel.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import importlib

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest, functional

--- a/tests/test_offhours.py
+++ b/tests/test_offhours.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tests/test_opsworks.py
+++ b/tests/test_opsworks.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from copy import deepcopy

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_put_metrics.py
+++ b/tests/test_put_metrics.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.utils import yaml_load

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tests/test_rdscluster.py
+++ b/tests/test_rdscluster.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.executor import MainThreadExecutor

--- a/tests/test_rdsparamgroup.py
+++ b/tests/test_rdsparamgroup.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest, functional

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import unittest

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.reports.csvout import Formatter

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import csv

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 # from c7n.filters import revisions

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tests/test_s3crypt.py
+++ b/tests/test_s3crypt.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import io

--- a/tests/test_sagemaker.py
+++ b/tests/test_sagemaker.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_sar.py
+++ b/tests/test_sar.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Kapil Thangavelu
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import mock

--- a/tests/test_secretsmanager.py
+++ b/tests/test_secretsmanager.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_servicecatalog.py
+++ b/tests/test_servicecatalog.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_shield.py
+++ b/tests/test_shield.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_simpledb.py
+++ b/tests/test_simpledb.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest, functional, event_data

--- a/tests/test_sqsexec.py
+++ b/tests/test_sqsexec.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Most tags tests within their corresponding resource tags, we use this

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import argparse

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tests/test_waf.py
+++ b/tests/test_waf.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import fnmatch

--- a/tools/c7n_azure/c7n_azure/__init__.py
+++ b/tools/c7n_azure/c7n_azure/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_azure/c7n_azure/actions/__init__.py
+++ b/tools/c7n_azure/c7n_azure/actions/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_azure/c7n_azure/actions/base.py
+++ b/tools/c7n_azure/c7n_azure/actions/base.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_azure/c7n_azure/actions/delete.py
+++ b/tools/c7n_azure/c7n_azure/actions/delete.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/actions/firewall.py
+++ b/tools/c7n_azure/c7n_azure/actions/firewall.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/actions/lock.py
+++ b/tools/c7n_azure/c7n_azure/actions/lock.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/actions/logic_app.py
+++ b/tools/c7n_azure/c7n_azure/actions/logic_app.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/actions/notify.py
+++ b/tools/c7n_azure/c7n_azure/actions/notify.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/actions/tagging.py
+++ b/tools/c7n_azure/c7n_azure/actions/tagging.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/azure_events.py
+++ b/tools/c7n_azure/c7n_azure/azure_events.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.eventgrid.models import EventSubscription, EventSubscriptionFilter

--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/container_host/__init__.py
+++ b/tools/c7n_azure/c7n_azure/container_host/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_azure/c7n_azure/container_host/host.py
+++ b/tools/c7n_azure/c7n_azure/container_host/host.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/container_host/modes.py
+++ b/tools/c7n_azure/c7n_azure/container_host/modes.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/entry.py
+++ b/tools/c7n_azure/c7n_azure/entry.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_azure/c7n_azure/function.py
+++ b/tools/c7n_azure/c7n_azure/function.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import copy

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_azure/c7n_azure/handler.py
+++ b/tools/c7n_azure/c7n_azure/handler.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/provider.py
+++ b/tools/c7n_azure/c7n_azure/provider.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/provisioning/__init__.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/provisioning/app_insights.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/app_insights.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 from msrestazure.azure_exceptions import CloudError
 
 from c7n_azure.provisioning.deployment_unit import DeploymentUnit

--- a/tools/c7n_azure/c7n_azure/provisioning/app_service_plan.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/app_service_plan.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import copy
 from azure.mgmt.web.models import AppServicePlan, SkuDescription
 from c7n_azure.provisioning.autoscale import AutoScaleUnit

--- a/tools/c7n_azure/c7n_azure/provisioning/autoscale.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/autoscale.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_azure.provisioning.deployment_unit import DeploymentUnit

--- a/tools/c7n_azure/c7n_azure/provisioning/deployment_unit.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/deployment_unit.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import logging
 
 from abc import ABCMeta, abstractmethod

--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/provisioning/resource_group.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/resource_group.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 from msrestazure.azure_exceptions import CloudError
 
 from c7n_azure.provisioning.deployment_unit import DeploymentUnit

--- a/tools/c7n_azure/c7n_azure/provisioning/storage_account.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/storage_account.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 from msrestazure.azure_exceptions import CloudError
 
 from c7n_azure.provisioning.deployment_unit import DeploymentUnit

--- a/tools/c7n_azure/c7n_azure/query.py
+++ b/tools/c7n_azure/c7n_azure/query.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/__init__.py
+++ b/tools/c7n_azure/c7n_azure/resources/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_azure/c7n_azure/resources/access_control.py
+++ b/tools/c7n_azure/c7n_azure/resources/access_control.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/aci.py
+++ b/tools/c7n_azure/c7n_azure/resources/aci.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_azure.provider import resources

--- a/tools/c7n_azure/c7n_azure/resources/apimanagement.py
+++ b/tools/c7n_azure/c7n_azure/resources/apimanagement.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_azure.actions.base import AzureBaseAction

--- a/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
+++ b/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/arm.py
+++ b/tools/c7n_azure/c7n_azure/resources/arm.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/batch.py
+++ b/tools/c7n_azure/c7n_azure/resources/batch.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/cdn.py
+++ b/tools/c7n_azure/c7n_azure/resources/cdn.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/cognitive_service.py
+++ b/tools/c7n_azure/c7n_azure/resources/cognitive_service.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/container_registry.py
+++ b/tools/c7n_azure/c7n_azure/resources/container_registry.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/container_service.py
+++ b/tools/c7n_azure/c7n_azure/resources/container_service.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
+++ b/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/cost_management_export.py
+++ b/tools/c7n_azure/c7n_azure/resources/cost_management_export.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/data_factory.py
+++ b/tools/c7n_azure/c7n_azure/resources/data_factory.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/databricks.py
+++ b/tools/c7n_azure/c7n_azure/resources/databricks.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/datalake_store.py
+++ b/tools/c7n_azure/c7n_azure/resources/datalake_store.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/disk.py
+++ b/tools/c7n_azure/c7n_azure/resources/disk.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/dns_zone.py
+++ b/tools/c7n_azure/c7n_azure/resources/dns_zone.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/event_hub.py
+++ b/tools/c7n_azure/c7n_azure/resources/event_hub.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/event_subscription.py
+++ b/tools/c7n_azure/c7n_azure/resources/event_subscription.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_azure.actions.base import AzureBaseAction

--- a/tools/c7n_azure/c7n_azure/resources/generic_arm_resource.py
+++ b/tools/c7n_azure/c7n_azure/resources/generic_arm_resource.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/hdinsight.py
+++ b/tools/c7n_azure/c7n_azure/resources/hdinsight.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/image.py
+++ b/tools/c7n_azure/c7n_azure/resources/image.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/iot_hub.py
+++ b/tools/c7n_azure/c7n_azure/resources/iot_hub.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/k8s_service.py
+++ b/tools/c7n_azure/c7n_azure/resources/k8s_service.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_certificate.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_certificate.py
@@ -1,16 +1,5 @@
-# Copyright 2019 Microsoft Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.from c7n_azure.provider import resources
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 
 import logging
 

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
@@ -1,16 +1,5 @@
-# Copyright 2018 Capital One Services, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.from c7n_azure.provider import resources
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 
 import logging
 

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_storage.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_storage.py
@@ -1,16 +1,5 @@
-# Copyright 2019 Microsoft Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.from c7n_azure.provider import resources
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 
 import logging
 

--- a/tools/c7n_azure/c7n_azure/resources/load_balancer.py
+++ b/tools/c7n_azure/c7n_azure/resources/load_balancer.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/network_interface.py
+++ b/tools/c7n_azure/c7n_azure/resources/network_interface.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/network_security_group.py
+++ b/tools/c7n_azure/c7n_azure/resources/network_security_group.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/policy_assignments.py
+++ b/tools/c7n_azure/c7n_azure/resources/policy_assignments.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_database.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_database.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/public_ip.py
+++ b/tools/c7n_azure/c7n_azure/resources/public_ip.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/record_set.py
+++ b/tools/c7n_azure/c7n_azure/resources/record_set.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/redis.py
+++ b/tools/c7n_azure/c7n_azure/resources/redis.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 ResourceMap = {
     "azure.aks": "c7n_azure.resources.k8s_service.KubernetesService",
     "azure.api-management": "c7n_azure.resources.apimanagement.ApiManagement",

--- a/tools/c7n_azure/c7n_azure/resources/resourcegroup.py
+++ b/tools/c7n_azure/c7n_azure/resources/resourcegroup.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_azure.constants import RESOURCE_GROUPS_TYPE

--- a/tools/c7n_azure/c7n_azure/resources/route_table.py
+++ b/tools/c7n_azure/c7n_azure/resources/route_table.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/search.py
+++ b/tools/c7n_azure/c7n_azure/resources/search.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
@@ -1,4 +1,5 @@
-# Copyright 2018 Capital One Services, LLC
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/c7n_azure/c7n_azure/resources/sqlserver.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqlserver.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_azure/c7n_azure/resources/storage.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/subscription.py
+++ b/tools/c7n_azure/c7n_azure/resources/subscription.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/vm.py
+++ b/tools/c7n_azure/c7n_azure/resources/vm.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.compute.models import HardwareProfile, VirtualMachineUpdate

--- a/tools/c7n_azure/c7n_azure/resources/vmss.py
+++ b/tools/c7n_azure/c7n_azure/resources/vmss.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/vnet.py
+++ b/tools/c7n_azure/c7n_azure/resources/vnet.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/resources/web_app.py
+++ b/tools/c7n_azure/c7n_azure/resources/web_app.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/c7n_azure/storage_utils.py
+++ b/tools/c7n_azure/c7n_azure/storage_utils.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from collections import namedtuple

--- a/tools/c7n_azure/c7n_azure/tags.py
+++ b/tools/c7n_azure/c7n_azure/tags.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import collections

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_azure/tests_azure/__init__.py
+++ b/tools/c7n_azure/tests_azure/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_azure/tests_azure/azure_common.py
+++ b/tools/c7n_azure/tests_azure/azure_common.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tools/c7n_azure/tests_azure/azure_serializer.py
+++ b/tools/c7n_azure/tests_azure/azure_serializer.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import json
 
 

--- a/tools/c7n_azure/tests_azure/data/dependencies/sample.py
+++ b/tools/c7n_azure/tests_azure/data/dependencies/sample.py
@@ -1,1 +1,3 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 print('test')

--- a/tools/c7n_azure/tests_azure/test_actions_autotag-base.py
+++ b/tools/c7n_azure/tests_azure/test_actions_autotag-base.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import copy

--- a/tools/c7n_azure/tests_azure/test_actions_autotag-date.py
+++ b/tools/c7n_azure/tests_azure/test_actions_autotag-date.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.monitor.models import EventData

--- a/tools/c7n_azure/tests_azure/test_actions_autotag-user.py
+++ b/tools/c7n_azure/tests_azure/test_actions_autotag-user.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.monitor.models import EventData

--- a/tools/c7n_azure/tests_azure/test_actions_mark-for-op.py
+++ b/tools/c7n_azure/tests_azure/test_actions_mark-for-op.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tools/c7n_azure/tests_azure/test_actions_tag-trim.py
+++ b/tools/c7n_azure/tests_azure/test_actions_tag-trim.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import re

--- a/tools/c7n_azure/tests_azure/test_actions_tag.py
+++ b/tools/c7n_azure/tests_azure/test_actions_tag.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from . import tools_tags as tools

--- a/tools/c7n_azure/tests_azure/test_actions_untag.py
+++ b/tools/c7n_azure/tests_azure/test_actions_untag.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from . import tools_tags as tools

--- a/tools/c7n_azure/tests_azure/test_azure_events.py
+++ b/tools/c7n_azure/tests_azure/test_azure_events.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.eventgrid.models import StorageQueueEventSubscriptionDestination

--- a/tools/c7n_azure/tests_azure/test_azure_query.py
+++ b/tools/c7n_azure/tests_azure/test_azure_query.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_azure/tests_azure/test_azure_utils.py
+++ b/tools/c7n_azure/tests_azure/test_azure_utils.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import sys

--- a/tools/c7n_azure/tests_azure/test_base_action.py
+++ b/tools/c7n_azure/tests_azure/test_base_action.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest

--- a/tools/c7n_azure/tests_azure/test_deployment_units.py
+++ b/tools/c7n_azure/tests_azure/test_deployment_units.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import pytest

--- a/tools/c7n_azure/tests_azure/test_diagnostic_settings.py
+++ b/tools/c7n_azure/tests_azure/test_diagnostic_settings.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/test_filter_policycompliance.py
+++ b/tools/c7n_azure/tests_azure/test_filter_policycompliance.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/test_filter_resource_lock.py
+++ b/tools/c7n_azure/tests_azure/test_filter_resource_lock.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/test_filters_cost.py
+++ b/tools/c7n_azure/tests_azure/test_filters_cost.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from collections import namedtuple

--- a/tools/c7n_azure/tests_azure/test_filters_marked_for_op.py
+++ b/tools/c7n_azure/tests_azure/test_filters_marked_for_op.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tools/c7n_azure/tests_azure/test_filters_parent.py
+++ b/tools/c7n_azure/tests_azure/test_filters_parent.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_azure.filters import ParentFilter

--- a/tools/c7n_azure/tests_azure/test_filters_tag.py
+++ b/tools/c7n_azure/tests_azure/test_filters_tag.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from . import tools_tags as tools

--- a/tools/c7n_azure/tests_azure/test_firewall_actions.py
+++ b/tools/c7n_azure/tests_azure/test_firewall_actions.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest

--- a/tools/c7n_azure/tests_azure/test_firewall_bypass_filter.py
+++ b/tools/c7n_azure/tests_azure/test_firewall_bypass_filter.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest

--- a/tools/c7n_azure/tests_azure/test_firewall_rules_filter.py
+++ b/tools/c7n_azure/tests_azure/test_firewall_rules_filter.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_azure/tests_azure/test_function.py
+++ b/tools/c7n_azure/tests_azure/test_function.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import sys

--- a/tools/c7n_azure/tests_azure/test_function_package.py
+++ b/tools/c7n_azure/tests_azure/test_function_package.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tools/c7n_azure/tests_azure/test_functional_actions_tags.py
+++ b/tools/c7n_azure/tests_azure/test_functional_actions_tags.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tools/c7n_azure/tests_azure/test_functional_filters_cost.py
+++ b/tools/c7n_azure/tests_azure/test_functional_filters_cost.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/test_functional_filters_parent.py
+++ b/tools/c7n_azure/tests_azure/test_functional_filters_parent.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import azure.keyvault.http_bearer_challenge_cache as kv_cache

--- a/tools/c7n_azure/tests_azure/test_functional_filters_tags.py
+++ b/tools/c7n_azure/tests_azure/test_functional_filters_tags.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from . import tools_tags as tools

--- a/tools/c7n_azure/tests_azure/test_functionapp_utils.py
+++ b/tools/c7n_azure/tests_azure/test_functionapp_utils.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/test_handler.py
+++ b/tools/c7n_azure/tests_azure/test_handler.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest, CUSTOM_SUBSCRIPTION_ID
 from c7n_azure.handler import run
 from os.path import dirname, join

--- a/tools/c7n_azure/tests_azure/test_lock_action.py
+++ b/tools/c7n_azure/tests_azure/test_lock_action.py
@@ -1,4 +1,5 @@
-# Copyright 2019 Microsoft Corporation
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tools/c7n_azure/tests_azure/test_logic_app.py
+++ b/tools/c7n_azure/tests_azure/test_logic_app.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/tests_azure/test_notify.py
+++ b/tools/c7n_azure/tests_azure/test_notify.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.common import AzureHttpError

--- a/tools/c7n_azure/tests_azure/test_output.py
+++ b/tools/c7n_azure/tests_azure/test_output.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_azure/tests_azure/test_policy_mode.py
+++ b/tools/c7n_azure/tests_azure/test_policy_mode.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.storage.models import StorageAccount

--- a/tools/c7n_azure/tests_azure/test_provider.py
+++ b/tools/c7n_azure/tests_azure/test_provider.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest, DEFAULT_SUBSCRIPTION_ID
 from mock import patch
 from c7n_azure.provider import Azure

--- a/tools/c7n_azure/tests_azure/test_resource_graph_source.py
+++ b/tools/c7n_azure/tests_azure/test_resource_graph_source.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tools/c7n_azure/tests_azure/test_resource_id.py
+++ b/tools/c7n_azure/tests_azure/test_resource_id.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/tests_azure/test_session.py
+++ b/tools/c7n_azure/tests_azure/test_session.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from adal import AdalError

--- a/tools/c7n_azure/tests_azure/test_storage_firewall_actions.py
+++ b/tools/c7n_azure/tests_azure/test_storage_firewall_actions.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import re

--- a/tools/c7n_azure/tests_azure/test_storageutils.py
+++ b/tools/c7n_azure/tests_azure/test_storageutils.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import pytest

--- a/tools/c7n_azure/tests_azure/test_tags.py
+++ b/tools/c7n_azure/tests_azure/test_tags.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest

--- a/tools/c7n_azure/tests_azure/test_utils_ip_range_helper.py
+++ b/tools/c7n_azure/tests_azure/test_utils_ip_range_helper.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest, cassette_name

--- a/tools/c7n_azure/tests_azure/test_utils_math.py
+++ b/tools/c7n_azure/tests_azure/test_utils_math.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest

--- a/tools/c7n_azure/tests_azure/test_utils_retention_period.py
+++ b/tools/c7n_azure/tests_azure/test_utils_retention_period.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 from .azure_common import BaseTest
 from c7n_azure.utils import RetentionPeriod
 

--- a/tools/c7n_azure/tests_azure/tests_resources/__init__.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_azure/tests_azure/tests_resources/test_access_control.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_access_control.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_aci.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_aci.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template, cassette_name

--- a/tools/c7n_azure/tests_azure/tests_resources/test_aks.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_aks.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_apimanagement.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_apimanagement.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_azure.resources.apimanagement import Resize

--- a/tools/c7n_azure/tests_azure/tests_resources/test_app_service_plan.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_app_service_plan.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.web import WebSiteManagementClient

--- a/tools/c7n_azure/tests_azure/tests_resources/test_armresource.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_armresource.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template, cassette_name

--- a/tools/c7n_azure/tests_azure/tests_resources/test_batch.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_batch.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_cdn.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_cdn.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_cognitive_service.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_cognitive_service.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_container_host.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_container_host.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import os

--- a/tools/c7n_azure/tests_azure/tests_resources/test_container_registry.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_container_registry.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_container_service.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_container_service.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest

--- a/tools/c7n_azure/tests_azure/tests_resources/test_cosmos_db.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_cosmos_db.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.cosmos.cosmos_client import CosmosClient

--- a/tools/c7n_azure/tests_azure/tests_resources/test_cost_management_export.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_cost_management_export.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tools/c7n_azure/tests_azure/tests_resources/test_data_factory.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_data_factory.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_databricks.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_databricks.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import pytest

--- a/tools/c7n_azure/tests_azure/tests_resources/test_datalake.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_datalake.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_disk.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_disk.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_dnszone.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_dnszone.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/tests_azure/tests_resources/test_event_hub.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_event_hub.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template, cassette_name

--- a/tools/c7n_azure/tests_azure/tests_resources/test_event_subscriptions.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_event_subscriptions.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.eventgrid.models import StorageQueueEventSubscriptionDestination

--- a/tools/c7n_azure/tests_azure/tests_resources/test_hdinsight.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_hdinsight.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template, cassette_name

--- a/tools/c7n_azure/tests_azure/tests_resources/test_iot_hub.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_iot_hub.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_keyvault.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_keyvault.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template, cassette_name

--- a/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_certificate.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_certificate.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import azure.keyvault.http_bearer_challenge_cache as kv_cache

--- a/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import azure.keyvault.http_bearer_challenge_cache as kv_cache

--- a/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_storage.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_storage.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import azure.keyvault.http_bearer_challenge_cache as kv_cache

--- a/tools/c7n_azure/tests_azure/tests_resources/test_load_balancer.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_load_balancer.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_network_interface.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_network_interface.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template, requires_arm_polling

--- a/tools/c7n_azure/tests_azure/tests_resources/test_networksecuritygroup.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_networksecuritygroup.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_policyassignment.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_policyassignment.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest

--- a/tools/c7n_azure/tests_azure/tests_resources/test_postgresql_database.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_postgresql_database.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import pytest

--- a/tools/c7n_azure/tests_azure/tests_resources/test_postgresql_server.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_postgresql_server.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import pytest

--- a/tools/c7n_azure/tests_azure/tests_resources/test_public_ip.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_public_ip.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_record_set.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_record_set.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/tests_azure/tests_resources/test_redis.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_redis.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_resourcegroup.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_resourcegroup.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_route_table.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_route_table.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_azure/tests_azure/tests_resources/test_search.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_search.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.sql.models import DatabaseUpdate, Sku

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqlserver.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqlserver.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import collections

--- a/tools/c7n_azure/tests_azure/tests_resources/test_storage.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_storage.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import pytest

--- a/tools/c7n_azure/tests_azure/tests_resources/test_storage_container.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_storage_container.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template, cassette_name

--- a/tools/c7n_azure/tests_azure/tests_resources/test_subscription.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_subscription.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from mock import patch

--- a/tools/c7n_azure/tests_azure/tests_resources/test_vm.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_vm.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tools/c7n_azure/tests_azure/tests_resources/test_vmss.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_vmss.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tests_resources/test_webapp.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_webapp.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template

--- a/tools/c7n_azure/tests_azure/tools_tags.py
+++ b/tools/c7n_azure/tests_azure/tools_tags.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.compute.models import VirtualMachineUpdate

--- a/tools/c7n_gcp/c7n_gcp/__init__.py
+++ b/tools/c7n_gcp/c7n_gcp/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_gcp/c7n_gcp/actions/__init__.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_gcp/c7n_gcp/actions/core.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/core.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/actions/cscc.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/cscc.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tools/c7n_gcp/c7n_gcp/actions/iampolicy.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/iampolicy.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/actions/labels.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/labels.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Karol Lassak
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/actions/notify.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/notify.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Copyright 2017 The Forseti Security Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/c7n_gcp/c7n_gcp/entry.py
+++ b/tools/c7n_gcp/c7n_gcp/entry.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/filters/__init__.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_gcp/c7n_gcp/filters/labels.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/labels.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Karol Lassak
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/handler.py
+++ b/tools/c7n_gcp/c7n_gcp/handler.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/mu.py
+++ b/tools/c7n_gcp/c7n_gcp/mu.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/output.py
+++ b/tools/c7n_gcp/c7n_gcp/output.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_gcp/c7n_gcp/policy.py
+++ b/tools/c7n_gcp/c7n_gcp/policy.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_gcp/c7n_gcp/provider.py
+++ b/tools/c7n_gcp/c7n_gcp/provider.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/resources/__init__.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_gcp/c7n_gcp/resources/appengine.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/appengine.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/resources/bigquery.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/bigquery.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/tools/c7n_gcp/c7n_gcp/resources/build.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/build.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_gcp.query import QueryResourceManager, TypeInfo

--- a/tools/c7n_gcp/c7n_gcp/resources/cloudbilling.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/cloudbilling.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_gcp.provider import resources

--- a/tools/c7n_gcp/c7n_gcp/resources/compute.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/compute.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/resources/dataflow.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/dataflow.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import re

--- a/tools/c7n_gcp/c7n_gcp/resources/dns.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/dns.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_gcp.provider import resources

--- a/tools/c7n_gcp/c7n_gcp/resources/function.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/function.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/resources/gke.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/gke.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import re

--- a/tools/c7n_gcp/c7n_gcp/resources/iam.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/iam.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/resources/kms.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/kms.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.utils import type_schema, local_session

--- a/tools/c7n_gcp/c7n_gcp/resources/logging.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/logging.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.utils import local_session, type_schema

--- a/tools/c7n_gcp/c7n_gcp/resources/mlengine.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/mlengine.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath

--- a/tools/c7n_gcp/c7n_gcp/resources/network.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/network.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import re

--- a/tools/c7n_gcp/c7n_gcp/resources/pubsub.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/pubsub.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.utils import type_schema

--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 ResourceMap = {
     "gcp.app-engine": "c7n_gcp.resources.appengine.AppEngineApp",
     "gcp.app-engine-certificate": "c7n_gcp.resources.appengine.AppEngineCertificate",

--- a/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_gcp.actions import SetIamPolicy, MethodAction

--- a/tools/c7n_gcp/c7n_gcp/resources/service.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/service.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/resources/source.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/source.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n_gcp.provider import resources

--- a/tools/c7n_gcp/c7n_gcp/resources/spanner.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/spanner.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.utils import type_schema

--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/c7n_gcp/resources/storage.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/storage.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.utils import type_schema

--- a/tools/c7n_gcp/setup.py
+++ b/tools/c7n_gcp/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_gcp/tests/test_api_disabled.py
+++ b/tools/c7n_gcp/tests/test_api_disabled.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_appengine.py
+++ b/tools/c7n_gcp/tests/test_appengine.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_bigquery.py
+++ b/tools/c7n_gcp/tests/test_bigquery.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_cloudbilling.py
+++ b/tools/c7n_gcp/tests/test_cloudbilling.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_cloudfunction.py
+++ b/tools/c7n_gcp/tests/test_cloudfunction.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_compute.py
+++ b/tools/c7n_gcp/tests/test_compute.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_cscc.py
+++ b/tools/c7n_gcp/tests/test_cscc.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_dataflow.py
+++ b/tools/c7n_gcp/tests/test_dataflow.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_deploymentmanager.py
+++ b/tools/c7n_gcp/tests/test_deploymentmanager.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tools/c7n_gcp/tests/test_dns.py
+++ b/tools/c7n_gcp/tests/test_dns.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_gcp_iam.py
+++ b/tools/c7n_gcp/tests/test_gcp_iam.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_gcp_labels.py
+++ b/tools/c7n_gcp/tests/test_gcp_labels.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Karol Lassak
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from gcp_common import BaseTest

--- a/tools/c7n_gcp/tests/test_gcp_storage.py
+++ b/tools/c7n_gcp/tests/test_gcp_storage.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_gke.py
+++ b/tools/c7n_gcp/tests/test_gke.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tools/c7n_gcp/tests/test_inventory.py
+++ b/tools/c7n_gcp/tests/test_inventory.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Kapil Thangavelu
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_kms.py
+++ b/tools/c7n_gcp/tests/test_kms.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_loadbalancer.py
+++ b/tools/c7n_gcp/tests/test_loadbalancer.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from time import sleep

--- a/tools/c7n_gcp/tests/test_logging.py
+++ b/tools/c7n_gcp/tests/test_logging.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_mlengine.py
+++ b/tools/c7n_gcp/tests/test_mlengine.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_network.py
+++ b/tools/c7n_gcp/tests/test_network.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tools/c7n_gcp/tests/test_notify_gcp.py
+++ b/tools/c7n_gcp/tests/test_notify_gcp.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_output_gcp.py
+++ b/tools/c7n_gcp/tests/test_output_gcp.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_query.py
+++ b/tools/c7n_gcp/tests/test_query.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_report.py
+++ b/tools/c7n_gcp/tests/test_report.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Kapil Thangavelu
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_resource.py
+++ b/tools/c7n_gcp/tests/test_resource.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_gcp/tests/test_service.py
+++ b/tools/c7n_gcp/tests/test_service.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_spanner.py
+++ b/tools/c7n_gcp/tests/test_spanner.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_gcp/tests/test_sql.py
+++ b/tools/c7n_gcp/tests/test_sql.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_guardian/c7n_guardian/__init__.py
+++ b/tools/c7n_guardian/c7n_guardian/__init__.py
@@ -1,1 +1,3 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_guardian/c7n_guardian/cli.py
+++ b/tools/c7n_guardian/c7n_guardian/cli.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_guardian/setup.py
+++ b/tools/c7n_guardian/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/__init__.py
+++ b/tools/c7n_kube/c7n_kube/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_kube/c7n_kube/actions/__init__.py
+++ b/tools/c7n_kube/c7n_kube/actions/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_kube/c7n_kube/actions/core.py
+++ b/tools/c7n_kube/c7n_kube/actions/core.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/actions/labels.py
+++ b/tools/c7n_kube/c7n_kube/actions/labels.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/actions/shared.py
+++ b/tools/c7n_kube/c7n_kube/actions/shared.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/client.py
+++ b/tools/c7n_kube/c7n_kube/client.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Copyright 2017 The Forseti Security Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/c7n_kube/c7n_kube/entry.py
+++ b/tools/c7n_kube/c7n_kube/entry.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/filters.py
+++ b/tools/c7n_kube/c7n_kube/filters.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/provider.py
+++ b/tools/c7n_kube/c7n_kube/provider.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/query.py
+++ b/tools/c7n_kube/c7n_kube/query.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/resources/__init__.py
+++ b/tools/c7n_kube/c7n_kube/resources/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/apps/__init__.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_kube/c7n_kube/resources/apps/daemonset.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/daemonset.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/apps/deployment.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/deployment.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/apps/replicaset.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/replicaset.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/apps/statefulset.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/statefulset.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/__init__.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_kube/c7n_kube/resources/core/configmap.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/configmap.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/namespace.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/namespace.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/node.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/node.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/pod.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/pod.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/replicationcontroller.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/replicationcontroller.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/secret.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/secret.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/service.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/service.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/serviceaccount.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/serviceaccount.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/core/volume.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/volume.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/c7n_kube/resources/crd.py
+++ b/tools/c7n_kube/c7n_kube/resources/crd.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/c7n_kube/resources/resource_map.py
+++ b/tools/c7n_kube/c7n_kube/resources/resource_map.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 ResourceMap = {
     "k8s.config-map": "c7n_kube.resources.core.configmap.ConfigMap",
     "k8s.custom-cluster-resource": "c7n_kube.resources.crd.CustomResourceDefinition",

--- a/tools/c7n_kube/setup.py
+++ b/tools/c7n_kube/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_kube/tests/common_kube.py
+++ b/tools/c7n_kube/tests/common_kube.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import atexit

--- a/tools/c7n_kube/tests/test_actions.py
+++ b/tools/c7n_kube/tests/test_actions.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/tests/test_custom_resource.py
+++ b/tools/c7n_kube/tests/test_custom_resource.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_kube/tests/test_labels.py
+++ b/tools/c7n_kube/tests/test_labels.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_kube/tests/test_namespace.py
+++ b/tools/c7n_kube/tests/test_namespace.py
@@ -1,4 +1,3 @@
-# Copyright 2018-2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tools/c7n_logexporter/c7n_logexporter/__init__.py
+++ b/tools/c7n_logexporter/c7n_logexporter/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_logexporter/c7n_logexporter/exporter.py
+++ b/tools/c7n_logexporter/c7n_logexporter/exporter.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_logexporter/c7n_logexporter/flowdeliver.py
+++ b/tools/c7n_logexporter/c7n_logexporter/flowdeliver.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """CWL Group -> Kinesis -> Firehose -> S3 -> Lambda -> S3

--- a/tools/c7n_logexporter/c7n_logexporter/stream.py
+++ b/tools/c7n_logexporter/c7n_logexporter/stream.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """VPC Flow log s3 archiver via kinesis cloudwatch subscription.

--- a/tools/c7n_logexporter/setup.py
+++ b/tools/c7n_logexporter/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_mailer/c7n_mailer/__init__.py
+++ b/tools/c7n_mailer/c7n_mailer/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/__init__.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/__init__.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import logging
 
 logging.getLogger('azure.storage.common.storageclient').setLevel(logging.WARNING)

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/azure_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/azure_queue_processor.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/deploy.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import copy

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/function.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/function.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/handle.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/handle.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/sendgrid_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/sendgrid_delivery.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/utils.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import functools
 import logging

--- a/tools/c7n_mailer/c7n_mailer/datadog_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/datadog_delivery.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/c7n_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/deploy.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import copy

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from itertools import chain

--- a/tools/c7n_mailer/c7n_mailer/handle.py
+++ b/tools/c7n_mailer/c7n_mailer/handle.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_mailer/c7n_mailer/ldap_lookup.py
+++ b/tools/c7n_mailer/c7n_mailer/ldap_lookup.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tools/c7n_mailer/c7n_mailer/replay.py
+++ b/tools/c7n_mailer/c7n_mailer/replay.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 """
 Allow local testing of mailer and templates by replaying an SQS message.
 

--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import time

--- a/tools/c7n_mailer/c7n_mailer/smtp_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/smtp_delivery.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/c7n_mailer/sns_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/sns_delivery.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import base64

--- a/tools/c7n_mailer/c7n_mailer/utils_email.py
+++ b/tools/c7n_mailer/c7n_mailer/utils_email.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import logging
 from email.mime.text import MIMEText
 from email.utils import parseaddr

--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_mailer/tests/common.py
+++ b/tools/c7n_mailer/tests/common.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/c7n_mailer/tests/test_azure.py
+++ b/tools/c7n_mailer/tests/test_azure.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/tests/test_azure_mailer_utils.py
+++ b/tools/c7n_mailer/tests/test_azure_mailer_utils.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/tests/test_datadog.py
+++ b/tools/c7n_mailer/tests/test_datadog.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 
 from mock import patch

--- a/tools/c7n_mailer/tests/test_email.py
+++ b/tools/c7n_mailer/tests/test_email.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/tests/test_ldap.py
+++ b/tools/c7n_mailer/tests/test_ldap.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/tests/test_misc.py
+++ b/tools/c7n_mailer/tests/test_misc.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # -*- coding: utf-8 -*-
 import argparse
 import unittest

--- a/tools/c7n_mailer/tests/test_schema.py
+++ b/tools/c7n_mailer/tests/test_schema.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/tests/test_slack.py
+++ b/tools/c7n_mailer/tests/test_slack.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import unittest
 import copy
 import json

--- a/tools/c7n_mailer/tests/test_smtp_delivery.py
+++ b/tools/c7n_mailer/tests/test_smtp_delivery.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/tests/test_sns.py
+++ b/tools/c7n_mailer/tests/test_sns.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # -*- coding: utf-8 -*-
 
 import os

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Run a custodian policy across an organization's accounts

--- a/tools/c7n_org/c7n_org/utils.py
+++ b/tools/c7n_org/c7n_org/utils.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import os

--- a/tools/c7n_org/scripts/azuresubs.py
+++ b/tools/c7n_org/scripts/azuresubs.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_org/scripts/gcpprojects.py
+++ b/tools/c7n_org/scripts/gcpprojects.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_org/scripts/orgaccounts.py
+++ b/tools/c7n_org/scripts/orgaccounts.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_org/setup.py
+++ b/tools/c7n_org/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_policystream/policystream.py
+++ b/tools/c7n_policystream/policystream.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 #
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_policystream/setup.py
+++ b/tools/c7n_policystream/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_policystream/tests/test_policystream.py
+++ b/tools/c7n_policystream/tests/test_policystream.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 
 import json
 import subprocess

--- a/tools/c7n_salactus/c7n_salactus/__init__.py
+++ b/tools/c7n_salactus/c7n_salactus/__init__.py
@@ -1,1 +1,3 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_salactus/c7n_salactus/cli.py
+++ b/tools/c7n_salactus/c7n_salactus/cli.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Salactus, eater of s3 buckets.

--- a/tools/c7n_salactus/c7n_salactus/db.py
+++ b/tools/c7n_salactus/c7n_salactus/db.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tools/c7n_salactus/c7n_salactus/inventory.py
+++ b/tools/c7n_salactus/c7n_salactus/inventory.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_salactus/c7n_salactus/objectacl.py
+++ b/tools/c7n_salactus/c7n_salactus/objectacl.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_salactus/c7n_salactus/rqworker.py
+++ b/tools/c7n_salactus/c7n_salactus/rqworker.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """

--- a/tools/c7n_salactus/c7n_salactus/worker.py
+++ b/tools/c7n_salactus/c7n_salactus/worker.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Salactus, eater of s3 buckets.

--- a/tools/c7n_salactus/setup.py
+++ b/tools/c7n_salactus/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_sentry/c7n_sentry/__init__.py
+++ b/tools/c7n_sentry/c7n_sentry/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_sentry/c7n_sentry/c7nsentry.py
+++ b/tools/c7n_sentry/c7n_sentry/c7nsentry.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """A cloudwatch log subscriber that records error messages into getsentry.com

--- a/tools/c7n_sentry/c7n_sentry/common.py
+++ b/tools/c7n_sentry/c7n_sentry/common.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import argparse

--- a/tools/c7n_sentry/setup.py
+++ b/tools/c7n_sentry/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from setuptools import setup

--- a/tools/c7n_sentry/test_sentry.py
+++ b/tools/c7n_sentry/test_sentry.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import unittest

--- a/tools/c7n_sphinxext/c7n_sphinxext/__init__.py
+++ b/tools/c7n_sphinxext/c7n_sphinxext/__init__.py
@@ -1,1 +1,3 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/c7n_sphinxext/c7n_sphinxext/docgen.py
+++ b/tools/c7n_sphinxext/c7n_sphinxext/docgen.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from functools import partial

--- a/tools/c7n_sphinxext/setup.py
+++ b/tools/c7n_sphinxext/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_sphinxext/tests.py
+++ b/tools/c7n_sphinxext/tests.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 
 import unittest
 

--- a/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
+++ b/tools/c7n_trailcreator/c7n_trailcreator/trailcreator.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """AWS AutoTag Resource Creators

--- a/tools/c7n_trailcreator/setup.py
+++ b/tools/c7n_trailcreator/setup.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 # Automatically generated from poetry/pyproject.toml
 # flake8: noqa
 # -*- coding: utf-8 -*-

--- a/tools/c7n_traildb/c7n_traildb/__init__.py
+++ b/tools/c7n_traildb/c7n_traildb/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/c7n_traildb/c7n_traildb/traildb.py
+++ b/tools/c7n_traildb/c7n_traildb/traildb.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_traildb/c7n_traildb/trailes.py
+++ b/tools/c7n_traildb/c7n_traildb/trailes.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_traildb/c7n_traildb/trailts.py
+++ b/tools/c7n_traildb/c7n_traildb/trailts.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/c7n_traildb/setup.py
+++ b/tools/c7n_traildb/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/dev/cfntypedb.py
+++ b/tools/dev/cfntypedb.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import boto3
 import json
 import jmespath

--- a/tools/dev/changelog.py
+++ b/tools/dev/changelog.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import pygit2

--- a/tools/dev/citoxenv.py
+++ b/tools/dev/citoxenv.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python
 import os
 pyver = os.environ.get('TRAVIS_PYTHON_VERSION', '')

--- a/tools/dev/citoxenv.py
+++ b/tools/dev/citoxenv.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-#!/usr/bin/env python
+
 import os
 pyver = os.environ.get('TRAVIS_PYTHON_VERSION', '')
 if pyver == '2.7':

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Kapil Thangavelu
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/dev/gcpiamdb.py
+++ b/tools/dev/gcpiamdb.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import click
 import json
 import requests

--- a/tools/dev/gcpstripagg.py
+++ b/tools/dev/gcpstripagg.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import json
 import fnmatch
 import click

--- a/tools/dev/iamdb.py
+++ b/tools/dev/iamdb.py
@@ -1,4 +1,3 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/dev/license-headers.py
+++ b/tools/dev/license-headers.py
@@ -1,8 +1,7 @@
-# Copyright 2016-2018 Capital One Services, LLC
+# Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Add License headers to all py files."""
 
-from difflib import SequenceMatcher
 import fnmatch
 import os
 import inspect
@@ -22,21 +21,36 @@ target_copyright_header = """\
 # Copyright The Cloud Custodian Authors.
 """
 
+# Direct permission was obtained from the following contributors via their
+# open source office or directly for individuals.
+old_headers = [
+    "Amazon",
+    "Capital One",
+    "Microsoft Corporation",
+    "Kapil Thangavelu",
+    "Karol Lassak"
+]
+
 
 def update_license_header(p):
     # switch from apache pre-amble to spdx identifier
     with open(p) as fh:
         contents = list(fh.readlines())
 
-    matcher = SequenceMatcher(None, apache_license_header, contents)
-    match = matcher.find_longest_match(
-        0, len(apache_license_header), 0, len(contents))
-
-    if match.size != len(apache_license_header):
+    if target_license_header in contents:
         return
 
-    contents[match.b: match.b + match.size] = [target_license_header]
-    print("Adding license header to %s" % (p,))
+    # From converting old apache pre-amble to spdx
+    # matcher = SequenceMatcher(None, apache_license_header, contents)
+    # match = matcher.find_longest_match(
+    #    0, len(apache_license_header), 0, len(contents))
+    # if match.size != len(apache_license_header):
+    #    return
+    # contents[match.b: match.b + match.size] = [target_license_header]
+    print(" Adding license header to %s" % (p,))
+
+    contents.insert(0, target_license_header)
+
     with open(p, 'w') as fh:
         fh.write("".join(contents))
         fh.flush()
@@ -46,17 +60,34 @@ def update_copyright_header(p):
     with open(p) as fh:
         contents = list(fh.readlines())
 
-    if target_copyright_header in contents:
+    offset = 0
+    for idx, l in enumerate(list(contents)):
+        if not l.startswith('#'):
+            break
+        for oh in old_headers:
+            if oh not in l:
+                continue
+            contents.pop(idx - offset)
+            offset += 1
+
+    if offset:
+        print(' removed old copyright header')
+
+    if target_copyright_header not in contents:
+        try:
+            idx = contents.index(target_license_header)
+        except ValueError:
+            print(' no license header %s' % p)
+            return
+
+        contents[idx:idx] = [target_copyright_header]
+
+        offset += 1
+
+    if not offset:
         return
 
-    try:
-        idx = contents.index(target_license_header)
-    except ValueError:
-        print('no license header %s' % p)
-        return
-
-    contents[idx:idx] = [target_copyright_header]
-    print("Adding copyright header to %s" % (p, ))
+    print(" Adding copyright header to %s" % (p, ))
     with open(p, 'w') as fh:
         fh.write("".join(contents))
         fh.flush()
@@ -64,11 +95,10 @@ def update_copyright_header(p):
 
 def update_headers(src_tree):
     """Main."""
-    print("src tree", src_tree)
+    print("checking src tree", src_tree)
     for root, dirs, files in os.walk(src_tree):
         py_files = fnmatch.filter(files, "*.py")
         for f in py_files:
-            print("checking", f)
             p = os.path.join(root, f)
             update_license_header(p)
             update_copyright_header(p)

--- a/tools/dev/pinnedpip.py
+++ b/tools/dev/pinnedpip.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import click

--- a/tools/dev/poetrypkg.py
+++ b/tools/dev/poetrypkg.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 """
 Supplemental tooling for managing custodian packaging.
 

--- a/tools/dev/tests/test_changelog.py
+++ b/tools/dev/tests/test_changelog.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 import json
 from pathlib import Path
 

--- a/tools/ops/azure/container-host/chart/deploy_chart.py
+++ b/tools/ops/azure/container-host/chart/deploy_chart.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/ops/azure/functionslc.py
+++ b/tools/ops/azure/functionslc.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Microsoft Corporation
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/ops/logsetup.py
+++ b/tools/ops/logsetup.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Cloud Watch Log Subscription Email Relay

--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import argparse

--- a/tools/ops/org-pr-monitor.py
+++ b/tools/ops/org-pr-monitor.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 """Generate metrics for a Github org's pull request status hooks.
 
 Monitoring CI tools, by tracking latency of status on a pull request,

--- a/tools/ops/policyrename.py
+++ b/tools/ops/policyrename.py
@@ -1,4 +1,3 @@
-# Copyright 2016-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Policy output rename utility

--- a/tools/sandbox/c7n_autodoc/c7n-autodoc.py
+++ b/tools/sandbox/c7n_autodoc/c7n-autodoc.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import yaml

--- a/tools/sandbox/c7n_autodoc/setup.py
+++ b/tools/sandbox/c7n_autodoc/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/sandbox/c7n_index/c7n_index/__init__.py
+++ b/tools/sandbox/c7n_index/c7n_index/__init__.py
@@ -1,1 +1,3 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 #

--- a/tools/sandbox/c7n_index/c7n_index/metrics.py
+++ b/tools/sandbox/c7n_index/c7n_index/metrics.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import datetime

--- a/tools/sandbox/c7n_index/setup.py
+++ b/tools/sandbox/c7n_index/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/__init__.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/admin.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/admin.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 # -*- coding: utf-8 -*-

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/app.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/app.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from bottle import Bottle, request, response, abort

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/audit.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/audit.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/cli.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/cli.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/client.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/client.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from getpass import getuser

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/controller.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/controller.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import calendar

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/db.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/db.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/errors.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/errors.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/handler.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/handler.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import os

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/utils.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/utils.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime

--- a/tools/sandbox/c7n_sphere11/c7n_sphere11/wsgigw.py
+++ b/tools/sandbox/c7n_sphere11/c7n_sphere11/wsgigw.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import urllib

--- a/tools/sandbox/c7n_sphere11/setup.py
+++ b/tools/sandbox/c7n_sphere11/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2016 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/sandbox/zerodark/setup.py
+++ b/tools/sandbox/zerodark/setup.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import os

--- a/tools/sandbox/zerodark/zerodark/__init__.py
+++ b/tools/sandbox/zerodark/zerodark/__init__.py
@@ -1,3 +1,2 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/sandbox/zerodark/zerodark/floweni.py
+++ b/tools/sandbox/zerodark/zerodark/floweni.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/sandbox/zerodark/zerodark/flowrecord.py
+++ b/tools/sandbox/zerodark/zerodark/flowrecord.py
@@ -1,3 +1,5 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright 2015 Observable Networks
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/sandbox/zerodark/zerodark/ipdb.py
+++ b/tools/sandbox/zerodark/zerodark/ipdb.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/sandbox/zerodark/zerodark/metrics.py
+++ b/tools/sandbox/zerodark/zerodark/metrics.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import click

--- a/tools/sandbox/zerodark/zerodark/resolver.py
+++ b/tools/sandbox/zerodark/zerodark/resolver.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tools/sandbox/zerodark/zerodark/utils.py
+++ b/tools/sandbox/zerodark/zerodark/utils.py
@@ -1,4 +1,3 @@
-# Copyright 2017-2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 """Utility functions

--- a/tools/utils/s3stat.py
+++ b/tools/utils/s3stat.py
@@ -1,4 +1,3 @@
-# Copyright 2015-2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime, timedelta

--- a/tools/utils/update_headers.py
+++ b/tools/utils/update_headers.py
@@ -1,4 +1,3 @@
-# Copyright 2017 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
﻿
Unifying copyright headers per cncf guidelines (https://github.com/cncf/foundation/blob/master/copyright-notices.md). Direct permission was obtained from corporate opensource offices for microsoft, amazon, and capital one. Direct permission was obtained from individual copyright holders, kapil thangavelu and karol lassak.

for clarification all code files in the repo should have the following header
```
# Copyright The Cloud Custodian Authors.                                                                                                                                                                                                                                                                                                                                                      
# SPDX-License-Identifier: Apache-2.0  
```


