### PR TITLE
core - log policy exceptions before closing log stream

### DIFF
--- a/c7n/output.py
+++ b/c7n/output.py
@@ -330,9 +330,9 @@ class LogOutput:
         return self
 
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
-        self.leave_log()
         if exc_type is not None:
             log.exception("Error while executing policy")
+        self.leave_log()
 
     def join_log(self):
         self.handler = self.get_handler()


### PR DESCRIPTION
this should close #6696 ... not sure if there's a way to write a test for this.