### PR TITLE
aws - s3 toggle-logging error handling and region variables

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -1106,6 +1106,7 @@ class Policy:
             'bucket_region': '{bucket_region}',
             'bucket_name': '{bucket_name}',
             'source_bucket_name': '{source_bucket_name}',
+            'source_bucket_region': '{source_bucket_region}',
             'target_bucket_name': '{target_bucket_name}',
             'target_prefix': '{target_prefix}',
             'LoadBalancerName': '{LoadBalancerName}'

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -745,16 +745,25 @@ class BucketActionBase(BaseAction):
         }
 
     def process(self, buckets):
-        with self.executor_factory(max_workers=3) as w:
+        return self._process_with_futures(buckets)
+
+    def _process_with_futures(self, buckets, *args, max_workers=3, **kwargs):
+        with self.executor_factory(max_workers=max_workers) as w:
             futures = {}
             results = []
+
             for b in buckets:
-                futures[w.submit(self.process_bucket, b)] = b
+                futures[w.submit(self.process_bucket, b, *args, **kwargs)] = b
+
             for f in as_completed(futures):
                 if f.exception():
-                    self.log.error('error modifying bucket:%s\n%s',
-                                   b['Name'], f.exception())
+                    b = futures[f]
+                    self.log.error(
+                        'error modifying bucket: policy:%s action:%s bucket:%s error:%s',
+                        self.manager.data.get('name'), self.name, b['Name'], f.exception()
+                    )
                 results += filter(None, [f.result()])
+
             return results
 
 
@@ -1031,7 +1040,7 @@ class BucketNotificationFilter(ValueFilter):
 
 
 @filters.register('bucket-logging')
-class BucketLoggingFilter(Filter):
+class BucketLoggingFilter(BucketFilterBase):
     """Filter based on bucket logging configuration.
 
     :example:
@@ -1094,14 +1103,14 @@ class BucketLoggingFilter(Filter):
             session = local_session(self.manager.session_factory)
             self.account_name = get_account_alias_from_sts(session)
 
-        variables = {
-            'account_id': self.manager.config.account_id,
+        variables = self.get_std_format_args(b)
+        variables.update({
             'account': self.account_name,
-            'region': self.manager.config.region,
             'source_bucket_name': b['Name'],
+            'source_bucket_region': get_region(b),
             'target_bucket_name': self.data.get('target_bucket'),
             'target_prefix': self.data.get('target_prefix'),
-        }
+        })
         data = format_string_values(self.data, **variables)
         target_bucket = data.get('target_bucket')
         target_prefix = data.get('target_prefix', b['Name'] + '/')
@@ -1633,39 +1642,44 @@ class ToggleLogging(BucketActionBase):
         return self
 
     def process(self, resources):
-        enabled = self.data.get('enabled', True)
+        session = local_session(self.manager.session_factory),
+        kwargs = {
+            "enabled": self.data.get('enabled', True),
+            "session": session,
+            "account_name": get_account_alias_from_sts(session),
+        }
 
-        # Account name for variable expansion
-        session = local_session(self.manager.session_factory)
-        account_name = get_account_alias_from_sts(session)
+        return self._process_with_futures(resources, **kwargs)
 
-        for r in resources:
-            client = bucket_client(session, r)
-            is_logging = bool(r.get('Logging'))
+    def process_bucket(self, r, enabled=None, session=None, account_name=None):
+        client = bucket_client(session, r)
+        is_logging = bool(r.get('Logging'))
 
-            if enabled:
-                variables = {
-                    'account_id': self.manager.config.account_id,
-                    'account': account_name,
-                    'region': self.manager.config.region,
-                    'source_bucket_name': r['Name'],
-                    'target_bucket_name': self.data.get('target_bucket'),
-                    'target_prefix': self.data.get('target_prefix'),
-                }
-                data = format_string_values(self.data, **variables)
-                config = {
-                    'TargetBucket': data.get('target_bucket'),
-                    'TargetPrefix': data.get('target_prefix', r['Name'] + '/')
-                }
-                if not is_logging or r.get('Logging') != config:
-                    client.put_bucket_logging(
-                        Bucket=r['Name'],
-                        BucketLoggingStatus={'LoggingEnabled': config}
-                    )
-
-            elif not enabled and is_logging:
+        if enabled:
+            variables = self.get_std_format_args(r)
+            variables.update({
+                'account': account_name,
+                'source_bucket_name': r['Name'],
+                'source_bucket_region': get_region(r),
+                'target_bucket_name': self.data.get('target_bucket'),
+                'target_prefix': self.data.get('target_prefix'),
+            })
+            data = format_string_values(self.data, **variables)
+            config = {
+                'TargetBucket': data.get('target_bucket'),
+                'TargetPrefix': data.get('target_prefix', r['Name'] + '/')
+            }
+            if not is_logging or r.get('Logging') != config:
                 client.put_bucket_logging(
-                    Bucket=r['Name'], BucketLoggingStatus={})
+                    Bucket=r['Name'],
+                    BucketLoggingStatus={'LoggingEnabled': config}
+                )
+                r['Logging'] = config
+
+        elif not enabled and is_logging:
+            client.put_bucket_logging(
+                Bucket=r['Name'], BucketLoggingStatus={})
+            r['Logging'] = {}
 
 
 @actions.register('attach-encrypt')

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1642,7 +1642,7 @@ class ToggleLogging(BucketActionBase):
         return self
 
     def process(self, resources):
-        session = local_session(self.manager.session_factory),
+        session = local_session(self.manager.session_factory)
         kwargs = {
             "enabled": self.data.get('enabled', True),
             "session": session,

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -762,6 +762,7 @@ class BucketActionBase(BaseAction):
                         'error modifying bucket: policy:%s action:%s bucket:%s error:%s',
                         self.manager.data.get('name'), self.name, b['Name'], f.exception()
                     )
+                    continue
                 results += filter(None, [f.result()])
 
             return results

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2116,7 +2116,7 @@ class S3Test(BaseTest):
                     {
                         "type": "toggle-logging",
                         "target_bucket": bname,
-                        "target_prefix": "{account}/{source_bucket_name}",
+                        "target_prefix": "{account}/{source_bucket_region}/{source_bucket_name}/",
                     }
                 ],
             },
@@ -2125,6 +2125,10 @@ class S3Test(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["Name"], bname)
+        self.assertEqual(
+            resources[0]["Logging"]["TargetPrefix"],
+            "{}/{}/{}/".format(account_name, client.meta.region_name, bname)
+        )
 
         if self.recording:
             time.sleep(5)
@@ -2162,6 +2166,9 @@ class S3Test(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["Name"], bname)
+        self.assertEqual(
+            resources[0]["Logging"]["TargetPrefix"], "{}/{}/".format(self.account_id, bname)
+        )
 
         if self.recording:
             time.sleep(5)


### PR DESCRIPTION
This adds a generic function for running actions on buckets using futures.  There's a lot of duplicate code in here that does essentially the same thing, so this is a first attempt at cleaning that up.  The `toggle-logging` action needed it to better deal with failures, so it seemed like a good place to start.

Additionally, this keeps the `bucket-logging` filter and `toggle-logging` action using the main `BucketActionBase` class and supporting the default variable substitution names.  This means you can use `{bucket_name}` and `{bucket_region}` which, in the case of these logging functions are equivalent to `{source_bucket_name}` and the new `{source_bucket_region}`.