### PR TITLE
gcp - project - propagate-labels from resource hierarchy

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -165,6 +165,8 @@ class ValuesFrom:
             data = json.loads(contents)
             if 'expr' in self.data:
                 return self._get_resource_values(data)
+            else:
+                return data
         elif format == 'csv' or format == 'csv2dict':
             data = csv.reader(io.StringIO(contents))
             if format == 'csv2dict':

--- a/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
@@ -218,7 +218,7 @@ class ProjectPropagateLabels(HierarchyAction):
          filters:
            - "tag:owner": absent
          actions:
-           - type: propagate-tags
+           - type: propagate-labels
              folder-labels:
                 url: file://folder-labels.json
 
@@ -227,7 +227,7 @@ class ProjectPropagateLabels(HierarchyAction):
 
     """
     schema = type_schema(
-        'propagate-tags',
+        'propagate-labels',
         required=('folder-labels',),
         **{
             'folder-labels': {

--- a/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
@@ -237,6 +237,7 @@ class ProjectPropagateLabels(HierarchyAction):
     attr_filter = ('lifecycleState', ('ACTIVE',))
     permissions = ('resourcemanager.folders.get',
                    'resourcemanager.projects.update')
+    method_spec = {'op': 'update'}
 
     def load_metadata(self):
         """Load hierarchy tags"""

--- a/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
@@ -1,10 +1,14 @@
 # Copyright 2018 Capital One Services, LLC
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+
+import itertools
+
 from c7n_gcp.actions import SetIamPolicy, MethodAction
 from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo
 
+from c7n.resolver import ValuesFrom
 from c7n.utils import type_schema, local_session
 
 
@@ -138,19 +142,17 @@ class HierarchyAction(MethodAction):
 
     def load_hierarchy(self, resources):
         parents = {}
-        folder_ids = set()
         session = local_session(self.manager.session_factory)
+
         for r in resources:
             client = self.get_client(session, self.manager.resource_type)
             ancestors = client.execute_command(
                 'getAncestry', {'projectId': r['projectId']}).get('ancestor')
-            parents[r['projectId']] = ancestors
-            for a in ancestors[1:-1]:
-                if a['resourceId']['type'] != 'folder':
-                    continue
-                folder_ids.add(a['resourceId']['id'])
+            parents[r['projectId']] = [
+                a['resourceId']['id'] for a in ancestors
+                if a['resourceId']['type'] == 'folder']
         self.parents = parents
-        self.folder_ids = folder_ids
+        self.folder_ids = set(itertools.chain(*self.parents.values()))
 
     def load_folders(self):
         folder_manager = self.manager.get_resource_manager('gcp.folder')
@@ -165,9 +167,86 @@ class HierarchyAction(MethodAction):
         raise NotImplementedError()
 
     def process(self, resources):
+        if self.attr_filter:
+            resources = self.filter_resources(resources)
+
         self.load_hierarchy(resources)
         self.load_metadata()
         op_set = self.diff(resources)
         client = self.manager.get_client()
         for op in op_set:
-            self.invoke_op(client, *op)
+            self.invoke_api(client, *op)
+
+
+@Project.action_registry.register('propagate-labels')
+class ProjectPropagateLabels(HierarchyAction):
+    """Propagate labels from the organization hierarchy to a project.
+
+    folder-labels should resolve to a data mapping of folder id to labels that should
+    be applied to descendants.
+    """
+    schema = type_schema(
+        'propagate-tags',
+        required=('folder-labels',),
+        **{
+            'path-label': {'type': 'string'},
+            # 'path': 'eng-dev-network'
+            'display-path': {'type': 'boolean'},
+            'folder-labels': {
+                '$ref': '#/definitions/filters_common/value_from'}},
+    )
+
+    method_spec = {'op': 'update'}
+    attr_filter = ('lifecycleState', ('ACTIVE',))
+
+    def load_metadata(self):
+        """Load hierarchy tags"""
+        self.resolver = ValuesFrom(self.data['folder-labels'], self.manager)
+        self.labels = self.resolver.get_values()
+        self.load_folders()
+        self.resolve_paths()
+
+    def resolve_paths(self):
+        self.folder_paths = {}
+
+        def get_path_segments(fid):
+            p = self.folders[fid]['parent']
+            if p.startswith('folder'):
+                for s in get_path_segments(p.split('/')[-1]):
+                    yield s
+            yield self.folders[fid]['displayName']
+
+        for fid in self.folder_ids:
+            self.folder_paths[fid] = '/'.join(get_path_segments(fid))
+
+    def resolve_labels(self, project_id):
+        hlabels = {}
+        parents = self.parents[project_id]
+        for p in reversed(parents):
+            pkeys = [p, self.folder_paths[p], 'folders/%s' % p]
+            for pk in pkeys:
+                hlabels.update(self.labels.get(pk, {}))
+
+        return hlabels
+
+    def diff(self, resources):
+        model = self.manager.resource_type
+
+        for r in resources:
+            hlabels = self.resolve_labels(r['projectId'])
+            if not hlabels:
+                continue
+
+            delta = False
+            rlabels = r.get('labels', {})
+            for k, v in hlabels.items():
+                if k not in rlabels or rlabels[k] != v:
+                    delta = True
+            if not delta:
+                continue
+
+            rlabels = dict(rlabels)
+            rlabels.update(hlabels)
+
+            if delta:
+                yield ('update', model.get_label_params(r, rlabels))

--- a/tools/c7n_gcp/tests/data/flights/project-propagate-tags/get-v1-projects-c7n-test-target_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-propagate-tags/get-v1-projects-c7n-test-target_1.json
@@ -1,0 +1,36 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 12 Nov 2020 15:56:00 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=51",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "349",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v1/projects/c7n-test-target?alt=json"
+  },
+  "body": {
+    "projectNumber": "413985786043",
+    "projectId": "c7n-test-target",
+    "lifecycleState": "ACTIVE",
+    "name": "C7N Test Target",
+    "labels": {
+      "env_type": "dev",
+      "app": "c7n",
+      "owner": "testing",
+      "cost-center": "qa"
+    },
+    "createTime": "2020-08-31T20:06:53.419Z",
+    "parent": {
+      "type": "folder",
+      "id": "389734459213"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-propagate-tags/get-v1-projects_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-propagate-tags/get-v1-projects_1.json
@@ -1,0 +1,60 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 12 Nov 2020 15:55:58 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=76",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "966",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v1/projects?filter=parent.id%3A389734459213+parent.type%3Afolder&alt=json"
+  },
+  "body": {
+    "projects": [
+      {
+        "projectNumber": "413985786043",
+        "projectId": "c7n-test-target",
+        "lifecycleState": "ACTIVE",
+        "name": "C7N Test Target",
+        "labels": {
+          "env_type": "dev",
+          "app": "c7n"
+        },
+        "createTime": "2020-08-31T20:06:53.419Z",
+        "parent": {
+          "type": "folder",
+          "id": "389734459213"
+        }
+      },
+      {
+        "projectNumber": "711388880679",
+        "projectId": "practical-truck-276716",
+        "lifecycleState": "ACTIVE",
+        "name": "My First Project",
+        "createTime": "2020-05-09T16:40:39.106Z",
+        "parent": {
+          "type": "folder",
+          "id": "389734459213"
+        }
+      },
+      {
+        "projectNumber": "741889997825",
+        "projectId": "hautomation",
+        "lifecycleState": "DELETE_REQUESTED",
+        "name": "hautomation",
+        "createTime": "2020-10-23T02:19:32.329Z",
+        "parent": {
+          "type": "folder",
+          "id": "389734459213"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-propagate-tags/get-v2-folders-264112811077_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-propagate-tags/get-v2-folders-264112811077_1.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 12 Nov 2020 15:55:59 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=200",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "178",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v2/folders/264112811077?alt=json"
+  },
+  "body": {
+    "name": "folders/264112811077",
+    "parent": "organizations/11144",
+    "displayName": "apps",
+    "lifecycleState": "ACTIVE",
+    "createTime": "2020-11-05T15:31:46.060Z"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-propagate-tags/get-v2-folders-389734459213_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-propagate-tags/get-v2-folders-389734459213_1.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 12 Nov 2020 15:55:59 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=43",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "174",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v2/folders/389734459213?alt=json"
+  },
+  "body": {
+    "name": "folders/389734459213",
+    "parent": "folders/264112811077",
+    "displayName": "ftests",
+    "lifecycleState": "ACTIVE",
+    "createTime": "2020-11-05T15:32:49.681Z"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-propagate-tags/post-v1-projects-c7n-test-target-getAncestry_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-propagate-tags/post-v1-projects-c7n-test-target-getAncestry_1.json
@@ -1,0 +1,46 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 12 Nov 2020 15:55:58 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=60",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "ancestor": [
+      {
+        "resourceId": {
+          "type": "project",
+          "id": "c7n-test-target"
+        }
+      },
+      {
+        "resourceId": {
+          "type": "folder",
+          "id": "389734459213"
+        }
+      },
+      {
+        "resourceId": {
+          "type": "folder",
+          "id": "264112811077"
+        }
+      },
+      {
+        "resourceId": {
+          "type": "organization",
+          "id": "11144"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-propagate-tags/post-v1-projects-practical-truck-276716-getAncestry_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-propagate-tags/post-v1-projects-practical-truck-276716-getAncestry_1.json
@@ -1,0 +1,46 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 12 Nov 2020 15:55:58 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=65",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "432",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "ancestor": [
+      {
+        "resourceId": {
+          "type": "project",
+          "id": "practical-truck-276716"
+        }
+      },
+      {
+        "resourceId": {
+          "type": "folder",
+          "id": "389734459213"
+        }
+      },
+      {
+        "resourceId": {
+          "type": "folder",
+          "id": "264112811077"
+        }
+      },
+      {
+        "resourceId": {
+          "type": "organization",
+          "id": "11144"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-propagate-tags/put-v1-projects-c7n-test-target_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-propagate-tags/put-v1-projects-c7n-test-target_1.json
@@ -1,0 +1,35 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 12 Nov 2020 15:55:59 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=606",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "349",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "projectNumber": "413985786043",
+    "projectId": "c7n-test-target",
+    "lifecycleState": "ACTIVE",
+    "name": "C7N Test Target",
+    "labels": {
+      "env_type": "dev",
+      "app": "c7n",
+      "owner": "testing",
+      "cost-center": "qa"
+    },
+    "createTime": "2020-08-31T20:06:53.419Z",
+    "parent": {
+      "type": "folder",
+      "id": "389734459213"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-propagate-tags/put-v1-projects-practical-truck-276716_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-propagate-tags/put-v1-projects-practical-truck-276716_1.json
@@ -1,0 +1,33 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 12 Nov 2020 15:56:00 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=280",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "316",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "projectNumber": "711388880679",
+    "projectId": "practical-truck-276716",
+    "lifecycleState": "ACTIVE",
+    "name": "My First Project",
+    "labels": {
+      "owner": "testing",
+      "cost-center": "qa"
+    },
+    "createTime": "2020-05-09T16:40:39.106Z",
+    "parent": {
+      "type": "folder",
+      "id": "389734459213"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/folder-labels.json
+++ b/tools/c7n_gcp/tests/data/folder-labels.json
@@ -1,0 +1,5 @@
+{
+    "folders/264112811077": {"owner": "sre", "cost-center": "rd"},
+    "apps/ftests": {"owner": "testing", "cost-center": "qa"}
+}
+    

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -4,6 +4,7 @@
 import logging
 
 import time
+import os
 
 from c7n_gcp.resources.resourcemanager import HierarchyAction
 from gcp_common import BaseTest
@@ -122,6 +123,38 @@ class FolderTest(BaseTest):
 
 
 class ProjectTest(BaseTest):
+
+    def test_propagate_tags(self):
+        factory = self.replay_flight_data('project-propagate-tags')
+
+        label_path = os.path.join(
+            os.path.dirname(__file__), 'data', 'folder-labels.json')
+
+        p = self.load_policy({
+            'name': 'p-label',
+            'resource': 'gcp.project',
+            'query': [
+                {'filter': 'parent.id:389734459213 parent.type:folder'}],
+            'filters': [
+                {'tag:cost-center': 'absent'}],
+            'actions': [
+                {'type': 'propagate-labels',
+                 'folder-labels': {
+                     'url': 'file://%s' % label_path}}
+            ],
+        }, session_factory=factory)
+        resources = p.run()
+        assert len(resources) == 3
+        # verify we successfully filtered out non active projects
+        assert {r['lifecycleState'] for r in resources} == {'ACTIVE', 'DELETE_REQUESTED'}
+        # verify tags
+        client = p.resource_manager.get_client()
+        project = client.execute_query(
+            'get', {'projectId': 'c7n-test-target'})
+        assert project['labels'] == {'app': 'c7n',
+                                     'cost-center': 'qa',
+                                     'env_type': 'dev',
+                                     'owner': 'testing'}
 
     def test_project_hierarchy(self):
         factory = self.replay_flight_data('project-hierarchy')

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -2,9 +2,11 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging
-
-import time
 import os
+import sys
+import time
+
+import pytest
 
 from c7n_gcp.resources.resourcemanager import HierarchyAction
 from gcp_common import BaseTest
@@ -124,6 +126,8 @@ class FolderTest(BaseTest):
 
 class ProjectTest(BaseTest):
 
+    @pytest.mark.skipif(
+        sys.platform.startswith('win'), reason='windows file path fun')
     def test_propagate_tags(self):
         factory = self.replay_flight_data('project-propagate-tags')
 


### PR DESCRIPTION
Propagate labels from the organization hierarchy to a project.
    folder-labels should resolve to a json data mapping of folder path
    to labels that should be applied to contained projects.
    as a worked example assume the following resource hierarchy
    
```
      - /dev
           /network
              /project-a
           /ml
              /project-b
```

Given a folder-labels json with contents like

```json
      {"dev": {"env": "dev", "owner": "dev"},
       "dev/network": {"owner": "network"},
       "dev/ml": {"owner": "ml"}
```
    
Running the following policy
```yaml
      policies:
       - name: tag-projects
         resource: gcp.project
         # use a server side filter to only look at projects
         # under the /dev folder the id for the dev folder needs
         # to be manually resolved outside of the policy.
         query:
           - filter: "parent.id:389734459211 parent.type:folder"
         filters:
           - "tag:owner": absent
         actions:
           - type: propagate-tags
             folder-labels:
                url: file://folder-labels.json
```

Will result in project-a being tagged with `owner: network` and `env: dev` and project-b being tagged with `owner: ml` and `env: dev`

note gcp is restrictive on labels and we don't perform any pre-validation of labels.
