### PR TITLE
add flag "universal_taggable = True" to config

### DIFF
--- a/c7n/resources/config.py
+++ b/c7n/resources/config.py
@@ -83,6 +83,7 @@ class ConfigRule(QueryResourceManager):
         filter_name = 'ConfigRuleNames'
         filter_type = 'list'
         cfn_type = 'AWS::Config::ConfigRule'
+        universal_taggable = True
 
 
 @ConfigRule.filter_registry.register('status')


### PR DESCRIPTION
Added this to be able to tag AWS config rules. 