### PR TITLE
aws.ebs-snapshot - add related filter for ebs volume

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -370,12 +370,18 @@ class SnapshotVolumeFilter(RelatedResourceFilter):
 
         policies:
           - name: snapshot-with-no-volume
+            description: Find any snapshots that do not have a corresponding volume.
             resource: aws.ebs-snapshot
             filters:
               - type: volume
                 key: VolumeId
                 value: absent
-
+          - name: find-snapshots-from-volume
+            resource: aws.ebs-snapshot
+            filters:
+              - type: volume
+                key: VolumeId
+                value: vol-foobarbaz
     """
 
     RelatedResource = 'c7n.resources.ebs.EBS'

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -372,10 +372,9 @@ class SnapshotVolumeFilter(RelatedResourceFilter):
           - name: snapshot-with-no-volume
             resource: aws.ebs-snapshot
             filters:
-                - not:
-                    - name: volume
-                      key: [].Arn
-                      op: absent
+              - type: volume
+                key: VolumeId
+                value: absent
 
     """
 

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -16,6 +16,7 @@ from c7n.filters import (
     CrossAccountAccessFilter, Filter, AgeFilter, ValueFilter,
     ANNOTATION_KEY)
 from c7n.filters.health import HealthEventFilter
+from c7n.filters.related import RelatedResourceFilter
 
 from c7n.manager import resources
 from c7n.resources.kms import ResourceKmsKeyAlias
@@ -358,6 +359,32 @@ class SnapshotSkipAmiSnapshots(Filter):
     def process(self, snapshots, event=None):
         resources = _filter_ami_snapshots(self, snapshots)
         return resources
+
+
+@Snapshot.filter_registry.register('volume')
+class SnapshotVolumeFilter(RelatedResourceFilter):
+    """
+    Filter EBS snapshots by their volume attributes.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: snapshot-with-no-volume
+            resource: aws.ebs-snapshot
+            filters:
+                - not:
+                    - name: volume
+                      key: [].Arn
+                      op: absent
+
+    """
+
+    RelatedResource = 'c7n.resources.ebs.EBS'
+    RelatedIdsExpression = 'VolumeId'
+    AnnotationKey = 'Volume'
+
+    schema = type_schema(
+        'volume', rinherit=ValueFilter.schema)
 
 
 @Snapshot.action_registry.register('delete')

