### PR TITLE
aws - universal tag augment with arn list

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -83,11 +83,10 @@ def universal_augment(self, resources):
     paginator = client.get_paginator('get_resources')
     paginator.PAGE_ITERATOR_CLS = RetryPageIterator
 
-    m = self.get_model()
-    resource_type = "%s:%s" % (m.arn_service or m.service, m.arn_type)
+    rfetch = [r for r in resources if 'Tags' not in r]
 
     for arn_resource_set in utils.chunks(
-            zip(self.get_arns(resources), resources), 100):
+            zip(self.get_arns(rfetch), rfetch), 100):
         arn_resource_map = dict(arn_resource_set)
         resource_tag_results = client.get_resources(
             ResourceARNList=list(arn_resource_map.keys())).get(
@@ -95,8 +94,6 @@ def universal_augment(self, resources):
         resource_tag_map = {
             r['ResourceARN']: r['Tags'] for r in resource_tag_results}
         for arn, r in arn_resource_map.items():
-            if 'Tags' in r:
-                continue
             r['Tags'] = resource_tag_map.get(arn, [])
 
     return resources

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -15,7 +15,6 @@ from datetime import datetime, timedelta
 from dateutil import tz as tzutil
 from dateutil.parser import parse
 
-import itertools
 import jmespath
 import time
 

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -87,16 +87,19 @@ def universal_augment(self, resources):
     m = self.get_model()
     resource_type = "%s:%s" % (m.arn_service or m.service, m.arn_type)
 
-    resource_tag_map_list = list(itertools.chain(
-        *[p['ResourceTagMappingList'] for p in paginator.paginate(
-            ResourceTypeFilters=[resource_type])]))
-    resource_tag_map = {
-        r['ResourceARN']: r['Tags'] for r in resource_tag_map_list}
-
-    for arn, r in zip(self.get_arns(resources), resources):
-        if 'Tags' in r:
-            continue
-        r['Tags'] = resource_tag_map.get(arn, [])
+    for arn_resource_set in utils.chunks(
+            zip(self.get_arns(resources), resources), 100):
+        arn_resource_map = dict(arn_resource_set)
+        resource_tag_results = client.get_resources(
+            ResourceTypeFilters=[resource_type],
+            ResourceARNList=list(arn_resource_map.keys())).get(
+                'ResourceTagMappingList', ())
+        resource_tag_map = {
+            r['ResourceARN']: r['Tags'] for r in resource_tag_results}
+        for arn, r in arn_resource_map.items():
+            if 'Tags' in r:
+                continue
+            r['Tags'] = resource_tag_map.get(arn, [])
 
     return resources
 

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -90,7 +90,6 @@ def universal_augment(self, resources):
             zip(self.get_arns(resources), resources), 100):
         arn_resource_map = dict(arn_resource_set)
         resource_tag_results = client.get_resources(
-            ResourceTypeFilters=[resource_type],
             ResourceARNList=list(arn_resource_map.keys())).get(
                 'ResourceTagMappingList', ())
         resource_tag_map = {

--- a/tests/data/placebo/test_sqs_get_augment/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_get_augment/sqs.GetQueueAttributes_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:644160558196:test-queue",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1602077117",
+            "LastModifiedTimestamp": "1602077117",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__owner_statement\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"SQS:*\",\"Resource\":\"arn:aws:sqs:us-east-1:644160558196:test-queue\"}]}",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_get_augment/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_sqs_get_augment/sqs.ListQueues_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "QueueUrls": [
+            "https://queue.amazonaws.com/644160558196/test-queue"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_get_augment/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_sqs_get_augment/tagging.GetResources_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:sqs:us-east-1:644160558196:test-queue",
+                "Tags": [
+                    {
+                        "Key": "App",
+                        "Value": "Args"
+                    },
+                    {
+                        "Key": "Env",
+                        "Value": "Dev"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,6 +1,6 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from .common import BaseTest, functional, event_data
+from .common import BaseTest, functional, event_data, placebo_dir
 from datetime import datetime
 from dateutil.tz import tzutc
 from pytest_terraform import terraform
@@ -11,6 +11,7 @@ import json
 import logging
 import pytest
 import time
+from pathlib import Path
 
 from c7n.resources.aws import shape_validate, Arn
 
@@ -136,6 +137,25 @@ def test_sqs_remove_matched(test, sqs_remove_matched):
     data = json.loads(queue_attributes["Attributes"]["Policy"])
 
     test.assertEqual([s["Sid"] for s in data.get("Statement", ())], ["SpecificAllow"])
+
+
+def test_sqs_get_resources_augment(test):
+    session_factory = test.replay_flight_data("test_sqs_get_augment")
+    p = test.load_policy(
+        {"name": "sqs", "resource": "sqs"},
+        session_factory=session_factory)
+    resources = p.resource_manager.get_resources([
+        'https://sqs.us-east-1.amazonaws.com/644160558196/test-queue'])
+    assert len(resources) == 1
+    assert {t['Key']: t['Value'] for t in resources[0]['Tags']} == {
+        'App': 'Args', 'Env': 'Dev'}
+    # assert even though multiple tagged queues in the env we only fetch data
+    # for the one we're processing.
+    dp = Path(placebo_dir('test_sqs_get_augment')) / 'tagging.GetResources_1.json'
+    assert dp.exists()
+    with dp.open() as fh:
+        data = json.load(fh)
+        assert len(data['data']['ResourceTagMappingList']) == 1
 
 
 class QueueTests(BaseTest):

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -178,7 +178,6 @@ class ZippedPill(pill.Pill):
             self.archive.close()
 
     def save_response(self, service, operation, response_data, http_response=200):
-
         filepath = self.get_new_file_path(service, operation)
         pill.LOG.debug("save_response: path=%s", filepath)
         json_data = {"status_code": http_response, "data": response_data}
@@ -257,6 +256,10 @@ class RedPill(pill.Pill):
         """
         Override to sanitize response metadata and account_ids
         """
+        # aws sso setups involve a short lived credential transfer
+        if service == "portal.sso":
+            return
+
         if 'ResponseMetadata' in response_data:
             response_data['ResponseMetadata'] = {}
 


### PR DESCRIPTION


depends on #6412﻿ merging and rebase

this minimizes apis calls for lambda policies using resources that use resource 
group tagging api by supporting the new feature in that api to get tags just
for a subset of resources 

https://awsapichanges.info/archive/changes/71b316-tagging.html

