### PR TITLE
releng - aws - fix quota tests

### DIFF
--- a/c7n/resources/quotas.py
+++ b/c7n/resources/quotas.py
@@ -80,7 +80,7 @@ class ServiceQuota(QueryResourceManager):
             return quotas.values()
 
         results = []
-        with self.executor_factory(max_workers=3) as w:
+        with self.executor_factory(max_workers=self.max_workers) as w:
             futures = {}
             for r in resources:
                 futures[w.submit(get_quotas, client, r)] = r

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -4,7 +4,7 @@
 
 from c7n.executor import MainThreadExecutor
 from c7n.resources.quotas import ServiceQuota
-from c7n.utils import local_session, yaml_load
+from c7n.utils import local_session
 
 from .common import BaseTest
 
@@ -26,8 +26,8 @@ class TestQuotas(BaseTest):
                 "key": "[].Status",
                 "value": "CASE_CLOSED",
                 "op": "in",
-                "value_type": "swap"}]
-            },
+                "value_type": "swap"}
+            ]},
             session_factory=session_factory
         )
         resources = p.run()
@@ -42,8 +42,8 @@ class TestQuotas(BaseTest):
                 "QuotaCode": "L-355B2B67"}],
             "actions": [{
                 "type": "request-increase",
-                "multiplier": 1.2}],
-            },
+                "multiplier": 1.2}
+            ]},
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
@@ -61,9 +61,9 @@ class TestQuotas(BaseTest):
             "resource": "aws.service-quota",
             "filters": [
                 {"UsageMetric": "present"},
-                {"type": "usage-metric"
-                 "limit": 20}]
-            },
+                {"type": "usage-metric",
+                 "limit": 20}
+            ]},
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -2,27 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
+from c7n.executor import MainThreadExecutor
+from c7n.resources.quotas import ServiceQuota
 from c7n.utils import local_session, yaml_load
 
 from .common import BaseTest
 
 
 class TestQuotas(BaseTest):
+
+    def setUp(self):
+        super().setUp()
+        self.patch(ServiceQuota, "executor_factory", MainThreadExecutor)
+
     def test_service_quota_request_history_filter(self):
         session_factory = self.replay_flight_data('test_service_quota')
-        policy = yaml_load("""
-        name: service-quota-history-filter
-        resource: aws.service-quota
-        filters:
-          - type: request-history
-            key: "[].Status"
-            value: CASE_CLOSED
-            op: in
-            value_type: swap
-        """)
-        p = self.load_policy(
-            policy,
+
+        p = self.load_policy({
+            "name": "service-quota-history-filter",
+            "resource": "aws.service-quota",
+            "filters": [{
+                "type": "request-history",
+                "key": "[].Status",
+                "value": "CASE_CLOSED",
+                "op": "in",
+                "value_type": "swap"}]
+            },
             session_factory=session_factory
         )
         resources = p.run()
@@ -30,16 +35,16 @@ class TestQuotas(BaseTest):
 
     def test_service_quota_request_increase(self):
         session_factory = self.replay_flight_data('test_service_quota')
-        policy = yaml_load("""
-        name: service-quota-request-increase
-        resource: aws.service-quota
-        filters:
-          - QuotaCode: L-355B2B67
-        actions:
-          - type: request-increase
-            multiplier: 1.2
-        """)
-        p = self.load_policy(policy, session_factory=session_factory)
+        p = self.load_policy({
+            "name": "service-quota-request-increase",
+            "resource": "aws.service-quota",
+            "filters": [{
+                "QuotaCode": "L-355B2B67"}],
+            "actions": [{
+                "type": "request-increase",
+                "multiplier": 1.2}],
+            },
+            session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
         client = local_session(session_factory).client('service-quotas')
@@ -51,14 +56,14 @@ class TestQuotas(BaseTest):
 
     def test_usage_metric_filter(self):
         session_factory = self.replay_flight_data('test_service_quota')
-        policy = yaml_load("""
-        name: service-quota-usage-metric
-        resource: aws.service-quota
-        filters:
-            - UsageMetric: present
-            - type: usage-metric
-              limit: 20
-        """)
-        p = self.load_policy(policy, session_factory=session_factory)
+        p = self.load_policy({
+            "name": "service-quota-usage-metric",
+            "resource": "aws.service-quota",
+            "filters": [
+                {"UsageMetric": "present"},
+                {"type": "usage-metric"
+                 "limit": 20}]
+            },
+            session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -360,9 +360,9 @@ class PillTest(CustodianTestCore):
 
         session = boto3.Session(region_name=region)
         if not zdata:
-            # pill = placebo.attach(session, test_dir)
-            pill = BluePill()
-            pill.attach(session, test_dir)            
+            pill = placebo.attach(session, test_dir)
+            # pill = BluePill()
+            # pill.attach(session, test_dir)
         else:
             pill = attach(session, self.archive_path, test_case, False)
 

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -360,9 +360,9 @@ class PillTest(CustodianTestCore):
 
         session = boto3.Session(region_name=region)
         if not zdata:
-            pill = placebo.attach(session, test_dir)
-            # pill = BluePill()
-            # pill.attach(session, test_dir)
+            # pill = placebo.attach(session, test_dir)
+            pill = BluePill()
+            pill.attach(session, test_dir)            
         else:
             pill = attach(session, self.archive_path, test_case, False)
 


### PR DESCRIPTION
these tests were failing periodically due to use of threading when doing replay.

- releng - aws - fix service quota tests
