### PR TITLE
aws.ami - include all launch configurations and default templates in unused filter

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -314,7 +314,6 @@ class ImageUnusedFilter(Filter):
             for m in ('asg', 'launch-config', 'ec2')]))
 
     def _pull_launch_configs_templates(self, asgs=None):
-        breakpoint()
         include_lcfg = self.data.get('include-launch-configurations', False)
 
         # if we dont pass in asgs and include-launch-configs is false, just bail

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -281,11 +281,16 @@ class ImageAgeFilter(AgeFilter):
 class ImageUnusedFilter(Filter):
     """Filters images based on usage
 
-    value:
-        true: image has no instances spawned from it
-        false: image has instances spawned from it
-    include-launch-configurations:
-        include all launch configurations and launch templates (default versions)
+    `value`: boolean
+
+    true: image has no instances spawned from it
+    false: image has instances spawned from it
+
+    `include-launch-configurations`: boolean
+
+    true: include all launch configurations and launch templates (default versions)
+    false: only include launch configurations and launch templates for existing
+    autoscaling groups
 
     :example:
 

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -320,9 +320,7 @@ class ImageUnusedFilter(Filter):
         if asgs is None and include_lcfg is False:
             return set()
 
-        if asgs is None:
-            asgs = []
-        elif asgs and include_lcfg:
+        if asgs is None or include_lcfg:
             asgs = []
 
         image_ids = set()
@@ -333,13 +331,14 @@ class ImageUnusedFilter(Filter):
             image_ids.update([
                 lcfg['ImageId'] for lcfg in lcfg_mgr.resources()
                 if lcfg['LaunchConfigurationName'] in lcfgs])
-        else:
+        elif not lcfgs and include_lcfg:
             image_ids.update([lcfg['ImageId'] for lcfg in lcfg_mgr.resources()])
 
         tmpl_mgr = self.manager.get_resource_manager('launch-template-version')
-        for tversion in tmpl_mgr.get_resources(
-                list(tmpl_mgr.get_asg_templates(asgs).keys())):
-            image_ids.add(tversion['LaunchTemplateData'].get('ImageId'))
+        if asgs or include_lcfg:
+            for tversion in tmpl_mgr.get_resources(
+                    list(tmpl_mgr.get_asg_templates(asgs).keys())):
+                image_ids.add(tversion['LaunchTemplateData'].get('ImageId'))
         return image_ids
 
     def _pull_asg_images(self):

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -281,8 +281,11 @@ class ImageAgeFilter(AgeFilter):
 class ImageUnusedFilter(Filter):
     """Filters images based on usage
 
-    true: image has no instances spawned from it
-    false: image has instances spawned from it
+    value:
+        true: image has no instances spawned from it
+        false: image has instances spawned from it
+    include-launch-configurations:
+        include all launch configurations and launch templates (default versions)
 
     :example:
 
@@ -294,17 +297,35 @@ class ImageUnusedFilter(Filter):
                 filters:
                   - type: unused
                     value: true
