### PR TITLE
policystream - fix the identification of removed policies

### DIFF
--- a/tools/c7n_policystream/policystream.py
+++ b/tools/c7n_policystream/policystream.py
@@ -399,11 +399,7 @@ class PolicyRepo:
                     current_policies += self.policy_files[f]
             elif delta.status == GIT_DELTA_INVERT['GIT_DELTA_DELETED']:
                 if f in self.policy_files:
-                    # if the policies were moved, only add in policies
-                    # that are not already accounted for.
-                    current_policies += self.policy_files[f].select(
-                        set(current_policies.keys()).difference(
-                            self.policy_files[f].keys()))
+                    current_policies += self.policy_files[f]
                     removed.add(f)
             elif delta.status == GIT_DELTA_INVERT['GIT_DELTA_RENAMED']:
                 change_policies += self._policy_file_rev(f, change)


### PR DESCRIPTION
The set difference was the wrong way around for identifying which policies
to identify in the previous set. The extra logic for only trying to identify
the policies that were not moved is not necessary, as evident by the added
test.