### PR TITLE
core - fix value filters that specify a value type but no op

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -581,7 +581,7 @@ class ValueFilter(BaseValueFilter):
                 return op(r, v)
             except TypeError:
                 return False
-        elif r == self.v:
+        elif r == v:
             return True
 
         return False

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -210,10 +210,20 @@ class TestValueFilter(unittest.TestCase):
 
     def test_value_type_expr(self):
         resource = {'a': 1, 'b': 1}
+
+        # test explicit op
         vf = filters.factory({
             "type": "value",
             "value": "b",
             "op": 'eq',
+            "value_type": "expr",
+            "key": "a"})
+        self.assertTrue(vf.match(resource))
+
+        # test implicit/fallback op
+        vf = filters.factory({
+            "type": "value",
+            "value": "b",
             "value_type": "expr",
             "key": "a"})
         self.assertTrue(vf.match(resource))


### PR DESCRIPTION
When processing a filter with a value type defined, be sure that all
comparisons target the converted value.

This addresses an edge case with value filters that specify a
value type but no op - the fallback equality test compared against the
pre-converted value.