### PR TITLE
c7n-org - support name templates for azure script

### DIFF
--- a/tools/c7n_azure/tests_azure/test_resource_graph_source.py
+++ b/tools/c7n_azure/tests_azure/test_resource_graph_source.py
@@ -57,7 +57,9 @@ class ResourceGraphSource(BaseTest):
 
         resources_resource_graph = json.loads(json.dumps(p2.run()[0]))
 
-        self.assertTrue(resource_cmp(resources_arm, resources_resource_graph))
+        self.assertTrue(resource_cmp(resources_arm,
+                                     resources_resource_graph,
+                                     ignore_properties=['keyCreationTime']))
 
     @arm_template('vm.json')
     def test_resource_graph_and_arm_sources_vm_are_equivalent(self):
@@ -108,7 +110,8 @@ def resource_cmp(res1, res2, ignore_properties=[]):
     if isinstance(res1, dict):
         for prop in res1:
             if prop not in ignore_properties and \
-                    (prop not in res2 or not resource_cmp(res1[prop], res2[prop])):
+                    (prop not in res2 or not resource_cmp(
+                        res1[prop], res2[prop], ignore_properties)):
                 return False
 
     elif isinstance(res1, list):
@@ -116,7 +119,7 @@ def resource_cmp(res1, res2, ignore_properties=[]):
             return False
 
         for item1, item2 in zip(res1, res2):
-            if not resource_cmp(item1, item2):
+            if not resource_cmp(item1, item2, ignore_properties):
                 return False
 
     elif isinstance(res1, str):

--- a/tools/c7n_org/scripts/azuresubs.py
+++ b/tools/c7n_org/scripts/azuresubs.py
@@ -6,6 +6,7 @@ from c7n_azure.session import Session
 from c7n.utils import yaml_dump
 from azure.mgmt.resource.subscriptions import SubscriptionClient
 
+NAME_TEMPLATE = "{name}"
 
 @click.command()
 @click.option(
@@ -16,7 +17,11 @@ from azure.mgmt.resource.subscriptions import SubscriptionClient
         ['Enabled', 'Warned', 'PastDue', 'Disabled', 'Deleted']),
     default=('Enabled',),
     help="File to store the generated config (default stdout)")
-def main(output, state):
+@click.option(
+    '--name',
+    default=NAME_TEMPLATE,
+    help="Name template for subscriptions in the config, defaults to %s" % NAME_TEMPLATE)
+def main(output, state, name):
     """
     Generate a c7n-org subscriptions config file
     """
@@ -31,6 +36,7 @@ def main(output, state):
             'subscription_id': sub['subscriptionId'],
             'name': sub['displayName']
         }
+        sub_info['name'] = name.format(**sub_info)
         results.append(sub_info)
 
     print(yaml_dump({'subscriptions': results}), file=output)

--- a/tools/c7n_org/scripts/azuresubs.py
+++ b/tools/c7n_org/scripts/azuresubs.py
@@ -8,6 +8,7 @@ from azure.mgmt.resource.subscriptions import SubscriptionClient
 
 NAME_TEMPLATE = "{name}"
 
+
 @click.command()
 @click.option(
     '-f', '--output', type=click.File('w'),


### PR DESCRIPTION
Add the name template support that exists in the AWS script to the Azure script.  This is standard `string.format()` syntax and the two fields available to you are `name` and `subscription_id`.

Closes #6424 

For example, you can append the first 5 characters of the Subscription ID to the Name with the following template using a precision format modifier:

``` 
> python azuresubs.py --name {name}-{subscription_id:5.5}

- name: c7n-tests-42f2c
  subscription_id: 42f2c294-bd12-2dfc-b7d5-304da32dfe3c

```

Additionally this includes a unit test fix for a new field in the Storage schema causing a discrepancy between resource graph and ARM API's.  