### PR TITLE
Aws - emr-security-config Kms Key Filter

### DIFF
--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -369,10 +369,7 @@ class EmrSecurityConfigurationKmsFilter(KmsRelatedFilter):
             related_ids = [r[model.id] for r in related]
             normalized_ids = []
             for rid in related_ids:
-                if rid.startswith('arn:'):
-                    normalized_ids.append(rid.rsplit('/', 1)[-1])
-                else:
-                    normalized_ids.append(rid)
+                normalized_ids.append(rid.rsplit('/', 1)[-1])
             self.related_ids = normalized_ids
             return related_ids
         else:

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -338,16 +338,19 @@ class EmrSecurityConfigurationKmsFilter(KmsRelatedFilter):
     """
     Filter a resource by its associcated kms key and optionally the alias name
     of the kms key by using 'c7n:AliasName'
+
     :example:
+
     .. code-block:: yaml
-        policies:
-          - name: emr-security-configuration-kms-key
-            resource: aws.emr-security-configuration
-            filters:
-              - type: kms-key
-                key: c7n:AliasName
-                value: "^(alias/aws/)"
-                op: regex
+
+            policies:
+              - name: emr-security-configuration-kms-key
+                resource: aws.emr-security-configuration
+                filters:
+                  - type: kms-key
+                    key: c7n:AliasName
+                    value: "^(alias/aws/)"
+                    op: regex
     """
 
     RelatedIdsExpression = 'SecurityConfiguration.EncryptionConfiguration.AtRestEncryptionConfiguration.\

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/elasticmapreduce.DescribeSecurityConfiguration_1.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/elasticmapreduce.DescribeSecurityConfiguration_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "Name": "test",
+        "SecurityConfiguration": "{\"EncryptionConfiguration\":{\"AtRestEncryptionConfiguration\":{\"LocalDiskEncryptionConfiguration\":{\"EncryptionKeyProviderType\":\"AwsKms\",\"AwsKmsKey\":\"arn:aws:kms:us-east-1:644160558196:alias/test\",\"EnableEbsEncryption\":true}},\"EnableInTransitEncryption\":false,\"EnableAtRestEncryption\":true}}",
+        "CreationDateTime": {
+            "__class__": "datetime",
+            "year": 2020,
+            "month": 12,
+            "day": 14,
+            "hour": 15,
+            "minute": 47,
+            "second": 4,
+            "microsecond": 624000
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/elasticmapreduce.ListSecurityConfigurations_1.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/elasticmapreduce.ListSecurityConfigurations_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityConfigurations": [
+            {
+                "Name": "test",
+                "CreationDateTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 12,
+                    "day": 14,
+                    "hour": 15,
+                    "minute": 47,
+                    "second": 4,
+                    "microsecond": 624000
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/kms.DescribeKey_1.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/kms.DescribeKey_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "KeyMetadata": {
+            "AWSAccountId": "644160558196",
+            "KeyId": "36812ccf-daaf-49b1-a24b-0eef254ffe41",
+            "Arn": "arn:aws:kms:us-east-1:644160558196:key/36812ccf-daaf-49b1-a24b-0eef254ffe41",
+            "CreationDate": {
+                "__class__": "datetime",
+                "year": 2016,
+                "month": 7,
+                "day": 24,
+                "hour": 4,
+                "minute": 51,
+                "second": 26,
+                "microsecond": 199000
+            },
+            "Enabled": true,
+            "Description": "Trails for the Skunk",
+            "KeyUsage": "ENCRYPT_DECRYPT",
+            "KeyState": "Enabled",
+            "Origin": "AWS_KMS",
+            "KeyManager": "CUSTOMER",
+            "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+            "EncryptionAlgorithms": [
+                "SYMMETRIC_DEFAULT"
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/kms.DescribeKey_2.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/kms.DescribeKey_2.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "KeyMetadata": {
+            "AWSAccountId": "644160558196",
+            "KeyId": "36812ccf-daaf-49b1-a24b-0eef254ffe41",
+            "Arn": "arn:aws:kms:us-east-1:644160558196:key/36812ccf-daaf-49b1-a24b-0eef254ffe41",
+            "CreationDate": {
+                "__class__": "datetime",
+                "year": 2016,
+                "month": 7,
+                "day": 24,
+                "hour": 4,
+                "minute": 51,
+                "second": 26,
+                "microsecond": 199000
+            },
+            "Enabled": true,
+            "Description": "Trails for the Skunk",
+            "KeyUsage": "ENCRYPT_DECRYPT",
+            "KeyState": "Enabled",
+            "Origin": "AWS_KMS",
+            "KeyManager": "CUSTOMER",
+            "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+            "EncryptionAlgorithms": [
+                "SYMMETRIC_DEFAULT"
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/kms.DescribeKey_3.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/kms.DescribeKey_3.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "KeyMetadata": {
+            "AWSAccountId": "644160558196",
+            "KeyId": "36812ccf-daaf-49b1-a24b-0eef254ffe41",
+            "Arn": "arn:aws:kms:us-east-1:644160558196:key/36812ccf-daaf-49b1-a24b-0eef254ffe41",
+            "CreationDate": {
+                "__class__": "datetime",
+                "year": 2016,
+                "month": 7,
+                "day": 24,
+                "hour": 4,
+                "minute": 51,
+                "second": 26,
+                "microsecond": 199000
+            },
+            "Enabled": true,
+            "Description": "Trails for the Skunk",
+            "KeyUsage": "ENCRYPT_DECRYPT",
+            "KeyState": "Enabled",
+            "Origin": "AWS_KMS",
+            "KeyManager": "CUSTOMER",
+            "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+            "EncryptionAlgorithms": [
+                "SYMMETRIC_DEFAULT"
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/kms.DescribeKey_4.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/kms.DescribeKey_4.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "KeyMetadata": {
+            "AWSAccountId": "644160558196",
+            "KeyId": "36812ccf-daaf-49b1-a24b-0eef254ffe41",
+            "Arn": "arn:aws:kms:us-east-1:644160558196:key/36812ccf-daaf-49b1-a24b-0eef254ffe41",
+            "CreationDate": {
+                "__class__": "datetime",
+                "year": 2016,
+                "month": 7,
+                "day": 24,
+                "hour": 4,
+                "minute": 51,
+                "second": 26,
+                "microsecond": 199000
+            },
+            "Enabled": true,
+            "Description": "Trails for the Skunk",
+            "KeyUsage": "ENCRYPT_DECRYPT",
+            "KeyState": "Enabled",
+            "Origin": "AWS_KMS",
+            "KeyManager": "CUSTOMER",
+            "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+            "EncryptionAlgorithms": [
+                "SYMMETRIC_DEFAULT"
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/kms.ListAliases_1.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/kms.ListAliases_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "Aliases": [
+            {
+                "AliasName": "alias/test",
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/test",
+                "TargetKeyId": "36812ccf-daaf-49b1-a24b-0eef254ffe41"
+            }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/kms.ListAliases_2.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/kms.ListAliases_2.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "Aliases": [
+            {
+                "AliasName": "alias/test",
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/test",
+                "TargetKeyId": "36812ccf-daaf-49b1-a24b-0eef254ffe41"
+            }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/kms.ListAliases_3.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/kms.ListAliases_3.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "Aliases": [
+            {
+                "AliasName": "alias/test",
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/test",
+                "TargetKeyId": "36812ccf-daaf-49b1-a24b-0eef254ffe41"
+            }
+        ],
+        "Truncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_security_configuration_kms_key/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_emr_security_configuration_kms_key/tagging.GetResources_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -255,6 +255,30 @@ class TestEMRSecurityConfiguration(BaseTest):
         self.assertEqual(resources[0]["SecurityConfiguration"]['EncryptionConfiguration']
              ['EnableInTransitEncryption'], False)
 
+    def test_emr_security_configuration_kms_key(self):
+        session_factory = self.replay_flight_data("test_emr_security_configuration_kms_key")
+        p = self.load_policy(
+            {
+                "name": "emr-security-configuration-kms-alias",
+                "resource": "emr-security-configuration",
+                "filters": [
+                    {
+                        "type": "kms-key",
+                        "key": "c7n:AliasName",
+                        "value": "^(alias/test)",
+                        "op": "regex"
+                    }
+                ]
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertTrue(len(resources), 1)
+        self.assertEqual(resources[0]['SecurityConfiguration']
+                        ['EncryptionConfiguration']['AtRestEncryptionConfiguration']
+                        ['LocalDiskEncryptionConfiguration']['AwsKmsKey'],
+                        'arn:aws:kms:us-east-1:644160558196:alias/test')
+
     def test_emr_security_configuration_delete(self):
         session_factory = self.replay_flight_data("test_emr_security_configuration_delete")
         p = self.load_policy(


### PR DESCRIPTION
Addresses #6318. Create a kms-key filter for the emr-security-config resource. I don't think this is the cleanest solution though since it makes extra api calls to get the related resources in the filter. This is because the kms key in the security config uses the alias arn and not the key arn. Not sure what the cleanest solution is here @kapilt.