### PR TITLE
feat: delete EKS node group resources

### DIFF
--- a/c7n/resources/eks.py
+++ b/c7n/resources/eks.py
@@ -3,12 +3,55 @@
 from c7n.actions import Action
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter, VpcFilter
 from c7n.manager import resources
-from c7n import tags
-from c7n.query import QueryResourceManager, TypeInfo, DescribeSource
+from c7n import tags, query
+from c7n.query import QueryResourceManager, TypeInfo, DescribeSource, \
+    ChildResourceManager, ChildDescribeSource
 from c7n.utils import local_session, type_schema
 from botocore.waiter import WaiterModel, create_waiter_with_client
 from .aws import shape_validate
 from .ecs import ContainerConfigSource
+
+
+@query.sources.register('describe-eks-nodegroup')
+class NodeGroupDescribeSource(ChildDescribeSource):
+
+    def get_query(self):
+        query = super(NodeGroupDescribeSource, self).get_query()
+        query.capture_parent_id = True
+        return query
+
+    def augment(self, resources):
+        results = []
+        client = local_session(self.manager.session_factory).client('eks')
+        for cluster_name, nodegroup_name in resources:
+            nodegroup = client.describe_nodegroup(
+                clusterName=cluster_name,
+                nodegroupName=nodegroup_name)['nodegroup']
+            if 'tags' in nodegroup:
+                nodegroup['Tags'] = [{'Key': k, 'Value': v} for k, v in nodegroup['tags'].items()]
+            results.append(nodegroup)
+        return results
+
+
+@resources.register('eks-nodegroup')
+class NodeGroup(ChildResourceManager):
+
+    class resource_type(TypeInfo):
+
+        service = 'eks'
+        arn = 'nodegroupArn'
+        arn_type = 'nodegroup'
+        id = 'nodegroupArn'
+        name = 'nodegroupName'
+        enum_spec = ('list_nodegroups', 'nodegroups', None)
+        parent_spec = ('eks', 'clusterName', None)
+        permissions_enum = ('eks:DescribeNodegroup',)
+        date = 'createdAt'
+
+    source_mapping = {
+        'describe-child': NodeGroupDescribeSource,
+        'describe': NodeGroupDescribeSource,
+    }
 
 
 class EKSDescribeSource(DescribeSource):

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -56,6 +56,7 @@ ResourceMap = {
     "aws.efs": "c7n.resources.efs.ElasticFileSystem",
     "aws.efs-mount-target": "c7n.resources.efs.ElasticFileSystemMountTarget",
     "aws.eks": "c7n.resources.eks.EKS",
+    "aws.eks-nodegroup": "c7n.resources.eks.NodeGroup",
     "aws.elasticbeanstalk": "c7n.resources.elasticbeanstalk.ElasticBeanstalk",
     "aws.elasticbeanstalk-environment": (
         "c7n.resources.elasticbeanstalk.ElasticBeanstalkEnvironment"),

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.DeleteNodegroup_1.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.DeleteNodegroup_1.json
@@ -1,0 +1,65 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroup": {
+            "nodegroupName": "deleted-example",
+            "nodegroupArn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/deleted-example/b4bcf913-32c7-2459-26d9-66ee6025e572",
+            "clusterName": "example",
+            "version": "1.19",
+            "releaseVersion": "1.19.6-20210526",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 9,
+                "hour": 22,
+                "minute": 1,
+                "second": 15,
+                "microsecond": 601000
+            },
+            "modifiedAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 9,
+                "hour": 22,
+                "minute": 3,
+                "second": 33,
+                "microsecond": 558000
+            },
+            "status": "DELETING",
+            "capacityType": "ON_DEMAND",
+            "scalingConfig": {
+                "minSize": 1,
+                "maxSize": 1,
+                "desiredSize": 1
+            },
+            "instanceTypes": [
+                "t3.medium"
+            ],
+            "subnets": [
+                "subnet-090b5147c5840ff04",
+                "subnet-0a87c93ecb21f181f"
+            ],
+            "amiType": "AL2_x86_64",
+            "nodeRole": "arn:aws:iam::644160558196:role/eks-node-group-example",
+            "labels": {},
+            "resources": {
+                "autoScalingGroups": [
+                    {
+                        "name": "eks-b4bcf913-32c7-2459-26d9-66ee6025e572"
+                    }
+                ]
+            },
+            "diskSize": 20,
+            "health": {
+                "issues": []
+            },
+            "tags": {
+                "ClusterName": "example",
+                "Name": "deleted-example"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_1.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_1.json
@@ -1,0 +1,65 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroup": {
+            "nodegroupName": "deleted-example",
+            "nodegroupArn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/deleted-example/b4bcf913-32c7-2459-26d9-66ee6025e572",
+            "clusterName": "example",
+            "version": "1.19",
+            "releaseVersion": "1.19.6-20210526",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 9,
+                "hour": 22,
+                "minute": 1,
+                "second": 15,
+                "microsecond": 601000
+            },
+            "modifiedAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 9,
+                "hour": 22,
+                "minute": 3,
+                "second": 15,
+                "microsecond": 960000
+            },
+            "status": "ACTIVE",
+            "capacityType": "ON_DEMAND",
+            "scalingConfig": {
+                "minSize": 1,
+                "maxSize": 1,
+                "desiredSize": 1
+            },
+            "instanceTypes": [
+                "t3.medium"
+            ],
+            "subnets": [
+                "subnet-090b5147c5840ff04",
+                "subnet-0a87c93ecb21f181f"
+            ],
+            "amiType": "AL2_x86_64",
+            "nodeRole": "arn:aws:iam::644160558196:role/eks-node-group-example",
+            "labels": {},
+            "resources": {
+                "autoScalingGroups": [
+                    {
+                        "name": "eks-b4bcf913-32c7-2459-26d9-66ee6025e572"
+                    }
+                ]
+            },
+            "diskSize": 20,
+            "health": {
+                "issues": []
+            },
+            "tags": {
+                "ClusterName": "example",
+                "Name": "deleted-example"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_2.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_2.json
@@ -1,0 +1,65 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroup": {
+            "nodegroupName": "not_deleted_example",
+            "nodegroupArn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/not_deleted_example/54bcf913-32c5-0470-56a4-57858068f5dd",
+            "clusterName": "example",
+            "version": "1.19",
+            "releaseVersion": "1.19.6-20210526",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 9,
+                "hour": 22,
+                "minute": 1,
+                "second": 15,
+                "microsecond": 34000
+            },
+            "modifiedAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 9,
+                "hour": 22,
+                "minute": 3,
+                "second": 7,
+                "microsecond": 360000
+            },
+            "status": "ACTIVE",
+            "capacityType": "ON_DEMAND",
+            "scalingConfig": {
+                "minSize": 1,
+                "maxSize": 1,
+                "desiredSize": 1
+            },
+            "instanceTypes": [
+                "t3.medium"
+            ],
+            "subnets": [
+                "subnet-090b5147c5840ff04",
+                "subnet-0a87c93ecb21f181f"
+            ],
+            "amiType": "AL2_x86_64",
+            "nodeRole": "arn:aws:iam::644160558196:role/eks-node-group-example",
+            "labels": {},
+            "resources": {
+                "autoScalingGroups": [
+                    {
+                        "name": "eks-54bcf913-32c5-0470-56a4-57858068f5dd"
+                    }
+                ]
+            },
+            "diskSize": 20,
+            "health": {
+                "issues": []
+            },
+            "tags": {
+                "ClusterName": "example",
+                "Name": "not-deleted-example"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_3.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.DescribeNodegroup_3.json
@@ -1,0 +1,65 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroup": {
+            "nodegroupName": "deleted-example",
+            "nodegroupArn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/deleted-example/b4bcf913-32c7-2459-26d9-66ee6025e572",
+            "clusterName": "example",
+            "version": "1.19",
+            "releaseVersion": "1.19.6-20210526",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 9,
+                "hour": 22,
+                "minute": 1,
+                "second": 15,
+                "microsecond": 601000
+            },
+            "modifiedAt": {
+                "__class__": "datetime",
+                "year": 2021,
+                "month": 6,
+                "day": 9,
+                "hour": 22,
+                "minute": 3,
+                "second": 33,
+                "microsecond": 558000
+            },
+            "status": "DELETING",
+            "capacityType": "ON_DEMAND",
+            "scalingConfig": {
+                "minSize": 1,
+                "maxSize": 1,
+                "desiredSize": 1
+            },
+            "instanceTypes": [
+                "t3.medium"
+            ],
+            "subnets": [
+                "subnet-090b5147c5840ff04",
+                "subnet-0a87c93ecb21f181f"
+            ],
+            "amiType": "AL2_x86_64",
+            "nodeRole": "arn:aws:iam::644160558196:role/eks-node-group-example",
+            "labels": {},
+            "resources": {
+                "autoScalingGroups": [
+                    {
+                        "name": "eks-b4bcf913-32c7-2459-26d9-66ee6025e572"
+                    }
+                ]
+            },
+            "diskSize": 20,
+            "health": {
+                "issues": []
+            },
+            "tags": {
+                "ClusterName": "example",
+                "Name": "deleted-example"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.ListClusters_1.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.ListClusters_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "clusters": [
+            "example",
+            "sbx-ditto",
+            "sbx-spark-kubernetes-aws-side"
+        ]
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_1.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroups": [
+            "deleted-example",
+            "not_deleted_example"
+        ]
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_2.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroups": []
+    }
+}

