### PR TITLE
azure - small container host bug fixes

### DIFF
--- a/tools/c7n_azure/c7n_azure/container_host/host.py
+++ b/tools/c7n_azure/c7n_azure/container_host/host.py
@@ -266,7 +266,7 @@ class Host:
 
             for name in periodic_to_remove:
                 self.scheduler.remove_job(job_id=name)
-        except AttributeError as exc:
+        except (AttributeError, KeyError) as exc:
             log.warning('Failure loading cached policy for cleanup %s %s' % (path, exc))
 
         os.unlink(path)

--- a/tools/c7n_azure/c7n_azure/container_host/host.py
+++ b/tools/c7n_azure/c7n_azure/container_host/host.py
@@ -87,6 +87,7 @@ class Host:
         # Configure scheduler
         self.scheduler = BlockingScheduler(Host.get_scheduler_config())
         logging.getLogger('apscheduler.executors.default').setLevel(logging.ERROR)
+        logging.getLogger('apscheduler').setLevel(logging.ERROR)
 
         # Schedule recurring policy updates
         self.scheduler.add_job(self.update_policies,
@@ -250,7 +251,10 @@ class Host:
                 return path
 
         try:
-            removed = [policies.pop(p['name']) for p in policy_config.get('policies', [])]
+            # Some policies might have bad format, so they have never been loaded
+            removed = [policies.pop(p['name'])
+                       for p in policy_config.get('policies', [])
+                       if p['name'] in policies]
             log.info('Removing policies %s' % removed)
 
             # update periodic
@@ -262,7 +266,7 @@ class Host:
 
             for name in periodic_to_remove:
                 self.scheduler.remove_job(job_id=name)
-        except (AttributeError, KeyError) as exc:
+        except AttributeError as exc:
             log.warning('Failure loading cached policy for cleanup %s %s' % (path, exc))
 
         os.unlink(path)
@@ -364,7 +368,7 @@ class Host:
             if not events:
                 continue
             events = AzureEvents.get_event_operations(events)
-            if operation_name in events:
+            if operation_name.upper() in (event.upper() for event in events):
                 self.scheduler.add_job(Host.run_policy,
                                        id=k + event['id'],
                                        name=k,
@@ -419,12 +423,17 @@ class Host:
 
     @staticmethod
     def get_scheduler_config():
+        if os.name == 'nt':
+            executor = "apscheduler.executors.pool:ThreadPoolExecutor"
+        else:
+            executor = "apscheduler.executors.pool:ProcessPoolExecutor"
+
         return {
             'apscheduler.jobstores.default': {
                 'type': 'memory'
             },
             'apscheduler.executors.default': {
-                'class': 'apscheduler.executors.pool:ProcessPoolExecutor',
+                'class': executor,
                 'max_workers': '4'
             },
             'apscheduler.executors.threadpool': {

--- a/tools/c7n_azure/tests_azure/tests_resources/test_container_host.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_container_host.py
@@ -493,7 +493,8 @@ class ContainerHostTest(BaseTest):
         with open(file_path, 'w') as f:
             f.write("bad yaml file")
 
-        host.unload_policy_file(file_path, None)
+        host.load_policy(file_path, host.policies)
+        host.unload_policy_file(file_path, host.policies)
         os_unlink.assert_called()
 
         # Clean up the file
@@ -535,6 +536,34 @@ class ContainerHostTest(BaseTest):
     @patch('c7n_azure.container_host.host.Storage.get_queue_client_by_storage_account')
     @patch('c7n_azure.container_host.host.Storage.get_blob_client_by_uri')
     @patch('os.unlink')
+    def test_unload_policy_file_without_name(self,
+            os_unlink, yaml_safe_load, _1, _2, _3, _4):
+        host = Host(DEFAULT_EVENT_QUEUE_ID, DEFAULT_EVENT_QUEUE_NAME, DEFAULT_POLICY_STORAGE)
+
+        # Create a bad yaml file (no name field)
+        file_path = tempfile.mktemp(suffix=".yaml")
+        with open(file_path, 'w') as f:
+            f.write("""
+                        policies:
+                          - mode:
+                              type: container-periodic
+                              schedule: '* * * * *'
+                            resource: azure.resourcegroup
+                        """)
+
+        host.load_policy(file_path, host.policies)
+        host.unload_policy_file(file_path, host.policies)
+        os_unlink.assert_called()
+
+        # Clean up the file
+        os.remove(file_path)
+
+    @patch('c7n_azure.container_host.host.Host.update_event_subscription')
+    @patch('c7n_azure.container_host.host.BlockingScheduler.start')
+    @patch('c7n_azure.container_host.host.Host.prepare_queue_storage')
+    @patch('c7n_azure.container_host.host.Storage.get_queue_client_by_storage_account')
+    @patch('c7n_azure.container_host.host.Storage.get_blob_client_by_uri')
+    @patch('os.unlink')
     def test_unload_policy_file_with_bad_schema(self,
             os_unlink, _1, _2, _3, _4, _5):
         host = Host(DEFAULT_EVENT_QUEUE_ID, DEFAULT_EVENT_QUEUE_NAME, DEFAULT_POLICY_STORAGE)
@@ -554,7 +583,8 @@ class ContainerHostTest(BaseTest):
         with open(file_path, 'w') as f:
             f.write(policy_string)
 
-        host.unload_policy_file(file_path, {})
+        host.load_policy(file_path, host.policies)
+        host.unload_policy_file(file_path, host.policies)
         os_unlink.assert_called()
 
         # Clean up the file


### PR DESCRIPTION
Four fixes here:

- `unload_policy_file` was attempting to unload policies which were never loaded (usually due to the policy YAML being invalid).  This could make it impossible to unload other policies which were contained in the same file as an invalid policy.  Remove the exception handler and instead update the list comprehension with the appropriate check.
- `run_policies_for_event` was case sensitive on identifying the event, and the actual casing of events fired in azure is often unpredictable.... 
- `ProcessPoolExecutor` can be problematic on Windows.  Use `ThreadPoolExecutor` on Windows (primarily for Windows developers as we don't ship this in a Windows container anyway).
- An additional logging suppression cleans up output

