### PR TITLE
azure - review wrong `schema_alias`

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
+++ b/tools/c7n_azure/c7n_azure/resources/appserviceplan.py
@@ -121,7 +121,6 @@ class ResizePlan(AzureBaseAction):
         },
         'additionalProperties': False
     }
-    schema_alias = True
 
     def _prepare_processing(self):
         self.client = self.manager.get_client()  # type azure.mgmt.web.WebSiteManagementClient

--- a/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
+++ b/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
@@ -368,7 +368,6 @@ class CosmosDBOfferFilter(ValueFilter):
     """
 
     schema = type_schema('offer', rinherit=ValueFilter.schema)
-    schema_alias = True
 
     def process(self, resources, event=None):
         return OfferHelper.execute_in_parallel_grouped_by_account(

--- a/tools/c7n_azure/c7n_azure/resources/network_interface.py
+++ b/tools/c7n_azure/c7n_azure/resources/network_interface.py
@@ -68,7 +68,6 @@ class EffectiveRouteTableFilter(ValueFilter):
                   - VirtualAppliance
     """
     schema = type_schema('effective-route-table', rinherit=ValueFilter.schema)
-    schema_alias = False
 
     def process(self, resources, event=None):
 

--- a/tools/c7n_azure/c7n_azure/resources/storage_container.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage_container.py
@@ -98,8 +98,6 @@ class StorageContainerSetPublicAccessAction(AzureBaseAction):
         }
     )
 
-    schema_alias = True
-
     def _prepare_processing(self):
         self.client = self.manager.get_client()
 

--- a/tools/c7n_azure/c7n_azure/resources/vm.py
+++ b/tools/c7n_azure/c7n_azure/resources/vm.py
@@ -166,7 +166,6 @@ class VirtualMachine(ArmResourceManager):
 @VirtualMachine.filter_registry.register('instance-view')
 class InstanceViewFilter(ValueFilter):
     schema = type_schema('instance-view', rinherit=ValueFilter.schema)
-    schema_alias = True
 
     def __call__(self, i):
         if 'instanceView' not in i:

--- a/tools/c7n_azure/c7n_azure/resources/web_app.py
+++ b/tools/c7n_azure/c7n_azure/resources/web_app.py
@@ -84,7 +84,6 @@ class WebApp(ArmResourceManager):
 @WebApp.filter_registry.register('configuration')
 class ConfigurationFilter(ValueFilter):
     schema = type_schema('configuration', rinherit=ValueFilter.schema)
-    schema_alias = True
 
     def __call__(self, i):
         if 'c7n:configuration' not in i:


### PR DESCRIPTION
Removed `schema_alias = True` for resource-specific filters.

closes https://github.com/cloud-custodian/cloud-custodian/issues/6564