### PR TITLE
Fix Exporter.py to allow c7n_logExpoter to run and update readme

### DIFF
--- a/tools/c7n_logexporter/README.md
+++ b/tools/c7n_logexporter/README.md
@@ -44,7 +44,30 @@ c7n-log-exporter export --help
 To ease usage when running across multiple accounts, a config file can be specified, as
 an example.
 
+### Using S3 Bucket as destination
+
 ```
+destination:
+  bucket: custodian-log-archive
+  prefix: logs2
+
+accounts:
+  - name: custodian-demo
+    role: "arn:aws:iam::111111111111:role/CloudCustodianRole"
+    groups:
+      - "/aws/lambda/*"
+      - "vpc-flow-logs"
+```
+
+### Using CloudWatch Destination as destination cross account
+The Cloudwatch Destination needs setup in account and access policy set on CloudWatch Destination to to allow 
+source account access to the Cloudwatch Destination
+
+subscription:
+  destination-arn: "arn:aws:logs:us-east-1:111111111111:destination:CustodianCWLogsDestination"
+  destination-role: "arn:aws:iam::111111111111:role/CWLtoKinesisRole"
+  name: "CustodianCWLogsDestination"
+
 destination:
   bucket: custodian-log-archive
   prefix: logs2

--- a/tools/c7n_logexporter/README.md
+++ b/tools/c7n_logexporter/README.md
@@ -63,6 +63,7 @@ accounts:
 The Cloudwatch Destination needs setup in account and access policy set on CloudWatch Destination to to allow 
 source account access to the Cloudwatch Destination
 
+```
 subscription:
   destination-arn: "arn:aws:logs:us-east-1:111111111111:destination:CustodianCWLogsDestination"
   destination-role: "arn:aws:iam::111111111111:role/CWLtoKinesisRole"

--- a/tools/c7n_logexporter/c7n_logexporter/exporter.py
+++ b/tools/c7n_logexporter/c7n_logexporter/exporter.py
@@ -140,8 +140,9 @@ def _process_subscribe_group(client, group_name, subscription, distribution):
                 f['destinationArn'] == subscription['destination-arn'] and
                 f['distribution'] == distribution):
             return
-    client.delete_subscription_filter(
-        logGroupName=group_name, filterName=sub_name)
+        else:
+            client.delete_subscription_filter(
+                logGroupName=group_name, filterName=sub_name)
     client.put_subscription_filter(
         logGroupName=group_name,
         destinationArn=subscription['destination-arn'],
@@ -209,7 +210,7 @@ def subscribe(config, accounts, region, merge, debug):
                 g = g.replace('*', '')
                 paginator = client.get_paginator('describe_log_groups')
                 allLogGroups = paginator.paginate(logGroupNamePrefix=g).build_full_result()
-                for l in allLogGroups:
+                for l in allLogGroups['logGroups']:
                     _process_subscribe_group(
                         client, l['logGroupName'], subscription, distribution)
             else:


### PR DESCRIPTION
When trying to run c7n_log_exporter we had 2 errors:
Error 1
TypeError: list indices must be integers or slices, not str in exporter.py Line 
client, l['logGroupName'], subscription, distribution)
It turns out it does not match the boto3 Cloudwatch Logs return:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs.html#CloudWatchLogs.Paginator.DescribeLogGroups
so need to add element of 'logGroups' in for loop to make it work
for l in allLogGroups['logGroups']:

Error 2
ResourceNotFoundException in exporter.py line 
delete_subscription_filter(
        logGroupName=group_name, filterName=sub_name)
Due to no subscription been present on CloudWatch Log but code looking to delete subscription

fixed by adding else statement so only tries to delete subscription when subscription found and not the same as config file.

Tested successfully and c7n_logExport runs and subscribes CloudWatch logs to CloudWatch destination

