### PR TITLE
azure - Ensure subscription override for all cases

### DIFF
--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -37,8 +37,6 @@ class AzureCredential:
         if authorization_file:
             with open(authorization_file) as json_file:
                 self._auth_params = json.load(json_file)
-            if subscription_id_override is not None:
-                self._auth_params['subscription_id'] = subscription_id_override
         else:
             self._auth_params = {
                 'client_id': os.environ.get(constants.ENV_CLIENT_ID),
@@ -46,8 +44,7 @@ class AzureCredential:
                 'access_token': os.environ.get(constants.ENV_ACCESS_TOKEN),
                 'tenant_id': os.environ.get(constants.ENV_TENANT_ID),
                 'use_msi': bool(os.environ.get(constants.ENV_USE_MSI)),
-                'subscription_id':
-                    subscription_id_override or os.environ.get(constants.ENV_SUB_ID),
+                'subscription_id': os.environ.get(constants.ENV_SUB_ID),
                 'keyvault_client_id': os.environ.get(constants.ENV_KEYVAULT_CLIENT_ID),
                 'keyvault_secret_id': os.environ.get(constants.ENV_KEYVAULT_SECRET_ID),
                 'enable_cli_auth': True
@@ -99,6 +96,9 @@ class AzureCredential:
             self._auth_params['tenant_id'] = account_json['tenantId']
             if error is not None:
                 raise Exception('Unable to query TenantId and SubscriptionId')
+
+        if subscription_id_override is not None:
+            self._auth_params['subscription_id'] = subscription_id_override
 
         self._subscription_id = self._auth_params['subscription_id']
         self._tenant_id = self._auth_params['tenant_id']


### PR DESCRIPTION
If CLI was used, `subscription_override_id` was ignored. Shuffle the code a little bit to ensure it is always top-priority.
It also lead to an issue with `c7n-org` because `subscriptrion_override` is ignored.


Closes https://github.com/cloud-custodian/cloud-custodian/issues/6628