### PR TITLE
aws - securityhub - multithreading support for batch import

### DIFF
--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -429,9 +429,6 @@ class PostFinding(Action):
                     stats['Update'] += 1
         import_response = client.batch_import_findings(
             Findings=findings)
-        # print(findings)
-        # print(import_response)
-        # print(len(findings))
         if import_response['FailedCount'] > 0:
             stats['Failed'] += import_response['FailedCount']
             self.log.error(

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -445,13 +445,6 @@ class PostFinding(Action):
             for resource_set in chunks(resources, batch_size):
                 futures[w.submit(self.process_findings, resource_set)] = resource_set
             for f in as_completed(futures):
-                if f.exception():
-                    b = futures[f]
-                    self.log.error(
-                        "Error on bucket:%s region:%s policy:%s error: %s",
-                        b['Name'], b.get('Location', 'unknown'),
-                        self.manager.data.get('name'), f.exception())
-                    continue
                 reporter += f.result()
         self.log.debug(
             "policy:%s securityhub %d findings resources %d new %d updated %d failed",


### PR DESCRIPTION
This PR adds multithreading support for security hub batch import after more extensive testings it seems that the perf increase is rather minimal with ~33% reduction in write time closing for now but linking in case perf ever becomes an issue