### PR TITLE
core - fix annotation merges inside `or` blocks

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -214,9 +214,10 @@ class Filter(Element):
             r[self.matched_annotation_key] = intersect_list(
                 values,
                 r.get(self.matched_annotation_key))
-
-        if not values and block_op != 'or':
-            return
+        elif block_op == 'or':
+            r[self.matched_annotation_key] = union_list(
+                values,
+                r.get(self.matched_annotation_key))
 
 
 class BaseValueFilter(Filter):
@@ -265,6 +266,16 @@ def intersect_list(a, b):
     for x in a:
         if x in b:
             res.append(x)
+    return res
+
+
+def union_list(a, b):
+    if not b:
+        return a
+    if not a:
+        return b
+    res = a
+    res.extend(x for x in b if x not in a)
     return res
 
 


### PR DESCRIPTION
Tweak the way that annotations are merged, so that they work under both `or` blocks and the default `and` block.

Before:

- Inside  `and` blocks: annotate based on the ***intersection*** of matches
- Inside `or` blocks: skip annotating altogether

After:

- Inside  `and` blocks: annotate based on the ***intersection*** of matches
- Inside `or` blocks: annotate based on the ***union*** of matches

Notes / Context:

- Though `merge_annotation` is defined in the core `Filter` class, today it is only used with SSH Key and Access Key filters for IAM users.
- This change was motivated by [this Gitter thread](https://gitter.im/cloud-custodian/cloud-custodian?at=60cbff915e8dfc4f118983d7).