### PR TITLE
Add VPC Filters for AWS Message Brokers (default-vpc and vpc filter)

### DIFF
--- a/c7n/resources/mq.py
+++ b/c7n/resources/mq.py
@@ -1,7 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from c7n.exceptions import ClientError
 from c7n.actions import Action
+from c7n.exceptions import ClientError
 from c7n.filters.metrics import MetricsFilter
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter, VpcFilter, DefaultVpcBase
 from c7n.filters.kms import KmsRelatedFilter

--- a/c7n/resources/mq.py
+++ b/c7n/resources/mq.py
@@ -8,17 +8,21 @@ from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
 from c7n.utils import local_session, type_schema
-from c7n.tags import RemoveTag, Tag, TagDelayedAction, TagActionFilter, universal_augment
+from c7n.tags import (
+    RemoveTag,
+    Tag,
+    TagDelayedAction,
+    TagActionFilter,
+    universal_augment,
+)
 
 
 @resources.register('message-broker')
 class MessageBroker(QueryResourceManager):
-
     class resource_type(TypeInfo):
         service = 'mq'
         enum_spec = ('list_brokers', 'BrokerSummaries', None)
-        detail_spec = (
-            'describe_broker', 'BrokerId', 'BrokerId', None)
+        detail_spec = ('describe_broker', 'BrokerId', 'BrokerId', None)
         cfn_type = 'AWS::AmazonMQ::Broker'
         id = 'BrokerId'
         arn = 'BrokerArn'
@@ -54,6 +58,7 @@ class KmsFilter(KmsRelatedFilter):
                 value: "^(alias/aws/mq)"
                 op: regex
     """
+
     RelatedIdsExpression = 'EncryptionOptions.KmsKeyId'
 
 
@@ -77,58 +82,95 @@ class MQSGFilter(SecurityGroupFilter):
 
 @MessageBroker.filter_registry.register('metrics')
 class MQMetrics(MetricsFilter):
-
     def get_dimensions(self, resource):
         # Fetching for Active broker instance only, https://amzn.to/2tLBhEB
-        return [{'Name': self.model.dimension,
-                 'Value': "{}-1".format(resource['BrokerName'])}]
+        return [
+            {
+                'Name': self.model.dimension,
+                'Value': "{}-1".format(resource['BrokerName']),
+            }
+        ]
+
 
 @MessageBroker.filter_registry.register('vpc')
 class VpcFilter(VpcFilter):
+    """Filter a resource by its VPC id. Choose to select resources that are in that VPC or select
+    resources that are not in that VPC using the 'op' field. Security group ID is used to get
+    the VPC ID of a message broker, since DescribeMessageBrokers does not return a VPC ID.
+    Since message brokers are exclusively launched in a single VPC, and their security groups
+    all belong to this VPC, only the first security group id is needed to check the VPC
+    ID of the message broker. Continue is used in the function if a client error occurs
+    when trying to get a broker's vpc -- this will skip this broker, but still attempt to grab
+    the vpc ids of the other brokers in the list.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: mq-vpc-filters
+                resource: message-broker
+                filters: [{'type': 'vpc', 'key': 'VpcId', 'value': 'vpc-xxxxxxxxxxx', 'op': 'eq'}]
+    """
 
     sg_vpc_dict = {}
 
     def get_related_ids(self, resources):
         client = local_session(self.manager.session_factory).client('ec2')
-        related_ids = []
+        related_ids = set()
         for r in resources:
-            sg_ids = r.get('SecurityGroups', [])
+            try:
+                sg_ids = r.get('SecurityGroups', [])
+            except IndexError:
+                continue
             vpc_id = self.sg_vpc_dict.get(sg_ids[0])
-            if(vpc_id):
-                related_ids.append(vpc_id)
+            if vpc_id:
+                related_ids.add(vpc_id)
                 continue
             try:
                 response = client.describe_security_groups(
                     GroupIds=[sg_ids[0]],
                 )
                 vpc_id = response.get('SecurityGroups')[0].get('VpcId')
-                related_ids.append(vpc_id)
+                related_ids.add(vpc_id)
                 self.sg_vpc_dict[sg_ids[0]] = vpc_id
-            except ClientError: 
-                continue 
-        return set(related_ids)
+            except ClientError:
+                continue
+        return related_ids
 
     RelatedIdsExpression = "VpcId"
 
 
 @MessageBroker.filter_registry.register('default-vpc')
 class DefaultVpc(DefaultVpcBase):
-    """ Matches if an mq broker is in the default vpc
+    """Matches if an mq broker is in the default vpc
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: mq-default-filters
+                resource: message-broker
+                filters: [{'type': 'default-vpc'}]
     """
 
     schema = type_schema('default-vpc')
 
     def retrieve_vpc_id(self, mq):
         client = local_session(self.manager.session_factory).client('ec2')
-        sg_ids = mq.get('SecurityGroups',[])
+        try:
+            sg_ids = mq.get('SecurityGroups', [])
+        except IndexError:
+            return
         try:
             response = client.describe_security_groups(
                 GroupIds=[sg_ids[0]],
             )
             vpc_id = response.get('SecurityGroups')[0].get('VpcId')
             return vpc_id
-        except IndexError: 
-            return 
+        except IndexError:
+            return
 
     def __call__(self, mq):
         vpc_id = self.retrieve_vpc_id(mq)
@@ -137,8 +179,7 @@ class DefaultVpc(DefaultVpcBase):
 
 @MessageBroker.action_registry.register('delete')
 class Delete(Action):
-    """Delete a set of message brokers
-    """
+    """Delete a set of message brokers"""
 
     schema = type_schema('delete')
     permissions = ("mq:DeleteBroker",)
@@ -178,7 +219,8 @@ class TagMessageBroker(Tag):
             try:
                 client.create_tags(
                     ResourceArn=r['BrokerArn'],
-                    Tags={t['Key']: t['Value'] for t in new_tags})
+                    Tags={t['Key']: t['Value'] for t in new_tags},
+                )
             except client.exceptions.ResourceNotFound:
                 continue
 
