### PR TITLE
aws - iam - allow stacked credential filters to remove 0 keys

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -2221,7 +2221,10 @@ class UserRemoveAccessKey(BaseAction):
                 m_keys = resolve_credential_keys(
                     r.get(CredentialReport.matched_annotation_key),
                     keys)
-                assert m_keys, "shouldn't have gotten this far without keys"
+                # It is possible for a _user_ to match multiple credential filters
+                # without having any single key match them all.
+                if not m_keys:
+                    continue
                 keys = m_keys
 
             for k in keys:

--- a/tests/data/placebo/test_iam_user_credential_multi_delete_noop/config.SelectResourceConfig_1.json
+++ b/tests/data/placebo/test_iam_user_credential_multi_delete_noop/config.SelectResourceConfig_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "Results": [
+            "{\"resourceId\":\"AIDAY5Y4D45RPP4IHNEMR\",\"configuration\":{\"path\":\"/\",\"attachedManagedPolicies\":[],\"groupList\":[],\"userPolicyList\":[],\"userName\":\"test1\",\"arn\":\"arn:aws:iam::644160558196:user/test1\",\"userId\":\"AIDAY5Y4D45RPP4IHNEMR\",\"createDate\":\"2020-12-22T03:06:09.000Z\",\"tags\":[]},\"supplementaryConfiguration\":{}}"
+        ],
+        "QueryInfo": {
+            "SelectFields": [
+                {
+                    "Name": "resourceId"
+                },
+                {
+                    "Name": "configuration"
+                },
+                {
+                    "Name": "supplementaryConfiguration"
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_multi_delete_noop/iam.GenerateCredentialReport_1.json
+++ b/tests/data/placebo/test_iam_user_credential_multi_delete_noop/iam.GenerateCredentialReport_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "State": "COMPLETE",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_multi_delete_noop/iam.GetCredentialReport_1.json
+++ b/tests/data/placebo/test_iam_user_credential_multi_delete_noop/iam.GetCredentialReport_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "Content": "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\n<root_account>,arn:aws:iam::644160558196:root,2020-11-23T18:42:55+00:00,not_supported,no_information,not_supported,not_supported,false,false,N/A,N/A,N/A,N/A,false,N/A,N/A,N/A,N/A,false,N/A,false,N/A\ntest1,arn:aws:iam::644160558196:user/test1,2020-12-22T03:06:09+00:00,false,N/A,N/A,N/A,false,false,2020-02-03T09:50:07+00:00,N/A,N/A,N/A,true,2021-02-03T09:50:21+00:00,N/A,N/A,N/A,false,N/A,false,N/A",
+        "ReportFormat": "text/csv",
+        "GeneratedTime": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 2,
+            "day": 4,
+            "hour": 15,
+            "minute": 24,
+            "second": 53,
+            "microsecond": 0
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_multi_delete_noop/iam.GetCredentialReport_2.json
+++ b/tests/data/placebo/test_iam_user_credential_multi_delete_noop/iam.GetCredentialReport_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "Content": "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\n<root_account>,arn:aws:iam::644160558196:root,2020-11-23T18:42:55+00:00,not_supported,no_information,not_supported,not_supported,false,false,N/A,N/A,N/A,N/A,false,N/A,N/A,N/A,N/A,false,N/A,false,N/A\ntest1,arn:aws:iam::644160558196:user/test1,2020-12-22T03:06:09+00:00,false,N/A,N/A,N/A,false,false,2020-02-03T09:50:07+00:00,N/A,N/A,N/A,true,2021-02-03T09:50:21+00:00,N/A,N/A,N/A,false,N/A,false,N/A",
+        "ReportFormat": "text/csv",
+        "GeneratedTime": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 2,
+            "day": 4,
+            "hour": 15,
+            "minute": 24,
+            "second": 53,
+            "microsecond": 0
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_user_credential_multi_delete_noop/iam.ListAccessKeys_1.json
+++ b/tests/data/placebo/test_iam_user_credential_multi_delete_noop/iam.ListAccessKeys_1.json
@@ -1,0 +1,39 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccessKeyMetadata": [
+            {
+                "UserName": "test1",
+                "AccessKeyId": "AKIAY5Y4D45RM747RB4P",
+                "Status": "Inactive",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 2,
+                    "day": 3,
+                    "hour": 9,
+                    "minute": 50,
+                    "second": 7,
+                    "microsecond": 0
+                }
+            },
+            {
+                "UserName": "test1",
+                "AccessKeyId": "AKIAY5Y4D45RLQZNWRQL",
+                "Status": "Active",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 2,
+                    "day": 3,
+                    "hour": 9,
+                    "minute": 50,
+                    "second": 21,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -108,6 +108,34 @@ class UserCredentialReportTest(BaseTest):
             p.resource_manager.get_arns(resources),
             ["arn:aws:iam::644160558196:user/kapil"])
 
+    def test_credential_access_key_multifilter_delete_noop(self):
+        factory = self.replay_flight_data('test_iam_user_credential_multi_delete_noop')
+        p = self.load_policy({
+            'name': 'user-cred-multi-noop',
+            'resource': 'iam-user',
+            'source': 'config',
+            'filters': [
+                {'UserName': 'test1'},
+                {"type": "credential",
+                 "key": "access_keys.last_rotated",
+                 "value": 30,
+                 'op': 'gt',
+                 "value_type": "age"},
+                {"type": "credential",
+                 "key": "access_keys.active",
+                 "value": True,
+                 "op": "eq"}],
+            'actions': [
+                {'type': 'remove-keys',
+                 'matched': True}]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(len(resources[0]['c7n:matched-keys']), 0)
+        client = factory().client('iam')
+        keys = client.list_access_keys(UserName='test1').get('AccessKeyMetadata')
+        self.assertEqual(len(keys), 2)
+
     def test_credential_access_key_reverse_filter_delete(self):
         factory = self.replay_flight_data(
             'test_iam_user_credential_reverse_filter_delete'


### PR DESCRIPTION
Addresses #6419 

When applying multiple `credential` filters for an IAM user in preparation for a `remove-keys` action, it's possible for a _user_ to match all filters without any individual _key_ matching all filters. Rather than erroring out altogether in that case, we can skip key removal for that user.

I added a comment and a test for this behavior because it's not obvious at a glance. It looks like there may be more/other work to be done here, but this at least reproduces and accounts for the behavior described in #6419.