### PR TITLE
azure - update mysql version used for tests

### DIFF
--- a/tools/c7n_azure/tests_azure/templates/mysql.json
+++ b/tools/c7n_azure/tests_azure/templates/mysql.json
@@ -24,7 +24,7 @@
             },
             "properties": {
                 "createMode": "Default",
-                "version": "5.6",
+                "version": "5.7",
                 "administratorLogin": "adminuser",
                 "administratorLoginPassword": "[concat('Pass1!@', variables('suffix'))]",
                 "storageProfile": {


### PR DESCRIPTION
5.6 is no longer available.