### PR TITLE
Added ec2:DescribeLaunchTemplateVersions to the permission list for the aws.ebs-snapshot 'unused' filter

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -276,7 +276,7 @@ class SnapshotUnusedFilter(Filter):
     def get_permissions(self):
         return list(itertools.chain(*[
             self.manager.get_resource_manager(m).get_permissions()
-            for m in ('asg', 'launch-config', 'ami')]))
+            for m in ('asg', 'launch-config', 'ami', 'launch-template-version')]))
 
     def _pull_asg_snapshots(self):
         asgs = self.manager.get_resource_manager('asg').resources()

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -2088,7 +2088,7 @@ class LaunchTemplate(query.QueryResourceManager):
         service = 'ec2'
         date = 'CreateTime'
         enum_spec = (
-            'describe_launch_templates', 'LaunchTemplates', None)
+            'describe_launch_template_versions', 'LaunchTemplates', None)
         filter_name = 'LaunchTemplateIds'
         filter_type = 'list'
         arn_type = "launch-template"


### PR DESCRIPTION
Not sure if this is exactly right, but it fixes the problem I _wanted_ to fix, which is that `ebs:DescribeLaunchTemplateVersions` was not listed in the docs as a permission requirement for the "unused" filter for the aws.ebs-snapshot resource.

For the `enum_spec` change in ec2.py, should I also change the second value of the tuple, so say to LaunchTemplateVersions? I'm not sure how that second value gets used, but changing it would seem to follow the pattern for `enum_spec`.
