### PR TITLE
ci - fix for functional test on log region 4 terraform

### DIFF
--- a/tests/terraform/log_delete/main.tf
+++ b/tests/terraform/log_delete/main.tf
@@ -1,5 +1,9 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_cloudwatch_log_group" "test_group" {
-  name = "Yada"
+  name = uuid()
 
   tags = {
     Environment = "production"


### PR DESCRIPTION
fix for functional run, terraform was targeting us-east-1 but policy was targeting us-west-2
﻿
