### PR TITLE
Fix: KeyError: 'Tags' when tagging some AWS SecretsManager secrets

### DIFF
--- a/c7n/resources/secretsmanager.py
+++ b/c7n/resources/secretsmanager.py
@@ -63,9 +63,7 @@ class TagSecretsManagerResource(Tag):
 
     def process_resource_set(self, client, resources, new_tags):
         for r in resources:
-            tags = {}
-            if 'Tags' in r:
-                tags = {t['Key']: t['Value'] for t in r['Tags']}
+            tags = {t['Key']: t['Value'] for t in r.get('Tags', ())}
             for t in new_tags:
                 tags[t['Key']] = t['Value']
             formatted_tags = [{'Key': k, 'Value': v} for k, v in tags.items()]

--- a/c7n/resources/secretsmanager.py
+++ b/c7n/resources/secretsmanager.py
@@ -63,7 +63,9 @@ class TagSecretsManagerResource(Tag):
 
     def process_resource_set(self, client, resources, new_tags):
         for r in resources:
-            tags = {t['Key']: t['Value'] for t in r['Tags']}
+            tags = {}
+            if 'Tags' in r:
+                tags = {t['Key']: t['Value'] for t in r['Tags']}
             for t in new_tags:
                 tags[t['Key']] = t['Value']
             formatted_tags = [{'Key': k, 'Value': v} for k, v in tags.items()]


### PR DESCRIPTION
### Summary

When applying tags to _some_ AWS Secrets Manager Secrets, Cloud Custodian fails with a `KeyError`. This PR fixes that edge case.

### Details

When running a policy to enforce tagging compliance in AWS Secrets Manager I am seeing the following error:

```
2021-04-30 12:00:03,292: custodian.output:ERROR Error while executing policy
Traceback (most recent call last):
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/policy.py", line 317, in run
    results = a.process(resources)
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/tags.py", line 413, in process
    self.process_resource_set, self.id_key, resources, tags, self.log)
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/tags.py", line 120, in _common_tag_processer
    raise error
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/resources/secretsmanager.py", line 66, in process_resource_set
    tags = {t['Key']: t['Value'] for t in r['Tags']}
KeyError: 'Tags'
2021-04-30 12:00:03,295: custodian.commands:ERROR Error while executing policy tag-noncompliance-aws-secrets-manager, continuing
Traceback (most recent call last):
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/commands.py", line 271, in run
    policy()
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/policy.py", line 1184, in __call__
    resources = mode.run()
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/policy.py", line 317, in run
    results = a.process(resources)
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/tags.py", line 413, in process
    self.process_resource_set, self.id_key, resources, tags, self.log)
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/tags.py", line 120, in _common_tag_processer
    raise error
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "./cloud-custodian-poc/.venv_custodian/lib/python3.7/site-packages/c7n/resources/secretsmanager.py", line 66, in process_resource_set
    tags = {t['Key']: t['Value'] for t in r['Tags']}
KeyError: 'Tags'
2021-04-30 12:00:03,328: custodian.commands:ERROR The following policies had errors while executing
 - tag-noncompliance-aws-secrets-manager
make: *** [apply-tagging] Error 2
```

Looking closer at the report, I see that some secrets do not contain the `Tags` key which is causing the above error.

```
[
  {
    "ARN": "arn:aws:secretsmanager:[redacted]",
    "Name": "credentials1",
    "LastChangedDate": "2021-04-29T08:39:11.491000+08:00",
    "LastAccessedDate": "2021-04-29T08:00:00+08:00",
    "SecretVersionsToStages": {
      "b606dfa9-f9f4-4132-82b4-04dc78fef73d": [
        "AWSCURRENT"
      ]
    },
    "CreatedDate": "2021-04-07T03:14:02.323000+08:00",
    "VersionIdsToStages": {
      "b606dfa9-f9f4-4132-82b4-04dc78fef73d": [
        "AWSCURRENT"
      ]
    },
    "c7n:MatchedFilters": [
      "tag:DataTaxonomy",
      "tag:Environment",
      "tag:ResourceOwner"
    ],
    "CustodianDate": "2021-04-30T12:01:55.111036",
    "policy": "tag-noncompliance-aws-secrets-manager",
    "region": "us-west-2"
  },
  {
    "ARN": "arn:aws:secretsmanager:[redacted]",
    "Name": "credentials2",
    "Description": "[redacted]",
    "LastChangedDate": "2021-04-28T08:01:26.053000+08:00",
    "LastAccessedDate": "2021-04-28T08:00:00+08:00",
    "Tags": [
      {
        "Key": "DataTaxonomy",
        "Value": "Operations Data"
      }
    ],
    "SecretVersionsToStages": {
      "bcd7d922-87c0-4a21-815c-2e10fbdea4d6": [
        "AWSCURRENT"
      ]
    },
    "CreatedDate": "2021-04-07T23:39:49.346000+08:00",
    "VersionIdsToStages": {
      "bcd7d922-87c0-4a21-815c-2e10fbdea4d6": [
        "AWSCURRENT"
      ]
    },
    "c7n:MatchedFilters": [
      "tag:Environment",
      "tag:ResourceOwner"
    ],
    "CustodianDate": "2021-04-30T12:01:55.111036",
    "policy": "tag-noncompliance-aws-secrets-manager",
    "region": "us-west-2"
  }
]
```

I'm honestly not sure why some secrets have an empty `Tags` key and some omit the `Tags` key completely. However in my case this fixed the problem and I was able to proceed with tagging.

I am unsure how to contribute a test for this change, however if it could be pointed out how to get started with the tests for this project I'd be happy to add a test for this also.