### PR TITLE
releng - docker builds with buildx

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
 - job: 'CustodianCask'
   displayName: 'Tool Tests - Cask'
   pool:
-    vmImage: 'Ubuntu-18.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - checkout: self
     fetchDepth: 1

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -45,6 +45,7 @@ jobs:
   # bin directory is in .dockerignore
   - script: |
       python3 -m pip install --upgrade pip
+      docker buildx create --use
       pip3 install docker click pytest pyyaml six
   # build a docker image and sanity test
   - script: |

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ See the notes below for more technical information on joining the meeting.
 
 - [Community Meeting Videos](https://www.youtube.com/watch?v=qy250y0UT-4&list=PLJ2Un8H_N5uBeAAWK95SnWvm_AuNJ8q2x)
 - [Community Meeting Notes Archive](https://github.com/cloud-custodian/community/discussions)
-
+- [Upcoming Community Events](https://cloudcustodian.io/events/)
 
 
 Additional Tools

--- a/docker/cli
+++ b/docker/cli
@@ -35,7 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && echo "install $pkg"  && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/cli
+++ b/docker/cli
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM ubuntu:20.04 as build-env
@@ -7,16 +8,20 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python3 - -y --version 1.1.9
+
+RUN echo $HOME
+ENV VIRTUAL_ENV="/usr/local" PATH="$PATH:/root/.poetry/bin"
 
 WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+RUN --mount=type=cache,target=/root/.cache poetry install --no-dev
+RUN --mount=type=cache,target=/root/.cache pip install -q wheel && pip install -U pip
+RUN --mount=type=cache,target=/root/.cache pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packages
 ADD tools/c7n_gcp /src/tools/c7n_gcp
@@ -30,9 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    $HOME/.poetry/bin/poetry install && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/cli-distroless
+++ b/docker/cli-distroless
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM debian:10-slim as build-env
@@ -7,16 +8,20 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python3 - -y --version 1.1.9
+
+RUN echo $HOME
+ENV VIRTUAL_ENV="/usr/local" PATH="$PATH:/root/.poetry/bin"
 
 WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+RUN --mount=type=cache,target=/root/.cache poetry install --no-dev
+RUN --mount=type=cache,target=/root/.cache pip install -q wheel && pip install -U pip
+RUN --mount=type=cache,target=/root/.cache pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packages
 ADD tools/c7n_gcp /src/tools/c7n_gcp
@@ -30,9 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    $HOME/.poetry/bin/poetry install && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/cli-distroless
+++ b/docker/cli-distroless
@@ -35,7 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && echo "install $pkg"  && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/mailer
+++ b/docker/mailer
@@ -35,7 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && echo "install $pkg"  && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/mailer
+++ b/docker/mailer
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM ubuntu:20.04 as build-env
@@ -7,16 +8,20 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python3 - -y --version 1.1.9
+
+RUN echo $HOME
+ENV VIRTUAL_ENV="/usr/local" PATH="$PATH:/root/.poetry/bin"
 
 WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+RUN --mount=type=cache,target=/root/.cache poetry install --no-dev
+RUN --mount=type=cache,target=/root/.cache pip install -q wheel && pip install -U pip
+RUN --mount=type=cache,target=/root/.cache pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packages
 ADD tools/c7n_gcp /src/tools/c7n_gcp
@@ -30,9 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    $HOME/.poetry/bin/poetry install && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM debian:10-slim as build-env
@@ -7,16 +8,20 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python3 - -y --version 1.1.9
+
+RUN echo $HOME
+ENV VIRTUAL_ENV="/usr/local" PATH="$PATH:/root/.poetry/bin"
 
 WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+RUN --mount=type=cache,target=/root/.cache poetry install --no-dev
+RUN --mount=type=cache,target=/root/.cache pip install -q wheel && pip install -U pip
+RUN --mount=type=cache,target=/root/.cache pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packages
 ADD tools/c7n_gcp /src/tools/c7n_gcp
@@ -30,9 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    $HOME/.poetry/bin/poetry install && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -35,7 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && echo "install $pkg"  && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/org
+++ b/docker/org
@@ -35,7 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && echo "install $pkg"  && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/org
+++ b/docker/org
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM ubuntu:20.04 as build-env
@@ -7,16 +8,20 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python3 - -y --version 1.1.9
+
+RUN echo $HOME
+ENV VIRTUAL_ENV="/usr/local" PATH="$PATH:/root/.poetry/bin"
 
 WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+RUN --mount=type=cache,target=/root/.cache poetry install --no-dev
+RUN --mount=type=cache,target=/root/.cache pip install -q wheel && pip install -U pip
+RUN --mount=type=cache,target=/root/.cache pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packages
 ADD tools/c7n_gcp /src/tools/c7n_gcp
@@ -30,9 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    $HOME/.poetry/bin/poetry install && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/org-distroless
+++ b/docker/org-distroless
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM debian:10-slim as build-env
@@ -7,16 +8,20 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python3 - -y --version 1.1.9
+
+RUN echo $HOME
+ENV VIRTUAL_ENV="/usr/local" PATH="$PATH:/root/.poetry/bin"
 
 WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+RUN --mount=type=cache,target=/root/.cache poetry install --no-dev
+RUN --mount=type=cache,target=/root/.cache pip install -q wheel && pip install -U pip
+RUN --mount=type=cache,target=/root/.cache pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packages
 ADD tools/c7n_gcp /src/tools/c7n_gcp
@@ -30,9 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    $HOME/.poetry/bin/poetry install && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/org-distroless
+++ b/docker/org-distroless
@@ -35,7 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && echo "install $pkg"  && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/policystream
+++ b/docker/policystream
@@ -55,7 +55,7 @@ RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/
 # Verify the install
 #  - policystream is not in ci due to libgit2 compilation needed
 #  - as a sanity check to distributing known good assets / we test here
-RUN . /usr/local/bin/activate && pytest tools/c7n_policystream
+RUN . /usr/local/bin/activate && pytest -p "no:terraform" tools/c7n_policystream
 
 FROM ubuntu:20.04
 

--- a/docker/policystream
+++ b/docker/policystream
@@ -35,7 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && echo "install $pkg"  && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/docker/policystream
+++ b/docker/policystream
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM ubuntu:20.04 as build-env
@@ -7,16 +8,20 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python3 - -y --version 1.1.9
+
+RUN echo $HOME
+ENV VIRTUAL_ENV="/usr/local" PATH="$PATH:/root/.poetry/bin"
 
 WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+RUN --mount=type=cache,target=/root/.cache poetry install --no-dev
+RUN --mount=type=cache,target=/root/.cache pip install -q wheel && pip install -U pip
+RUN --mount=type=cache,target=/root/.cache pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packages
 ADD tools/c7n_gcp /src/tools/c7n_gcp
@@ -30,9 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    $HOME/.poetry/bin/poetry install && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 
@@ -55,7 +58,7 @@ RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/
 # Verify the install
 #  - policystream is not in ci due to libgit2 compilation needed
 #  - as a sanity check to distributing known good assets / we test here
-RUN . /usr/local/bin/activate && pytest -p "no:terraform" tools/c7n_policystream
+RUN . /usr/local/bin/activate && pytest -n "no:terraform" tools/c7n_policystream
 
 FROM ubuntu:20.04
 

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM debian:10-slim as build-env
@@ -7,16 +8,20 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py  | python3 - -y --version 1.1.9
+
+RUN echo $HOME
+ENV VIRTUAL_ENV="/usr/local" PATH="$PATH:/root/.poetry/bin"
 
 WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
 ADD c7n /src/c7n/
-RUN . /usr/local/bin/activate && $HOME/.poetry/bin/poetry install --no-dev
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
+RUN --mount=type=cache,target=/root/.cache poetry install --no-dev
+RUN --mount=type=cache,target=/root/.cache pip install -q wheel && pip install -U pip
+RUN --mount=type=cache,target=/root/.cache pip install -q aws-xray-sdk psutil jsonpatch
 
 # Add provider packages
 ADD tools/c7n_gcp /src/tools/c7n_gcp
@@ -30,9 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    $HOME/.poetry/bin/poetry install && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 
@@ -55,7 +58,7 @@ RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/
 # Verify the install
 #  - policystream is not in ci due to libgit2 compilation needed
 #  - as a sanity check to distributing known good assets / we test here
-RUN . /usr/local/bin/activate && pytest tools/c7n_policystream
+RUN . /usr/local/bin/activate && pytest -n "no:terraform" tools/c7n_policystream
 
 FROM gcr.io/distroless/python3-debian10
 

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -35,7 +35,7 @@ RUN rm -R tools/c7n_openstack/tests
 
 # Install requested providers
 ARG providers="azure gcp kube openstack"
-RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && poetry install --no-dev && cd ../../; done
+RUN --mount=type=cache,target=/root/.cache  for pkg in $providers; do cd tools/c7n_$pkg && echo "install $pkg"  && poetry install --no-dev && cd ../../; done
 
 RUN mkdir /output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ jsonschema = "^3.2.0"
 argcomplete = "^1.11.1"
 python-dateutil = "^2.8.1"
 pyyaml = "^5.3"
+attrs = "^21"
 tabulate = "^0.8.6"
 importlib-metadata = ">1.7.0;python_version<3.8"
 

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -471,7 +471,8 @@ def test_image(image_id, image_name, providers):
     if providers not in (None, ()):
         env["CUSTODIAN_PROVIDERS"] = " ".join(providers)
     subprocess.check_call(
-        [Path(sys.executable).parent / "pytest", "-p", "no:terraform", "-v", "tests/test_docker.py"],
+        [Path(sys.executable).parent / "pytest", "-p",
+         "no:terraform", "-v", "tests/test_docker.py"],
         env=env,
         stderr=subprocess.STDOUT,
     )

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -147,7 +147,7 @@ RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/
 # Verify the install
 #  - policystream is not in ci due to libgit2 compilation needed
 #  - as a sanity check to distributing known good assets / we test here
-RUN . /usr/local/bin/activate && pytest tools/c7n_policystream
+RUN . /usr/local/bin/activate && pytest -n "no:terraform" tools/c7n_policystream
 """
 
 

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -471,7 +471,7 @@ def test_image(image_id, image_name, providers):
     if providers not in (None, ()):
         env["CUSTODIAN_PROVIDERS"] = " ".join(providers)
     subprocess.check_call(
-        [Path(sys.executable).parent / "pytest", "-v", "tests/test_docker.py"],
+        [Path(sys.executable).parent / "pytest", "-p", "no:terraform", "-v", "tests/test_docker.py"],
         env=env,
         stderr=subprocess.STDOUT,
     )


### PR DESCRIPTION
switch out tools/dev/dockerpkg to using docker buildx instead of direct api usage.

related #6102 

the hope is once we have bulidx support we can more easily enable get to cross compilation architecture delivery.


Additionally intent is to also decrease docker image build times via external cache to github action cache.