### PR TITLE
aws - copy-related-tag exception when processing resource set

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -1055,10 +1055,7 @@ class CopyRelatedResourceTag(Tag):
             return
         if not isinstance(tag_action, UniversalTag):
             tags = [{'Key': k, 'Value': v} for k, v in tags.items()]
-        tag_action.process_resource_set(
-            client,
-            resource_set=[r],
-            tags=tags)
+        tag_action.process_resource_set(client, [r], tags)
         return True
 
     def get_resource_tag_map(self, r_type, ids):


### PR DESCRIPTION
I was getting an exception when trying to use `copy-related-tag` between an `ecs-task` and `ecs-task-definition`:
```
2021-01-27 09:36:58,609: custodian.output:ERROR Error while executing policy
Traceback (most recent call last):
  File "/Users/tstansell/.local/c7n/lib/python3.8/site-packages/c7n/policy.py", line 313, in run
    results = a.process(resources)
  File "/Users/tstansell/.local/c7n/lib/python3.8/site-packages/c7n/tags.py", line 1036, in process
    elif self.process_resource(
  File "/Users/tstansell/.local/c7n/lib/python3.8/site-packages/c7n/tags.py", line 1061, in process_resource
    tag_action.process_resource_set(
TypeError: process_resource_set() got an unexpected keyword argument 'resource_set'
```