@@ -235,7 +277,6 @@ class MarkForOpMessageBroker(TagDelayedAction):
 
 @resources.register('message-config')
 class MessageConfig(QueryResourceManager):
-
     class resource_type(TypeInfo):
         service = 'mq'
         enum_spec = ('list_configurations', 'Configurations', None)

--- a/c7n/resources/mq.py
+++ b/c7n/resources/mq.py
@@ -8,21 +8,17 @@ from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
 from c7n.utils import local_session, type_schema
-from c7n.tags import (
-    RemoveTag,
-    Tag,
-    TagDelayedAction,
-    TagActionFilter,
-    universal_augment,
-)
+from c7n.tags import RemoveTag, Tag, TagDelayedAction, TagActionFilter, universal_augment
 
 
 @resources.register('message-broker')
 class MessageBroker(QueryResourceManager):
+
     class resource_type(TypeInfo):
         service = 'mq'
         enum_spec = ('list_brokers', 'BrokerSummaries', None)
-        detail_spec = ('describe_broker', 'BrokerId', 'BrokerId', None)
+        detail_spec = (
+            'describe_broker', 'BrokerId', 'BrokerId', None)
         cfn_type = 'AWS::AmazonMQ::Broker'
         id = 'BrokerId'
         arn = 'BrokerArn'
@@ -82,14 +78,11 @@ class MQSGFilter(SecurityGroupFilter):
 
 @MessageBroker.filter_registry.register('metrics')
 class MQMetrics(MetricsFilter):
+
     def get_dimensions(self, resource):
         # Fetching for Active broker instance only, https://amzn.to/2tLBhEB
-        return [
-            {
-                'Name': self.model.dimension,
-                'Value': "{}-1".format(resource['BrokerName']),
-            }
-        ]
+        return [{'Name': self.model.dimension,
+                 'Value': "{}-1".format(resource['BrokerName'])}]
 
 
 @MessageBroker.filter_registry.register('vpc')
@@ -219,8 +212,7 @@ class TagMessageBroker(Tag):
             try:
                 client.create_tags(
                     ResourceArn=r['BrokerArn'],
-                    Tags={t['Key']: t['Value'] for t in new_tags},
-                )
+                    Tags={t['Key']: t['Value'] for t in new_tags})
             except client.exceptions.ResourceNotFound:
                 continue
 
@@ -277,6 +269,7 @@ class MarkForOpMessageBroker(TagDelayedAction):
 
 @resources.register('message-config')
 class MessageConfig(QueryResourceManager):
+
     class resource_type(TypeInfo):
         service = 'mq'
         enum_spec = ('list_configurations', 'Configurations', None)

--- a/c7n/resources/mq.py
+++ b/c7n/resources/mq.py
@@ -136,7 +136,9 @@ class VpcFilter(VpcFilter):
 
 @MessageBroker.filter_registry.register('default-vpc')
 class DefaultVpc(DefaultVpcBase):
-    """Matches if an mq broker is in the default vpc
+    """Matches if an mq broker is in the default vpc. Helper function
+    retrieve_vpc_id returns an optional[str] which can be a VPC ID, or None
+    if there is an error in the API call.
 
     :example:
 
@@ -152,10 +154,7 @@ class DefaultVpc(DefaultVpcBase):
 
     def retrieve_vpc_id(self, mq):
         client = local_session(self.manager.session_factory).client('ec2')
