### PR TITLE
[Azure SDK integration branch PR] Legacy clients & Storage queue new behavior

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions/delete.py
+++ b/tools/c7n_azure/c7n_azure/actions/delete.py
@@ -64,6 +64,6 @@ class DeleteAction(AzureBaseAction):
         if is_resource_group(resource):
             self.client.resource_groups.delete(resource['name'])
         else:
-            self.client.resources.delete_by_id(resource['id'],
-                                               self.session.resource_api_version(resource['id']))
+            self.client.resources.begin_delete_by_id(resource['id'],
+                                                     self.session.resource_api_version(resource['id']))
         return "deleted"

--- a/tools/c7n_azure/c7n_azure/resources/access_control.py
+++ b/tools/c7n_azure/c7n_azure/resources/access_control.py
@@ -4,22 +4,16 @@
 import logging
 import re
 
-from azure.graphrbac import GraphRbacManagementClient
+from c7n.filters import Filter, FilterValidationError, ValueFilter
+from c7n.filters.related import RelatedResourceFilter
+from c7n.query import sources
+from c7n.resources import load_resources
+from c7n.utils import local_session, type_schema
 from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.constants import GRAPH_AUTH_ENDPOINT
-from c7n_azure.provider import Azure
-from c7n_azure.provider import resources
-from c7n_azure.query import QueryResourceManager, DescribeSource
+from c7n_azure.provider import Azure, resources
+from c7n_azure.query import DescribeSource, QueryResourceManager
 from c7n_azure.utils import GraphHelper
-
-from c7n.filters import Filter
-from c7n.filters import FilterValidationError
-from c7n.filters import ValueFilter
-from c7n.filters.related import RelatedResourceFilter
-from c7n.resources import load_resources
-from c7n.query import sources
-from c7n.utils import local_session
-from c7n.utils import type_schema
 
 log = logging.getLogger('custodian.azure.access_control')
 
@@ -110,7 +104,7 @@ class RoleAssignment(QueryResourceManager):
 
     def augment(self, resources):
         s = self.get_session().get_session_for_resource(GRAPH_AUTH_ENDPOINT)
-        graph_client = GraphRbacManagementClient(s.get_credentials(), s.get_tenant_id())
+        graph_client = s.client('azure.graphrbac.GraphRbacManagementClient')
 
         object_ids = list(set(
             resource['properties']['principalId'] for resource in resources

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -244,7 +244,7 @@ class WhiteListFilter(Filter):
 
         if self.graph_client is None:
             s = Session(resource_endpoint_type=GRAPH_AUTH_ENDPOINT)
-            self.graph_client = GraphRbacManagementClient(s.get_credentials(), s.get_tenant_id())
+            self.graph_client = s.client('azure.graphrbac.GraphRbacManagementClient')
 
         # Retrieve graph objects for all object_id
         object_ids = [p['objectId'] for p in access_policies]


### PR DESCRIPTION
- Add legacy credentials to work with Graph, DNS and RecordSet (part of DNS SDK) clients until they support Track 2 auth
  - https://github.com/Azure/azure-sdk-for-python/issues/17148
  - https://github.com/Azure/azure-sdk-for-python/issues/17302
- Storage Queue `receive_messages` appears to pull all messages from the queue which is the behavior change from previous version. As a workaround, we just query first page of results.
  - https://github.com/Azure/azure-sdk-for-python/issues/17301
- Minor function name update