### PR TITLE
tools/c7n_policystream - support specifying dir on cli

### DIFF
--- a/tools/c7n_policystream/policystream.py
+++ b/tools/c7n_policystream/policystream.py
@@ -881,12 +881,12 @@ def diff(repo_uri, source, target, output, verbose):
 @click.option('--assume', help="Role assumption for AWS stream outputs")
 @click.option('--before', help="Only stream commits before given date")
 @click.option('--after', help="Only stream commits after given date")
-@click.option('--policy-dir', multiple=True, default=[],
-              help="Only look at policy files in the given directories")
+@click.option('--policy-pattern', multiple=True, default=[],
+              help="Only look at policy files matching the giving glob pattern (including dir)")
 @click.option('--sort', multiple=True, default=["reverse", "time"],
               type=click.Choice(SORT_TYPE.keys()),
               help="Git sort ordering")
-def stream(repo_uri, stream_uri, verbose, assume, sort, before=None, after=None, policy_dir=()):
+def stream(repo_uri, stream_uri, verbose, assume, sort, before=None, after=None, policy_pattern=()):
     """Stream git history policy changes to destination.
 
 
@@ -913,8 +913,8 @@ def stream(repo_uri, stream_uri, verbose, assume, sort, before=None, after=None,
     if sort:
         sort = reduce(operator.or_, [SORT_TYPE[s] for s in sort])
     matcher = None
-    if policy_dir:
-        matcher = partial(policy_path_matcher, allowed_prefixes=policy_dir)
+    if policy_pattern:
+        matcher = partial(policy_path_matcher, patterns=policy_pattern)
 
     with contextlib.closing(TempDir().open()) as temp_dir:
         if repo_uri is None:

--- a/tools/c7n_policystream/policystream.py
+++ b/tools/c7n_policystream/policystream.py
@@ -243,18 +243,11 @@ def commit_date(commit):
     return datetime.fromtimestamp(float(commit.author.time), tzinfo)
 
 
-def policy_path_matcher(path, allowed_prefixes=()):
-    print(path)
-    if allowed_prefixes:
-        found = False
-        for a in allowed_prefixes:
-            if path.startswith(a):
-                found = True
-                break
-        if not found:
-            return False
-    if (path.endswith('.yaml') or path.endswith('.yml')) and not path.startswith('.'):
-        return True
+def policy_path_matcher(path, patterns=('*.yaml', '*.yml')):
+    for p in patterns:
+        if fnmatch(path, p):
+            return True
+    return False
 
 
 class PolicyRepo:

--- a/tools/c7n_policystream/policystream.py
+++ b/tools/c7n_policystream/policystream.py
@@ -243,7 +243,16 @@ def commit_date(commit):
     return datetime.fromtimestamp(float(commit.author.time), tzinfo)
 
 
-def policy_path_matcher(path):
+def policy_path_matcher(path, allowed_prefixes=()):
+    print(path)
+    if allowed_prefixes:
+        found = False
+        for a in allowed_prefixes:
+            if path.startswith(a):
+                found = True
+                break
+        if not found:
+            return False
     if (path.endswith('.yaml') or path.endswith('.yml')) and not path.startswith('.'):
         return True
 
@@ -778,7 +787,7 @@ def org_checkout(organization, github_url, github_token, clone_dir,
         else:
             repo = pygit2.Repository(repo_path)
             if repo.status():
-                log.warning('repo %s not clean skipping update')
+                log.warning('repo %s not clean skipping update', r['name'])
                 continue
             log.debug("Syncing repo: %s/%s" % (organization, r['name']))
             pull(repo, callbacks)
@@ -879,10 +888,12 @@ def diff(repo_uri, source, target, output, verbose):
 @click.option('--assume', help="Role assumption for AWS stream outputs")
 @click.option('--before', help="Only stream commits before given date")
 @click.option('--after', help="Only stream commits after given date")
+@click.option('--policy-dir', multiple=True, default=[],
+              help="Only look at policy files in the given directories")
 @click.option('--sort', multiple=True, default=["reverse", "time"],
               type=click.Choice(SORT_TYPE.keys()),
               help="Git sort ordering")
-def stream(repo_uri, stream_uri, verbose, assume, sort, before=None, after=None):
+def stream(repo_uri, stream_uri, verbose, assume, sort, before=None, after=None, policy_dir=()):
     """Stream git history policy changes to destination.
 
 
@@ -908,6 +919,9 @@ def stream(repo_uri, stream_uri, verbose, assume, sort, before=None, after=None)
         after = parse(after)
     if sort:
         sort = reduce(operator.or_, [SORT_TYPE[s] for s in sort])
+    matcher = None
+    if policy_dir:
+        matcher = partial(policy_path_matcher, allowed_prefixes=policy_dir)
 
     with contextlib.closing(TempDir().open()) as temp_dir:
         if repo_uri is None:
@@ -919,7 +933,7 @@ def stream(repo_uri, stream_uri, verbose, assume, sort, before=None, after=None)
         else:
             repo = pygit2.Repository(repo_uri)
         load_available()
-        policy_repo = PolicyRepo(repo_uri, repo)
+        policy_repo = PolicyRepo(repo_uri, repo, matcher)
         change_count = 0
 
         with contextlib.closing(transport(stream_uri, assume)) as t:

--- a/tools/c7n_policystream/tests/test_policystream.py
+++ b/tools/c7n_policystream/tests/test_policystream.py
@@ -282,8 +282,8 @@ class StreamTest(TestUtils):
              ('moved', 'lambda-check', 'move policy')])
 
 
+@pytest.mark.skipif(pygit2 is None, reason="pygit2 not installed")
 def test_path_matcher():
-
     for p, result in (
             ('foo/bar.yml', True),
             ('foo/bar.json', False),

--- a/tools/c7n_policystream/tests/test_policystream.py
+++ b/tools/c7n_policystream/tests/test_policystream.py
@@ -280,3 +280,18 @@ class StreamTest(TestUtils):
              ('add', 'lambda-check', 'switch'),
              ('add', 'ec2-check', 'new file'),
              ('moved', 'lambda-check', 'move policy')])
+
+
+def test_path_matcher():
+
+    for p, result in (
+            ('foo/bar.yml', True),
+            ('foo/bar.json', False),
+            ('zoo/rabbit.yaml', True),
+    ):
+        assert policystream.policy_path_matcher(p) is result
+
+    for p, patterns, result in (
+            ('foo/bar.yml', ('dir/*.yaml',), False),
+            ('foo/bar.json', ('foo/*.json',), True)):
+        assert policystream.policy_path_matcher(p, patterns) is result


### PR DESCRIPTION
if you have a mixed repo of with policies files and other content, then allowing to specify
a directory containing the policies is needed to avoid ambiguity with other yaml files present.
﻿
