### PR TITLE
[do-not-merge - wip] releng - trim Azure SDK

### DIFF
--- a/docker/cli
+++ b/docker/cli
@@ -7,7 +7,7 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py     | python3 - -y --version 1.1.9
 
 WORKDIR /src
 
@@ -33,6 +33,12 @@ ARG providers="azure gcp kube openstack"
 RUN . /usr/local/bin/activate && \
     for pkg in $providers; do cd tools/c7n_$pkg && \
     $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \
+    pip uninstall --yes azure-sdk-trim
 
 RUN mkdir /output
 

--- a/docker/cli-distroless
+++ b/docker/cli-distroless
@@ -7,7 +7,7 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py     | python3 - -y --version 1.1.9
 
 WORKDIR /src
 
@@ -33,6 +33,12 @@ ARG providers="azure gcp kube openstack"
 RUN . /usr/local/bin/activate && \
     for pkg in $providers; do cd tools/c7n_$pkg && \
     $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \
+    pip uninstall --yes azure-sdk-trim
 
 RUN mkdir /output
 

--- a/docker/mailer
+++ b/docker/mailer
@@ -7,7 +7,7 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py     | python3 - -y --version 1.1.9
 
 WORKDIR /src
 
@@ -33,6 +33,12 @@ ARG providers="azure gcp kube openstack"
 RUN . /usr/local/bin/activate && \
     for pkg in $providers; do cd tools/c7n_$pkg && \
     $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \
+    pip uninstall --yes azure-sdk-trim
 
 RUN mkdir /output
 

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -7,7 +7,7 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py     | python3 - -y --version 1.1.9
 
 WORKDIR /src
 
@@ -33,6 +33,12 @@ ARG providers="azure gcp kube openstack"
 RUN . /usr/local/bin/activate && \
     for pkg in $providers; do cd tools/c7n_$pkg && \
     $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \
+    pip uninstall --yes azure-sdk-trim
 
 RUN mkdir /output
 

--- a/docker/org
+++ b/docker/org
@@ -7,7 +7,7 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py     | python3 - -y --version 1.1.9
 
 WORKDIR /src
 
@@ -33,6 +33,12 @@ ARG providers="azure gcp kube openstack"
 RUN . /usr/local/bin/activate && \
     for pkg in $providers; do cd tools/c7n_$pkg && \
     $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \
+    pip uninstall --yes azure-sdk-trim
 
 RUN mkdir /output
 

--- a/docker/org-distroless
+++ b/docker/org-distroless
@@ -7,7 +7,7 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py     | python3 - -y --version 1.1.9
 
 WORKDIR /src
 
@@ -33,6 +33,12 @@ ARG providers="azure gcp kube openstack"
 RUN . /usr/local/bin/activate && \
     for pkg in $providers; do cd tools/c7n_$pkg && \
     $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \
+    pip uninstall --yes azure-sdk-trim
 
 RUN mkdir /output
 

--- a/docker/policystream
+++ b/docker/policystream
@@ -7,7 +7,7 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py     | python3 - -y --version 1.1.9
 
 WORKDIR /src
 
@@ -33,6 +33,12 @@ ARG providers="azure gcp kube openstack"
 RUN . /usr/local/bin/activate && \
     for pkg in $providers; do cd tools/c7n_$pkg && \
     $HOME/.poetry/bin/poetry install && cd ../../; done
+
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \
+    pip uninstall --yes azure-sdk-trim
 
 RUN mkdir /output
 

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -7,7 +7,7 @@ RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
 RUN apt-get --yes install build-essential curl python3-venv python3-dev --no-install-recommends
 RUN python3 -m venv /usr/local
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - -y --version 1.1.9
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py     | python3 - -y --version 1.1.9
 
 WORKDIR /src
 
@@ -34,6 +34,12 @@ RUN . /usr/local/bin/activate && \
     for pkg in $providers; do cd tools/c7n_$pkg && \
     $HOME/.poetry/bin/poetry install && cd ../../; done
 
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \
+    pip uninstall --yes azure-sdk-trim
+
 RUN mkdir /output
 
 # Compile libgit2
@@ -55,7 +61,7 @@ RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/
 # Verify the install
 #  - policystream is not in ci due to libgit2 compilation needed
 #  - as a sanity check to distributing known good assets / we test here
-RUN . /usr/local/bin/activate && pytest tools/c7n_policystream
+RUN . /usr/local/bin/activate && pytest -p "no:terraform" tools/c7n_policystream
 
 FROM gcr.io/distroless/python3-debian10
 

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -64,6 +64,12 @@ RUN . /usr/local/bin/activate && \\
     for pkg in $providers; do cd tools/c7n_$pkg && \\
     $HOME/.poetry/bin/poetry install && cd ../../; done
 
+RUN apt-get install --yes git && pip install git+https://github.com/clumio-code/azure-sdk-trim@v0.1.0#egg=azure-sdk-trim && \\
+    azure-sdk-trim --azure_dir /usr/local/lib/python3.8/site-packages/azure/mgmt && \\
+    python -m compileall -b /usr/local/lib/python3.8/site-packages/azure && \\
+    find /usr/local/lib/python3.8/site-packages/azure -name '*.py' -delete && \\
+    pip uninstall --yes azure-sdk-trim
+
 RUN mkdir /output
 """
 
@@ -147,7 +153,7 @@ RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/
 # Verify the install
 #  - policystream is not in ci due to libgit2 compilation needed
 #  - as a sanity check to distributing known good assets / we test here
-RUN . /usr/local/bin/activate && pytest -n "no:terraform" tools/c7n_policystream
+RUN . /usr/local/bin/activate && pytest -p "no:terraform" tools/c7n_policystream
 """
 
 


### PR DESCRIPTION
Azure SDK includes a lot of old versions, so it is really bloated for Compute\Storage\Network libraries.

This change uses azure-sdk-trim script (https://github.com/clumio-code/azure-sdk-trim) that removes unused (non-default) versions and it allows to free up ~210mb.

Docker image size is reduced from 700 to 500mb.

Still work in progress to validate there is no regressions in Azure module.