-        try:
-            sg_ids = mq.get('SecurityGroups', [])
-        except IndexError:
-            return
+        sg_ids = mq.get('SecurityGroups', [])
         try:
             response = client.describe_security_groups(
                 GroupIds=[sg_ids[0]],

--- a/tests/data/placebo/test_message_broker_vpc_default_filter/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_default_filter/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,43 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "Description": "AWS created security group for d-90677cc91c directory controllers",
+                "GroupName": "d-90677cc91c_controllers",
+                "IpPermissions": [ 
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": [
+                            {
+                                "GroupId": "sg-08f62b8c3dd4669bc",
+                                "UserId": "012345678910"
+                            }
+                        ]
+                    }
+                ],
+                "OwnerId": "012345678910",
+                "GroupId": "sg-08f62b8c3dd4669bc",
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": [
+                            {
+                                "GroupId": "sg-08f62b8c3dd4669bc",
+                                "UserId": "012345678910"
+                            }
+                        ]
+                    }
+                ],
+                "VpcId": "vpc-0598080981e0332f9"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_default_filter/ec2.DescribeSecurityGroups_2.json
+++ b/tests/data/placebo/test_message_broker_vpc_default_filter/ec2.DescribeSecurityGroups_2.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "Description": "default VPC security group",
+                "GroupName": "default",
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "108.56.181.242/32"
+                            },
+                            {
+                                "CidrIp": "67.166.173.46/32"
+                            }
+                        ],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": [
+                            {
+                                "GroupId": "sg-6c7fa917",
+                                "UserId": "012345678910"
+                            }
+                        ]
+                    }
+                ],
+                "OwnerId": "012345678910",
+                "GroupId": "sg-6c7fa917",
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": []
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "NetworkLocation",
+                        "Value": "Private"
+                    }
+                ],
+                "VpcId": "vpc-d2d616b5"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_default_filter/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_default_filter/ec2.DescribeVpcs_1.json
@@ -1,0 +1,184 @@
+{
+    "status_code": 200,
+    "data": {
+        "Vpcs": [
+            {
+                "CidrBlock": "10.0.0.0/24",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-0a59f94e3fca9fbc0",
+                "OwnerId": "012345678910",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-07bd86efac3732a5b",
+                        "CidrBlock": "10.0.0.0/24",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "implied"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "10.205.0.0/18",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-03005fb9b8740263d",
+                "OwnerId": "012345678910",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-0f6765530d80dc044",
+                        "CidrBlock": "10.205.0.0/18",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "c7n"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "testing-vpc"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "172.16.0.0/16",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-0598080981e0332f9",
+                "OwnerId": "012345678910",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-07a76233f273c7199",
+                        "CidrBlock": "172.16.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "AWSServiceAccount",
+                        "Value": "012345678910"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "192.168.0.0/16",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-01a1ffc078406ab62",
+                "OwnerId": "012345678910",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-08a949c48a6dbd293",
+                        "CidrBlock": "192.168.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "aws:cloudformation:stack-id",
+                        "Value": "arn:aws:cloudformation:us-east-1:012345678910:stack/eksctl-sanjay-cluster/ad933be0-88bf-11ea-8212-1208f0f76cbf"
+                    },
+                    {
+                        "Key": "DontTurnOff",
+                        "Value": "CloudCustodian"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "eksctl-sanjay-cluster/VPC"
+                    },
+                    {
+                        "Key": "aws:cloudformation:logical-id",
+                        "Value": "VPC"
+                    },
+                    {
+                        "Key": "alpha.eksctl.io/eksctl-version",
+                        "Value": "0.18.0"
+                    },
+                    {
+                        "Key": "aws:cloudformation:stack-name",
+                        "Value": "eksctl-sanjay-cluster"
+                    },
+                    {
+                        "Key": "alpha.eksctl.io/cluster-name",
+                        "Value": "sanjay"
+                    },
+                    {
+                        "Key": "eksctl.cluster.k8s.io/v1alpha1/cluster-name",
+                        "Value": "sanjay"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "172.31.0.0/16",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-d2d616b5",
+                "OwnerId": "012345678910",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-33669f5a",
+                        "CidrBlock": "172.31.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": true,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "FlowLogTest"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "10.0.0.0/16",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-072f438c953672ace",
+                "OwnerId": "012345678910",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-0194dd85e1c73db14",
+                        "CidrBlock": "10.0.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "public with private"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_default_filter/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_default_filter/ec2.DescribeVpcs_1.json
@@ -3,58 +3,6 @@
     "data": {
         "Vpcs": [
             {
-                "CidrBlock": "10.0.0.0/24",
-                "DhcpOptionsId": "dopt-24ff1940",
-                "State": "available",
-                "VpcId": "vpc-0a59f94e3fca9fbc0",
-                "OwnerId": "012345678910",
-                "InstanceTenancy": "default",
-                "CidrBlockAssociationSet": [
-                    {
-                        "AssociationId": "vpc-cidr-assoc-07bd86efac3732a5b",
-                        "CidrBlock": "10.0.0.0/24",
-                        "CidrBlockState": {
-                            "State": "associated"
-                        }
-                    }
-                ],
-                "IsDefault": false,
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": "implied"
-                    }
-                ]
-            },
-            {
-                "CidrBlock": "10.205.0.0/18",
-                "DhcpOptionsId": "dopt-24ff1940",
-                "State": "available",
-                "VpcId": "vpc-03005fb9b8740263d",
-                "OwnerId": "012345678910",
-                "InstanceTenancy": "default",
-                "CidrBlockAssociationSet": [
-                    {
-                        "AssociationId": "vpc-cidr-assoc-0f6765530d80dc044",
-                        "CidrBlock": "10.205.0.0/18",
-                        "CidrBlockState": {
-                            "State": "associated"
-                        }
-                    }
-                ],
-                "IsDefault": false,
-                "Tags": [
-                    {
-                        "Key": "Owner",
-                        "Value": "c7n"
-                    },
-                    {
-                        "Key": "Name",
-                        "Value": "testing-vpc"
-                    }
-                ]
-            },
-            {
                 "CidrBlock": "172.16.0.0/16",
                 "DhcpOptionsId": "dopt-24ff1940",
                 "State": "available",
@@ -79,58 +27,6 @@
                 ]
             },
             {
-                "CidrBlock": "192.168.0.0/16",
-                "DhcpOptionsId": "dopt-24ff1940",
-                "State": "available",
-                "VpcId": "vpc-01a1ffc078406ab62",
-                "OwnerId": "012345678910",
-                "InstanceTenancy": "default",
-                "CidrBlockAssociationSet": [
-                    {
-                        "AssociationId": "vpc-cidr-assoc-08a949c48a6dbd293",
-                        "CidrBlock": "192.168.0.0/16",
-                        "CidrBlockState": {
-                            "State": "associated"
-                        }
-                    }
-                ],
-                "IsDefault": false,
-                "Tags": [
-                    {
-                        "Key": "aws:cloudformation:stack-id",
-                        "Value": "arn:aws:cloudformation:us-east-1:012345678910:stack/eksctl-sanjay-cluster/ad933be0-88bf-11ea-8212-1208f0f76cbf"
-                    },
-                    {
-                        "Key": "DontTurnOff",
-                        "Value": "CloudCustodian"
-                    },
-                    {
-                        "Key": "Name",
-                        "Value": "eksctl-sanjay-cluster/VPC"
-                    },
-                    {
-                        "Key": "aws:cloudformation:logical-id",
-                        "Value": "VPC"
-                    },
-                    {
-                        "Key": "alpha.eksctl.io/eksctl-version",
-                        "Value": "0.18.0"
-                    },
-                    {
-                        "Key": "aws:cloudformation:stack-name",
-                        "Value": "eksctl-sanjay-cluster"
-                    },
-                    {
-                        "Key": "alpha.eksctl.io/cluster-name",
-                        "Value": "sanjay"
-                    },
-                    {
-                        "Key": "eksctl.cluster.k8s.io/v1alpha1/cluster-name",
-                        "Value": "sanjay"
-                    }
-                ]
-            },
-            {
                 "CidrBlock": "172.31.0.0/16",
                 "DhcpOptionsId": "dopt-24ff1940",
                 "State": "available",
@@ -151,30 +47,6 @@
                     {
                         "Key": "Name",
                         "Value": "FlowLogTest"
-                    }
-                ]
-            },
-            {
-                "CidrBlock": "10.0.0.0/16",
-                "DhcpOptionsId": "dopt-24ff1940",
-                "State": "available",
-                "VpcId": "vpc-072f438c953672ace",
-                "OwnerId": "012345678910",
-                "InstanceTenancy": "default",
-                "CidrBlockAssociationSet": [
-                    {
-                        "AssociationId": "vpc-cidr-assoc-0194dd85e1c73db14",
-                        "CidrBlock": "10.0.0.0/16",
-                        "CidrBlockState": {
-                            "State": "associated"
-                        }
-                    }
-                ],
-                "IsDefault": false,
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": "public with private"
                     }
                 ]
             }

