### PR TITLE
feat: delete EKS node group resources

### DIFF
--- a/c7n/resources/eks.py
+++ b/c7n/resources/eks.py
@@ -5,9 +5,8 @@ from botocore.exceptions import ClientError
 from c7n.actions import Action
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter, VpcFilter
 from c7n.manager import resources
-from c7n import tags
-from c7n.query import QueryResourceManager, ChildResourceManager, TypeInfo, DescribeSource
-from c7n import query
+from c7n import tags, query
+from c7n.query import QueryResourceManager, ChildResourceManager, ChildDescribeSource, TypeInfo, DescribeSource
 from c7n.utils import local_session, type_schema, get_retry
 from botocore.waiter import WaiterModel, create_waiter_with_client
 from .aws import shape_validate
@@ -15,7 +14,7 @@ from .ecs import ContainerConfigSource
 
 
 @query.sources.register('describe-eks-nodegroup')
-class NodeGroupDescribeSource(query.ChildDescribeSource):
+class NodeGroupDescribeSource(ChildDescribeSource):
 
     def get_query(self):
         query = super(NodeGroupDescribeSource, self).get_query()

--- a/c7n/resources/eks.py
+++ b/c7n/resources/eks.py
@@ -35,7 +35,7 @@ class NodeGroupDescribeSource(query.ChildDescribeSource):
         return results
 
 
