### PR TITLE
azure - resolve arm tagging issues

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions/tagging.py
+++ b/tools/c7n_azure/c7n_azure/actions/tagging.py
@@ -308,8 +308,12 @@ class AutoTagUser(AutoTagBase):
             return False
 
     def _get_tag_value_from_resource(self, resource):
-        first_op = self._get_first_event(resource).serialize(True)
-        return self._get_tag_value_from_event({'data': first_op})
+        first_op = self._get_first_event(resource)
+
+        if not first_op:
+            return None
+
+        return self._get_tag_value_from_event({'data': first_op.serialize(True)})
 
 
 class AutoTagDate(AutoTagBase):

--- a/tools/c7n_azure/c7n_azure/resources/arm.py
+++ b/tools/c7n_azure/c7n_azure/resources/arm.py
@@ -54,7 +54,11 @@ class ArmResourceManager(QueryResourceManager, metaclass=QueryMeta):
         return self.augment([r.serialize(True) for r in data])
 
     def tag_operation_enabled(self, resource_type):
-        return not self.resource_type.resource_type.lower().startswith(tuple(arm_tags_unsupported))
+        return ArmResourceManager.generic_resource_supports_tagging(resource_type)
+
+    @staticmethod
+    def generic_resource_supports_tagging(resource_type):
+        return not resource_type.lower().startswith(tuple(arm_tags_unsupported))
 
     @staticmethod
     def register_arm_specific(registry, resource_class):
@@ -63,7 +67,8 @@ class ArmResourceManager(QueryResourceManager, metaclass=QueryMeta):
             return
 
         # Register tag actions for everything except a few non-compliant resources
-        if resource_class.tag_operation_enabled:
+        if ArmResourceManager.generic_resource_supports_tagging(
+                resource_class.resource_type.resource_type):
             resource_class.action_registry.register('tag', Tag)
             resource_class.action_registry.register('untag', RemoveTag)
             resource_class.action_registry.register('auto-tag-user', AutoTagUser)

--- a/tools/c7n_azure/c7n_azure/resources/arm.py
+++ b/tools/c7n_azure/c7n_azure/resources/arm.py
@@ -19,6 +19,7 @@ arm_tags_unsupported = ['microsoft.network/dnszones',
                         'microsoft.sql/servers/databases',
                         'microsoft.storage/storageaccounts/blobservices/containers']
 
+
 class ArmTypeInfo(TypeInfo, metaclass=TypeMeta):
     # api client construction information for ARM resources
     id = 'id'

--- a/tools/c7n_azure/c7n_azure/resources/arm.py
+++ b/tools/c7n_azure/c7n_azure/resources/arm.py
@@ -13,8 +13,11 @@ from c7n_azure.query import QueryResourceManager, QueryMeta, ChildResourceManage
     ChildTypeInfo, TypeMeta
 from c7n_azure.utils import ResourceIdParser
 
-arm_resource_types = {}
-
+# ARM resources which do not currently support tagging
+# for database it is a C7N known issue (#4543)
+arm_tags_unsupported = ['microsoft.network/dnszones',
+                        'microsoft.sql/servers/databases',
+                        'microsoft.storage/storageaccounts/blobservices/containers']
 
 class ArmTypeInfo(TypeInfo, metaclass=TypeMeta):
     # api client construction information for ARM resources
@@ -27,7 +30,6 @@ class ArmTypeInfo(TypeInfo, metaclass=TypeMeta):
         'resourceGroup'
     )
     resource_type = None
-    enable_tag_operations = True
 
 
 class ArmResourceManager(QueryResourceManager, metaclass=QueryMeta):
@@ -51,7 +53,7 @@ class ArmResourceManager(QueryResourceManager, metaclass=QueryMeta):
         return self.augment([r.serialize(True) for r in data])
 
     def tag_operation_enabled(self, resource_type):
-        return self.resource_type.enable_tag_operations
+        return not self.resource_type.resource_type.lower().startswith(tuple(arm_tags_unsupported))
 
     @staticmethod
     def register_arm_specific(registry, resource_class):
@@ -59,10 +61,8 @@ class ArmResourceManager(QueryResourceManager, metaclass=QueryMeta):
         if not issubclass(resource_class, ArmResourceManager):
             return
 
-        arm_resource_types[
-            resource_class.resource_type.resource_type.lower()] = resource_class.resource_type
-
-        if resource_class.resource_type.enable_tag_operations:
+        # Register tag actions for everything except a few non-compliant resources
+        if resource_class.tag_operation_enabled:
             resource_class.action_registry.register('tag', Tag)
             resource_class.action_registry.register('untag', RemoveTag)
             resource_class.action_registry.register('auto-tag-user', AutoTagUser)

--- a/tools/c7n_azure/c7n_azure/resources/generic_arm_resource.py
+++ b/tools/c7n_azure/c7n_azure/resources/generic_arm_resource.py
@@ -4,7 +4,7 @@
 from c7n_azure.constants import RESOURCE_GROUPS_TYPE
 from c7n_azure.provider import resources
 from c7n_azure.query import DescribeSource, ResourceQuery
-from c7n_azure.resources.arm import ArmResourceManager, arm_tags_unsupported
+from c7n_azure.resources.arm import ArmResourceManager
 
 from c7n.filters.core import Filter, type_schema
 from c7n.query import sources
