### PR TITLE
aws - security hub - batch findings import retry

### DIFF
--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -431,8 +431,9 @@ class PostFinding(Action):
                             self.manager).process([resource])
                     else:
                         stats['Update'] += 1
-            import_response = client.batch_import_findings(
-                Findings=findings)
+            import_response = self.manager.retry(
+                client.batch_import_findings, Findings=findings
+            )
             if import_response['FailedCount'] > 0:
                 stats['Failed'] += import_response['FailedCount']
                 self.log.error(


### PR DESCRIPTION
This PR adds retry logic for the batch import findings API call in case of throttling errors. This API is burstable from 10 to 30 TPS but uses a leaky bucket algorithm so 10 TPS (1000 findings when using a 100 batch size) is the only speed we could reasonably expect to maintain. Nonetheless, with potential upcoming PRs for multithreading support to scenarios when performance is degraded because other services are interacting with Security Hub adding a retry on the import is a nice measure to help support the eventual delivery of findings when neccessary.