### PR TITLE
aws - metrics - push start time back to the top of the last hour

### DIFF
--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -128,8 +128,11 @@ class MetricsFilter(Filter):
 
         self.metric = self.data['name']
         self.end = datetime.utcnow()
-        self.start = self.end - duration
-        self.period = int(self.data.get('period', duration.total_seconds()))
+
+        # Adjust the start time to gracefully handle CloudWatch's retention schedule, which rolls up
+        # data points progressively (1 minute --> 5 minutes --> 1 hour) over time.
+        self.start = (self.end - duration).replace(minute=0)
+        self.period = int(self.data.get('period', (self.end - self.start).total_seconds()))
         self.statistics = self.data.get('statistics', 'Average')
         self.model = self.manager.get_model()
         self.op = OPERATORS[self.data.get('op', 'less-than')]

--- a/tests/data/placebo/test_metric_period_rounding/monitoring.GetMetricStatistics_1.json
+++ b/tests/data/placebo/test_metric_period_rounding/monitoring.GetMetricStatistics_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "NumberOfMessagesSent",
+        "Datapoints": [
+            {
+                "Timestamp": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 9,
+                    "day": 4,
+                    "hour": 4,
+                    "minute": 0,
+                    "second": 0,
+                    "microsecond": 0
+                },
+                "Sum": 0.0,
+                "Unit": "Count"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_metric_period_rounding/monitoring.GetMetricStatistics_2.json
+++ b/tests/data/placebo/test_metric_period_rounding/monitoring.GetMetricStatistics_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "NumberOfMessagesSent",
+        "Datapoints": [
+            {
+                "Timestamp": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 9,
+                    "day": 4,
+                    "hour": 4,
+                    "minute": 0,
+                    "second": 0,
+                    "microsecond": 0
+                },
+                "Sum": 2.0,
+                "Unit": "Count"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_metric_period_rounding/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_metric_period_rounding/sqs.GetQueueAttributes_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-2:644160558196:84d3d899-fbdb-ab41-fca1-419b452dc4ed",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1606240393",
+            "LastModifiedTimestamp": "1606240393",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__owner_statement\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"SQS:*\",\"Resource\":\"arn:aws:sqs:us-east-2:644160558196:84d3d899-fbdb-ab41-fca1-419b452dc4ed\"}]}",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_metric_period_rounding/sqs.GetQueueAttributes_2.json
+++ b/tests/data/placebo/test_metric_period_rounding/sqs.GetQueueAttributes_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-2:644160558196:5673a565-78cb-d2f9-c58b-ab8257e72da2",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1606240404",
+            "LastModifiedTimestamp": "1606240404",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__owner_statement\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"SQS:*\",\"Resource\":\"arn:aws:sqs:us-east-2:644160558196:5673a565-78cb-d2f9-c58b-ab8257e72da2\"}]}",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_metric_period_rounding/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_metric_period_rounding/sqs.ListQueues_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "QueueUrls": [
+            "https://us-east-2.queue.amazonaws.com/644160558196/84d3d899-fbdb-ab41-fca1-419b452dc4ed",
+            "https://us-east-2.queue.amazonaws.com/644160558196/5673a565-78cb-d2f9-c58b-ab8257e72da2"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_metric_period_rounding/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_metric_period_rounding/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}


### PR DESCRIPTION
When calculating a start time for the metrics filter, zero out the
minutes so we always start from the top of an hour.

CloudWatch rounds down to the last 1-minute, 5-minute or 1-hour interval
based on its own retention schedule. By always rounding
down to the hour on our end, we accept 1 hour granularity but avoid
the burden of keeping pace with CloudWatch's retention details.

If CloudWatch rounds farther back than we do, we sometimes get
2 data points back which leads to false positive matches when filtering
on metrics beyond ~63 days ([reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricStatistics.html)).

**Note:** #6310 is somewhat related but addresses a different problem. The two changes seem largely compatible, though accepting that change without this one could lead to under-reporting Average stats. (We would risk splitting the difference between two datapoints, where one represents 63+ days of data and the other covers less than an hour).