### PR TITLE
aws - config source - selectively demangle/title keys

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -279,6 +279,7 @@ class ConfigSource:
 
     def __init__(self, manager):
         self.manager = manager
+        self.titleCase = self.manager.resource_type.id[0].isupper()
 
     def get_permissions(self):
         return ["config:GetResourceConfigHistory",
@@ -338,7 +339,8 @@ class ConfigSource:
 
     def load_resource(self, item):
         item_config = self._load_item_config(item)
-        resource = camelResource(item_config, implicitDate=True)
+        resource = camelResource(
+            item_config, implicitDate=True, implicitTitle=self.titleCase)
         self._load_resource_tags(resource, item)
         return resource
 

--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -455,15 +455,8 @@ class StageClientCertificateFilter(RelatedResourceFilter):
     """
     schema = type_schema('client-certificate', rinherit=ValueFilter.schema)
     RelatedResource = "c7n.resources.apigw.RestClientCertificate"
+    RelatedIdsExpression = 'clientCertificateId'
     annotation_key = "c7n:matched-client-certificate"
-    source_related_id_map = {
-        "config": "ClientCertificateId",
-        "describe": "clientCertificateId"
-    }
-
-    def __init__(self, data, manager):
-        self.RelatedIdsExpression = self.source_related_id_map[manager.source_type]
-        super(StageClientCertificateFilter, self).__init__(data, manager)
 
     def process(self, resources, event=None):
         related = self.get_related(resources)

--- a/c7n/resources/secretsmanager.py
+++ b/c7n/resources/secretsmanager.py
@@ -16,7 +16,7 @@ class SecretsManager(QueryResourceManager):
         service = 'secretsmanager'
         enum_spec = ('list_secrets', 'SecretList', None)
         detail_spec = ('describe_secret', 'SecretId', 'Name', None)
-        cfn_type = 'AWS::SecretsManager::Secret'
+        config_type = cfn_type = 'AWS::SecretsManager::Secret'
         name = id = 'Name'
         arn = 'ARN'
 

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -245,7 +245,7 @@ def chunks(iterable, size=50):
         yield batch
 
 
-def camelResource(obj, implicitDate=False):
+def camelResource(obj, implicitDate=False, implicitTitle=True):
     """Some sources from apis return lowerCased where as describe calls
 
     always return TitleCase, this function turns the former to the later
@@ -257,7 +257,12 @@ def camelResource(obj, implicitDate=False):
         return obj
     for k in list(obj.keys()):
         v = obj.pop(k)
-        obj["%s%s" % (k[0].upper(), k[1:])] = v
+        if implicitTitle:
+            ok = "%s%s" % (k[0].upper(), k[1:])
+        else:
+            ok = k
+        obj[ok] = v
+
         if implicitDate:
             # config service handles datetime differently then describe sdks
             # the sdks use knowledge of the shape to support language native
@@ -272,11 +277,12 @@ def camelResource(obj, implicitDate=False):
                 except ParserError:
                     dv = None
                 if dv:
-                    obj["%s%s" % (k[0].upper(), k[1:])] = dv
+                    obj[ok] = dv
         if isinstance(v, dict):
-            camelResource(v)
+            camelResource(v, implicitDate, implicitTitle)
         elif isinstance(v, list):
-            list(map(camelResource, v))
+            for e in v:
+                camelResource(e, implicitDate, implicitTitle)
     return obj
 
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -301,8 +301,8 @@ class PolicyMetaLint(BaseTest):
             'AWS::ApiGatewayV2::Api',
             'AWS::ServiceCatalog::CloudFormationProvisionedProduct',
             'AWS::ServiceCatalog::CloudFormationProduct',
-            'AWS::SSM::FileData',
-            'AWS::SecretsManager::Secret'}
+            'AWS::SSM::FileData'}
+
 
         resource_map = {}
         for k, v in manager.resources.items():

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -303,7 +303,6 @@ class PolicyMetaLint(BaseTest):
             'AWS::ServiceCatalog::CloudFormationProduct',
             'AWS::SSM::FileData'}
 
-
         resource_map = {}
         for k, v in manager.resources.items():
             if not v.resource_type.config_type:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -319,6 +319,17 @@ class UtilTest(BaseTest):
             ],
         )
 
+    def test_camel_case_implicit(self):
+        d = {'ownerId': 'abc',
+             'modifyDateIso': '2021-01-05T13:43:26.749906',
+             'createTimeMillis': '1609854135165',
+             'createTime': '1609854135'}
+        r = utils.camelResource(d, implicitTitle=False, implicitDate=True)
+        assert set(r) == {'ownerId', 'modifyDateIso', 'createTimeMillis', 'createTime'}
+        r.pop('ownerId')
+        for k in r:
+            assert r[k].strftime('%Y/%m/%d') == '2021/01/05'
+
     def test_camel_case(self):
         d = {
             "zebraMoon": [{"instanceId": 123}, "moon"],


### PR DESCRIPTION
some resources/services use lower case keys, we should selectively detect
that and avoid titling keys when doing our config demangle/transform back
to describe format.
﻿
