### PR TITLE
aws - sqs - trigger paginated queue listing

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -328,8 +328,8 @@ class ConfigSource:
         else:
             _c = None
 
-        s = "select configuration, supplementaryConfiguration where resourceType = '{}'".format(
-            self.manager.resource_type.config_type)
+        s = ("select resourceId, configuration, supplementaryConfiguration "
+             "where resourceType = '{}'").format(self.manager.resource_type.config_type)
 
         if _c:
             s += "AND {}".format(_c)

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -33,7 +33,7 @@ class DescribeQueue(DescribeSource):
                 if e.response['Error']['Code'] == 'AWS.SimpleQueueService.NonExistentQueue':
                     return
                 if e.response['Error']['Code'] == 'AccessDenied':
-                    self.log.warning("Denied access to sqs %s" % r)
+                    self.manager.log.warning("Denied access to sqs %s" % r)
                     return
                 raise
             return queue
@@ -57,7 +57,7 @@ class SQS(QueryResourceManager):
     class resource_type(TypeInfo):
         service = 'sqs'
         arn_type = ""
-        enum_spec = ('list_queues', 'QueueUrls', None)
+        enum_spec = ('list_queues', 'QueueUrls', {'MaxResults': 1000})
         detail_spec = ("get_queue_attributes", "QueueUrl", None, "Attributes")
         cfn_type = config_type = 'AWS::SQS::Queue'
         id = 'QueueUrl'

--- a/tests/data/placebo/test_sqs_access_denied/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_access_denied/sqs.GetQueueAttributes_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 403,
+    "data": {
+        "Error": {
+            "Type": "Sender",
+            "Code": "AccessDenied",
+            "Message": "Access to the resource https://queue.amazonaws.com/ is denied.",
+            "Detail": null
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_access_denied/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_sqs_access_denied/sqs.ListQueues_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "QueueUrls": [
+            "https://queue.amazonaws.com/123456789012/access_denied_test"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -120,7 +120,7 @@ class ConfigSourceTest(BaseTest):
         # default query construction
         self.assertTrue(
             source.get_query_params(None)['expr'].startswith(
-                'select configuration, supplementaryConfiguration where resourceType'))
+                'select resourceId, configuration, supplementaryConfiguration where resourceType'))
 
         p.data['query'] = [{'clause': "configuration.imageId = 'xyz'"}]
         self.assertIn("imageId = 'xyz'", source.get_query_params(None)['expr'])

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -543,6 +543,9 @@ class QueueTests(BaseTest):
         )
         url1 = "https://us-east-2.queue.amazonaws.com/644160558196/BrickHouse"
         url2 = "https://sqs.us-east-2.amazonaws.com/644160558196/BrickHouse"
+        *_, enum_extra_args = p.resource_manager.resource_type.enum_spec
+        # MaxResults arg is required to enable list_queues pagination
+        self.assertIn("MaxResults", enum_extra_args)
         resources = p.resource_manager.get_resources([url1])
         self.assertEqual(resources[0]["QueueUrl"], url1)
         resources = p.resource_manager.get_resources([url2])


### PR DESCRIPTION
I ran into a few issues with SQS policies recently and this aims to fix them. The last change applies beyond SQS, and there may be a good reason to rethink or reverse it.

- Update the sqs `enum_spec` to explicitly specify `MaxResults`.
  The SQS `list_queues` method won't return a continuation token
  otherwise.

- Fix a cascading error case handling `AccessDenied` errors.

- Add `resourceId` to the query expression for Config sources. Without
  it, using the Config source for an SQS policy fails [here][1] with a `KeyError`.

[1]: https://github.com/cloud-custodian/cloud-custodian/blob/28ca845f31c249c045ad5114f132c9fd6b76c6a1/c7n/resources/sqs.py#L50