### PR TITLE
Update chunk size to reflect entityValues max size

### DIFF
--- a/c7n/filters/health.py
+++ b/c7n/filters/health.py
@@ -41,7 +41,7 @@ class HealthEventFilter(Filter):
         found = set()
         seen = set()
 
-        for resource_set in chunks(resource_map.keys(), 100):
+        for resource_set in chunks(resource_map.keys(), 99):
             f['entityValues'] = resource_set
             events = client.describe_events(filter=f)['events']
             events = [e for e in events if e['arn'] not in seen]


### PR DESCRIPTION
Recently (June 1st) AWS has changed max value of "entityvalues" from 100 to 99, please note official doc still has the original value: https://docs.aws.amazon.com/health/latest/APIReference/API_EntityFilter.html
This change breaks "Health" queries if number of resources is equal or greater than 100, for example:

Request:
```
{"filter": {"services": ["EC2"], "regions": ["us-east-1", "global"], "eventStatusCodes": ["upcoming"], "entityValues": ["i-092c558997e5fbc9b", "i-0c408f6559d0140ac", "i-0fbe2dc8d66070f1d",
<Truncated for brevity, there are exactly 100 instance IDs>
"i-0d6614be4cf66cff8", "i-02751a71a06d09523", "i-0aa03694bab9b7a54", "i-07e27e9c0a7c5b2cd", "i-08e809f8afde099bc", "i-06a7b32f001912ae1", "i-00fe407a9a95dc591", "i-05d775d993c042994", "i-0a402efd21d36b886"]}}
```

Response, error 400:
```
{"__type":"ValidationException","message":"1 validation error detected: Value '[i-092c558997e5fbc9b, i-0c408f6559d0140ac, i-0fbe2dc8d66070f1d, i-08b23474753a07bd2, i-04a0f9ca73862f137,
<Truncated for brevity>
i-08e809f8afde099bc, i-06a7b32f001912ae1, i-00fe407a9a95dc591, i-05d775d993c042994, i-0a402efd21d36b886]' at 'filter.entityValues' failed to satisfy constraint: Member must have length less than or equal to 99"}
```
