### PR TITLE
aws - ecs-task-definition get_resources exception due to double augment

### DIFF
--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -574,6 +574,9 @@ class TaskDefinition(query.QueryResourceManager):
         'describe': DescribeTaskDefinition
     }
 
+    def get_resources(self, ids, cache=True, augment=True):
+        return super(TaskDefinition, self).get_resources(ids, cache, augment=False)
+
 
 @TaskDefinition.action_registry.register('delete')
 class DeleteTaskDefinition(BaseAction):

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -273,7 +273,7 @@ class TestEcsTaskDefinition(BaseTest):
             session_factory=session_factory,
         )
         arn = "arn:aws:ecs:us-east-1:644160558196:task-definition/ecs-read-only-root:1"
-        resources = p.resource_manager.get_source('describe').get_resources([arn])
+        resources = p.resource_manager.get_resources([arn])
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["taskDefinitionArn"], arn)
         self.assertEqual(


### PR DESCRIPTION
Trying to use `copy-related-tags` to copy tags from a task definition to an ecs task was resulting in a stacktrace during get_resources.  Turns out the test for get_resources was only running the source function, not the one in the query manager, so this was getting missed.