### PR TITLE
aws.s3 - set bucket key enabled for AWSSSE, alias/aws/s3 and make configurable for CMK

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -3376,7 +3376,7 @@ class SetBucketEncryption(KMSKeyResolverMixin, BucketActionBase):
             if not key:
                 raise Exception('Valid KMS Key required but does not exist')
 
-            # Checking if the bucket id or arn passed in is the defualt s3 key
+            # Checking if the bucket id or arn passed in is the default s3 key
             if (key['Description'] == default_key_desc and
                     key['KeyManager'] == 'AWS'):
                 bucket_key = True


### PR DESCRIPTION
closes #6536 

Adds the ability to set `bucket-key` to true in the `set-bucket-encryption` action. Defaults and overrides false values for AWS SSE and `alias/aws/s3` keys since those have the required permissions by default (safe operation). Otherwise, from CMK you must specify `bucket-key` explicitly to true or false.

Example policy:
```yaml
policies:
  - name: set-encryption
    resource: aws.s3
    filters:
      - Name: my-bucket
    actions:
      - type: set-bucket-encryption
        crypto: aws:kms
        key: alias/my-key
        bucket-key: true
```