--- a/tests/data/placebo/test_message_broker_vpc_default_filter/mq.DescribeBroker_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_default_filter/mq.DescribeBroker_1.json
@@ -1,0 +1,76 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AuthenticationStrategy": "simple",
+        "AutoMinorVersionUpgrade": true,
+        "BrokerArn": "arn:aws:mq:us-east-1:012345678910:broker:TestBroker2:b-c7aa6808-ba11-4d0c-b570-795e4724c841",
+        "BrokerId": "b-c7aa6808-ba11-4d0c-b570-795e4724c841",
+        "BrokerInstances": [
+            {
+                "ConsoleURL": "https://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:8162",
+                "Endpoints": [
+                    "ssl://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:61617",
+                    "amqp+ssl://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:5671",
+                    "stomp+ssl://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:61614",
+                    "mqtt+ssl://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:8883",
+                    "wss://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:61619"
+                ],
+                "IpAddress": "54.221.242.156"
+            }
+        ],
+        "BrokerName": "TestBroker2",
+        "BrokerState": "RUNNING",
+        "Configurations": {
+            "Current": {
+                "Id": "c-35ea55fd-c8e6-4730-9e8f-d5329db8e9b7",
+                "Revision": 1
+            },
+            "History": []
+        },
+        "Created": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 3,
+            "day": 8,
+            "hour": 17,
+            "minute": 10,
+            "second": 34,
+            "microsecond": 888000
+        },
+        "DeploymentMode": "SINGLE_INSTANCE",
+        "EncryptionOptions": {
+            "UseAwsOwnedKey": true
+        },
+        "EngineType": "ActiveMQ",
+        "EngineVersion": "5.15.14",
+        "HostInstanceType": "mq.t3.micro",
+        "Logs": {
+            "Audit": false,
+            "AuditLogGroup": "/aws/amazonmq/broker/b-c7aa6808-ba11-4d0c-b570-795e4724c841/audit",
+            "General": false,
+            "GeneralLogGroup": "/aws/amazonmq/broker/b-c7aa6808-ba11-4d0c-b570-795e4724c841/general"
+        },
+        "MaintenanceWindowStartTime": {
+            "DayOfWeek": "THURSDAY",
+            "TimeOfDay": "07:00",
+            "TimeZone": "UTC"
+        },
+        "PubliclyAccessible": true,
+        "SecurityGroups": [
+            "sg-08f62b8c3dd4669bc"
+        ],
+        "StorageType": "efs",
+        "SubnetIds": [
+            "subnet-083ab4dd1a8b6eaa6"
+        ],
+        "Tags": {
+            "testing": "test2"
+        },
+        "Users": [
+            {
+                "Username": "testing"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_default_filter/mq.DescribeBroker_2.json
+++ b/tests/data/placebo/test_message_broker_vpc_default_filter/mq.DescribeBroker_2.json
@@ -1,0 +1,76 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AuthenticationStrategy": "simple",
+        "AutoMinorVersionUpgrade": true,
+        "BrokerArn": "arn:aws:mq:us-east-1:012345678910:broker:TestBroker1:b-cec75166-abad-49f9-bad0-015c7e405219",
+        "BrokerId": "b-cec75166-abad-49f9-bad0-015c7e405219",
+        "BrokerInstances": [
+            {
+                "ConsoleURL": "https://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:8162",
+                "Endpoints": [
+                    "ssl://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:61617",
+                    "amqp+ssl://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:5671",
+                    "stomp+ssl://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:61614",
+                    "mqtt+ssl://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:8883",
+                    "wss://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:61619"
+                ],
+                "IpAddress": "52.204.80.11"
+            }
+        ],
+        "BrokerName": "TestBroker1",
+        "BrokerState": "RUNNING",
+        "Configurations": {
+            "Current": {
+                "Id": "c-4165d773-b914-4761-8bb1-a3d18acd6bd9",
+                "Revision": 1
+            },
+            "History": []
+        },
+        "Created": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 3,
+            "day": 8,
+            "hour": 17,
+            "minute": 8,
+            "second": 50,
+            "microsecond": 622000
+        },
+        "DeploymentMode": "SINGLE_INSTANCE",
+        "EncryptionOptions": {
+            "UseAwsOwnedKey": true
+        },
+        "EngineType": "ActiveMQ",
+        "EngineVersion": "5.15.14",
+        "HostInstanceType": "mq.t3.micro",
+        "Logs": {
+            "Audit": false,
+            "AuditLogGroup": "/aws/amazonmq/broker/b-cec75166-abad-49f9-bad0-015c7e405219/audit",
+            "General": false,
+            "GeneralLogGroup": "/aws/amazonmq/broker/b-cec75166-abad-49f9-bad0-015c7e405219/general"
+        },
+        "MaintenanceWindowStartTime": {
+            "DayOfWeek": "MONDAY",
+            "TimeOfDay": "13:00",
+            "TimeZone": "UTC"
+        },
+        "PubliclyAccessible": true,
+        "SecurityGroups": [
+            "sg-6c7fa917"
+        ],
+        "StorageType": "efs",
+        "SubnetIds": [
+            "subnet-efbcccb7"
+        ],
+        "Tags": {
+            "test": "test1"
+        },
+        "Users": [
+            {
+                "Username": "testing"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_default_filter/mq.ListBrokers_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_default_filter/mq.ListBrokers_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BrokerSummaries": [
+            {
+                "BrokerArn": "arn:aws:mq:us-east-1:012345678910:broker:TestBroker2:b-c7aa6808-ba11-4d0c-b570-795e4724c841",
+                "BrokerId": "b-c7aa6808-ba11-4d0c-b570-795e4724c841",
+                "BrokerName": "TestBroker2",
+                "BrokerState": "RUNNING",
+                "Created": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 17,
+                    "minute": 10,
+                    "second": 34,
+                    "microsecond": 888000
+                },
+                "DeploymentMode": "SINGLE_INSTANCE",
+                "EngineType": "ActiveMQ",
+                "HostInstanceType": "mq.t3.micro"
+            },
+            {
+                "BrokerArn": "arn:aws:mq:us-east-1:012345678910:broker:TestBroker1:b-cec75166-abad-49f9-bad0-015c7e405219",
+                "BrokerId": "b-cec75166-abad-49f9-bad0-015c7e405219",
+                "BrokerName": "TestBroker1",
+                "BrokerState": "RUNNING",
+                "Created": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 17,
+                    "minute": 8,
+                    "second": 50,
+                    "microsecond": 622000
+                },
+                "DeploymentMode": "SINGLE_INSTANCE",
+                "EngineType": "ActiveMQ",
+                "HostInstanceType": "mq.t3.micro"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_filter/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_filter/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "Description": "AWS created security group for d-90677cc91c directory controllers",
+                "GroupName": "d-90677cc91c_controllers",
+                "IpPermissions": [
+                    {
+                        "FromPort": 138,
+                        "IpProtocol": "udp",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "ToPort": 138,
+                        "UserIdGroupPairs": []
+                    }  
+                ],
+                "OwnerId": "012345678910",
+                "GroupId": "sg-08f62b8c3dd4669bc",
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": [
+                            {
+                                "GroupId": "sg-08f62b8c3dd4669bc",
+                                "UserId": "012345678910"
+                            }
+                        ]
+                    }
+                ],
+                "VpcId": "vpc-0598080981e0332f9"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_filter/ec2.DescribeSecurityGroups_2.json
+++ b/tests/data/placebo/test_message_broker_vpc_filter/ec2.DescribeSecurityGroups_2.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "Description": "default VPC security group",
+                "GroupName": "default",
+                "IpPermissions": [
+                    {
+                        "FromPort": 27017,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "172.31.16.236/32"
+                            }
+                        ],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "ToPort": 27017,
+                        "UserIdGroupPairs": []
+                    }
+                ],
+                "OwnerId": "012345678910",
+                "GroupId": "sg-6c7fa917",
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": []
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "NetworkLocation",
+                        "Value": "Private"
+                    }
+                ],
+                "VpcId": "vpc-d2d616b5"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_filter/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_filter/ec2.DescribeVpcs_1.json
@@ -1,0 +1,56 @@
+{
+    "status_code": 200,
+    "data": {
+        "Vpcs": [
+            {
+                "CidrBlock": "172.16.0.0/16",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-0598080981e0332f9",
+                "OwnerId": "012345678910",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-07a76233f273c7199",
+                        "CidrBlock": "172.16.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": [
+                    {
+                        "Key": "AWSServiceAccount",
+                        "Value": "012345678910"
+                    }
+                ]
+            },
+            {
+                "CidrBlock": "172.31.0.0/16",
+                "DhcpOptionsId": "dopt-24ff1940",
+                "State": "available",
+                "VpcId": "vpc-d2d616b5",
+                "OwnerId": "012345678910",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-33669f5a",
+                        "CidrBlock": "172.31.0.0/16",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": true,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "FlowLogTest"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_filter/mq.DescribeBroker_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_filter/mq.DescribeBroker_1.json
@@ -1,0 +1,76 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AuthenticationStrategy": "simple",
+        "AutoMinorVersionUpgrade": true,
+        "BrokerArn": "arn:aws:mq:us-east-1:012345678910:broker:TestBroker2:b-c7aa6808-ba11-4d0c-b570-795e4724c841",
+        "BrokerId": "b-c7aa6808-ba11-4d0c-b570-795e4724c841",
+        "BrokerInstances": [
+            {
+                "ConsoleURL": "https://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:8162",
+                "Endpoints": [
+                    "ssl://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:61617",
+                    "amqp+ssl://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:5671",
+                    "stomp+ssl://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:61614",
+                    "mqtt+ssl://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:8883",
+                    "wss://b-c7aa6808-ba11-4d0c-b570-795e4724c841-1.mq.us-east-1.amazonaws.com:61619"
+                ],
+                "IpAddress": "54.221.242.156"
+            }
+        ],
+        "BrokerName": "TestBroker2",
+        "BrokerState": "RUNNING",
+        "Configurations": {
+            "Current": {
+                "Id": "c-35ea55fd-c8e6-4730-9e8f-d5329db8e9b7",
+                "Revision": 1
+            },
+            "History": []
+        },
+        "Created": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 3,
+            "day": 8,
+            "hour": 17,
+            "minute": 10,
+            "second": 34,
+            "microsecond": 888000
+        },
+        "DeploymentMode": "SINGLE_INSTANCE",
+        "EncryptionOptions": {
+            "UseAwsOwnedKey": true
+        },
+        "EngineType": "ActiveMQ",
+        "EngineVersion": "5.15.14",
+        "HostInstanceType": "mq.t3.micro",
+        "Logs": {
+            "Audit": false,
+            "AuditLogGroup": "/aws/amazonmq/broker/b-c7aa6808-ba11-4d0c-b570-795e4724c841/audit",
+            "General": false,
+            "GeneralLogGroup": "/aws/amazonmq/broker/b-c7aa6808-ba11-4d0c-b570-795e4724c841/general"
+        },
+        "MaintenanceWindowStartTime": {
+            "DayOfWeek": "THURSDAY",
+            "TimeOfDay": "07:00",
+            "TimeZone": "UTC"
+        },
+        "PubliclyAccessible": true,
+        "SecurityGroups": [
+            "sg-08f62b8c3dd4669bc"
+        ],
+        "StorageType": "efs",
+        "SubnetIds": [
+            "subnet-083ab4dd1a8b6eaa6"
+        ],
+        "Tags": {
+            "testing": "test2"
+        },
+        "Users": [
+            {
+                "Username": "testing"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_filter/mq.DescribeBroker_2.json
+++ b/tests/data/placebo/test_message_broker_vpc_filter/mq.DescribeBroker_2.json
@@ -1,0 +1,76 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AuthenticationStrategy": "simple",
+        "AutoMinorVersionUpgrade": true,
+        "BrokerArn": "arn:aws:mq:us-east-1:012345678910:broker:TestBroker1:b-cec75166-abad-49f9-bad0-015c7e405219",
+        "BrokerId": "b-cec75166-abad-49f9-bad0-015c7e405219",
+        "BrokerInstances": [
+            {
+                "ConsoleURL": "https://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:8162",
+                "Endpoints": [
+                    "ssl://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:61617",
+                    "amqp+ssl://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:5671",
+                    "stomp+ssl://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:61614",
+                    "mqtt+ssl://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:8883",
+                    "wss://b-cec75166-abad-49f9-bad0-015c7e405219-1.mq.us-east-1.amazonaws.com:61619"
+                ],
+                "IpAddress": "52.204.80.11"
+            }
+        ],
+        "BrokerName": "TestBroker1",
+        "BrokerState": "RUNNING",
+        "Configurations": {
+            "Current": {
+                "Id": "c-4165d773-b914-4761-8bb1-a3d18acd6bd9",
+                "Revision": 1
+            },
+            "History": []
+        },
+        "Created": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 3,
+            "day": 8,
+            "hour": 17,
+            "minute": 8,
+            "second": 50,
+            "microsecond": 622000
+        },
+        "DeploymentMode": "SINGLE_INSTANCE",
+        "EncryptionOptions": {
+            "UseAwsOwnedKey": true
+        },
+        "EngineType": "ActiveMQ",
+        "EngineVersion": "5.15.14",
+        "HostInstanceType": "mq.t3.micro",
+        "Logs": {
+            "Audit": false,
+            "AuditLogGroup": "/aws/amazonmq/broker/b-cec75166-abad-49f9-bad0-015c7e405219/audit",
+            "General": false,
+            "GeneralLogGroup": "/aws/amazonmq/broker/b-cec75166-abad-49f9-bad0-015c7e405219/general"
+        },
+        "MaintenanceWindowStartTime": {
+            "DayOfWeek": "MONDAY",
+            "TimeOfDay": "13:00",
+            "TimeZone": "UTC"
+        },
+        "PubliclyAccessible": true,
+        "SecurityGroups": [
+            "sg-6c7fa917"
+        ],
+        "StorageType": "efs",
+        "SubnetIds": [
+            "subnet-efbcccb7"
+        ],
+        "Tags": {
+            "test": "test1"
+        },
+        "Users": [
+            {
+                "Username": "testing"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_message_broker_vpc_filter/mq.ListBrokers_1.json
+++ b/tests/data/placebo/test_message_broker_vpc_filter/mq.ListBrokers_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BrokerSummaries": [
+            {
+                "BrokerArn": "arn:aws:mq:us-east-1:012345678910:broker:TestBroker2:b-c7aa6808-ba11-4d0c-b570-795e4724c841",
+                "BrokerId": "b-c7aa6808-ba11-4d0c-b570-795e4724c841",
+                "BrokerName": "TestBroker2",
+                "BrokerState": "RUNNING",
+                "Created": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 17,
+                    "minute": 10,
+                    "second": 34,
+                    "microsecond": 888000
+                },
+                "DeploymentMode": "SINGLE_INSTANCE",
+                "EngineType": "ActiveMQ",
+                "HostInstanceType": "mq.t3.micro"
+            },
+            {
+                "BrokerArn": "arn:aws:mq:us-east-1:012345678910:broker:TestBroker1:b-cec75166-abad-49f9-bad0-015c7e405219",
+                "BrokerId": "b-cec75166-abad-49f9-bad0-015c7e405219",
+                "BrokerName": "TestBroker1",
+                "BrokerState": "RUNNING",
+                "Created": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 17,
+                    "minute": 8,
+                    "second": 50,
+                    "microsecond": 622000
+                },
+                "DeploymentMode": "SINGLE_INSTANCE",
+                "EngineType": "ActiveMQ",
+                "HostInstanceType": "mq.t3.micro"
+            }
+        ]
+    }
+}

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -145,3 +145,31 @@ class MessageQueue(BaseTest):
         self.assertEqual(
             tags,
             {'Env': 'Dev'})
+
+    def test_mq_message_broker_vpc_filter(self):
+        session_factory = self.replay_flight_data('test_message_broker_vpc_filter')
+        p = self.load_policy(
+            {
+                'name': 'test-message-broker-vpc-filter',
+                'resource': 'message-broker', 
+                'filters': [{'type': 'vpc', 'key': 'VpcId', 'value': 'vpc-0598080981e0332f9', 'op': 'eq'}]
+            },
+            session_factory=session_factory, 
+            cache=True
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    
+    def test_mq_message_broker_default_vpc(self):
+        session_factory = self.replay_flight_data('test_message_broker_vpc_default_filter')
+        p = self.load_policy(
+            {
+                "name": "mq-default-filters",
+                "resource": "message-broker",
+                "filters": [{"type": "default-vpc"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -6,6 +6,7 @@ from .common import BaseTest
 
 
 class MessageQueue(BaseTest):
+
     def test_query_with_subnet_sg_filter(self):
         factory = self.replay_flight_data("test_mq_query")
         p = self.load_policy(
@@ -13,13 +14,12 @@ class MessageQueue(BaseTest):
                 "name": "mq",
                 "resource": "message-broker",
                 "filters": [
-                    {'type': 'subnet', 'key': 'tag:NetworkLocation', 'value': 'Public'},
-                    {
-                        'type': 'security-group',
-                        'key': 'tag:NetworkLocation',
-                        'value': 'Private',
-                    },
-                ],
+                    {'type': 'subnet',
+                     'key': 'tag:NetworkLocation',
+                     'value': 'Public'},
+                    {'type': 'security-group',
+                     'key': 'tag:NetworkLocation',
+                     'value': 'Private'}]
             },
             config={'region': 'us-east-1'},
             session_factory=factory,
@@ -31,22 +31,16 @@ class MessageQueue(BaseTest):
     def test_metrics(self):
         factory = self.replay_flight_data('test_mq_metrics')
         p = self.load_policy(
-            {
-                'name': 'mq-metrics',
-                'resource': 'message-broker',
-                'filters': [
-                    {
-                        'type': 'metrics',
-                        'name': 'CpuUtilization',
-                        'op': 'gt',
-                        'value': 0,
-                        'days': 1,
-                    }
-                ],
-            },
+            {'name': 'mq-metrics',
+             'resource': 'message-broker',
+             'filters': [{
+                 'type': 'metrics',
+                 'name': 'CpuUtilization',
+                 'op': 'gt',
+                 'value': 0,
+                 'days': 1}]},
             config={'region': 'us-east-1'},
-            session_factory=factory,
-        )
+            session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['BrokerName'], 'dev')
@@ -60,10 +54,14 @@ class MessageQueue(BaseTest):
                 'name': 'test-message-broker-kms-filter',
                 'resource': 'message-broker',
                 'filters': [
-                    {'type': 'kms-key', 'key': 'c7n:AliasName', 'value': 'alias/aws/mq'}
-                ],
+                    {
+                        'type': 'kms-key',
+                        'key': 'c7n:AliasName',
+                        'value': 'alias/aws/mq'
+                    }
+                ]
             },
-            session_factory=session_factory,
+            session_factory=session_factory
         )
         resources = p.run()
         self.assertTrue(len(resources), 1)
@@ -96,11 +94,13 @@ class MessageQueue(BaseTest):
                 "resource": "message-broker",
                 'filters': [{'tag:Role': 'Dev'}],
                 "actions": [
-                    {'type': 'tag', 'tags': {'Env': 'Dev'}},
-                    {'type': 'remove-tag', 'tags': ['Role']},
-                    {'type': 'mark-for-op', 'op': 'delete', 'days': 2},
-                ],
-            },
+                    {'type': 'tag',
+                     'tags': {'Env': 'Dev'}},
+                    {'type': 'remove-tag',
+                     'tags': ['Role']},
+                    {'type': 'mark-for-op',
+                     'op': 'delete',
+                     'days': 2}]},
             config={'region': 'us-east-1'},
             session_factory=factory,
         )
