### PR TITLE
releng/aws ftest fixes

### DIFF
--- a/tests/terraform/aws_code_build_vpc/codebuild_project.tf
+++ b/tests/terraform/aws_code_build_vpc/codebuild_project.tf
@@ -4,7 +4,7 @@
 # }
 
 resource "aws_iam_role" "example" {
-  name = "example"
+  name = "example-code-build-unused"
 
   assume_role_policy = <<EOF
 {

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -101,7 +101,7 @@ def test_sqs_set_encryption(test, sqs_set_encryption):
     queue_url = resources[0]["QueueUrl"]
 
     queue_attributes = client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])
-    check_master_key = queue_attributes["Attributes"]["KmsMasterKeyId"]
+    check_master_key = queue_attributes["Attributes"].get("KmsMasterKeyId", '')
     test.assertEqual(check_master_key, key_id)
 
 


### PR DESCRIPTION
- unique the role name among tests
- sqs test fail on assert instead of error if key missing
