### PR TITLE
tools/c7n-org - support comma separated values for cli options supporting multiple values

### DIFF
--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -143,20 +143,27 @@ output
 
 Use `c7n-org report` to generate a csv report from the output directory.
 
-## Selecting accounts and policy for execution
+## Selecting accounts, regions, policies for execution
 
 You can filter the accounts to be run against by either passing the
 account name or id via the `-a` flag, which can be specified multiple
-times.
+times, or alternatively with comma separated values.
 
 Groups of accounts can also be selected for execution by specifying
 the `-t` tag filter.  Account tags are specified in the config
 file. ie given the above accounts config file you can specify all prod
-accounts with `-t type:prod`.
+accounts with `-t type:prod`. you can specify the -t flag multiple
+times or use a comma separated list.
 
 You can specify which policies to use for execution by either
 specifying `-p` or selecting groups of policies via their tags with
-`-l`.
+`-l`, both options support being specified multiple times or using
+comma separated values.
+
+By default in aws, c7n-org will execute in parallel across regions,
+the '-r' flag can be specified multiple times, and defaults to
+(us-east-1, us-west-2).  a special value of `all` will execute across
+all regions.
 
 
 See `c7n-org run --help` for more information.

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -196,7 +196,16 @@ def resolve_regions(regions, account):
         return [region['RegionName'] for region in client.describe_regions()['Regions']]
     if not regions:
         return ('us-east-1', 'us-west-2')
-    return regions
+
+    resolved_regions = []
+    # support a comma seperated list of regions as a single parameter
+    for r in regions:
+        if ',' in r:
+            resolved_regions.extend([n.strip() for n in r.split(',')])
+        else:
+            resolved_regions.append(r)
+    # unique the set
+    return list(dict.fromkeys(resolved_regions))
 
 
 def get_session(account, session_name, region):

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -212,7 +212,7 @@ def comma_expand(values):
         elif v:
             resolved_values.append(v)
     # unique the set
-    return list(dict.fromkeys(resolved_regions))
+    return list(dict.fromkeys(resolved_values))
 
 
 def get_session(account, session_name, region):

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -163,6 +163,11 @@ def init(config, use, debug, verbose, accounts, tags, policies, resource=None, p
     logging.getLogger('custodian.s3').setLevel(logging.ERROR)
     logging.getLogger('urllib3').setLevel(logging.WARNING)
 
+    accounts = comma_expand(accounts)
+    policies = comma_expand(policies)
+    tags = comma_expand(tags)
+    policy_tags = comma_expand(policy_tags)
+
     # Filter out custodian log messages on console output if not
     # at warning level or higher, see LogFilter docs and #2674
     for h in logging.getLogger().handlers:
@@ -197,13 +202,15 @@ def resolve_regions(regions, account):
     if not regions:
         return ('us-east-1', 'us-west-2')
 
-    resolved_regions = []
-    # support a comma seperated list of regions as a single parameter
-    for r in regions:
-        if ',' in r:
-            resolved_regions.extend([n.strip() for n in r.split(',')])
-        else:
-            resolved_regions.append(r)
+    return comma_expand(regions)
+
+def comma_expand(values):
+    resolved_values = []
+    for v in values:
+        if ',' in v:
+            resolved_values.extend([n.strip() for n in v.split(',')])
+        elif v:
+            resolved_values.append(v)
     # unique the set
     return list(dict.fromkeys(resolved_regions))
 
@@ -237,6 +244,8 @@ def get_session(account, session_name, region):
 
 def filter_accounts(accounts_config, tags, accounts, not_accounts=None):
     filtered_accounts = []
+    accounts = comma_expand(accounts)
+    not_accounts = comma_expand(not_accounts)
     for a in accounts_config.get('accounts', ()):
         if not_accounts and a['name'] in not_accounts:
             continue

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -204,8 +204,11 @@ def resolve_regions(regions, account):
 
     return comma_expand(regions)
 
+
 def comma_expand(values):
     resolved_values = []
+    if not values:
+        return []
     for v in values:
         if ',' in v:
             resolved_values.extend([n.strip() for n in v.split(',')])

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -173,6 +173,13 @@ class OrgTest(TestUtils):
         self.assertEqual(
             [n['name'] for n in t4['policies']], ['find-ml'])
 
+    def test_resolve_regions_comma_separated(self):
+        self.assertEqual(
+            org.resolve_regions([
+                'us-west-2,eu-west-1,us-east-1,us-west-2',
+                'eu-west-1,us-east-2,us-east-1'], None),
+            ['us-west-2', 'eu-west-1', 'us-east-1', 'us-east-2'])
+        
     def test_resolve_regions(self):
         account = {"name": "dev",
                    "account_id": "112233445566",

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -179,7 +179,7 @@ class OrgTest(TestUtils):
                 'us-west-2,eu-west-1,us-east-1,us-west-2',
                 'eu-west-1,us-east-2,us-east-1'], None),
             ['us-west-2', 'eu-west-1', 'us-east-1', 'us-east-2'])
-        
+
     def test_resolve_regions(self):
         account = {"name": "dev",
                    "account_id": "112233445566",


### PR DESCRIPTION
allow regions to be passed in as a comma separated list ala `-r us-east-1,eu-west-1` also supports the same for tags, accounts, policies cli options.