### PR TITLE
aws - ec2 keypair id for tagging functionality

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2293,7 +2293,8 @@ class KeyPair(query.QueryResourceManager):
         service = 'ec2'
         arn_type = 'key-pair'
         enum_spec = ('describe_key_pairs', 'KeyPairs', None)
-        name = id = 'KeyName'
+        name = 'KeyName'
+        id = 'KeyPairId'
         filter_name = 'KeyNames'
 
 


### PR DESCRIPTION
I fixed the ec2 keypair "id" reference in the code. 

In the current version, custodian will fail when trying to tag keypairs because it is trying to use "KeyName" as the keypair ID rather than "KeyPairID". Example of error seen in below image.
<img width="1152" alt="Screen Shot 2021-01-28 at 2 39 54 PM" src="https://user-images.githubusercontent.com/36454652/106196151-b2478980-6176-11eb-8fc1-ed5e87bdedc6.png">

Custodian should be using the `ID` field rather than the `Name` field for ec2 keypairs.
<img width="628" alt="Screen Shot 2021-01-28 at 2 40 27 PM" src="https://user-images.githubusercontent.com/36454652/106196312-e58a1880-6176-11eb-81fd-afc7fe67ecae.png">

You can see that there is a difference in the AWS API documentation. (https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-key-pairs.html)

