### PR TITLE
ci - aws arn resolver test nix thread usage for repeatability

### DIFF
--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -17,8 +17,6 @@ from c7n.executor import MainThreadExecutor
 
 from .common import BaseTest
 
-
-
 from aws_xray_sdk.core.models.segment import Segment
 from aws_xray_sdk.core.models.subsegment import Subsegment
 
@@ -80,8 +78,8 @@ class TestArnResolver:
         resolver = aws.ArnResolver(p.resource_manager)
         load_resources(('aws.sqs', 'aws.lambda'))
         test.patch(SQS, 'executor_factory', MainThreadExecutor)
-        arn_map = resolver.resolve([arns[0]])
-        # assert len(arn_map) == 3
+        arn_map = resolver.resolve(arns)
+        assert len(arn_map) == 3
         assert None not in arn_map.values()
 
     def test_arn_meta(self):


### PR DESCRIPTION
addresses some random failures in ci
﻿
also converts tests to pytest style for use with repeat plugin