### PR TITLE
enable richer policy metadata

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -258,7 +258,7 @@ def generate(resource_types=()):
                 'comments': {'type': 'string'},
                 'description': {'type': 'string'},
                 'tags': {'type': 'array', 'items': {'type': 'string'}},
-                'metadata': {'$ref': '#/definitions/basic_dict'},
+                'metadata': {'type': ['object', 'array']},
                 'mode': {'$ref': '#/definitions/policy-mode'},
                 'source': {'enum': ['describe', 'config', 'inventory',
                                     'resource-graph', 'disk', 'static']},

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -297,7 +297,25 @@ class SchemaTest(BaseTest):
 
     def test_metadata(self):
         data = {
-            "policies": [{"name": "test", "resource": "ec2", "metadata": {"createdBy": "Totoro"}}],
+            "policies": [
+                {
+                    "name": "object_test",
+                    "resource": "ec2",
+                    "metadata": {
+                        "createdBy": "Totoro",
+                        "version": 1988,
+                        "relatedTo": ['Ghibli', 'Classic', 'Miyazaki']
+                    }
+                },
+                {
+                    "name": "array_test",
+                    "resource": "ec2",
+                    "metadata": [
+                        {"createdBy": "Crimson Pig"},
+                        {"relatedTo": ['Porco', 'Rosso']}
+                    ]
+                }
+            ],
         }
         load_resources(('aws.ec2',))
         validator = self.get_validator(data)


### PR DESCRIPTION
For https://github.com/cloud-custodian/cloud-custodian/issues/6445, enables richer policy metadata by allowing object and array types in the schema validation. 