### PR TITLE
aws - kms - document filtering by KeyManager

### DIFF
--- a/c7n/filters/kms.py
+++ b/c7n/filters/kms.py
@@ -13,6 +13,8 @@ class KmsRelatedFilter(RelatedResourceFilter):
 
     :example:
 
+    Match a specific key alias:
+
         .. code-block:: yaml
 
             policies:
@@ -20,8 +22,22 @@ class KmsRelatedFilter(RelatedResourceFilter):
                   resource: dms-instance
                   filters:
                     - type: kms-key
-                      key: c7n:AliasName
+                      key: "c7n:AliasName"
                       value: alias/aws/dms
+
+    Or match against native key attributes such as ``KeyManager``, which
+    more explicitly distinguishes between ``AWS`` and ``CUSTOMER``-managed
+    keys. The above policy can also be written as:
+
+        .. code-block:: yaml
+
+            policies:
+                - name: dms-aws-managed-key
+                  resource: dms-instance
+                  filters:
+                    - type: kms-key
+                      key: KeyManager
+                      value: AWS
     """
 
     schema = type_schema(

--- a/c7n/resources/awslambda.py
+++ b/c7n/resources/awslambda.py
@@ -251,23 +251,7 @@ class LambdaCrossAccountAccessFilter(CrossAccountAccessFilter):
 
 @AWSLambda.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-        .. code-block:: yaml
-
-            policies:
-                - name: lambda-kms-key-filters
-                  resource: aws.lambda
-                  filters:
-                    - type: kms-key
-                      key: c7n:AliasName
-                      value: "^(alias/aws/lambda)"
-                      op: regex
-    """
     RelatedIdsExpression = 'KMSKeyArn'
 
 

--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -612,23 +612,6 @@ class LogCrossAccountFilter(CrossAccountAccessFilter):
 
 @LogGroup.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
-
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: cw-log-group-kms-key-filter
-            resource: log-group
-            filters:
-              - type: kms-key
-                key: c7n:AliasName
-                value: "^(alias/cw)"
-                op: regex
-    """
 
     RelatedIdsExpression = 'kmsKeyId'
 

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -61,23 +61,7 @@ class Table(query.QueryResourceManager):
 
 @Table.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-    .. code-block:: yaml
-
-            policies:
-              - name: dynamodb-kms-key-filters
-                resource: dynamodb-table
-                filters:
-                  - type: kms-key
-                    key: c7n:AliasName
-                    value: "^(alias/aws/dynamodb)"
-                    op: regex
-    """
     RelatedIdsExpression = 'SSEDescription.KMSMasterKeyArn'
 
 

--- a/c7n/resources/efs.py
+++ b/c7n/resources/efs.py
@@ -86,23 +86,7 @@ class SecurityGroup(SecurityGroupFilter):
 
 @ElasticFileSystem.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-        .. code-block:: yaml
-
-            policies:
-                - name: efs-kms-key-filters
-                  resource: efs
-                  filters:
-                    - type: kms-key
-                      key: c7n:AliasName
-                      value: "^(alias/aws/)"
-                      op: regex
-    """
     RelatedIdsExpression = 'KmsKeyId'
 
 

--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -96,23 +96,7 @@ class Metrics(MetricsFilter):
 
 @ElasticSearchDomain.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: elasticsearch-kms-key
-            resource: aws.elasticsearch
-            filters:
-              - type: kms-key
-                key: c7n:AliasName
-                value: "^(alias/aws/es)"
-                op: regex
-    """
     RelatedIdsExpression = 'EncryptionAtRestOptions.KmsKeyId'
 
 

--- a/c7n/resources/fsx.py
+++ b/c7n/resources/fsx.py
@@ -305,43 +305,11 @@ class DeleteFileSystem(BaseAction):
 
 @FSx.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-        .. code-block:: yaml
-
-            policies:
-                - name: fsx-kms-key-filters
-                  resource: fsx
-                  filters:
-                    - type: kms-key
-                      key: c7n:AliasName
-                      value: "^(alias/aws/fsx)"
-                      op: regex
-    """
     RelatedIdsExpression = 'KmsKeyId'
 
 
 @FSxBackup.filter_registry.register('kms-key')
 class KmsFilterFsxBackup(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-        .. code-block:: yaml
-
-            policies:
-                - name: fsx-backup-kms-key-filters
-                  resource: fsx-backup
-                  filters:
-                    - type: kms-key
-                      key: c7n:AliasName
-                      value: "^(alias/aws/fsx)"
-                      op: regex
-    """
     RelatedIdsExpression = 'KmsKeyId'

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -405,23 +405,7 @@ class GlueSecurityConfiguration(QueryResourceManager):
 
 @GlueSecurityConfiguration.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the alias name
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: glue-security-configuration-kms-key
-            resource: glue-security-configuration
-            filters:
-              - type: kms-key
-                key: c7n:AliasName
-                value: "^(alias/aws/)"
-                op: regex
-    """
     schema = type_schema(
         'kms-key',
         rinherit=ValueFilter.schema,

--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -329,22 +329,5 @@ class DeleteVideoStream(Action):
 
 @KinesisVideoStream.filter_registry.register('kms-key')
 class KmsFilterVideoStream(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the alias name
-    of the kms key by using 'c7n:AliasName'
-
-    :example:
-
-    .. code-block:: yaml
-
-            policies:
-              - name: kinesis-video-stream-kms-key
-                resource: aws.kinesis-video
-                filters:
-                  - type: kms-key
-                    key: c7n:AliasName
-                    value: "^(alias/aws/)"
-                    op: regex
-    """
 
     RelatedIdsExpression = 'KmsKeyId'