-@resources.register('nodegroup')
+@resources.register('eks-nodegroup')
 class NodeGroup(ChildResourceManager):
 
     chunk_size = 10

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -56,7 +56,7 @@ ResourceMap = {
     "aws.efs": "c7n.resources.efs.ElasticFileSystem",
     "aws.efs-mount-target": "c7n.resources.efs.ElasticFileSystemMountTarget",
     "aws.eks": "c7n.resources.eks.EKS",
-    "aws.nodegroup": "c7n.resources.eks.NodeGroup",
+    "aws.eks-nodegroup": "c7n.resources.eks.NodeGroup",
     "aws.elasticbeanstalk": "c7n.resources.elasticbeanstalk.ElasticBeanstalk",
     "aws.elasticbeanstalk-environment": (
         "c7n.resources.elasticbeanstalk.ElasticBeanstalkEnvironment"),

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -56,6 +56,7 @@ ResourceMap = {
     "aws.efs": "c7n.resources.efs.ElasticFileSystem",
     "aws.efs-mount-target": "c7n.resources.efs.ElasticFileSystemMountTarget",
     "aws.eks": "c7n.resources.eks.EKS",
+    "aws.nodegroup": "c7n.resources.eks.NodeGroup",
     "aws.elasticbeanstalk": "c7n.resources.elasticbeanstalk.ElasticBeanstalk",
     "aws.elasticbeanstalk-environment": (
         "c7n.resources.elasticbeanstalk.ElasticBeanstalkEnvironment"),

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.DeleteNodegroup_1.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.DeleteNodegroup_1.json
@@ -1,0 +1,62 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroup": {
+            "nodegroupName": "node_group_example",
+            "nodegroupArn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/node_group_example/68bcf549-87e9-d8db-5223-83347dd49c8a",
+            "clusterName": "example",
+            "version": "1.19",
+            "releaseVersion": "1.19.6-20210526",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 8,
+                "hour": 10,
+                "minute": 42,
+                "second": 58,
+                "microsecond": 623000
+            },
+            "modifiedAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 8,
+                "hour": 10,
+                "minute": 45,
+                "second": 1,
+                "microsecond": 86000
+            },
+            "status": "DELETING",
+            "capacityType": "ON_DEMAND",
+            "scalingConfig": {
+                "minSize": 1,
+                "maxSize": 1,
+                "desiredSize": 1
+            },
+            "instanceTypes": [
+                "m5.large"
+            ],
+            "subnets": [
+                "subnet-0fdbcc64e3fa8acc4",
+                "subnet-0e7b90b136e09b1a3"
+            ],
+            "amiType": "AL2_x86_64",
+            "nodeRole": "arn:aws:iam::644160558196:role/eks-node-group-example",
+            "labels": {},
+            "resources": {
+                "autoScalingGroups": [
+                    {
+                        "name": "eks-68bcf549-87e9-d8db-5223-83347dd49c8a"
+                    }
+                ]
+            },
+            "diskSize": 20,
+            "health": {
+                "issues": []
+            },
+            "tags": {}
+        }
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_1.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_1.json
@@ -1,0 +1,62 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroup": {
+            "nodegroupName": "node_group_example",
+            "nodegroupArn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/node_group_example/68bcf549-87e9-d8db-5223-83347dd49c8a",
+            "clusterName": "example",
+            "version": "1.19",
+            "releaseVersion": "1.19.6-20210526",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 8,
+                "hour": 10,
+                "minute": 42,
+                "second": 58,
+                "microsecond": 623000
+            },
+            "modifiedAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 8,
+                "hour": 10,
+                "minute": 44,
+                "second": 48,
+                "microsecond": 519000
+            },
+            "status": "ACTIVE",
+            "capacityType": "ON_DEMAND",
+            "scalingConfig": {
+                "minSize": 1,
+                "maxSize": 1,
+                "desiredSize": 1
+            },
+            "instanceTypes": [
+                "m5.large"
+            ],
+            "subnets": [
+                "subnet-0fdbcc64e3fa8acc4",
+                "subnet-0e7b90b136e09b1a3"
+            ],
+            "amiType": "AL2_x86_64",
+            "nodeRole": "arn:aws:iam::644160558196:role/eks-node-group-example",
+            "labels": {},
+            "resources": {
+                "autoScalingGroups": [
+                    {
+                        "name": "eks-68bcf549-87e9-d8db-5223-83347dd49c8a"
+                    }
+                ]
+            },
+            "diskSize": 20,
+            "health": {
+                "issues": []
+            },
+            "tags": {}
+        }
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_2.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_2.json
@@ -1,0 +1,62 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroup": {
+            "nodegroupName": "node_group_example",
+            "nodegroupArn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/node_group_example/68bcf549-87e9-d8db-5223-83347dd49c8a",
+            "clusterName": "example",
+            "version": "1.19",
+            "releaseVersion": "1.19.6-20210526",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 8,
+                "hour": 10,
+                "minute": 42,
+                "second": 58,
+                "microsecond": 623000
+            },
+            "modifiedAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 8,
+                "hour": 10,
+                "minute": 45,
+                "second": 1,
+                "microsecond": 86000
+            },
+            "status": "DELETING",
+            "capacityType": "ON_DEMAND",
+            "scalingConfig": {
+                "minSize": 1,
+                "maxSize": 1,
+                "desiredSize": 1
+            },
+            "instanceTypes": [
+                "m5.large"
+            ],
+            "subnets": [
+                "subnet-0fdbcc64e3fa8acc4",
+                "subnet-0e7b90b136e09b1a3"
+            ],
+            "amiType": "AL2_x86_64",
+            "nodeRole": "arn:aws:iam::644160558196:role/eks-node-group-example",
+            "labels": {},
+            "resources": {
+                "autoScalingGroups": [
+                    {
+                        "name": "eks-68bcf549-87e9-d8db-5223-83347dd49c8a"
+                    }
+                ]
+            },
+            "diskSize": 20,
+            "health": {
+                "issues": []
+            },
+            "tags": {}
+        }
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.ListClusters_1.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.ListClusters_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "clusters": [
+            "sbx-spark-kubernetes-aws-side",
+            "sbx-ditto",
+            "example"
+        ]
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_1.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroups": []
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_2.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroups": []
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_3.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_3.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroups": [
+            "node_group_example"
+        ]
+    }
+}

