### PR TITLE
c7n_mailer: add formatting for rds-cluster resources

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -188,6 +188,12 @@ def resource_format(resource, resource_type):
                 resource['Engine'], resource['EngineVersion']),
             resource['DBInstanceClass'],
             resource['AllocatedStorage'])
+    elif resource_type == 'rds-cluster':
+        return "%s %s %s" % (
+            resource['DBClusterIdentifier'],
+            "%s-%s" % (
+                resource['Engine'], resource['EngineVersion']),
+            resource['AllocatedStorage'])
     elif resource_type == 'asg':
         tag_map = {t['Key']: t['Value'] for t in resource.get('Tags', ())}
         return "%s %s %s" % (

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -92,6 +92,17 @@ class ResourceFormat(unittest.TestCase):
                 'aws.internet-gateway'),
             'id: igw-x  attachments: 0')
 
+    def test_rds_cluster(self):
+        self.assertEqual(
+            utils.resource_format(
+                {'DBClusterIdentifier': 'database-2',
+                 'Engine': 'mysql-aurora',
+                 'EngineVersion': '5.7.mysql_aurora.2.07.2',
+                 'AllocatedStorage': '1'},
+                'rds-cluster'),
+            'database-2 mysql-aurora-5.7.mysql_aurora.2.07.2 1',
+        )
+
     def test_s3(self):
         self.assertEqual(
             utils.resource_format(


### PR DESCRIPTION
This adds rds-cluster support to `resource_format`.