--- a/c7n/resources/mq.py
+++ b/c7n/resources/mq.py
@@ -36,23 +36,7 @@ class MessageBroker(QueryResourceManager):
 
 @MessageBroker.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: message-broker-kms-key-filter
-            resource: message-broker
-            filters:
-              - type: kms-key
-                key: c7n:AliasName
-                value: "^(alias/aws/mq)"
-                op: regex
-    """
     RelatedIdsExpression = 'EncryptionOptions.KmsKeyId'
 
 

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -113,23 +113,7 @@ RDSCluster.filter_registry.register('network-location', net_filters.NetworkLocat
 
 @RDSCluster.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-        .. code-block:: yaml
-
-            policies:
-                - name: rdscluster-kms-key-filter
-                  resource: aws.rds-cluster
-                  filters:
-                    - type: kms-key
-                      key: c7n:AliasName
-                      value: "^(alias/aws/rds)"
-                      op: regex
-    """
     RelatedIdsExpression = 'KmsKeyId'
 
 

--- a/c7n/resources/redshift.py
+++ b/c7n/resources/redshift.py
@@ -302,23 +302,7 @@ class Parameter(ValueFilter):
 
 @Redshift.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-        .. code-block:: yaml
-
-            policies:
-                - name: redshift-kms-key-filters
-                  resource: redshift
-                  filters:
-                    - type: kms-key
-                      key: c7n:AliasName
-                      value: "^(alias/aws/)"
-                      op: regex
-    """
     RelatedIdsExpression = 'KmsKeyId'
 
 

--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -565,30 +565,7 @@ class NotebookSubnetFilter(SubnetFilter):
 @NotebookInstance.filter_registry.register('kms-key')
 @SagemakerEndpointConfig.filter_registry.register('kms-key')
 class NotebookKmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: sagemaker-kms-key-filters
-            resource: aws.sagemaker-notebook
-            filters:
-              - type: kms-key
-                key: c7n:AliasName
-                value: "^(alias/aws/sagemaker)"
-                op: regex
-
-          - name: sagemaker-endpoint-kms-key-filters
-            resource: aws.sagemaker-endpoint-config
-            filters:
-              - type: kms-key
-                key: c7n:AliasName
-                value: "alias/aws/sagemaker"
-    """
     RelatedIdsExpression = "KmsKeyId"
 
 

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -348,22 +348,6 @@ class ModifyPolicyStatement(ModifyPolicyBase):
 
 @SNS.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filters SNS topic by kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
-
-    :example:
-
-        .. code-block:: yaml
-
-            policies:
-                - name: sns-encrypt-key-check
-                  resource: sns
-                  filters:
-                    - type: kms-key
-                      key: c7n:AliasName
-                      value: alias/aws/sns
-    """
 
     RelatedIdsExpression = 'KmsMasterKeyId'
 

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -124,29 +124,7 @@ class SQSCrossAccount(CrossAccountAccessFilter):
 
 @SQS.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
-    The KmsMasterId returned for SQS sometimes has the alias name directly in the value.
 
-    :example:
-
-        .. code-block:: yaml
-
-            policies:
-                - name: sqs-kms-key-filters
-                  resource: aws.sqs
-                  filters:
-                    - or:
-                      - type: value
-                        key: KmsMasterKeyId
-                        value: "^(alias/aws/)"
-                        op: regex
-                      - type: kms-key
-                        key: c7n:AliasName
-                        value: "^(alias/aws/)"
-                        op: regex
-    """
     RelatedIdsExpression = 'KmsMasterKeyId'
 
 

--- a/c7n/resources/workspaces.py
+++ b/c7n/resources/workspaces.py
@@ -89,21 +89,5 @@ class WorkspaceConnectionStatusFilter(ValueFilter):
 
 @Workspace.filter_registry.register('kms-key')
 class KmsFilter(KmsRelatedFilter):
-    """
-    Filter a resource by its associcated kms key and optionally the aliasname
-    of the kms key by using 'c7n:AliasName'
 
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: workspace-kms-key-filter
-            resource: workspaces
-            filters:
-              - type: kms-key
-                key: c7n:AliasName
-                value: "^(alias/aws/workspaces)"
-                op: regex
-    """
     RelatedIdsExpression = 'VolumeEncryptionKey'


### PR DESCRIPTION
_This is a component of the larger KMS filter refinement proposal in #6486._

- Flesh out top-level documentation for the `kms-key` filter, so that it includes an example of filtering by the `KeyManager` attribute.
- Remove resource-level child class docstrings. This avoids a lot of duplication (since usage is the same across resources), and ensures that all `kms-key` documentation picks up the updated example.