--- a/tests/terraform/eks_nodegroup_delete/main.tf
+++ b/tests/terraform/eks_nodegroup_delete/main.tf
@@ -1,0 +1,155 @@
+provider "aws" {
+  region = "eu-central-1"
+}
+
+terraform {
+    backend "local" {}
+}
+
+# Networking
+
+resource "aws_default_route_table" "example" {
+  default_route_table_id = aws_vpc.example.default_route_table_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.example.id
+  }
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_subnet" "cluster_example" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.example.cidr_block, 8, count.index)
+  vpc_id            = aws_vpc.example.id
+  map_public_ip_on_launch = true
+}
+
+resource "aws_subnet" "node_group_example" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.example.cidr_block, 8, count.index+2)
+  vpc_id            = aws_vpc.example.id
+  map_public_ip_on_launch = true
+
+  tags = {
+    "kubernetes.io/cluster/${aws_eks_cluster.example.name}" = "shared"
+  }
+}
+
+resource "aws_internet_gateway" "example" {
+  vpc_id = aws_vpc.example.id
+}
+
+# EKS Cluster
+
+resource "aws_eks_cluster" "example" {
+  name     = "example"
+  role_arn = aws_iam_role.cluster_example.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.cluster_example[*].id
+  }
+
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role_policy_attachment.example-AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.example-AmazonEKSVPCResourceController,
+  ]
+}
+
+resource "aws_iam_role" "cluster_example" {
+  name = "eks-cluster-example"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster_example.name
+}
+
+# Optionally, enable Security Groups for Pods
+# Reference: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSVPCResourceController" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.cluster_example.name
+}
+
+### Node Group
+
+resource "aws_eks_node_group" "example" {
+  cluster_name    = aws_eks_cluster.example.name
+  node_role_arn   = aws_iam_role.node_group_example.arn
+  node_group_name = "node_group_example"
+  subnet_ids      = aws_subnet.node_group_example[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.example-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.example-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.example-AmazonEC2ContainerRegistryReadOnly,
+  ]
+}
+
+resource "aws_iam_role" "node_group_example" {
+  name = "eks-node-group-example"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_group_example.name
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_group_example.name
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_group_example.name
+}

