### PR TITLE
azure - extra dependencies for sqlserver template

### DIFF
--- a/tools/c7n_azure/tests_azure/templates/sqlserver.json
+++ b/tools/c7n_azure/tests_azure/templates/sqlserver.json
@@ -49,8 +49,10 @@
                 "status": "Enabled"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Sql/servers/databases', parameters('servers_cctestsqlserver_name'), 'cctestdb')]"
-              ]
+               "[resourceId('Microsoft.Sql/servers/databases', parameters('servers_cctestsqlserver_name'), 'cctestdb')]",
+               "[resourceId('Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies', parameters('servers_cctestsqlserver_name'), 'cctestdb', 'default')]",
+               "[resourceId('Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies', parameters('servers_cctestsqlserver_name'), 'cctestdb', 'default')]"
+            ]
             },
             {
                "name": "default",


### PR DESCRIPTION
Seems like there was a potential racing when child resources are created.. With this change it was successfully deployed