### PR TITLE
CloudWatch Logs - Subscription Filter

### DIFF
--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -728,18 +728,6 @@ class LogSubscriptionFilter(ValueFilter):
     def process(self, resources, event=None):
         client = local_session(self.manager.session_factory).client('logs')
         results = []
-        for rset in chunks(resources, 50):
-            try:
-                results.extend(self.process_resource_set(client, rset))
-            except Exception as e:
-                self.log.error(
-                    "Error checking log groups subscription-filters %s",
-                    e)
-                continue
-        return results
-
-    def process_resource_set(self, client, resources):
-        results = []
         for r in resources:
             filters = self.manager.retry(
                 client.describe_subscription_filters,

--- a/tests/data/placebo/test_log_group_subscription_filter/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_log_group_subscription_filter/logs.DescribeLogGroups_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "4276749e-33fa-11e8-a554-9fa6e27bb9bd",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "4276749e-33fa-11e8-a554-9fa6e27bb9bd",
+                "date": "Fri, 30 Mar 2018 09:10:58 GMT",
+                "content-length": "213",
+                "content-type": "application/x-amz-json-1.1"
+            }
+        },
+        "logGroups": [
+            {
+                "arn": "arn:aws:logs:us-east-2:644160558196:log-group:/aws/codebuild/custodian:*",
+                "creationTime": 1504743622686,
+                "metricFilterCount": 0,
+                "logGroupName": "/aws/codebuild/custodian",
+                "storedBytes": 1389598
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_log_group_subscription_filter/logs.DescribeSubscriptionFilters_1.json
+++ b/tests/data/placebo/test_log_group_subscription_filter/logs.DescribeSubscriptionFilters_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "subscriptionFilters": [
+            {
+                "filterPattern": "",
+                "filterName": "LambdaStream_CloudCustodian",
+                "creationTime": 1522400974050,
+                "logGroupName": "/aws/codebuild/custodian",
+                "destinationArn": "arn:aws:lambda:us-east-2:1111111111111:function:CloudCustodian",
+                "distribution": "ByLogStream"
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "428b0e3a-33fa-11e8-9de6-7753a7c865fe",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "428b0e3a-33fa-11e8-9de6-7753a7c865fe",
+                "date": "Fri, 30 Mar 2018 09:10:58 GMT",
+                "content-length": "270",
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_log_group_subscription_filter/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_log_group_subscription_filter/tagging.GetResources_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+        ],
+        "ResponseMetadata": {
+            "RequestId": "a91843b0-2524-11e8-ae44-39655428e147",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "a91843b0-2524-11e8-ae44-39655428e147",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "139",
+                "date": "Sun, 11 Mar 2018 12:06:41 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -70,6 +70,21 @@ class LogGroupTest(BaseTest):
         aliases = kms.list_aliases(KeyId=resources[0]['kmsKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/cw')
 
+    def test_subscription_filter(self):
+        factory = self.replay_flight_data("test_log_group_subscription_filter")
+        p = self.load_policy(
+            {
+                "name": "subscription-filter",
+                "resource": "log-group",
+                "filters": [{"type": "subscription-filter"}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["c7n:SubscriptionFilters"][0]["destinationArn"],
+            "arn:aws:lambda:us-east-2:1111111111111:function:CloudCustodian")
+
     def test_age_normalize(self):
         factory = self.replay_flight_data("test_log_group_age_normalize")
         p = self.load_policy({


### PR DESCRIPTION
Add a filter for CWL SubscriptionFilters

Within my organization, we often set up forwarding to Splunk.  This filter would allow us to look for and modify CWL groups with/without subscriptions.