### PR TITLE
azure - data mask policy filter

### DIFF
--- a/tools/c7n_azure/tests_azure/cassettes/SqlDatabaseTest.test_data_masking_filter.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlDatabaseTest.test_data_masking_filter.json
@@ -1,0 +1,252 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/servers?api-version=2019-06-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Fri, 30 Apr 2021 16:48:58 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "1200"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "5558ad35-b8e7-45a7-9c6e-a493baa9e5cb",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "kind": "v12.0",
+                                "properties": {
+                                    "administratorLogin": "custodian",
+                                    "version": "12.0",
+                                    "state": "Ready",
+                                    "fullyQualifiedDomainName": "cctestsqlservertqtfgpqzllch4.database.windows.net",
+                                    "privateEndpointConnections": [
+                                        {
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4/privateEndpointConnections/test123-33f26040-5de1-486a-9b76-a56f28a46a12",
+                                            "properties": {
+                                                "privateEndpoint": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Network/privateEndpoints/test123"
+                                                },
+                                                "privateLinkServiceConnectionState": {
+                                                    "status": "Approved",
+                                                    "description": "Auto-approved",
+                                                    "actionsRequired": "None"
+                                                },
+                                                "provisioningState": "Ready"
+                                            }
+                                        }
+                                    ],
+                                    "minimalTlsVersion": "1.2",
+                                    "publicNetworkAccess": "Disabled"
+                                },
+                                "location": "eastus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4",
+                                "name": "cctestsqlservertqtfgpqzllch4",
+                                "type": "Microsoft.Sql/servers"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4/databases?api-version=2017-10-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Fri, 30 Apr 2021 16:48:59 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "2734"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Standard",
+                                    "tier": "Standard",
+                                    "capacity": 10
+                                },
+                                "kind": "v12.0,user",
+                                "properties": {
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "maxSizeBytes": 268435456000,
+                                    "status": "Online",
+                                    "databaseId": "7af22fe1-cb5a-49f9-bdf0-638e0e9cbc9f",
+                                    "creationDate": "2021-04-21T15:14:57.6Z",
+                                    "currentServiceObjectiveName": "S0",
+                                    "requestedServiceObjectiveName": "S0",
+                                    "defaultSecondaryLocation": "centralus",
+                                    "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "zoneRedundant": false,
+                                    "earliestRestoreDate": "2021-04-21T15:25:17Z",
+                                    "readScale": "Disabled",
+                                    "readReplicaCount": 0,
+                                    "currentSku": {
+                                        "name": "Standard",
+                                        "tier": "Standard",
+                                        "capacity": 10
+                                    }
+                                },
+                                "location": "eastus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4/databases/cclongtermretentiondb",
+                                "name": "cclongtermretentiondb",
+                                "type": "Microsoft.Sql/servers/databases"
+                            },
+                            {
+                                "sku": {
+                                    "name": "Standard",
+                                    "tier": "Standard",
+                                    "capacity": 10
+                                },
+                                "kind": "v12.0,user",
+                                "properties": {
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "maxSizeBytes": 2147483648,
+                                    "status": "Online",
+                                    "databaseId": "99338c6f-5608-4257-9861-0cdfa07417f0",
+                                    "creationDate": "2021-04-21T15:14:57.457Z",
+                                    "currentServiceObjectiveName": "S0",
+                                    "requestedServiceObjectiveName": "S0",
+                                    "defaultSecondaryLocation": "centralus",
+                                    "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "zoneRedundant": false,
+                                    "earliestRestoreDate": "2021-04-21T15:25:07Z",
+                                    "readScale": "Disabled",
+                                    "readReplicaCount": 0,
+                                    "currentSku": {
+                                        "name": "Standard",
+                                        "tier": "Standard",
+                                        "capacity": 10
+                                    }
+                                },
+                                "location": "eastus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4/databases/cctestdb",
+                                "name": "cctestdb",
+                                "type": "Microsoft.Sql/servers/databases"
+                            },
+                            {
+                                "sku": {
+                                    "name": "System",
+                                    "tier": "System",
+                                    "capacity": 0
+                                },
+                                "kind": "v12.0,system",
+                                "managedBy": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4",
+                                "properties": {
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "maxSizeBytes": 32212254720,
+                                    "status": "Online",
+                                    "databaseId": "f66fbb30-0835-4b16-b20c-537cfba87945",
+                                    "creationDate": "2021-04-21T15:13:00.593Z",
+                                    "currentServiceObjectiveName": "System0",
+                                    "requestedServiceObjectiveName": "System0",
+                                    "defaultSecondaryLocation": "centralus",
+                                    "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "zoneRedundant": false,
+                                    "readScale": "Disabled",
+                                    "readReplicaCount": 0,
+                                    "currentSku": {
+                                        "name": "System",
+                                        "tier": "System",
+                                        "capacity": 0
+                                    }
+                                },
+                                "location": "eastus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4/databases/master",
+                                "name": "master",
+                                "type": "Microsoft.Sql/servers/databases"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4/databases/cctestdb/dataMaskingPolicies/Default?api-version=2014-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Fri, 30 Apr 2021 16:48:59 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+                    ],
+                    "dataserviceversion": [
+                        "3.0;"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "content-length": [
+                        "599"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4/databases/cctestdb/dataMaskingPolicies/Default",
+                        "name": "Default",
+                        "type": "Microsoft.Sql/servers/databases/dataMaskingPolicies",
+                        "location": "East US 2",
+                        "kind": null,
+                        "managedBy": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlservertqtfgpqzllch4/databases/cctestdb",
+                        "properties": {
+                            "dataMaskingState": "Disabled",
+                            "applicationPrincipals": "",
+                            "exemptPrincipals": "",
+                            "maskingLevel": ""
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py
@@ -120,6 +120,24 @@ class SqlDatabaseTest(BaseTest):
         resources = p.run()
         self.assertEqual(1, len(resources))
 
+    def test_data_masking_filter(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-database',
+            'resource': 'azure.sql-database',
+            'filters': [
+                {
+                    'type': 'value',
+                    'key': 'name',
+                    'value': 'cctestdb'
+                },
+                {
+                    'type': 'data-masking-policy',
+                    'enabled': False
+                }],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+
 
 class ShortTermBackupRetentionPolicyFilterTest(BaseTest):
 


### PR DESCRIPTION
```
        policies:
          - name: sql-database-masking
            resource: azure.sql-database
            filters:
              - type: data-masking-policy
                enabled: false
```

Data masking policy returns quite a few fields but as of the current API version all of them are deprecated (and `null`) except the enabled state - so this filter simply lets you query by a boolean value to see if masking is enabled.

Closes #6550 