### PR TITLE
Dont enforce an empty payload to avoid AWS 400 InvalidEventPatternException

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -1071,7 +1071,11 @@ class CloudWatchEventSource(AWSEventBase):
             payload['detail-type'] = events
         elif event_type == 'phd':
             payload['source'] = ['aws.health']
-            payload.setdefault('detail', {})
+
+            phd_event_keys = ['events', 'statuses', 'categories']
+            if len([k for k in self.data.keys() if k in phd_event_keys]) > 0:
+                payload.setdefault('detail', {})
+
             if self.data.get('events'):
                 payload['detail'].update({
                     'eventTypeCode': list(self.data['events'])


### PR DESCRIPTION
Resolves #6507

A regression in #6141 causes an InvalidEventPatternException

yaml:

```
policies:
  - name: phd-alerts
    resource: account
    comment: Olay PHD alerts
    mode:
      type: phd
      role: arn:aws:iam::1111111111:role/cloud_custodian_role
    description: Any PHD alert
```

Was working until that PR. As a result you get the following AWS exception:

```
2021-04-21 12:51:07,887: custodian.commands:ERROR Error while executing policy phd-alerts, continuing
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/c7n/commands.py", line 271, in run
    policy()
  File "/usr/lib/python3.6/site-packages/c7n/policy.py", line 1182, in __call__
    resources = mode.provision()
  File "/usr/lib/python3.6/site-packages/c7n/policy.py", line 510, in provision
    role=self.policy.options.assume_role)
  File "/usr/lib/python3.6/site-packages/c7n/mu.py", line 396, in publish
    if e.add(func):
  File "/usr/lib/python3.6/site-packages/c7n/mu.py", line 1115, in add
    response = self.client.put_rule(**params)
  File "/usr/lib/python3.6/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/lib/python3.6/site-packages/botocore/client.py", line 676, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidEventPatternException: An error occurred (InvalidEventPatternException) when calling the PutRule ope
ration: Event pattern is not valid. Reason: Empty objects are not allowed
 at [Source: (String)"{"source": ["aws.health"], "detail": {}}"; line: 1, column: 40]
```