### PR TITLE
Use aliases in case AWS managed key is provided

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -3114,6 +3114,8 @@ class KMSKeyResolverMixin:
                 self.arns[r] = client.describe_key(
                     KeyId=self.data.get('key')
                 ).get('KeyMetadata').get('Arn')
+                if self.data.get('key').startswith('alias/aws'):
+                    self.arns[r] = client.list_aliases(KeyId=self.arns[r]).get('Aliases')[0].get('AliasArn')
             except ClientError as e:
                 self.log.error('Error resolving kms ARNs for set-bucket-encryption: %s key: %s' % (
                     e, self.data.get('key')))


### PR DESCRIPTION
Address https://github.com/cloud-custodian/cloud-custodian/issues/6321 where filter fails when AWS managed KMS key is used