@@ -111,15 +111,12 @@ class MessageQueue(BaseTest):
             time.sleep(1)
         tags = client.list_tags(ResourceArn=resources[0]["BrokerArn"])["Tags"]
         self.assertEqual(
-            {t['Key']: t['Value'] for t in resources[0]['Tags']}, {'Role': 'Dev'}
-        )
+            {t['Key']: t['Value'] for t in resources[0]['Tags']},
+            {'Role': 'Dev'})
         self.assertEqual(
             tags,
-            {
-                'Env': 'Dev',
-                'maid_status': 'Resource does not meet policy: delete@2019/01/31',
-            },
-        )
+            {'Env': 'Dev',
+             'maid_status': 'Resource does not meet policy: delete@2019/01/31'})
 
     def test_mq_config_tagging(self):
         factory = self.replay_flight_data("test_mq_config_tagging")
@@ -129,10 +126,10 @@ class MessageQueue(BaseTest):
                 "resource": "message-config",
                 'filters': [{'tag:Role': 'Dev'}],
                 "actions": [
-                    {'type': 'tag', 'tags': {'Env': 'Dev'}},
-                    {'type': 'remove-tag', 'tags': ['Role']},
-                ],
-            },
+                    {'type': 'tag',
+                     'tags': {'Env': 'Dev'}},
+                    {'type': 'remove-tag',
+                     'tags': ['Role']}]},
             config={'region': 'us-east-1'},
             session_factory=factory,
         )
