### PR TITLE
aws - ami deregister causes policy exception when snapshot in use

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -125,7 +125,7 @@ class Deregister(BaseAction):
                 try:
                     self.manager.retry(client.delete_snapshot, SnapshotId=s)
                 except ClientError as e:
-                    if e.error['Code'] == 'InvalidSnapshot.InUse':
+                    if e.response['Error']['Code'] == 'InvalidSnapshot.InUse':
                         continue
 
 


### PR DESCRIPTION
Was getting the following exception:
```
if e.error['Code'] == 'InvalidSnapshot.InUse':
AttributeError: 'ClientError' object has no attribute 'error'
```