### PR TITLE
azure - unit test fix 

### DIFF
--- a/tools/c7n_azure/tests_azure/test_session.py
+++ b/tools/c7n_azure/tests_azure/test_session.py
@@ -91,9 +91,10 @@ class SessionTest(BaseTest):
         mock_run.return_value = \
             f'{{"id":"{DEFAULT_SUBSCRIPTION_ID}", "tenantId":"{DEFAULT_TENANT_ID}"}}'
 
-        s = Session()
-
-        self.assertEqual(s.get_subscription_id(), DEFAULT_SUBSCRIPTION_ID)
+        with patch.dict(os.environ, {}, clear=True):
+            s = Session()
+            self.assertEqual(s.get_subscription_id(), DEFAULT_SUBSCRIPTION_ID)
+            self.assertEqual(s.get_tenant_id(), DEFAULT_TENANT_ID)
 
     @patch('azure.identity.ClientSecretCredential.get_token')
     @patch('c7n_azure.session.log.error')


### PR DESCRIPTION
This test was completely incorrect without patching the environment dictionary.  It was failing or testing the wrong code path depending on local `env`.