--- a/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_3.json
+++ b/tests/data/placebo/test_eks_nodegroup_delete/eks.ListNodegroups_3.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "nodegroups": []
+    }
+}

--- a/tests/terraform/eks_nodegroup_delete/eks-nodegroup.tf
+++ b/tests/terraform/eks_nodegroup_delete/eks-nodegroup.tf
@@ -1,0 +1,81 @@
+resource "aws_eks_node_group" "deleted_example" {
+  cluster_name    = aws_eks_cluster.example.name
+  node_role_arn   = aws_iam_role.node_group_example.arn
+  node_group_name = "deleted-example"
+  subnet_ids      = aws_subnet.node_group_example[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  tags = {
+    "Name" = "deleted-example"
+    "ClusterName" =  aws_eks_cluster.example.name
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.example-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.example-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.example-AmazonEC2ContainerRegistryReadOnly,
+  ]
+}
+
+resource "aws_eks_node_group" "not_deleted_example" {
+  cluster_name    = aws_eks_cluster.example.name
+  node_role_arn   = aws_iam_role.node_group_example.arn
+  node_group_name = "not_deleted_example"
+  subnet_ids      = aws_subnet.node_group_example[*].id
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  tags = {
+    "Name" = "not-deleted-example"
+    "ClusterName" =  aws_eks_cluster.example.name
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.example-AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.example-AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.example-AmazonEC2ContainerRegistryReadOnly,
+  ]
+}
+
+resource "aws_iam_role" "node_group_example" {
+  name = "eks-node-group-example"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_group_example.name
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_group_example.name
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_group_example.name
+}

--- a/tests/terraform/eks_nodegroup_delete/main.tf
+++ b/tests/terraform/eks_nodegroup_delete/main.tf
@@ -1,0 +1,46 @@
+resource "aws_eks_cluster" "example" {
+  name     = "example"
+  role_arn = aws_iam_role.cluster_example.arn
+
+  vpc_config {
+    subnet_ids = aws_subnet.cluster_example[*].id
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role_policy_attachment.example-AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.example-AmazonEKSVPCResourceController,
+  ]
+}
+
+resource "aws_iam_role" "cluster_example" {
+  name = "eks-cluster-example"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster_example.name
+}
+
+# Optionally, enable Security Groups for Pods
+# Reference: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
+resource "aws_iam_role_policy_attachment" "example-AmazonEKSVPCResourceController" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.cluster_example.name
+}

