### PR TITLE
[WIP] [Require Input] Send cloud-custodian metrics to a statsd server

### DIFF
--- a/c7n/output.py
+++ b/c7n/output.py
@@ -507,7 +507,6 @@ class StatsDMetricsOutput(Metrics):
         self.client = DogStatsd(namespace='cloud-custodian')
 
     def _format_metric(self, key, value, unit, dimensions):
-        time_now = datetime.datetime.utcnow()
         message = {
             'metric': key,
             'value': value,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ click==8.0.1; python_version >= "3.6"
 colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and platform_system == "Windows" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0" and platform_system == "Windows"
 coverage==5.5; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
 cryptography==3.4.8; sys_platform == "linux" and python_version >= "3.6"
+datadog==0.34.1; python_version >= "3.6"
 docutils==0.17.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 execnet==1.9.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.6" and python_version < "4.0"
 flake8==3.9.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")


### PR DESCRIPTION
This PR contains a proof of concept for the feature described in https://github.com/cloud-custodian/cloud-custodian/issues/6923. The idea is to support sending metrics of cloud-custodian to a `statsd` server, which is a vendor-agnostic method. This is intended to be useful for users not using the native monitoring solutions by a cloud provider i.e CloudWatch, StackDriver etc.

**Note**: I want to validate if this is something cloud-custodian is willing to incorporate into their codebase before committing more time to polish it (add tests etc). If yes, I would love to continue work on this :) 

How I tested this:
- Ran `make install`
- Started a statsd container: `docker run -p 8125:8125/udp dasch/statsd-debug`
- `c7n-org run .... --metrics-uri statsd://`
