### PR TITLE
report - strip date portion from s3 output dir

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,6 +1,6 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from c7n.reports.csvout import Formatter
+from c7n.reports.csvout import Formatter, strip_output_path
 from .common import BaseTest, load_data
 
 
@@ -129,3 +129,20 @@ class TestMultiReport(BaseTest):
             recs = list(map(lambda x: self.records[x], rec_ids))
             rows = list(map(lambda x: self.rows[x], row_ids))
             self.assertEqual(formatter.to_csv(recs), rows)
+
+    def test_s3_base_output_path(self):
+        """When searching S3 to populate a report, the base output path
+        should end with the policy name."""
+
+        policy_name = "my_c7n_policy"
+        output_paths = [
+            f"logs/{policy_name}",
+            f"/logs/{policy_name}",
+            f"logs/{policy_name}/2021/01/01/01/",
+            f"/logs/{policy_name}/with/more/extra/path/segments",
+        ]
+
+        self.assertTrue(all(
+            strip_output_path(p, policy_name) == f"logs/{policy_name}"
+            for p in output_paths
+        ))


### PR DESCRIPTION
This fixes some `custodian report` behavior when reporting against S3 output destinations. Prior to the change, as far as I can tell it was only finding output from policies run within the last hour. When listing objects, it would make the call with parameters like:

```
'Prefix':'logs/my-policy/2021/03/31/05/'
'StartAfter':'logs/my-policy/2021/03/31/05/2021/03/30/00/resources.json.gz'
```

This change adjusts that call to look more like:

```
'Prefix':'logs/my-policy/'
'StartAfter':'logs/my-policy/2021/03/30/00/resources.json.gz'
```

Which gets the base behavior working and allows `--days` to function as expected also. Hat tip to [windowsrefund](https://github.com/windowsrefund) for raising this issue in Gitter.