### PR TITLE
update secretsmanager.py

### DIFF
--- a/c7n/resources/secretsmanager.py
+++ b/c7n/resources/secretsmanager.py
@@ -15,10 +15,10 @@ class SecretsManager(QueryResourceManager):
     class resource_type(TypeInfo):
         service = 'secretsmanager'
         enum_spec = ('list_secrets', 'SecretList', None)
-        detail_spec = ('describe_secret', 'SecretId', 'ARN', None)
+        detail_spec = ('describe_secret', 'SecretId', 'Name', None)
         cfn_type = 'AWS::SecretsManager::Secret'
-        arn = id = 'ARN'
-        name = 'Name'
+        name = id = 'Name'
+        arn = 'ARN'
 
 
 SecretsManager.filter_registry.register('marked-for-op', TagActionFilter)


### PR DESCRIPTION
fixing issue-6295. 


Secrets Manager's documentation is a little ambiguous. the SecretID can be either the ARN or the Name.  For situations with mode:cloudtrail, a CreateSecret event requestParameter utilizes the "Name" value and not the ARN.

Example:

```
        "requestParameters": {
            "name": "asfgzxcfew",
            "clientRequestToken": "6d7a43af-75b4-4369-a265-b427a373a3e0"
        },
```

 because the source code previously specified ARN, it would not return any resources.

example:

```
- Found resource ids:[asfgzxcfew]

- Resources [] 
```


With this pull request, we now see the following:


```
Resources [{'ARN': 'arn:aws:secretsmanager:us-east-1:<redacted>:secret:asfgzxcfew-hKPwGM', 'Name': 'asfgzxcfew', 'LastChangedDate': datetime.datetime(2020, 11, 16, 16, 32, 22, 402000, tzinfo=tzlocal()), 'Tags': [], 'SecretVersionsToStages': {'6d7a43af-75b4-4369-a265-b427a373a3e0': ['AWSCURRENT']}, 'CreatedDate': datetime.datetime(2020, 11, 16, 16, 32, 22, 336000, tzinfo=tzlocal()), 'VersionIdsToStages': {'6d7a43af-75b4-4369-a265-b427a373a3e0': ['AWSCURRENT']}}]
```

Now, we can apply filters/actions on the resource.
