### PR TITLE
Initial devcontainer.json for VSCode and CodeSpaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+	"name": "Cloud Custodian Development",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"image": "python:3.8-buster",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"python.linting.pylintEnabled": false,
+		"python.linting.flake8Enabled": true,
+		"python.linting.enabled": true
+	},
+
+	"extensions": ["ms-python.python"],
+
+	"postCreateCommand": "cd .devcontainer && ./prep_container.sh",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
 	"name": "Cloud Custodian Development",
-
-	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	
 	"image": "python:3.8-buster",
 
 	// Set *default* container specific settings.json values on container create.

--- a/.devcontainer/prep_container.sh
+++ b/.devcontainer/prep_container.sh
@@ -4,7 +4,7 @@ set -x
 # Workspace
 cd ..
 
-# Install pre-requisites
+# Install prerequisites
 pip3 install -U virtualenv tox
 
 # Poetry

--- a/.devcontainer/prep_container.sh
+++ b/.devcontainer/prep_container.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+set -x
+
+# Workspace
+cd ..
+
+# Install pre-requisites
+pip3 install -U virtualenv tox
+
+# Poetry
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+source $HOME/.poetry/env
+
+# Virtual env
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install
+make install-poetry

--- a/tools/dev/docker_tox_linux/Dockerfile
+++ b/tools/dev/docker_tox_linux/Dockerfile
@@ -18,7 +18,7 @@
 
 
 
-FROM python:3.7-stretch
+FROM python:3.8-buster
 
 LABEL name="custodian tox" \
       description="Run Custodian test suite" \
@@ -30,9 +30,9 @@ RUN pip3 install tox
 
 ADD . /src
 WORKDIR /src
-RUN tox -e py37 --notest
+RUN tox -e py38 --notest
 
-ARG TOX_ENV=py37
+ARG TOX_ENV=py38
 
 # Setup for EntryPoint
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8" TOX_ENV_ENV=$TOX_ENV

--- a/tools/dev/docker_tox_windows/Dockerfile
+++ b/tools/dev/docker_tox_windows/Dockerfile
@@ -4,7 +4,7 @@
 # Change working directory to the repository root and run:
 # docker build -t custodian_tox_win . -f tools/dev/docker_tox_windows/Dockerfile && docker run -it custodian_tox_win
 
-FROM python:3.7-windowsservercore
+FROM python:3.8-windowsservercore
 
 LABEL name="custodian tox windows" \
       description="Run Custodian test suite" \
@@ -19,4 +19,4 @@ ADD . /src
 # Setup for EntryPoint
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 WORKDIR /src
-ENTRYPOINT ["tox", "-e", "py37"]
+ENTRYPOINT ["tox", "-e", "py38"]


### PR DESCRIPTION
Here is a working one and we can evolve over time with more extensions/configuration.

I went with a post-create script because the local dockerfile method is not supported for people using CodeSpaces.  

**To Use:**
Open the repository in VSCode and choose "Reopen in Container" from the Command Palette, then go get a coffee during package installation.  You can also choose "Rebuild Container" to start fresh.

(I also updated two older dev dockerfiles in the repo, which aren't directly related to the devcontainer)