### PR TITLE
Fix API Gateway Metric Filter

### DIFF
--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -97,6 +97,7 @@ class MetricsFilter(Filter):
 
     # ditto for spot fleet
     DEFAULT_NAMESPACE = {
+        'apigateway': 'AWS/ApiGateway',
         'cloudfront': 'AWS/CloudFront',
         'cloudsearch': 'AWS/CloudSearch',
         'dynamodb': 'AWS/DynamoDB',
@@ -163,7 +164,7 @@ class MetricsFilter(Filter):
 
     def get_dimensions(self, resource):
         return [{'Name': self.model.dimension,
-                 'Value': resource[self.model.dimension]}]
+                 'Value': resource[self.model.dimension_field or self.model.dimension]}]
 
     def get_user_dimensions(self):
         dims = []

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -844,6 +844,7 @@ class TypeInfo(metaclass=TypeMeta):
     # resource id can be passed as this value. further customizations
     # of dimensions require subclass metrics filter.
     dimension = None
+    dimension_field = None
 
     # AWS Cloudformation type
     cfn_type = None

--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -134,7 +134,8 @@ class RestApi(query.QueryResourceManager):
         id = 'id'
         name = 'name'
         date = 'createdDate'
-        dimension = 'GatewayName'
+        dimension = 'ApiName'
+        dimension_field = 'name'
         cfn_type = config_type = "AWS::ApiGateway::RestApi"
         universal_taggable = object()
         permissions_enum = ('apigateway:GET',)


### PR DESCRIPTION
add default apigw metric namespace, add ability to override metric key, test for override. Closes #6725 