### PR TITLE
aws - check-permissions - gracefully handle non-existent iam entities

### DIFF
--- a/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/iam.DeleteRole_1.json
+++ b/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/iam.DeleteRole_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/iam.GetRole_1.json
+++ b/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/iam.GetRole_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Type": "Sender",
+            "Code": "NoSuchEntity",
+            "Message": "The role with name c7n_test_check_permissions cannot be found."
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/iam.SimulatePrincipalPolicy_1.json
+++ b/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/iam.SimulatePrincipalPolicy_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Type": "Sender",
+            "Code": "NoSuchEntity",
+            "Message": "Unable to retrieve specified IAM entity."
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/lambda.ListFunctions_1.json
+++ b/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/lambda.ListFunctions_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Functions": [
+            {
+                "FunctionName": "c7n_test_check_permissions",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n_test_check_permissions",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/c7n_test_check_permissions",
+                "Handler": "handler.lambda_handler",
+                "CodeSize": 206,
+                "Description": "",
+                "Timeout": 3,
+                "MemorySize": 128,
+                "LastModified": "2021-11-08T04:25:52.895+0000",
+                "CodeSha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "3c2e0fdd-07af-41c1-bd10-df309dadd446",
+                "PackageType": "Zip"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_aws_lambda_check_permission_deleted_role/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/aws_lambda_check_permissions/main.tf
+++ b/tests/terraform/aws_lambda_check_permissions/main.tf
@@ -1,0 +1,40 @@
+data "archive_file" "lambda_package" {
+  type        = "zip"
+  output_path = "${path.module}/lambda_package.zip"
+
+  source {
+    content  = <<EOF
+def lambda_handler(event, context):
+  print('Hello from Lambda')
+EOF
+    filename = "${path.module}/handler.py"
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "c7n_test_check_permissions"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "test_check_permissions" {
+  filename      = data.archive_file.lambda_package.output_path
+  runtime       = "python3.8"
+  handler       = "handler.lambda_handler"
+  function_name = "c7n_test_check_permissions"
+  role          = aws_iam_role.lambda.arn
+}

--- a/tests/terraform/aws_lambda_check_permissions/tf_resources.json
+++ b/tests/terraform/aws_lambda_check_permissions/tf_resources.json
@@ -1,0 +1,102 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "archive_file": {
+            "lambda_package": {
+                "excludes": null,
+                "id": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_base64sha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "output_file_mode": null,
+                "output_md5": "dbda80a51ce93cd8b7917d718b98351f",
+                "output_path": "./lambda_package.zip",
+                "output_sha": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_size": 206,
+                "source": [
+                    {
+                        "content": "def lambda_handler(event, context):\n  print('Hello from Lambda')\n",
+                        "filename": "./handler.py"
+                    }
+                ],
+                "source_content": null,
+                "source_content_filename": null,
+                "source_dir": null,
+                "source_file": null,
+                "type": "zip"
+            }
+        },
+        "aws_iam_role": {
+            "lambda": {
+                "arn": "arn:aws:iam::644160558196:role/c7n_test_check_permissions",
+                "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                "create_date": "2021-11-08T04:25:44Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "c7n_test_check_permissions",
+                "inline_policy": [
+                    {
+                        "name": "",
+                        "policy": ""
+                    }
+                ],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "c7n_test_check_permissions",
+                "name_prefix": "",
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "tags_all": {},
+                "unique_id": "AROAY5Y4D45RPLLU2OO3I"
+            }
+        },
+        "aws_lambda_function": {
+            "test_check_permissions": {
+                "architectures": [
+                    "x86_64"
+                ],
+                "arn": "arn:aws:lambda:us-east-1:644160558196:function:c7n_test_check_permissions",
+                "code_signing_config_arn": "",
+                "dead_letter_config": [],
+                "description": "",
+                "environment": [],
+                "file_system_config": [],
+                "filename": "./lambda_package.zip",
+                "function_name": "c7n_test_check_permissions",
+                "handler": "handler.lambda_handler",
+                "id": "c7n_test_check_permissions",
+                "image_config": [],
+                "image_uri": "",
+                "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:c7n_test_check_permissions/invocations",
+                "kms_key_arn": "",
+                "last_modified": "2021-11-08T04:25:52.895+0000",
+                "layers": null,
+                "memory_size": 128,
+                "package_type": "Zip",
+                "publish": false,
+                "qualified_arn": "arn:aws:lambda:us-east-1:644160558196:function:c7n_test_check_permissions:$LATEST",
+                "reserved_concurrent_executions": -1,
+                "role": "arn:aws:iam::644160558196:role/c7n_test_check_permissions",
+                "runtime": "python3.8",
+                "s3_bucket": null,
+                "s3_key": null,
+                "s3_object_version": null,
+                "signing_job_arn": "",
+                "signing_profile_version_arn": "",
+                "source_code_hash": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "source_code_size": 206,
+                "tags": null,
+                "tags_all": {},
+                "timeout": 3,
+                "timeouts": null,
+                "tracing_config": [
+                    {
+                        "mode": "PassThrough"
+                    }
+                ],
+                "version": "$LATEST",
+                "vpc_config": []
+            }
+        }
+    }
+}

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1,6 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import json
+import time
 from mock import patch
 
 from botocore.exceptions import ClientError
@@ -9,6 +10,7 @@ from c7n.executor import MainThreadExecutor
 from c7n.resources.aws import shape_validate
 from c7n.resources.awslambda import AWSLambda, ReservedConcurrency
 from c7n.mu import PythonPackageArchive
+from pytest_terraform import terraform
 
 
 SAMPLE_FUNC = """\
@@ -608,3 +610,36 @@ class TestModifyVpcSecurityGroupsAction(BaseTest):
         self.assertTrue(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['KMSKeyArn'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/skunk/trails')
+
+
+@terraform('aws_lambda_check_permissions', teardown=terraform.TEARDOWN_IGNORE)
+def test_lambda_check_permission_deleted_role(test, aws_lambda_check_permissions):
+    '''Ensure that the check-permissions filter doesn't raise an exception if
+    a Lambda function's role has been deleted.'''
+
+    factory = test.replay_flight_data('test_aws_lambda_check_permission_deleted_role')
+
+    iam_client = factory().client('iam')
+    role_name = aws_lambda_check_permissions['aws_iam_role.lambda.name']
+    function_name = aws_lambda_check_permissions[
+        'aws_lambda_function.test_check_permissions.function_name']
+
+    iam_client.delete_role(RoleName=role_name)
+    if test.recording:
+        time.sleep(5)
+
+    p = test.load_policy(
+        {
+            'name': 'lambda-check-deleted-role',
+            'resource': 'aws.lambda',
+            'filters': [
+                {'FunctionName': function_name},
+                {'type': 'check-permissions',
+                 'match': 'denied',
+                 'actions': ['iam:CreateUser']}
+            ]
+        },
+        session_factory=factory)
+
+    resources = p.run()
+    test.assertEqual(len(resources), 1)


### PR DESCRIPTION
When simulating permissions for an IAM resource that doesn't exist, return no permissions rather than raising an error.

Warn when the policy target a non-IAM resource, as this may indicate an invalid weak reference (see #6963 for an example).