--- a/tests/terraform/eks_nodegroup_delete/tf_resources.json
+++ b/tests/terraform/eks_nodegroup_delete/tf_resources.json
@@ -1,0 +1,301 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_availability_zones": {
+            "available": {
+                "all_availability_zones": null,
+                "exclude_names": null,
+                "exclude_zone_ids": null,
+                "filter": null,
+                "group_names": [
+                    "eu-central-1"
+                ],
+                "id": "eu-central-1",
+                "names": [
+                    "eu-central-1a",
+                    "eu-central-1b",
+                    "eu-central-1c"
+                ],
+                "state": "available",
+                "zone_ids": [
+                    "euc1-az2",
+                    "euc1-az3",
+                    "euc1-az1"
+                ]
+            }
+        },
+        "aws_default_route_table": {
+            "example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:route-table/rtb-0791f4f256ddf87f3",
+                "default_route_table_id": "rtb-0791f4f256ddf87f3",
+                "id": "rtb-0791f4f256ddf87f3",
+                "owner_id": "644160558196",
+                "propagating_vgws": null,
+                "route": [
+                    {
+                        "cidr_block": "0.0.0.0/0",
+                        "destination_prefix_list_id": "",
+                        "egress_only_gateway_id": "",
+                        "gateway_id": "igw-0024af182d3fa4153",
+                        "instance_id": "",
+                        "ipv6_cidr_block": "",
+                        "nat_gateway_id": "",
+                        "network_interface_id": "",
+                        "transit_gateway_id": "",
+                        "vpc_endpoint_id": "",
+                        "vpc_peering_connection_id": ""
+                    }
+                ],
+                "tags": null,
+                "vpc_id": "vpc-07ebba7604ed0ce08"
+            }
+        },
+        "aws_eks_cluster": {
+            "example": {
+                "arn": "arn:aws:eks:eu-central-1:644160558196:cluster/example",
+                "certificate_authority": [
+                    {
+                        "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1EWXdPREEzTXpneU1sb1hEVE14TURZd05qQTNNemd5TWxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTHNMCnV1ZElmdHNYMThHdVUyTVNwZDlKUVZremtKcFl2RWRtbk5oNGJ0U2paRUdVLzdvUzByL0ZlM2tQOU1RRHo3cFQKZVpPSVYwVWtmR01abnQxaExUa0FwRlVVZTgrZUdlSHNnVlcxNVdVUHh5SGtCNFcwaFpDZkF6ZVNNK1JkTGU2dApZV2NtM0RCcEZzdm1XbC91VURMcG1RMFNoZCtDNmNCbGx6MFAvWi9TTGR1SnhqeWUwOEhFQm9yOHVlc2xlMnc3CkE4UHpoV0xNRDFJZ0V4LzZXdmdsTHg0bUF5SHJJOXIyZjVBNncwdDY1eEtEbFVyNm9MSlYwdzFiSlpXZDhuOTAKL2Zac24xZDVNWThXS3ZKSlNuanBVRTVuVmp2dDJHNEVMeG9xUGxuQ0VtbC9KcVVsMHgwWEJxbzVGc1dlNXVDbwp0U2phckVXZnN2N0d1b0JHSExjQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZQS2xWemJWZks5VEVGdWtsRndqaEZodkw1ZkFNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBdXNCMkF0R2xBSFdaVWl4ZDN3cnM3S3YzZWxISGt1Y3dTYkNVWHlZT0h4S2ZiUFNDOAoydnN3ZGZISDF1N1k1dGk4Z0I0K0Q3WkNwRmkrRGlwcjNjZ2FvWGhvTnNsdG54cUFESGJpa2YrekJWZnlXRHZuClFYSDJjcFFvcElyc3l4ZTJwZVhwaloxRzB4TFhadk40aXJ5R3hNenYvcmpLOUVDcVpXbzNGK0ZweTRwWmtIL1EKZmhxOFQyMzkwbFBFU3BpZll6d2s2elRGY2QrTUw5SnF5c21KYzQ5cVVic3ZkRzZQS0NHMzVUN3ZOUk9hWVh5Twpjdm81T0l6MU1mSUpDZjhYY1NyQys3eTFlZ0VNc2FRK051RWNSbW1BNGd6MHdhYUtUa2RlRkJNMy9sR1BmNUthCkNFc1NERlY5c3BkUC9hNmJFTTJLck1UT0tNWVlma1p3V0VTNAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                    }
+                ],
+                "created_at": "2021-06-08 07:31:50.69 +0000 UTC",
+                "enabled_cluster_log_types": null,
+                "encryption_config": [],
+                "endpoint": "https://66B40CB0A70686E82533DD13B97E5500.gr7.eu-central-1.eks.amazonaws.com",
+                "id": "example",
+                "identity": [
+                    {
+                        "oidc": [
+                            {
+                                "issuer": "https://oidc.eks.eu-central-1.amazonaws.com/id/66B40CB0A70686E82533DD13B97E5500"
+                            }
+                        ]
+                    }
+                ],
+                "kubernetes_network_config": [
+                    {
+                        "service_ipv4_cidr": "172.20.0.0/16"
+                    }
+                ],
+                "name": "example",
+                "platform_version": "eks.5",
+                "role_arn": "arn:aws:iam::644160558196:role/eks-cluster-example",
+                "status": "ACTIVE",
+                "tags": null,
+                "timeouts": null,
+                "version": "1.19",
+                "vpc_config": [
+                    {
+                        "cluster_security_group_id": "sg-04716cb4019002972",
+                        "endpoint_private_access": false,
+                        "endpoint_public_access": true,
+                        "public_access_cidrs": [
+                            "0.0.0.0/0"
+                        ],
+                        "security_group_ids": null,
+                        "subnet_ids": [
+                            "subnet-04003ba7bc4d63523",
+                            "subnet-094dee44b3576dce3"
+                        ],
+                        "vpc_id": "vpc-07ebba7604ed0ce08"
+                    }
+                ]
+            }
+        },
+        "aws_eks_node_group": {
+            "example": {
+                "ami_type": "AL2_x86_64",
+                "arn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/node_group_example/68bcf549-87e9-d8db-5223-83347dd49c8a",
+                "capacity_type": "ON_DEMAND",
+                "cluster_name": "example",
+                "disk_size": 20,
+                "force_update_version": null,
+                "id": "example:node_group_example",
+                "instance_types": [
+                    "m5.large"
+                ],
+                "labels": null,
+                "launch_template": [],
+                "node_group_name": "node_group_example",
+                "node_role_arn": "arn:aws:iam::644160558196:role/eks-node-group-example",
+                "release_version": "1.19.6-20210526",
+                "remote_access": [],
+                "resources": [
+                    {
+                        "autoscaling_groups": [
+                            {
+                                "name": "eks-68bcf549-87e9-d8db-5223-83347dd49c8a"
+                            }
+                        ],
+                        "remote_access_security_group_id": ""
+                    }
+                ],
+                "scaling_config": [
+                    {
+                        "desired_size": 1,
+                        "max_size": 1,
+                        "min_size": 1
+                    }
+                ],
+                "status": "ACTIVE",
+                "subnet_ids": [
+                    "subnet-0e7b90b136e09b1a3",
+                    "subnet-0fdbcc64e3fa8acc4"
+                ],
+                "tags": null,
+                "timeouts": null,
+                "version": "1.19"
+            }
+        },
+        "aws_iam_role": {
+            "cluster_example": {
+                "arn": "arn:aws:iam::644160558196:role/eks-cluster-example",
+                "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                "create_date": "2021-06-08T07:31:31Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "eks-cluster-example",
+                "inline_policy": [
+                    {
+                        "name": "",
+                        "policy": ""
+                    }
+                ],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "eks-cluster-example",
+                "name_prefix": null,
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "unique_id": "AROA43SAJ7OOA2D5NRWIL"
+            },
+            "node_group_example": {
+                "arn": "arn:aws:iam::644160558196:role/eks-node-group-example",
+                "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                "create_date": "2021-06-08T07:31:31Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "eks-node-group-example",
+                "inline_policy": [
+                    {
+                        "name": "",
+                        "policy": ""
+                    }
+                ],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "eks-node-group-example",
+                "name_prefix": null,
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "unique_id": "AROA43SAJ7OONAD3NAOYY"
+            }
+        },
+        "aws_iam_role_policy_attachment": {
+            "example-AmazonEC2ContainerRegistryReadOnly": {
+                "id": "eks-node-group-example-20210608073134844200000001",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+                "role": "eks-node-group-example"
+            },
+            "example-AmazonEKSClusterPolicy": {
+                "id": "eks-cluster-example-20210608073135371600000005",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
+                "role": "eks-cluster-example"
+            },
+            "example-AmazonEKSVPCResourceController": {
+                "id": "eks-cluster-example-20210608073135315400000004",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController",
+                "role": "eks-cluster-example"
+            },
+            "example-AmazonEKSWorkerNodePolicy": {
+                "id": "eks-node-group-example-20210608073134870800000003",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+                "role": "eks-node-group-example"
+            },
+            "example-AmazonEKS_CNI_Policy": {
+                "id": "eks-node-group-example-20210608073134845900000002",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+                "role": "eks-node-group-example"
+            }
+        },
+        "aws_internet_gateway": {
+            "example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:internet-gateway/igw-0024af182d3fa4153",
+                "id": "igw-0024af182d3fa4153",
+                "owner_id": "644160558196",
+                "tags": null,
+                "vpc_id": "vpc-07ebba7604ed0ce08"
+            }
+        },
+        "aws_subnet": {
+            "cluster_example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:subnet/subnet-04003ba7bc4d63523",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "eu-central-1a",
+                "availability_zone_id": "euc1-az2",
+                "cidr_block": "10.0.0.0/24",
+                "customer_owned_ipv4_pool": "",
+                "id": "subnet-04003ba7bc4d63523",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": true,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-07ebba7604ed0ce08"
+            },
+            "node_group_example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:subnet/subnet-0e7b90b136e09b1a3",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "eu-central-1a",
+                "availability_zone_id": "euc1-az2",
+                "cidr_block": "10.0.2.0/24",
+                "customer_owned_ipv4_pool": "",
+                "id": "subnet-0e7b90b136e09b1a3",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": true,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "tags": {
+                    "kubernetes.io/cluster/example": "shared"
+                },
+                "tags_all": {
+                    "kubernetes.io/cluster/example": "shared"
+                },
+                "timeouts": null,
+                "vpc_id": "vpc-07ebba7604ed0ce08"
+            }
+        },
+        "aws_vpc": {
+            "example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:vpc/vpc-07ebba7604ed0ce08",
+                "assign_generated_ipv6_cidr_block": false,
+                "cidr_block": "10.0.0.0/16",
+                "default_network_acl_id": "acl-03f2d1b7d1033ec07",
+                "default_route_table_id": "rtb-0791f4f256ddf87f3",
+                "default_security_group_id": "sg-0fdf3a15e025748ef",
+                "dhcp_options_id": "dopt-d74e4fbc",
+                "enable_classiclink": null,
+                "enable_classiclink_dns_support": null,
+                "enable_dns_hostnames": false,
+                "enable_dns_support": true,
+                "id": "vpc-07ebba7604ed0ce08",
+                "instance_tenancy": "default",
+                "ipv6_association_id": "",
+                "ipv6_cidr_block": "",
+                "main_route_table_id": "rtb-0791f4f256ddf87f3",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sometimes it is required to delete only EKS node groups, not EKS cluster
so that **eks-nodegroup** resource type is added to have possibility to work with EKS node group as well.

Add **delete** action for EKS node group resource type.

Issue: #6735 