### PR TITLE
core - reduce filter - fix value_regex validation

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -256,6 +256,26 @@ class BaseValueFilter(Filter):
             r = ValueRegex(regex).get_resource_value(r)
         return r
 
+    def _validate_value_regex(self, regex):
+        """Specific validation for `value_regex` type
+
+        The `value_regex` type works a little differently.  In
+        particular it doesn't support OPERATORS that perform
+        operations on a list of values, specifically 'intersect',
+        'contains', 'difference', 'in' and 'not-in'
+        """
+        # Sanity check that we can compile
+        try:
+            pattern = re.compile(regex)
+            if pattern.groups != 1:
+                raise PolicyValidationError(
+                    "value_regex must have a single capturing group: %s" %
+                    self.data)
+        except re.error as e:
+            raise PolicyValidationError(
+                "Invalid value_regex: %s %s" % (e, self.data))
+        return self
+
 
 def intersect_list(a, b):
     if b is None:
@@ -511,26 +531,6 @@ class ValueFilter(BaseValueFilter):
         if 'value_regex' in self.data:
             return self._validate_value_regex(self.data['value_regex'])
 
-        return self
-
-    def _validate_value_regex(self, regex):
-        """Specific validation for `value_regex` type
-
-        The `value_regex` type works a little differently.  In
-        particular it doesn't support OPERATORS that perform
-        operations on a list of values, specifically 'intersect',
-        'contains', 'difference', 'in' and 'not-in'
-        """
-        # Sanity check that we can compile
-        try:
-            pattern = re.compile(regex)
-            if pattern.groups != 1:
-                raise PolicyValidationError(
-                    "value_regex must have a single capturing group: %s" %
-                    self.data)
-        except re.error as e:
-            raise PolicyValidationError(
-                "Invalid value_regex: %s %s" % (e, self.data))
         return self
 
     def __call__(self, i):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1391,6 +1391,7 @@ class TestReduceFilter(BaseFilterTest):
                 "limit": 1
             }
         )
+        f.validate()
         rs = f.process(resources)
         self.assertEqual(
             [r['InstanceId'] for r in rs],


### PR DESCRIPTION
Some logic from `ValueFilter` was extracted into `BaseValueFilter` during the initial implementation
of the `reduce` filter in #5874. That did not include the `_validate_value_regex` method. This
prevents reduce filters with a `value_regex` parameter from validating. It does not block
_processing_ though, so the existing tests were passing without error.

To address this:

* Add a validation step to a filter test to demonstrate the problem.
* Move `_validate_value_regex` from `ValueFilter` to `BaseValueFilter`.