@@ -143,9 +140,11 @@ class MessageQueue(BaseTest):
             time.sleep(1)
         tags = client.list_tags(ResourceArn=resources[0]["Arn"])["Tags"]
         self.assertEqual(
-            {t['Key']: t['Value'] for t in resources[0]['Tags']}, {'Role': 'Dev'}
-        )
-        self.assertEqual(tags, {'Env': 'Dev'})
+            {t['Key']: t['Value'] for t in resources[0]['Tags']},
+            {'Role': 'Dev'})
+        self.assertEqual(
+            tags,
+            {'Env': 'Dev'})
 
     def test_mq_message_broker_vpc_filter(self):
         session_factory = self.replay_flight_data('test_message_broker_vpc_filter')
@@ -163,7 +162,6 @@ class MessageQueue(BaseTest):
                 ],
             },
             session_factory=session_factory,
-            cache=True,
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -6,7 +6,6 @@ from .common import BaseTest
 
 
 class MessageQueue(BaseTest):
-
     def test_query_with_subnet_sg_filter(self):
         factory = self.replay_flight_data("test_mq_query")
         p = self.load_policy(
@@ -14,12 +13,13 @@ class MessageQueue(BaseTest):
                 "name": "mq",
                 "resource": "message-broker",
                 "filters": [
-                    {'type': 'subnet',
-                     'key': 'tag:NetworkLocation',
-                     'value': 'Public'},
-                    {'type': 'security-group',
-                     'key': 'tag:NetworkLocation',
-                     'value': 'Private'}]
+                    {'type': 'subnet', 'key': 'tag:NetworkLocation', 'value': 'Public'},
+                    {
+                        'type': 'security-group',
+                        'key': 'tag:NetworkLocation',
+                        'value': 'Private',
+                    },
+                ],
             },
             config={'region': 'us-east-1'},
             session_factory=factory,
