### PR TITLE
docs - switch event id for AuthorizeSecurityGroup examples

### DIFF
--- a/docs/source/aws/examples/securitygroupsaddpermission.rst
+++ b/docs/source/aws/examples/securitygroupsaddpermission.rst
@@ -25,7 +25,7 @@ User defined rule is added to the filtered results.
            events:
              - source: ec2.amazonaws.com
                event: AuthorizeSecurityGroupIngress
-               ids: "requestParameters.groupId"
+               ids: "responseElements.securityGroupRuleSet.items[].groupId"
              - source: ec2.amazonaws.com
                event: RevokeSecurityGroupIngress
                ids: "requestParameters.groupId"

--- a/docs/source/aws/examples/securitygroupsdetectremediate.rst
+++ b/docs/source/aws/examples/securitygroupsdetectremediate.rst
@@ -25,10 +25,10 @@ rule additions on them!
            events:
              - source: ec2.amazonaws.com
                event: AuthorizeSecurityGroupIngress
-               ids: "requestParameters.groupId"
+               ids: "responseElements.securityGroupRuleSet.items[].groupId"
              - source: ec2.amazonaws.com
                event: AuthorizeSecurityGroupEgress
-               ids: "requestParameters.groupId"
+               ids: "responseElements.securityGroupRuleSet.items[].groupId"
              - source: ec2.amazonaws.com
                event: RevokeSecurityGroupEgress
                ids: "requestParameters.groupId"


### PR DESCRIPTION
Following the discussion in #6920, pull a security group ID from the response rather than the request. This allows the event pattern to pick up new authorizations made by group name rather than ID, for security groups in the default VPC.

Note that this change would not work for the RevokeSecurityGroup events - handling that case would require some magic under the hood to look for and explicitly handle a groupName request parameter.

Thanks to @samarts03 for raising this issue both in Gitter and GitHub!