### PR TITLE
aws - tags - retry on InternalServiceException errors

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -56,17 +56,19 @@ class UniversalTagTest(BaseTest):
         self.patch(time, "sleep", sleep)
         method = MagicMock()
         method.side_effect = [
-            {"FailedResourcesMap": {"arn:abc": {"ErrorCode": "ThrottlingException"}}},
+            {"FailedResourcesMap": {
+                "arn:abc": {"ErrorCode": "ThrottlingException"},
+                "arn:def": {"ErrorCode": "InternalServiceException"}}},
             {"Result": 32},
         ]
         self.assertEqual(
-            universal_retry(method, ["arn:abc", "arn:def"]), {"Result": 32}
+            universal_retry(method, ["arn:abc", "arn:def", "arn:ghi"]), {"Result": 32}
         )
         sleep.assert_called_once()
         self.assertTrue(
             method.call_args_list == [
+                call(ResourceARNList=["arn:abc", "arn:def", "arn:ghi"]),
                 call(ResourceARNList=["arn:abc", "arn:def"]),
-                call(ResourceARNList=["arn:abc"]),
             ]
         )
 


### PR DESCRIPTION
Add `InternalServiceException` to the list of retriable errors for
universal tagging operations. From the docs:

InternalServiceException – This can mean that the Resource Groups
Tagging API didn't receive a response from another AWS service.
It can also mean the the resource type in the request is not
supported by the Resource Groups Tagging API. In these cases, it's
safe to retry the request and then call GetResources to verify the
changes.

Source: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/resourcegroupstaggingapi.html#ResourceGroupsTaggingAPI.Client.tag_resources