@@ -31,16 +31,22 @@ class MessageQueue(BaseTest):
     def test_metrics(self):
         factory = self.replay_flight_data('test_mq_metrics')
         p = self.load_policy(
-            {'name': 'mq-metrics',
-             'resource': 'message-broker',
-             'filters': [{
-                 'type': 'metrics',
-                 'name': 'CpuUtilization',
-                 'op': 'gt',
-                 'value': 0,
-                 'days': 1}]},
+            {
+                'name': 'mq-metrics',
+                'resource': 'message-broker',
+                'filters': [
+                    {
+                        'type': 'metrics',
+                        'name': 'CpuUtilization',
+                        'op': 'gt',
+                        'value': 0,
+                        'days': 1,
+                    }
+                ],
+            },
             config={'region': 'us-east-1'},
-            session_factory=factory)
+            session_factory=factory,
+        )
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['BrokerName'], 'dev')
@@ -54,14 +60,10 @@ class MessageQueue(BaseTest):
                 'name': 'test-message-broker-kms-filter',
                 'resource': 'message-broker',
                 'filters': [
-                    {
-                        'type': 'kms-key',
-                        'key': 'c7n:AliasName',
-                        'value': 'alias/aws/mq'
-                    }
-                ]
+                    {'type': 'kms-key', 'key': 'c7n:AliasName', 'value': 'alias/aws/mq'}
+                ],
             },
