### PR TITLE
update gcp subnet get re match string

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,16 +1,34 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "make",
-    "isShellCommand": true,
     "echoCommand": true,
     "args": [],
-    "showOutput": "always",
     "tasks": [
-        {"taskName": "test",
-         "args": ["test"]},
-        {"taskName": "coverage",
-         "args": ["coverage"]}
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "make",
+            "args": [
+                "test",
+                "test"
+            ],
+            "problemMatcher": [],
+            "group": {
+                "_id": "test",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "coverage",
+            "type": "shell",
+            "command": "make",
+            "args": [
+                "coverage",
+                "coverage"
+            ],
+            "problemMatcher": []
+        }
     ]
 }

--- a/tools/c7n_gcp/c7n_gcp/resources/network.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/network.py
@@ -55,7 +55,7 @@ class Subnet(QueryResourceManager):
         def get(client, resource_info):
 
             path_param_re = re.compile(
-                '.*?/projects/(.*?)/regions/(.*?)/subnetworks/(.*)')
+                '.*?projects/(.*?)/regions/(.*?)/subnetworks/(.*)')
             project, region, subnet = path_param_re.match(
                 resource_info["resourceName"]).groups()
             return client.execute_query(


### PR DESCRIPTION
Current regex match string in c7n_gcp/resources/network.py line 58 excludes event in production.
Please see https://github.com/cloud-custodian/cloud-custodian/issues/6915 for more details.