### PR TITLE
tags - allow for rename of tags based on priority list of source keys

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -484,7 +484,12 @@ class RenameTag(Action):
 
     schema = utils.type_schema(
         'rename-tag',
-        old_key={'type': 'string'},
+        old_key={
+            'oneOf': [
+                {'type': 'string'},
+                {'type': 'array', 'items': {'type': 'string'}},
+            ]
+        },
         new_key={'type': 'string'})
     schema_alias = True
 

--- a/tests/data/placebo/test_ec2_rename_tag/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_rename_tag/ec2.DescribeInstances_1.json
@@ -258,7 +258,11 @@
                                 "Key": "Name"
                             }, 
                             {
-                                "Value": "Result2", 
+                                "Value": "Result2",
+                                "Key": "testing"
+                            },
+                            {
+                                "Value": "Result2",
                                 "Key": "Testing"
                             }
                         ], 
@@ -381,9 +385,13 @@
                         "VirtualizationType": "hvm", 
                         "Tags": [
                             {
-                                "Value": "Result1", 
+                                "Value": "Result1",
                                 "Key": "Testing"
                             }, 
+                            {
+                                "Value": "Result1",
+                                "Key": "testing"
+                            },
                             {
                                 "Value": "c7n-ec2-test-02", 
                                 "Key": "Name"

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -765,6 +765,45 @@ class TestTag(BaseTest):
         resources = policy.run()
         self.assertEqual(len(resources), 3)
 
+    def test_ec2_rename_tag_list(self):
+        session_factory = self.replay_flight_data("test_ec2_rename_tag")
+
+        policy = self.load_policy(
+            {
+                "name": "ec2-rename-start",
+                "resource": "ec2",
+                "filters": [{"tag:Testing": "present"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 3)
+
+        policy = self.load_policy(
+            {
+                "name": "ec2-rename-tag",
+                "resource": "ec2",
+                "actions": [
+                    {"type": "rename-tag", "old_key": ["testing", "Testing"], "new_key": "Testing1"}
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 3)
+
+        policy = self.load_policy(
+            {
+                "name": "ec2-rename-end",
+                "resource": "ec2",
+                "filters": [{"tag:Testing1": "present"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 3)
+
+
     def test_ec2_mark_zero(self):
         localtz = tz.gettz("America/New_York")
         dt = datetime.datetime.now(localtz)


### PR DESCRIPTION
This PR allows users to rename tag keys based on a priority list of tags, this is mostly to enable users to combine multiple potential policies into a single policy, for example:

```yaml
policies:
  - name: rename-tags-multi-case
    resource: aws.asg
    filters:
      - or:
        - "tag:owneremail": present
        - "tag:Owneremail": present
        - "tag:ownerEmail": present
    actions:
      - type: rename-tag
        source:
          - owneremail
          - Owneremail
          - ownerEmail
        dest: OwnerEmail
 ```

The keys are looked up in order from top to bottom and the first matching tag will be used for the new tag's value.