### PR TITLE
Add an Events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html lang="en">
     <head>
 
-        <meta charset="utf-8 ">
-        <meta http-equiv="X-UA-Compatible " content="IE=edge ">
-        <meta name="viewport " content="width=device-width, initial-scale=1 ">
-        <meta name="description " content="Cloud Custodian ">
-        <meta name="author " content="Capital One ">
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="description" content="Cloud Custodian events calendar">
+        <meta name="author" content="The Cloud Custodian Authors">
 
         <title>Cloud Custodian</title>
 
         <!-- Bootstrap Core CSS -->
-        <link href="css/bootstrap.min.css " rel="stylesheet ">
+        <link href="css/bootstrap.min.css" rel="stylesheet">
 
         <!-- Custom CSS -->
-        <link href="css/landing-page.css " rel="stylesheet ">
+        <link href="css/landing-page.css" rel="stylesheet">
 
         <!-- Custom Glyphs and Fonts -->
         <script defer src="https://use.fontawesome.com/releases/v5.8.1/js/all.js" integrity="sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ" crossorigin="anonymous"></script>

--- a/events.html
+++ b/events.html
@@ -1,0 +1,106 @@
+<html>
+    <head>
+
+        <meta charset="utf-8 ">
+        <meta http-equiv="X-UA-Compatible " content="IE=edge ">
+        <meta name="viewport " content="width=device-width, initial-scale=1 ">
+        <meta name="description " content="Cloud Custodian ">
+        <meta name="author " content="Capital One ">
+
+        <title>Cloud Custodian</title>
+
+        <!-- Bootstrap Core CSS -->
+        <link href="css/bootstrap.min.css " rel="stylesheet ">
+
+        <!-- Custom CSS -->
+        <link href="css/landing-page.css " rel="stylesheet ">
+
+        <!-- Custom Glyphs and Fonts -->
+        <script defer src="https://use.fontawesome.com/releases/v5.8.1/js/all.js" integrity="sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ" crossorigin="anonymous"></script>
+        <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro" rel="stylesheet">
+
+    </head>
+    <body>
+
+        <div class="container fluid">
+        <!-- Navigation -->
+            <header>
+                <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+                    <a class="navbar-brand" href="index.html#">
+                        <img src="/img/cloud-custodian.svg" width="30" height="30" class="d-inline-block align-top" alt="Cloud Custodian logo">
+                        Cloud Custodian
+                    </a>
+                    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor03" aria-controls="navbarColor03" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+
+                    <div class="collapse navbar-collapse" id="navbarColor03">
+                        <ul class="navbar-nav ml-auto">
+                            <li class="nav-item">
+                                <a class="nav-link" href="docs/index.html ">
+                                    <i class="fas fa-book fa-fw "></i>
+                                    Docs
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="https://pypi.python.org/pypi/c7n ">
+                                    <i class="fas fa-cloud-download-alt fa-fw "></i>
+                                    Install
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="https://github.com/cloud-custodian/cloud-custodian ">
+                                    <i class="fab fa-sm fa-github"></i>
+                                    GitHub
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="https://gitter.im/cloud-custodian/cloud-custodian ">
+                                    <i class="fab fa-sm fa-gitter"></i>
+                                    Community
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="events.html">
+                                    <i class="fa fa-calendar"></i>
+                                    Calendar
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+            </header>
+
+            <main role="main" style="padding-top: 5em">
+        
+                <section>
+                    <iframe
+                    src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FDetroit&src=Y19naDhzc2pia3JvaWVxcWFzN2trbWgzdG9yc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23616161&title=Cloud%20Custodian"
+                    style="border:solid 1px #777" width="800" height="600"
+                    frameborder="0" scrolling="no" display:block></iframe>
+                </section>
+            <section>
+                <strong>Contact jorge@stacklet.io if you'd like to add a Cloud Custodian
+                related event to this community calendar.</strong>
+            </section>
+
+            <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+
+            <!-- Bootstrap Core JavaScript -->
+            <script src="js/bootstrap.min.js "></script>
+
+<!-- Google Analytics -->
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-162730326-1', 'auto');
+ga('send', 'pageview');
+</script>
+
+        </div>
+    </body>
+</html>