--- a/tests/terraform/eks_nodegroup_delete/network.tf
+++ b/tests/terraform/eks_nodegroup_delete/network.tf
@@ -1,0 +1,42 @@
+resource "aws_default_route_table" "example" {
+  default_route_table_id = aws_vpc.example.default_route_table_id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.example.id
+  }
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_subnet" "cluster_example" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.example.cidr_block, 8, count.index)
+  vpc_id            = aws_vpc.example.id
+  map_public_ip_on_launch = true
+}
+
+resource "aws_subnet" "node_group_example" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.example.cidr_block, 8, count.index+2)
+  vpc_id            = aws_vpc.example.id
+  map_public_ip_on_launch = true
+
+  tags = {
+    "kubernetes.io/cluster/${aws_eks_cluster.example.name}" = "shared"
+  }
+}
+
+resource "aws_internet_gateway" "example" {
+  vpc_id = aws_vpc.example.id
+}

--- a/tests/terraform/eks_nodegroup_delete/providers.tf
+++ b/tests/terraform/eks_nodegroup_delete/providers.tf
@@ -1,0 +1,1 @@
+provider "aws" {}

--- a/tests/terraform/eks_nodegroup_delete/tf_resources.json
+++ b/tests/terraform/eks_nodegroup_delete/tf_resources.json
@@ -1,0 +1,350 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_availability_zones": {
+            "available": {
+                "all_availability_zones": null,
+                "exclude_names": null,
+                "exclude_zone_ids": null,
+                "filter": null,
+                "group_names": [
+                    "eu-central-1"
+                ],
+                "id": "eu-central-1",
+                "names": [
+                    "eu-central-1a",
+                    "eu-central-1b",
+                    "eu-central-1c"
+                ],
+                "state": "available",
+                "zone_ids": [
+                    "euc1-az2",
+                    "euc1-az3",
+                    "euc1-az1"
+                ]
+            }
+        },
+        "aws_default_route_table": {
+            "example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:route-table/rtb-0bd6a3614c5bfc10d",
+                "default_route_table_id": "rtb-0bd6a3614c5bfc10d",
+                "id": "rtb-0bd6a3614c5bfc10d",
+                "owner_id": "644160558196",
+                "propagating_vgws": null,
+                "route": [
+                    {
+                        "cidr_block": "0.0.0.0/0",
+                        "destination_prefix_list_id": "",
+                        "egress_only_gateway_id": "",
+                        "gateway_id": "igw-0e5d436a368635698",
+                        "instance_id": "",
+                        "ipv6_cidr_block": "",
+                        "nat_gateway_id": "",
+                        "network_interface_id": "",
+                        "transit_gateway_id": "",
+                        "vpc_endpoint_id": "",
+                        "vpc_peering_connection_id": ""
+                    }
+                ],
+                "tags": null,
+                "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+            }
+        },
+        "aws_eks_cluster": {
+            "example": {
+                "arn": "arn:aws:eks:eu-central-1:644160558196:cluster/example",
+                "certificate_authority": [
+                    {
+                        "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1EWXdPVEU0TlRZMU4xb1hEVE14TURZd056RTROVFkxTjFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTW9tCmdlWVFhdEovbjNSWDJBcFE0bEE5Z3NBUW8xTVlvRWJJMEJsZ0ZtTS9kWCsrVmkrS0QvMGUvejVNclYwSTVORS8KS2VsVXBJTWo4em5KdU52dmJlMUtkWXVnRm1XOE5VYUtqdklwMVhVcC9meHJ2cDBBZ2E5TEkzcUt3TS9RN3IyZwp1dnc0TndyM2ZDaEhkMU9lU2x5Z0swUWFpelNQV05pa3prNDBZQTY2VmprYkIvb05NWVE0ai9nL08xa2JMQnpoCmxoRUE2T3lxb0JQRjhVNzIwWnhEMUxENldwUFY5UkpXUHlrdkVWRXhKbmE4NWI1UWZVVXRkSU8xWlZEd2NZbmIKcGU3QnNFMDdOaUNJL3R1RlpxUkJIYzhKVytodkZKdUhEckE0RVNsbkM4Rll4MnFTTHZkRVJoNHJmS0U1QXYvaQpHSXJ5ZE5RSXdVTkZ6OGtpdlBNQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZIMXhZM2FmNW1vSDFwZVRoWGRmVlFVSHdMZDBNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBd3VVOHpGKzBXb2szckxMTHZCOGw4ZUw5VEhSalVvVXRybW1ZdnBhckh6OVVrZmYwUQpQY29SbUwxSEVHVDNvUDJ3cnJoeDFnV1dtenJHUnc2S3JLNHdON1ZpVFZnSHpIdFNBR0tBSEpPSm9KQ0d6YjBTCnBkc0tZbGthazFxajJ3Tlo2NEg3OXM0RHFnd1h1citjS1pCY1Q0NkJ4UGE5dUU5WGkvNFV4ckNzN1BRbjdOL0gKNkdMTnVXQzY4L1BnRDdxNUgxQ1JvbVdZMlExQlQrcDNObkZTMkJRMWVqWkJyb2dERzByaE5SZkI0OHNmNnFZNwpra1h6aTlYdVp5QjRGa1EwRnpzR1c2aEF4c01XM0xnV2FueUZubTMyUEdxb1EzczlMSUIyV05kWEZudkQvSVkzCnVFc3NoVml6a2xpdGFna1UrblFuN2tQRE9hZVpvdDZpUUg1VwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                    }
+                ],
+                "created_at": "2021-06-09 18:51:25.242 +0000 UTC",
+                "enabled_cluster_log_types": null,
+                "encryption_config": [],
+                "endpoint": "https://D70C67F0CA5533EC6169BE7EEEF1F566.yl4.eu-central-1.eks.amazonaws.com",
+                "id": "example",
+                "identity": [
+                    {
+                        "oidc": [
+                            {
+                                "issuer": "https://oidc.eks.eu-central-1.amazonaws.com/id/D70C67F0CA5533EC6169BE7EEEF1F566"
+                            }
+                        ]
+                    }
+                ],
+                "kubernetes_network_config": [
+                    {
+                        "service_ipv4_cidr": "172.20.0.0/16"
+                    }
+                ],
+                "name": "example",
+                "platform_version": "eks.5",
+                "role_arn": "arn:aws:iam::644160558196:role/eks-cluster-example",
+                "status": "ACTIVE",
+                "tags": null,
+                "timeouts": null,
+                "version": "1.19",
+                "vpc_config": [
+                    {
+                        "cluster_security_group_id": "sg-01a195a3755018b3f",
+                        "endpoint_private_access": false,
+                        "endpoint_public_access": true,
+                        "public_access_cidrs": [
+                            "0.0.0.0/0"
+                        ],
+                        "security_group_ids": null,
+                        "subnet_ids": [
+                            "subnet-0a228654ec7e42459",
+                            "subnet-0b743fe5e4b41ff30"
+                        ],
+                        "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+                    }
+                ]
+            }
+        },
+        "aws_eks_node_group": {
+            "deleted_example": {
+                "ami_type": "AL2_x86_64",
+                "arn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/deleted-example/b4bcf913-32c7-2459-26d9-66ee6025e572",
+                "capacity_type": "ON_DEMAND",
+                "cluster_name": "example",
+                "disk_size": 20,
+                "force_update_version": null,
+                "id": "example:deleted-example",
+                "instance_types": [
+                    "t3.medium"
+                ],
+                "labels": null,
+                "launch_template": [],
+                "node_group_name": "deleted-example",
+                "node_role_arn": "arn:aws:iam::644160558196:role/eks-node-group-example",
+                "release_version": "1.19.6-20210526",
+                "remote_access": [],
+                "resources": [
+                    {
+                        "autoscaling_groups": [
+                            {
+                                "name": "eks-b4bcf913-32c7-2459-26d9-66ee6025e572"
+                            }
+                        ],
+                        "remote_access_security_group_id": ""
+                    }
+                ],
+                "scaling_config": [
+                    {
+                        "desired_size": 1,
+                        "max_size": 1,
+                        "min_size": 1
+                    }
+                ],
+                "status": "ACTIVE",
+                "subnet_ids": [
+                    "subnet-090b5147c5840ff04",
+                    "subnet-0a87c93ecb21f181f"
+                ],
+                "tags": {
+                    "ClusterName": "example",
+                    "Name": "deleted-example"
+                },
+                "timeouts": null,
+                "version": "1.19"
+            },
+            "not_deleted_example": {
+                "ami_type": "AL2_x86_64",
+                "arn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/not_deleted_example/54bcf913-32c5-0470-56a4-57858068f5dd",
+                "capacity_type": "ON_DEMAND",
+                "cluster_name": "example",
+                "disk_size": 20,
+                "force_update_version": null,
+                "id": "example:not_deleted_example",
+                "instance_types": [
+                    "t3.medium"
+                ],
+                "labels": null,
+                "launch_template": [],
+                "node_group_name": "not_deleted_example",
+                "node_role_arn": "arn:aws:iam::644160558196:role/eks-node-group-example",
+                "release_version": "1.19.6-20210526",
+                "remote_access": [],
+                "resources": [
+                    {
+                        "autoscaling_groups": [
+                            {
+                                "name": "eks-54bcf913-32c5-0470-56a4-57858068f5dd"
+                            }
+                        ],
+                        "remote_access_security_group_id": ""
+                    }
+                ],
+                "scaling_config": [
+                    {
+                        "desired_size": 1,
+                        "max_size": 1,
+                        "min_size": 1
+                    }
+                ],
+                "status": "ACTIVE",
+                "subnet_ids": [
+                    "subnet-090b5147c5840ff04",
+                    "subnet-0a87c93ecb21f181f"
+                ],
+                "tags": {
+                    "ClusterName": "example",
+                    "Name": "not-deleted-example"
+                },
+                "timeouts": null,
+                "version": "1.19"
+            }
+        },
+        "aws_iam_role": {
+            "cluster_example": {
+                "arn": "arn:aws:iam::644160558196:role/eks-cluster-example",
+                "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                "create_date": "2021-06-09T18:50:49Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "eks-cluster-example",
+                "inline_policy": [
+                    {
+                        "name": "",
+                        "policy": ""
+                    }
+                ],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "eks-cluster-example",
+                "name_prefix": null,
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "unique_id": "AROA43SAJ7OOP5YLNW3LI"
+            },
+            "node_group_example": {
+                "arn": "arn:aws:iam::644160558196:role/eks-node-group-example",
+                "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                "create_date": "2021-06-09T18:50:49Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "eks-node-group-example",
+                "inline_policy": [
+                    {
+                        "name": "",
+                        "policy": ""
+                    }
+                ],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "eks-node-group-example",
+                "name_prefix": null,
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "unique_id": "AROA43SAJ7OODDQFYMOIB"
+            }
+        },
+        "aws_iam_role_policy_attachment": {
+            "example-AmazonEC2ContainerRegistryReadOnly": {
+                "id": "eks-node-group-example-20210609185057653700000002",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+                "role": "eks-node-group-example"
+            },
+            "example-AmazonEKSClusterPolicy": {
+                "id": "eks-cluster-example-20210609185057670700000005",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
+                "role": "eks-cluster-example"
+            },
+            "example-AmazonEKSVPCResourceController": {
+                "id": "eks-cluster-example-20210609185057306000000001",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController",
+                "role": "eks-cluster-example"
+            },
+            "example-AmazonEKSWorkerNodePolicy": {
+                "id": "eks-node-group-example-20210609185057669800000004",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+                "role": "eks-node-group-example"
+            },
+            "example-AmazonEKS_CNI_Policy": {
+                "id": "eks-node-group-example-20210609185057660500000003",
+                "policy_arn": "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+                "role": "eks-node-group-example"
+            }
+        },
+        "aws_internet_gateway": {
+            "example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:internet-gateway/igw-0e5d436a368635698",
+                "id": "igw-0e5d436a368635698",
+                "owner_id": "644160558196",
+                "tags": null,
+                "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+            }
+        },
+        "aws_subnet": {
+            "cluster_example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:subnet/subnet-0b743fe5e4b41ff30",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "eu-central-1a",
+                "availability_zone_id": "euc1-az2",
+                "cidr_block": "10.0.0.0/24",
+                "customer_owned_ipv4_pool": "",
+                "id": "subnet-0b743fe5e4b41ff30",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": true,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+            },
+            "node_group_example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:subnet/subnet-090b5147c5840ff04",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "eu-central-1a",
+                "availability_zone_id": "euc1-az2",
+                "cidr_block": "10.0.2.0/24",
+                "customer_owned_ipv4_pool": "",
+                "id": "subnet-090b5147c5840ff04",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": true,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "tags": {
+                    "kubernetes.io/cluster/example": "shared"
+                },
+                "tags_all": {
+                    "kubernetes.io/cluster/example": "shared"
+                },
+                "timeouts": null,
+                "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+            }
+        },
+        "aws_vpc": {
+            "example": {
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:vpc/vpc-0192b1f9a4d0dbeb4",
+                "assign_generated_ipv6_cidr_block": false,
+                "cidr_block": "10.0.0.0/16",
+                "default_network_acl_id": "acl-042eff2fea9196d03",
+                "default_route_table_id": "rtb-0bd6a3614c5bfc10d",
+                "default_security_group_id": "sg-07c8a96d6e06c8dd9",
+                "dhcp_options_id": "dopt-d74e4fbc",
+                "enable_classiclink": null,
+                "enable_classiclink_dns_support": null,
+                "enable_dns_hostnames": false,
+                "enable_dns_support": true,
+                "id": "vpc-0192b1f9a4d0dbeb4",
+                "instance_tenancy": "default",
+                "ipv6_association_id": "",
+                "ipv6_cidr_block": "",
+                "main_route_table_id": "rtb-0bd6a3614c5bfc10d",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}

--- a/tests/test_eks.py
+++ b/tests/test_eks.py
@@ -3,6 +3,44 @@
 import time
 from .common import BaseTest
 
+from pytest_terraform import terraform
+
+
+@terraform('eks_nodegroup_delete')
+def test_eks_nodegroup_delete(test, eks_nodegroup_delete):
+    aws_region = 'eu-central-1'
+    session_factory = test.replay_flight_data('test_eks_nodegroup_delete', region=aws_region)
+
+    client = session_factory().client('eks')
+    eks_cluster_name = eks_nodegroup_delete['aws_eks_node_group.deleted_example.cluster_name']
+    eks_nodegroup_name = eks_nodegroup_delete['aws_eks_node_group.deleted_example.node_group_name']
+
+    p = test.load_policy(
+        {
+            'name': 'eks-nodegroup-delete',
+            'resource': 'eks-nodegroup',
+            'filters': [
+                {'clusterName': eks_cluster_name},
+                {'and': [
+                    {'tag:Name': eks_nodegroup_name},
+                    {'tag:ClusterName': eks_cluster_name},
+                ]},
+            ],
+            'actions': [{'type': 'delete'}],
+        },
+        session_factory=session_factory,
+        config={'region': aws_region},
+    )
+
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+
+    nodegroup = client.describe_nodegroup(
+        clusterName=eks_cluster_name,
+        nodegroupName=eks_nodegroup_name
+    )['nodegroup']
+    test.assertEqual(nodegroup['status'], 'DELETING')
+
 
 class EKS(BaseTest):
 


### PR DESCRIPTION
Sometimes it is required to delete only EKS node groups, not EKS cluster
so that **eks-nodegroup** resource type is added to have possibility to work with EKS node group as well.

Add **delete** action for EKS node group resource type.

Issue: #6735