### PR TITLE
aws - mu refactor - add permission extracted and mugc support tag for mode detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,14 @@ click = "^8.0"
 
 [tool.black]
 skip-string-normalization = true
+
+[tool.pylint.messages_control]
+disable = [
+  "missing-docstring",
+  "invalid-name",
+  "too-many-lines",
+  "unused-argument",
+  "fixme",
+  "empty-docstring",
+  "logging-not-lazy"
+]


### PR DESCRIPTION

while testing #6969 some oddities wrt to add permission handling
where noted, this pr refactors mu's event classes to consistently
use a base class which also provide a centralized implementation
of add_permission.

additionally mugc was updated to support using the custodian-info
tag on lambdas to determine which event mode the function is using,
falling back to the previous if no tag is found. the tag has been
present in custodian releases and provisioned lambda functions for 
over two years. this will allow mugc to expand to other event modes
more easily.
