### PR TITLE
Initial commit using speaker affiliations from the CNCF Governance as…

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,7 +4,6 @@ There are some unreferenceable users that are leveraging Cloud Custodian that ar
 
 There are many additional adopters of Cloud Custodian in the evaluating phase that will be added to this list as they transition to production deployments.
 
-- Amazon Web Services
 - Capital One
 - Code 42
 - Grupo

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,14 @@
+Below is a list of adopters of Cloud Custodian in production environments that have publicly shared the details of their usage as well as the benefits provided by Cloud Custodian that their business relies on. 
+
+There are some unreferenceable users that are leveraging Cloud Custodian that are not yet able to share details of their usage publicly at this time.
+
+There are many additional adopters of Cloud Custodian in the evaluating phase that will be added to this list as they transition to production deployments.
+
+- Amazon Web Services
+- Capital One
+- Code 42
+- Grupo
+- HBO Max
+- JP Morgan Chase & Co
+- Premise Data
+- Zapier


### PR DESCRIPTION
… Code Day

As part of the CNCF incubation process we need to have an ADOPTERS.md file showing who is using c7n in production. This is an initial list of organizations who have publically given talks or have otherwise talked about c7n publically. 

The introductory text is taken from other incubating projects that are using ADOPTERS.md. 

This list will grow over time as organizations add themselves. 
