### PR TITLE
azure - container registry alias and rg warning

### DIFF
--- a/tools/c7n_azure/c7n_azure/query.py
+++ b/tools/c7n_azure/c7n_azure/query.py
@@ -100,9 +100,6 @@ class ResourceGraphSource:
                 % self.manager.data['resource'])
 
     def get_resources(self, _):
-        log.warning('The Azure Resource Graph source '
-                    'should not be used in production scenarios at this time.')
-
         session = self.manager.get_session()
         client = session.client('azure.mgmt.resourcegraph.ResourceGraphClient')
 

--- a/tools/c7n_azure/c7n_azure/resources/container_registry.py
+++ b/tools/c7n_azure/c7n_azure/resources/container_registry.py
@@ -5,7 +5,7 @@ from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
 
 
-@resources.register('containerregistry')
+@resources.register('container-registry', aliases=['containerregistry'])
 class ContainerRegistry(ArmResourceManager):
     """Container Registry Resource
 
@@ -17,7 +17,7 @@ class ContainerRegistry(ArmResourceManager):
 
         policies:
         - name: get-container-registry
-          resource: azure.containerregistry
+          resource: azure.container-registry
           filters:
             - type: value
               key: name

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -10,6 +10,7 @@ ResourceMap = {
     "azure.cognitiveservice": "c7n_azure.resources.cognitive_service.CognitiveService",
     "azure.container-group": "c7n_azure.resources.aci.ContainerGroup",
     "azure.containerregistry": "c7n_azure.resources.container_registry.ContainerRegistry",
+    "azure.container-registry": "c7n_azure.resources.container_registry.ContainerRegistry",
     "azure.containerservice": "c7n_azure.resources.container_service.ContainerService",
     "azure.cosmosdb": "c7n_azure.resources.cosmos_db.CosmosDB",
     "azure.cosmosdb-collection": "c7n_azure.resources.cosmos_db.CosmosDBCollection",


### PR DESCRIPTION
- Removing resource graph warning
- Fixing resource name and adding back compatibility via alias