### PR TITLE
Add tagging support to AWS IAM Policies

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -28,7 +28,7 @@ from c7n.filters.iamaccess import CrossAccountAccessFilter
 from c7n.manager import resources
 from c7n.query import ConfigSource, QueryResourceManager, DescribeSource, TypeInfo
 from c7n.resolver import ValuesFrom
-from c7n.tags import TagActionFilter, TagDelayedAction, Tag, RemoveTag
+from c7n.tags import TagActionFilter, TagDelayedAction, Tag, RemoveTag, universal_augment
 from c7n.utils import (
     get_partition, local_session, type_schema, chunks, filter_empty, QueryParser,
     select_keys
@@ -405,11 +405,14 @@ class Policy(QueryResourceManager):
         # Denotes this resource type exists across regions
         global_resource = True
         arn = 'Arn'
+        universal_taggable = object()
 
     source_mapping = {
         'describe': DescribePolicy,
         'config': ConfigSource
     }
+
+    augment = universal_augment
 
 
 class PolicyQueryParser(QueryParser):

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -390,6 +390,9 @@ class DescribePolicy(DescribeSource):
                     continue
         return results
 
+    def augment(self, resources):
+        return universal_augment(self.manager, super().augment(resources))
+
 
 @resources.register('iam-policy')
 class Policy(QueryResourceManager):
@@ -411,8 +414,6 @@ class Policy(QueryResourceManager):
         'describe': DescribePolicy,
         'config': ConfigSource
     }
-
-    augment = universal_augment
 
 
 class PolicyQueryParser(QueryParser):

--- a/tests/data/placebo/test_iam_policy_allow_all/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_iam_policy_allow_all/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_allow_all/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_iam_policy_allow_all/tagging.GetResources_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_allow_all/tagging.GetResources_3.json
+++ b/tests/data/placebo/test_iam_policy_allow_all/tagging.GetResources_3.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_attached/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_iam_policy_attached/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_attached/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_iam_policy_attached/tagging.GetResources_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_attached/tagging.GetResources_3.json
+++ b/tests/data/placebo/test_iam_policy_attached/tagging.GetResources_3.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_check_permission/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_iam_policy_check_permission/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_delete/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_iam_policy_delete/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_get_resource/iam.GetPolicy_1.json
+++ b/tests/data/placebo/test_iam_policy_get_resource/iam.GetPolicy_1.json
@@ -1,46 +1,38 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "Policy": {
-            "PolicyName": "AWSHealthFullAccess", 
-            "Description": "Allows full access to the AWS Health Apis and Notifications and the Personal Health Dashboard", 
+            "PolicyName": "AWSHealthFullAccess",
+            "PolicyId": "ANPAI3CUMPCPEUPCSXC4Y",
+            "Arn": "arn:aws:iam::aws:policy/AWSHealthFullAccess",
+            "Path": "/",
+            "DefaultVersionId": "v3",
+            "AttachmentCount": 0,
+            "PermissionsBoundaryUsageCount": 0,
+            "IsAttachable": true,
+            "Description": "Allows full access to the AWS Health Apis and Notifications and the Personal Health Dashboard",
             "CreateDate": {
-                "hour": 12, 
-                "__class__": "datetime", 
-                "month": 12, 
-                "second": 31, 
-                "microsecond": 0, 
-                "year": 2016, 
-                "day": 6, 
-                "minute": 30
-            }, 
-            "AttachmentCount": 1, 
-            "IsAttachable": true, 
-            "PolicyId": "ANPAI3CUMPCPEUPCSXC4Y", 
-            "DefaultVersionId": "v1", 
-            "Path": "/", 
-            "Arn": "arn:aws:iam::aws:policy/AWSHealthFullAccess", 
+                "__class__": "datetime",
+                "year": 2016,
+                "month": 12,
+                "day": 6,
+                "hour": 12,
+                "minute": 30,
+                "second": 31,
+                "microsecond": 0
+            },
             "UpdateDate": {
-                "hour": 12, 
-                "__class__": "datetime", 
-                "month": 12, 
-                "second": 31, 
-                "microsecond": 0, 
-                "year": 2016, 
-                "day": 6, 
-                "minute": 30
-            }
-        }, 
-        "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "14a8da87-e865-11e6-a572-dddd468753c8", 
-            "HTTPHeaders": {
-                "x-amzn-requestid": "14a8da87-e865-11e6-a572-dddd468753c8", 
-                "date": "Wed, 01 Feb 2017 09:59:10 GMT", 
-                "content-length": "808", 
-                "content-type": "text/xml"
-            }
-        }
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 11,
+                "day": 16,
+                "hour": 18,
+                "minute": 11,
+                "second": 34,
+                "microsecond": 0
+            },
+            "Tags": []
+        },
+        "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/test_iam_policy_unattached/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_iam_policy_unattached/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_unattached/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_iam_policy_unattached/tagging.GetResources_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_iam_policy_unattached/tagging.GetResources_3.json
+++ b/tests/data/placebo/test_iam_policy_unattached/tagging.GetResources_3.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}


### PR DESCRIPTION
Add tag loading and tagging to AWS IAM Policies.
Resolves: https://github.com/cloud-custodian/cloud-custodian/issues/6679 