+                    include-launch-configurations: true
     """
 
-    schema = type_schema('unused', value={'type': 'boolean'})
+    schema = type_schema(
+        'unused',
+        value={'type': 'boolean'},
+        **{
+            'include-launch-configurations': {'type': 'boolean'}
+        }
+    )
 
     def get_permissions(self):
         return list(itertools.chain(*[
             self.manager.get_resource_manager(m).get_permissions()
             for m in ('asg', 'launch-config', 'ec2')]))
 
-    def _pull_asg_images(self):
-        asgs = self.manager.get_resource_manager('asg').resources()
+    def _pull_launch_configs_templates(self, asgs=None):
+        breakpoint()
+        include_lcfg = self.data.get('include-launch-configurations', False)
+
+        # if we dont pass in asgs and include-launch-configs is false, just bail
+        if asgs is None and include_lcfg is False:
+            return set()
+
+        if asgs is None:
+            asgs = []
+        elif asgs and include_lcfg:
+            asgs = []
+
         image_ids = set()
         lcfgs = set(a['LaunchConfigurationName'] for a in asgs if 'LaunchConfigurationName' in a)
         lcfg_mgr = self.manager.get_resource_manager('launch-config')
@@ -313,6 +334,8 @@ class ImageUnusedFilter(Filter):
             image_ids.update([
                 lcfg['ImageId'] for lcfg in lcfg_mgr.resources()
                 if lcfg['LaunchConfigurationName'] in lcfgs])
+        else:
+            image_ids.update([lcfg['ImageId'] for lcfg in lcfg_mgr.resources()])
 
         tmpl_mgr = self.manager.get_resource_manager('launch-template-version')
         for tversion in tmpl_mgr.get_resources(
@@ -320,12 +343,23 @@ class ImageUnusedFilter(Filter):
             image_ids.add(tversion['LaunchTemplateData'].get('ImageId'))
         return image_ids
 
+    def _pull_asg_images(self):
+        asgs = self.manager.get_resource_manager('asg').resources()
+        result = self._pull_launch_configs_templates(asgs)
+        return result
+
     def _pull_ec2_images(self):
         ec2_manager = self.manager.get_resource_manager('ec2')
         return {i['ImageId'] for i in ec2_manager.resources()}
 
     def process(self, resources, event=None):
-        images = self._pull_ec2_images().union(self._pull_asg_images())
+
+        op = self._pull_asg_images
+        # asg launch configs is a superset of all launch configs
+        if self.data.get('include-launch-configurations'):
+            op = self._pull_launch_configs_templates
+
+        images = self._pull_ec2_images().union(op())
         if self.data.get('value', True):
             return [r for r in resources if r['ImageId'] not in images]
         return [r for r in resources if r['ImageId'] in images]

--- a/tests/data/placebo/test_unused_ami_launch_template/autoscaling.DescribeLaunchConfigurations_1.json
+++ b/tests/data/placebo/test_unused_ami_launch_template/autoscaling.DescribeLaunchConfigurations_1.json
@@ -1,0 +1,98 @@
+{
+    "status_code": 200, 
+    "data": {
+        "LaunchConfigurations": [
+            {
+                "UserData": "", 
+                "IamInstanceProfile": "root_joshua", 
+                "EbsOptimized": false, 
+                "LaunchConfigurationARN": "arn:aws:autoscaling:us-east-1:644160558196:launchConfiguration:7977f161-adb2-4ddc-b46f-3652c30ccd3b:launchConfigurationName/c7n-asg-lcCopy", 
+                "InstanceMonitoring": {
+                    "Enabled": false
+                }, 
+                "ClassicLinkVPCSecurityGroups": [], 
+                "CreatedTime": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 47, 
+                    "microsecond": 47000, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 12
+                }, 
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda", 
+                        "Ebs": {
+                            "DeleteOnTermination": true, 
+                            "VolumeSize": 8, 
+                            "VolumeType": "gp2"
+                        }
+                    }
+                ], 
+                "KeyName": "", 
+                "SecurityGroups": [
+                    "sg-6c7fa917"
+                ], 
+                "LaunchConfigurationName": "c7n-asg-lcCopy", 
+                "KernelId": "", 
+                "RamdiskId": "", 
+                "ImageId": "ami-c481fad3", 
+                "InstanceType": "t2.micro"
+            }, 
+            {
+                "UserData": "", 
+                "IamInstanceProfile": "root_joshua", 
+                "EbsOptimized": false, 
+                "LaunchConfigurationARN": "arn:aws:autoscaling:us-east-1:644160558196:launchConfiguration:a491155b-5041-49e4-9d25-3c835ab382bf:launchConfigurationName/c7n-asg-test-01", 
+                "InstanceMonitoring": {
+                    "Enabled": false
+                }, 
+                "ClassicLinkVPCSecurityGroups": [], 
+                "CreatedTime": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 53, 
+                    "microsecond": 274000, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 0
+                }, 
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda", 
+                        "Ebs": {
+                            "DeleteOnTermination": true, 
+                            "VolumeSize": 8, 
+                            "VolumeType": "gp2"
+                        }
+                    }
+                ], 
+                "KeyName": "", 
+                "SecurityGroups": [
+                    "sg-04eef27e"
+                ], 
+                "LaunchConfigurationName": "c7n-asg-test-01", 
+                "KernelId": "", 
+                "RamdiskId": "", 
+                "ImageId": "ami-e0fba8f7", 
+                "InstanceType": "t2.micro", 
+                "AssociatePublicIpAddress": false
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cd68befe-97b4-11e6-87ba-853f619ec559", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cd68befe-97b4-11e6-87ba-853f619ec559", 
+                "vary": "Accept-Encoding", 
+                "content-length": "2816", 
+                "content-type": "text/xml", 
+                "date": "Fri, 21 Oct 2016 17:35:47 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_unused_ami_launch_template/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_unused_ami_launch_template/ec2.DescribeImages_1.json
@@ -77,6 +77,44 @@
                 "RootDeviceType": "ebs",
                 "SriovNetSupport": "simple",
                 "VirtualizationType": "hvm"
+            },
+            {
+                "Architecture": "x86_64",
+                "CreationDate": "2018-11-04T06:24:45.000Z",
+                "ImageId": "ami-e0fba8f7",
+                "ImageLocation": "644160558196/Ubuntu1404",
+                "ImageType": "machine",
+                "Public": false,
+                "OwnerId": "644160558196",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sda1",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-0d16416527e67c663",
+                            "VolumeSize": 8,
+                            "VolumeType": "standard",
+                            "Encrypted": true
+                        }
+                    },
+                    {
+                        "DeviceName": "/dev/sdb",
+                        "VirtualName": "ephemeral0"
+                    },
+                    {
+                        "DeviceName": "/dev/sdc",
+                        "VirtualName": "ephemeral1"
+                    }
+                ],
+                "Description": "Mock image",
+                "EnaSupport": true,
+                "Hypervisor": "xen",
+                "Name": "Ubuntu1404",
+                "RootDeviceName": "/dev/sda1",
+                "RootDeviceType": "ebs",
+                "SriovNetSupport": "simple",
+                "VirtualizationType": "hvm"
             }
         ],
         "ResponseMetadata": {

--- a/tests/data/placebo/test_unused_ami_launch_template/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_unused_ami_launch_template/ec2.DescribeImages_1.json
@@ -39,6 +39,44 @@
                 "RootDeviceType": "ebs",
                 "SriovNetSupport": "simple",
                 "VirtualizationType": "hvm"
+            },
+            {
+                "Architecture": "x86_64",
+                "CreationDate": "2018-11-04T06:24:45.000Z",
+                "ImageId": "ami-c481fad3",
+                "ImageLocation": "644160558196/Ubuntu1404",
+                "ImageType": "machine",
+                "Public": false,
+                "OwnerId": "644160558196",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sda1",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-0d16416527e67c663",
+                            "VolumeSize": 8,
+                            "VolumeType": "standard",
+                            "Encrypted": true
+                        }
+                    },
+                    {
+                        "DeviceName": "/dev/sdb",
+                        "VirtualName": "ephemeral0"
+                    },
+                    {
+                        "DeviceName": "/dev/sdc",
+                        "VirtualName": "ephemeral1"
+                    }
+                ],
+                "Description": "Mock image",
+                "EnaSupport": true,
+                "Hypervisor": "xen",
+                "Name": "Ubuntu1404",
+                "RootDeviceName": "/dev/sda1",
+                "RootDeviceType": "ebs",
+                "SriovNetSupport": "simple",
+                "VirtualizationType": "hvm"
             }
         ],
         "ResponseMetadata": {

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -168,6 +168,26 @@ class TestAMI(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['ImageId'], 'ami-0515ff4f8f9dbeb31')
 
+    def test_unused_ami_with_asg_launch_templates_false(self):
+        factory = self.replay_flight_data('test_unused_ami_launch_template')
+        p = self.load_policy(
+            {
+                "name": "test-unused-ami",
+                "resource": "ami",
+                "filters": [
+                    {
+                        "type": "unused",
+                        "include-launch-configurations": False
+                    }
+                ]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 3)
+        images = set([a['ImageId'] for a in resources])
+        self.assertEqual(images, set(['ami-0515ff4f8f9dbeb31', 'ami-e0fba8f7', 'ami-c481fad3']))
+
     def test_unused_ami_true(self):
         factory = self.replay_flight_data("test_unused_ami_true")
         p = self.load_policy(

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -152,7 +152,16 @@ class TestAMI(BaseTest):
     def test_unused_ami_with_asg_launch_templates(self):
         factory = self.replay_flight_data('test_unused_ami_launch_template')
         p = self.load_policy(
-            {"name": "test-unused-ami", "resource": "ami", "filters": ["unused"]},
+            {
+                "name": "test-unused-ami",
+                "resource": "ami",
+                "filters": [
+                    {
+                        "type": "unused",
+                        "include-launch-configurations": True
+                    }
+                ]
+            },
             session_factory=factory,
         )
         resources = p.run()


### PR DESCRIPTION
closes #6554 

Adds ability to examine all launch configurations and default launch templates for unused Amis rather than just the extant autoscaling group launch configs/templates.