### PR TITLE
Excluding tag keys starting with "aws:" from being copied.

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -1185,13 +1185,13 @@ def coalesce_copy_user_tags(resource, copy_tags, user_tags):
 
     if isinstance(copy_tags, list):
         if '*' in copy_tags:
-            copy_keys = {t['Key'] for t in r_tags}
+            copy_keys = {t['Key'] for t in r_tags if not t['Key'].startswith('aws:')}
         else:
             copy_keys = set(copy_tags)
 
     if isinstance(copy_tags, bool):
         if copy_tags is True:
-            copy_keys = {t['Key'] for t in r_tags}
+            copy_keys = {t['Key'] for t in r_tags if not t['Key'].startswith('aws:')}
         else:
             copy_keys = set()
 


### PR DESCRIPTION
This addresses issue #6952. It excludes tag keys starting with "aws:" from being copied, since that results in an AWS API error.