@@ -79,11 +79,6 @@ class GenericArmResource(ArmResourceManager):
             result.append(resource)
 
         return self.augment([r.serialize(True) for r in result])
-
-    def tag_operation_enabled(self, resource_type):
-        # Tag operations work on nearly all generic arm resources
-        # but we need to exclude known unsupported.
-        return resource_type.lower().startswith(tuple(arm_tags_unsupported))
 
     @property
     def source_type(self):

--- a/tools/c7n_azure/c7n_azure/resources/generic_arm_resource.py
+++ b/tools/c7n_azure/c7n_azure/resources/generic_arm_resource.py
@@ -4,7 +4,7 @@
 from c7n_azure.constants import RESOURCE_GROUPS_TYPE
 from c7n_azure.provider import resources
 from c7n_azure.query import DescribeSource, ResourceQuery
-from c7n_azure.resources.arm import ArmResourceManager, arm_resource_types
+from c7n_azure.resources.arm import ArmResourceManager, arm_tags_unsupported
 
 from c7n.filters.core import Filter, type_schema
 from c7n.query import sources
@@ -56,7 +56,6 @@ class GenericArmResource(ArmResourceManager):
         client = 'ResourceManagementClient'
 
         resource_type = 'armresource'
-        enable_tag_operations = True
         diagnostic_settings_enabled = False
 
         default_report_fields = (
@@ -82,9 +81,9 @@ class GenericArmResource(ArmResourceManager):
         return self.augment([r.serialize(True) for r in result])
 
     def tag_operation_enabled(self, resource_type):
-        if resource_type.lower() in arm_resource_types:
-            return arm_resource_types[resource_type.lower()].enable_tag_operations
-        return False
+        # Tag operations work on nearly all generic arm resources
+        # but we need to exclude known unsupported.
+        return resource_type.lower().startswith(tuple(arm_tags_unsupported))
 
     @property
     def source_type(self):

--- a/tools/c7n_azure/c7n_azure/resources/record_set.py
+++ b/tools/c7n_azure/c7n_azure/resources/record_set.py
@@ -38,7 +38,6 @@ class RecordSet(ChildArmResourceManager):
         # NOTE: Record Sets each have their own resource_type value
         resource_type = 'Microsoft.Network/dnszones/{A|AAAA|CAA|CNAME|LIST|MX|NS|PTR|SOA|SRV|TXT}'
 
-        enable_tag_operations = False
 
         @classmethod
         def extra_args(cls, dns_zone):

--- a/tools/c7n_azure/c7n_azure/resources/record_set.py
+++ b/tools/c7n_azure/c7n_azure/resources/record_set.py
@@ -38,7 +38,6 @@ class RecordSet(ChildArmResourceManager):
         # NOTE: Record Sets each have their own resource_type value
         resource_type = 'Microsoft.Network/dnszones/{A|AAAA|CAA|CNAME|LIST|MX|NS|PTR|SOA|SRV|TXT}'
 
-
         @classmethod
         def extra_args(cls, dns_zone):
             return {

--- a/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
@@ -59,7 +59,6 @@ class SqlDatabase(ChildArmResourceManager):
         enum_spec = ('databases', 'list_by_server', None)
         parent_manager_name = 'sqlserver'
         resource_type = 'Microsoft.Sql/servers/databases'
-        enable_tag_operations = False  # GH Issue #4543
         default_report_fields = (
             'name',
             'location',

--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -40,7 +40,6 @@ class StorageContainer(ChildArmResourceManager):
         parent_manager_name = 'storage'
         diagnostic_settings_enabled = False
         resource_type = 'Microsoft.Storage/storageAccounts/blobServices/containers'
-        enable_tag_operations = False
         raise_on_exception = False
         default_report_fields = (
             'name',

--- a/tools/c7n_azure/tests_azure/tests_resources/test_armresource.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_armresource.py
@@ -3,6 +3,7 @@
 from ..azure_common import BaseTest, arm_template, cassette_name
 from mock import patch
 from c7n_azure.resources.generic_arm_resource import GenericArmResource
+from c7n_azure.resources.arm import arm_tags_unsupported
 from c7n.exceptions import PolicyValidationError
 
 
@@ -18,6 +19,14 @@ class ArmResourceTest(BaseTest):
                 'resource': 'azure.armresource'
             }, validate=True)
             self.assertTrue(p)
+
+    def test_tag_operation_enabled(self):
+        r = GenericArmResource(self.test_context, {})
+        # False for excluded resources
+        for t in arm_tags_unsupported:
+            self.assertFalse(r.tag_operation_enabled(t))
+        # Default true
+        self.assertTrue(r.tag_operation_enabled("SomeResource"))
 
     @arm_template('vm.json')
     @cassette_name('common')


### PR DESCRIPTION
Resolving two bugs:

1) For historical creator tagging if there was no history we'd throw exceptions.  The tagging of this resource would have failed anyway so this was a cosmetic issue.

2) For tagging generic ARM resources we assume they all support tags but there are a few exceptions.  We used to attribute this in the resource metadata but that makes it challenging to find with lazy loading.  I simplified this code down quite a bit and just maintain an exception list in the `arm.py`.   Most users we are familiar with on Azure were running container host which loads all resources so we hadn't realized this was broken for a long time now in CLI executions.