--- a/tests/data/placebo/test_ebs_volume_related_filter/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_ebs_volume_related_filter/ec2.DescribeSnapshots_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "Snapshots": [
+            {
+                "Description": "",
+                "Encrypted": false,
+                "OwnerId": "644160558196",
+                "Progress": "100%",
+                "SnapshotId": "snap-03ab300c6ce8d9e7e",
+                "StartTime": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 15,
+                    "hour": 23,
+                    "minute": 16,
+                    "second": 16,
+                    "microsecond": 135000
+                },
+                "State": "completed",
+                "VolumeId": "vol-0ec2ee2808bf1bb7d",
+                "VolumeSize": 8
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_volume_related_filter/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_ebs_volume_related_filter/ec2.DescribeSnapshots_1.json
@@ -7,6 +7,26 @@
                 "Encrypted": false,
                 "OwnerId": "644160558196",
                 "Progress": "100%",
+                "SnapshotId": "snap-02185b624983574f8",
+                "StartTime": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 16,
+                    "hour": 20,
+                    "minute": 24,
+                    "second": 10,
+                    "microsecond": 691000
+                },
+                "State": "completed",
+                "VolumeId": "vol-02dbf91b6667bcdad",
+                "VolumeSize": 1
+            },
+            {
+                "Description": "",
+                "Encrypted": false,
+                "OwnerId": "644160558196",
+                "Progress": "100%",
                 "SnapshotId": "snap-03ab300c6ce8d9e7e",
                 "StartTime": {
                     "__class__": "datetime",

--- a/tests/data/placebo/test_ebs_volume_related_filter/ec2.DescribeVolumes_1.json
+++ b/tests/data/placebo/test_ebs_volume_related_filter/ec2.DescribeVolumes_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Code": "InvalidVolume.NotFound",
+            "Message": "The volume 'vol-0ec2ee2808bf1bb7d' does not exist."
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_volume_related_filter/ec2.DescribeVolumes_2.json
+++ b/tests/data/placebo/test_ebs_volume_related_filter/ec2.DescribeVolumes_2.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "Volumes": [
+            {
+                "Attachments": [],
+                "AvailabilityZone": "us-east-1a",
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 16,
+                    "hour": 20,
+                    "minute": 24,
+                    "second": 1,
+                    "microsecond": 646000
+                },
+                "Encrypted": false,
+                "Size": 1,
+                "SnapshotId": "",
+                "State": "available",
+                "VolumeId": "vol-02dbf91b6667bcdad",
+                "VolumeType": "standard",
+                "MultiAttachEnabled": false
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -443,8 +443,8 @@ class SnapshotVolumeFilter(BaseTest):
                 "filters": [
                     {
                         "type": "volume",
-                        "key": "VolumeId",
-                        "value": "vol-02dbf91b6667bcdad"
+                        "key": "AvailabilityZone",
+                        "value": "us-east-1a"
                     }
                 ]
             }, session_factory=factory

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -435,7 +435,7 @@ class SnapshotSetPermissions(BaseTest):
 class SnapshotVolumeFilter(BaseTest):
 
     def test_ebs_volume_filter(self):
-        factory = self.record_flight_data("test_ebs_volume_related_filter")
+        factory = self.replay_flight_data("test_ebs_volume_related_filter")
         p = self.load_policy(
             {
                 "name": "ebs-snapshot-volume",

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -16,6 +16,7 @@ from c7n.resources.ebs import (
     ErrorHandler,
     SnapshotQueryParser as QueryParser
 )
+from c7n.utils import yaml_load
 
 from .common import BaseTest
 
@@ -430,6 +431,22 @@ class SnapshotSetPermissions(BaseTest):
             SnapshotId=resources[0]['SnapshotId'],
             Attribute='createVolumePermission')['CreateVolumePermissions']
         assert perms == [{"UserId": "112233445566"}]
+
+
+class SnapshotVolumeFilter(BaseTest):
+
+    def test_ebs_volume_filter(self):
+        factory = self.replay_flight_data("test_ebs_volume_related_filter")
+        p = self.load_policy(yaml_load("""
+           name: ebs-snapshot-volume
+           resource: aws.ebs-snapshot
+           filters:
+             - type: volume
+               key: VolumeId
+               value: absent
+        """), session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
 
 
 class AttachedInstanceTest(BaseTest):

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -16,7 +16,6 @@ from c7n.resources.ebs import (
     ErrorHandler,
     SnapshotQueryParser as QueryParser
 )
-from c7n.utils import yaml_load
 
 from .common import BaseTest
 
@@ -436,15 +435,20 @@ class SnapshotSetPermissions(BaseTest):
 class SnapshotVolumeFilter(BaseTest):
 
     def test_ebs_volume_filter(self):
-        factory = self.replay_flight_data("test_ebs_volume_related_filter")
-        p = self.load_policy(yaml_load("""
-           name: ebs-snapshot-volume
-           resource: aws.ebs-snapshot
-           filters:
-             - type: volume
-               key: VolumeId
-               value: absent
-        """), session_factory=factory)
+        factory = self.record_flight_data("test_ebs_volume_related_filter")
+        p = self.load_policy(
+            {
+                "name": "ebs-snapshot-volume",
+                "resource": "aws.ebs-snapshot",
+                "filters": [
+                    {
+                        "type": "volume",
+                        "key": "VolumeId",
+                        "value": "vol-02dbf91b6667bcdad"
+                    }
+                ]
+            }, session_factory=factory
+        )
         resources = p.run()
         self.assertEqual(len(resources), 1)
 


### PR DESCRIPTION
Closes #6131 

```yaml
name: find-snapshots-with-no-volume
resource: aws.ebs-snapshot
  filters:
    - type: volume
      key: VolumeId
      value: absent
```

Of course, you can also filter on volume tags, other abs volume attires, etc. as you would expect for a related resource filter.