-            session_factory=session_factory
+            session_factory=session_factory,
         )
         resources = p.run()
         self.assertTrue(len(resources), 1)
@@ -94,13 +96,11 @@ class MessageQueue(BaseTest):
                 "resource": "message-broker",
                 'filters': [{'tag:Role': 'Dev'}],
                 "actions": [
-                    {'type': 'tag',
-                     'tags': {'Env': 'Dev'}},
-                    {'type': 'remove-tag',
-                     'tags': ['Role']},
-                    {'type': 'mark-for-op',
-                     'op': 'delete',
-                     'days': 2}]},
+                    {'type': 'tag', 'tags': {'Env': 'Dev'}},
+                    {'type': 'remove-tag', 'tags': ['Role']},
+                    {'type': 'mark-for-op', 'op': 'delete', 'days': 2},
+                ],
+            },
             config={'region': 'us-east-1'},
             session_factory=factory,
         )
@@ -111,12 +111,15 @@ class MessageQueue(BaseTest):
             time.sleep(1)
         tags = client.list_tags(ResourceArn=resources[0]["BrokerArn"])["Tags"]
         self.assertEqual(
-            {t['Key']: t['Value'] for t in resources[0]['Tags']},
-            {'Role': 'Dev'})
+            {t['Key']: t['Value'] for t in resources[0]['Tags']}, {'Role': 'Dev'}
+        )
         self.assertEqual(
             tags,
-            {'Env': 'Dev',
-             'maid_status': 'Resource does not meet policy: delete@2019/01/31'})
+            {
+                'Env': 'Dev',
+                'maid_status': 'Resource does not meet policy: delete@2019/01/31',
+            },
+        )
 
     def test_mq_config_tagging(self):
         factory = self.replay_flight_data("test_mq_config_tagging")
@@ -126,10 +129,10 @@ class MessageQueue(BaseTest):
                 "resource": "message-config",
                 'filters': [{'tag:Role': 'Dev'}],
                 "actions": [
-                    {'type': 'tag',
-                     'tags': {'Env': 'Dev'}},
-                    {'type': 'remove-tag',
-                     'tags': ['Role']}]},
+                    {'type': 'tag', 'tags': {'Env': 'Dev'}},
+                    {'type': 'remove-tag', 'tags': ['Role']},
+                ],
+            },
             config={'region': 'us-east-1'},
             session_factory=factory,
         )
@@ -140,29 +143,35 @@ class MessageQueue(BaseTest):
             time.sleep(1)
         tags = client.list_tags(ResourceArn=resources[0]["Arn"])["Tags"]
         self.assertEqual(
-            {t['Key']: t['Value'] for t in resources[0]['Tags']},
-            {'Role': 'Dev'})
-        self.assertEqual(
-            tags,
-            {'Env': 'Dev'})
+            {t['Key']: t['Value'] for t in resources[0]['Tags']}, {'Role': 'Dev'}
+        )
+        self.assertEqual(tags, {'Env': 'Dev'})
 
     def test_mq_message_broker_vpc_filter(self):
         session_factory = self.replay_flight_data('test_message_broker_vpc_filter')
         p = self.load_policy(
             {
                 'name': 'test-message-broker-vpc-filter',
-                'resource': 'message-broker', 
-                'filters': [{'type': 'vpc', 'key': 'VpcId', 'value': 'vpc-0598080981e0332f9', 'op': 'eq'}]
+                'resource': 'message-broker',
+                'filters': [
+                    {
+                        'type': 'vpc',
+                        'key': 'VpcId',
+                        'value': 'vpc-0598080981e0332f9',
+                        'op': 'eq',
+                    }
+                ],
             },
-            session_factory=session_factory, 
-            cache=True
+            session_factory=session_factory,
+            cache=True,
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
-    
     def test_mq_message_broker_default_vpc(self):
-        session_factory = self.replay_flight_data('test_message_broker_vpc_default_filter')
+        session_factory = self.replay_flight_data(
+            'test_message_broker_vpc_default_filter'
+        )
         p = self.load_policy(
             {
                 "name": "mq-default-filters",


### PR DESCRIPTION
This contribution includes two new filters for AWS MQ -- a VPC filter which allows you to search for message brokers based on VPC ID, and a default-VPC filter which returns the message brokers that were created in a default VPC. Since the DescribeMessageBrokers API call does not return a VPC ID as a part of it's response, I used the message brokers' security group IDs (a required field on brokers) to look up the broker's VPC.