### PR TITLE
emr - use cluster state query from policy, if provided

### DIFF
--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -32,8 +32,8 @@ class EMRCluster(QueryResourceManager):
         service = 'emr'
         arn_type = 'emr'
         permission_prefix = 'elasticmapreduce'
-        cluster_states = ['WAITING', 'BOOTSTRAPPING', 'RUNNING', 'STARTING']
-        enum_spec = ('list_clusters', 'Clusters', {'ClusterStates': cluster_states})
+        default_cluster_states = ['WAITING', 'BOOTSTRAPPING', 'RUNNING', 'STARTING']
+        enum_spec = ('list_clusters', 'Clusters', None)
         name = 'Name'
         id = 'Id'
         date = "Status.Timeline.CreationDateTime"
@@ -46,9 +46,7 @@ class EMRCluster(QueryResourceManager):
     def __init__(self, ctx, data):
         super(EMRCluster, self).__init__(ctx, data)
         self.queries = QueryFilter.parse(
-            self.data.get('query', [
-                {'ClusterStates': [
-                    'running', 'bootstrapping', 'waiting']}]))
+            self.data.get('query', []))
 
     @classmethod
     def get_permissions(cls):
@@ -91,7 +89,7 @@ class EMRCluster(QueryResourceManager):
             result.append(
                 {
                     'Name': 'ClusterStates',
-                    'Values': ['WAITING', 'RUNNING', 'BOOTSTRAPPING'],
+                    'Values': self.resource_type.default_cluster_states
                 }
             )
         return result

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -35,7 +35,7 @@ class TestEMR(BaseTest):
                 {"Values": ["val3"], "Name": "tag:bar"},
                 # default query
                 {
-                    "Values": ["WAITING", "RUNNING", "BOOTSTRAPPING"],
+                    "Values": ["WAITING", "BOOTSTRAPPING", "RUNNING", "STARTING"],
                     "Name": "ClusterStates",
                 },
             ],


### PR DESCRIPTION
- Don't define a fixed `ClusterStates` query in `enum_spec.extra_args`. That was effectively trumping queries defined in policies.

- Consolidate the default/fallback behavior for the `ClusterStates` query parameter. Some of the previous logic was redundant or invalid, but was also never exercised because of the hardcoded `enum_spec.extra_args` value.

Addresses #6656 