### PR TITLE
CSV and simple report can optionaly output all findings

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -122,6 +122,9 @@ def _report_options(p):
         '--format', default='csv', choices=['csv', 'grid', 'simple', 'json'],
         help="Format to output data in (default: %(default)s). "
         "Options include simple, grid, csv, json")
+    p.add_argument(
+        '--all-findings', default=False, action="store_true",
+        help="Outputs all findings per resource. Defaults to a single finding per resource. ")
 
 
 def _metrics_options(p):

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -96,7 +96,7 @@ def report(policies, start_date, options, output_fh, raw_output_fh=None):
 
         records += policy_records
 
-    rows = formatter.to_csv(records)
+    rows = formatter.to_csv(records, unique=not options.all_findings)
 
     if options.format == 'csv':
         writer = csv.writer(output_fh, formatter.headers(), quoting=csv.QUOTE_ALL)
@@ -213,9 +213,10 @@ class Formatter:
 
         if unique:
             uniq = self.uniq_by_id(records)
+            log.debug("Uniqued from %d to %d" % (len(records), len(uniq)))
         else:
             uniq = records
-        log.debug("Uniqued from %d to %d" % (len(records), len(uniq)))
+            log.debug("Selected %d record(s)" % len(records))
         rows = list(map(self.extract_csv, uniq))
         return rows
 


### PR DESCRIPTION
CSV and simple report always filter duplicates. This pull request **adds a command line option to allow all findings to be reported**.

Say you have two policies targetting `aws.ec2` resources.

- Unencrypted EBS (37 records found)
- Mising tag (9 records found)

You can get a report for each policy if I select it with `--policies unencrypted` xor `--policy missing-tag`. The `json` output format has all 46 records, but the `CSV` and `simple` format always output this message (because of the missing flag this PR adds):

```
2021-11-18 17:41:31,158: custodian.reports:DEBUG Found 9 records for region us-east-1
2021-11-18 17:41:31,162: custodian.reports:DEBUG Found 37 records for region us-east-1
2021-11-18 17:41:31,164: custodian.reports:DEBUG Uniqued from 46 to 37
```

The  existing check for `--resource aws.ec2` flag is still enforced to ensure the output will have the same columns for each finding.