### PR TITLE
tools/c7n_sphinxext - fix typo in changed content comparision for reference doc gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ lint:
 	flake8 c7n tests tools
 
 clean:
+	make -f docs/Makefile.sphinx clean
 	rm -rf .tox .Python bin include lib pip-selfcheck.json
 
 analyzer-bandit:

--- a/docs/Makefile.sphinx
+++ b/docs/Makefile.sphinx
@@ -59,6 +59,9 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf $(SRCDIR)/generated
+	rm -f $(SRCDIR)/aws/resources/*
+	rm -f $(SRCDIR)/gcp/resources/*
+	rm -f $(SRCDIR)/azure/resources/*
 
 html:
 #	$(SPHINXBINS)/sphinx-apidoc -H "AWS" -o $(SRCDIR)/generated/aws $(SRCDIR)/../../c7n $(SRCDIR)/../../tests $(SRCDIR)/../../c7n/ipaddress.py

--- a/tools/c7n_sphinxext/c7n_sphinxext/docgen.py
+++ b/tools/c7n_sphinxext/c7n_sphinxext/docgen.py
@@ -263,7 +263,7 @@ def write_modified_file(fpath, content, diff_changes=False):
             disk_content = fh.read()
 
     if disk_content:
-        file_md5 = hashlib.md5(content.encode('utf8'))
+        file_md5 = hashlib.md5(disk_content.encode('utf8'))
 
     if file_md5 and content_md5.hexdigest() == file_md5.hexdigest():
         return False


### PR DESCRIPTION
this was causing some issues in ci
﻿
