### PR TITLE
aws - ddb config remove manual dt convert, config sources does it automatically

### DIFF
--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from botocore.exceptions import ClientError
 from concurrent.futures import as_completed
-from datetime import datetime
 
 from c7n.actions import BaseAction, ModifyVpcSecurityGroupsAction
 from c7n.filters.kms import KmsRelatedFilter

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -20,13 +20,6 @@ class ConfigTable(query.ConfigSource):
 
     def load_resource(self, item):
         resource = super(ConfigTable, self).load_resource(item)
-        resource['CreationDateTime'] = datetime.fromtimestamp(resource['CreationDateTime'] / 1000.0)
-        if ('BillingModeSummary' in resource and
-                'LastUpdateToPayPerRequestDateTime' in resource['BillingModeSummary']):
-            resource['BillingModeSummary'][
-                'LastUpdateToPayPerRequestDateTime'] = datetime.fromtimestamp(
-                    resource['BillingModeSummary']['LastUpdateToPayPerRequestDateTime'] / 1000.0)
-
         sse_info = resource.pop('Ssedescription', None)
         if sse_info is None:
             return resource

--- a/tools/c7n_salactus/requirements.txt
+++ b/tools/c7n_salactus/requirements.txt
@@ -10,7 +10,7 @@ functools32==3.2.3-2
 futures==3.3.0
 ipaddress>=1.0.17
 itsdangerous==1.1.0
-Jinja2==2.10.3
+Jinja2==2.11.3
 jmespath>=0.9.0
 jsonschema>=2.5.1
 MarkupSafe==1.1.1


### PR DESCRIPTION
closes #6470﻿ this workaround was implemented pre this marshalling being done for all datetime like fields in a resource by the base class config source.