--- a/events.html
+++ b/events.html
@@ -1,4 +1,4 @@
-<html>
+<!DOCTYPE html lang="en">
     <head>
 
         <meta charset="utf-8 ">

--- a/events.html
+++ b/events.html
@@ -83,7 +83,7 @@
                 <strong>Contact jorge@stacklet.io if you'd like to add a Cloud Custodian
                 related event to this community calendar.</strong>
             </section>
-
+        </main>
             <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
 

--- a/events.html
+++ b/events.html
@@ -71,7 +71,7 @@
                 </nav>
             </header>
 
-            <main role="main" style="padding-top: 5em">
+            <main style="padding-top: 5em">
         
                 <section>
                     <iframe

--- a/events.html
+++ b/events.html
@@ -76,8 +76,8 @@
                 <section>
                     <iframe
                     src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=America%2FDetroit&src=Y19naDhzc2pia3JvaWVxcWFzN2trbWgzdG9yc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23616161&title=Cloud%20Custodian"
-                    style="border:solid 1px #777" width="800" height="600"
-                    frameborder="0" scrolling="no" display:block></iframe>
+                    style="border:solid 1px #777;  display:block;" width="800" height="600"
+                    scrolling="no"></iframe>
                 </section>
             <section>
                 <strong>Contact jorge@stacklet.io if you'd like to add a Cloud Custodian

--- a/events/index.html
+++ b/events/index.html
@@ -61,7 +61,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="events.html">
+                                <a class="nav-link" href="events/index.html">
                                     <i class="fa fa-calendar"></i>
                                     Calendar
                                 </a>

--- a/events/index.html
+++ b/events/index.html
@@ -10,10 +10,10 @@
         <title>Cloud Custodian</title>
 
         <!-- Bootstrap Core CSS -->
-        <link href="css/bootstrap.min.css" rel="stylesheet">
+        <link href="/css/bootstrap.min.css" rel="stylesheet">
 
         <!-- Custom CSS -->
-        <link href="css/landing-page.css" rel="stylesheet">
+        <link href="/css/landing-page.css" rel="stylesheet">
 
         <!-- Custom Glyphs and Fonts -->
         <script defer src="https://use.fontawesome.com/releases/v5.8.1/js/all.js" integrity="sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ" crossorigin="anonymous"></script>
@@ -26,7 +26,7 @@
         <!-- Navigation -->
             <header>
                 <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
-                    <a class="navbar-brand" href="index.html#">
+                    <a class="navbar-brand" href="/">
                         <img src="/img/cloud-custodian.svg" width="30" height="30" class="d-inline-block align-top" alt="Cloud Custodian logo">
                         Cloud Custodian
                     </a>
@@ -88,7 +88,7 @@
             <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
 
             <!-- Bootstrap Core JavaScript -->
-            <script src="js/bootstrap.min.js "></script>
+            <script src="/js/bootstrap.min.js "></script>
 
 <!-- Google Analytics -->
 <script>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="events.html">
+                                <a class="nav-link" href="events/index.html">
                                     <i class="fa fa-calendar"></i>
                                     Calendar
                                 </a>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,12 @@
                                     Community
                                 </a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="events.html">
+                                    <i class="fa fa-calendar"></i>
+                                    Calendar
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 </nav>

--- a/index.html
+++ b/index.html
@@ -49,13 +49,13 @@
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="https://github.com/capitalone/cloud-custodian ">
+                                <a class="nav-link" href="https://github.com/cloud-custodian/cloud-custodian ">
                                     <i class="fab fa-sm fa-github"></i>
                                     GitHub
                                 </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="https://gitter.im/capitalone/cloud-custodian ">
+                                <a class="nav-link" href="https://gitter.im/cloud-custodian/cloud-custodian ">
                                     <i class="fab fa-sm fa-gitter"></i>
                                     Community
                                 </a>


### PR DESCRIPTION
This embeds a gcal widget onto a new Events page.

- Added new page and linked to from the navs, font-awesome icon included!
- Updated cloud custodian logo/text on the top left to always go to index.html and not just #
- There are nicer/cooler widgets for calendars on the web but chose to just embed this one to avoid new dependencies.
- We need a better method to have the community submit events, but deferring to just having them email me for now. 
- Updated URLs to the preferred upstream properties

cc @marcoceppi to check this since my html is rusty.