### PR TITLE
tests - bug fix for s3 ap, eks node delete functional test

### DIFF
--- a/c7n/resources/s3control.py
+++ b/c7n/resources/s3control.py
@@ -21,6 +21,7 @@ class AccessPointDescribe(DescribeSource):
             arn = Arn.parse(r['AccessPointArn'])
             ap = client.get_access_point(AccountId=arn.account_id, Name=r['Name'])
             ap.pop('ResponseMetadata', None)
+            ap['AccessPointArn'] = arn.arn
             results.append(ap)
         return results
 

--- a/tests/data/placebo/s3_access_point_query/s3-control.GetAccessPointPolicy_1.json
+++ b/tests/data/placebo/s3_access_point_query/s3-control.GetAccessPointPolicy_1.json
@@ -2,6 +2,6 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\"],\"Resource\":\"arn:aws:s3:us-east-1:644160558196:accesspoint/c7n-ap-moving-doe/object/*\"}]}"
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\"],\"Resource\":\"arn:aws:s3:us-east-2:644160558196:accesspoint/c7n-ap-liberal-anemone/object/*\"}]}"
     }
 }

--- a/tests/data/placebo/s3_access_point_query/s3-control.GetAccessPoint_1.json
+++ b/tests/data/placebo/s3_access_point_query/s3-control.GetAccessPoint_1.json
@@ -2,8 +2,8 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "Name": "c7n-ap-moving-doe",
-        "Bucket": "c7n-ap-moving-doe",
+        "Name": "c7n-ap-liberal-anemone",
+        "Bucket": "c7n-ap-liberal-anemone",
         "NetworkOrigin": "Internet",
         "PublicAccessBlockConfiguration": {
             "BlockPublicAcls": true,
@@ -14,20 +14,12 @@
         "CreationDate": {
             "__class__": "datetime",
             "year": 2021,
-            "month": 9,
-            "day": 4,
-            "hour": 14,
-            "minute": 50,
-            "second": 56,
+            "month": 11,
+            "day": 22,
+            "hour": 17,
+            "minute": 24,
+            "second": 5,
             "microsecond": 0
-        },
-        "Alias": "c7n-ap-moving-doe-4zh4cmmki3my5asuwpqiocjgrqknsuse1a-s3alias",
-        "AccessPointArn": "arn:aws:s3:us-east-1:644160558196:accesspoint/c7n-ap-moving-doe",
-        "Endpoints": {
-            "ipv4": "s3-accesspoint.us-east-1.amazonaws.com",
-            "fips": "s3-accesspoint-fips.us-east-1.amazonaws.com",
-            "fips_dualstack": "s3-accesspoint-fips.dualstack.us-east-1.amazonaws.com",
-            "dualstack": "s3-accesspoint.dualstack.us-east-1.amazonaws.com"
         }
     }
 }

--- a/tests/data/placebo/s3_access_point_query/s3-control.GetAccessPoint_2.json
+++ b/tests/data/placebo/s3_access_point_query/s3-control.GetAccessPoint_2.json
@@ -4,9 +4,9 @@
         "Error": {
             "Message": "The specified accesspoint does not exist",
             "Code": "NoSuchAccessPoint",
-            "AccessPointName": "c7n-ap-moving-doe"
+            "AccessPointName": "c7n-ap-liberal-anemone"
         },
-        "HostId": "8CK0js/iX9/HLg1cmbXLfugyZ6SH73N7BktxPymcAmpz/O6cukdPSYTLIXDQZEj3LUD8GNelJ/g=",
+        "HostId": "vXxC6U5Qfd+31g23s1w4B2B3I9V7pUZB53XKdZtpvpEasjzF0SRV3KiYhPlwkuOCZVObMKlHKCs=",
         "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/s3_access_point_query/s3-control.ListAccessPoints_1.json
+++ b/tests/data/placebo/s3_access_point_query/s3-control.ListAccessPoints_1.json
@@ -4,11 +4,10 @@
         "ResponseMetadata": {},
         "AccessPointList": [
             {
-                "Name": "c7n-ap-moving-doe",
+                "Name": "c7n-ap-liberal-anemone",
                 "NetworkOrigin": "Internet",
-                "Bucket": "c7n-ap-moving-doe",
-                "AccessPointArn": "arn:aws:s3:us-east-1:644160558196:accesspoint/c7n-ap-moving-doe",
-                "Alias": "c7n-ap-moving-doe-4zh4cmmki3my5asuwpqiocjgrqknsuse1a-s3alias"
+                "Bucket": "c7n-ap-liberal-anemone",
+                "AccessPointArn": "arn:aws:s3:us-east-2:644160558196:accesspoint/c7n-ap-liberal-anemone"
             }
         ]
     }

--- a/tests/data/placebo/s3_access_point_query/sts.GetCallerIdentity_1.json
+++ b/tests/data/placebo/s3_access_point_query/sts.GetCallerIdentity_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "UserId": "AROAXYCHC33BTMJIK3JOU:sonny@stacklet.io",
+        "Account": "644160558196",
+        "Arn": "arn:aws:sts::644160558196:assumed-role/AWSReservedSSO_AWSAdministratorAccess_32be95b7471a99e1/sonny@stacklet.io",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/eks_nodegroup_delete/providers.tf
+++ b/tests/terraform/eks_nodegroup_delete/providers.tf
@@ -1,1 +1,3 @@
-provider "aws" {}
+provider "aws" {
+  region = "eu-central-1"
+}

--- a/tests/terraform/eks_nodegroup_delete/tf_resources.json
+++ b/tests/terraform/eks_nodegroup_delete/tf_resources.json
@@ -27,9 +27,9 @@
         },
         "aws_default_route_table": {
             "example": {
-                "arn": "arn:aws:ec2:eu-central-1:644160558196:route-table/rtb-0bd6a3614c5bfc10d",
-                "default_route_table_id": "rtb-0bd6a3614c5bfc10d",
-                "id": "rtb-0bd6a3614c5bfc10d",
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:route-table/rtb-09e8b3b482f368cd6",
+                "default_route_table_id": "rtb-09e8b3b482f368cd6",
+                "id": "rtb-09e8b3b482f368cd6",
                 "owner_id": "644160558196",
                 "propagating_vgws": null,
                 "route": [
@@ -37,7 +37,7 @@
                         "cidr_block": "0.0.0.0/0",
                         "destination_prefix_list_id": "",
                         "egress_only_gateway_id": "",
-                        "gateway_id": "igw-0e5d436a368635698",
+                        "gateway_id": "igw-099fb28beca5a804b",
                         "instance_id": "",
                         "ipv6_cidr_block": "",
                         "nat_gateway_id": "",
@@ -48,7 +48,9 @@
                     }
                 ],
                 "tags": null,
-                "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-0b1f77811b823c7d8"
             }
         },
         "aws_eks_cluster": {
@@ -56,19 +58,19 @@
                 "arn": "arn:aws:eks:eu-central-1:644160558196:cluster/example",
                 "certificate_authority": [
                     {
-                        "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1EWXdPVEU0TlRZMU4xb1hEVE14TURZd056RTROVFkxTjFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTW9tCmdlWVFhdEovbjNSWDJBcFE0bEE5Z3NBUW8xTVlvRWJJMEJsZ0ZtTS9kWCsrVmkrS0QvMGUvejVNclYwSTVORS8KS2VsVXBJTWo4em5KdU52dmJlMUtkWXVnRm1XOE5VYUtqdklwMVhVcC9meHJ2cDBBZ2E5TEkzcUt3TS9RN3IyZwp1dnc0TndyM2ZDaEhkMU9lU2x5Z0swUWFpelNQV05pa3prNDBZQTY2VmprYkIvb05NWVE0ai9nL08xa2JMQnpoCmxoRUE2T3lxb0JQRjhVNzIwWnhEMUxENldwUFY5UkpXUHlrdkVWRXhKbmE4NWI1UWZVVXRkSU8xWlZEd2NZbmIKcGU3QnNFMDdOaUNJL3R1RlpxUkJIYzhKVytodkZKdUhEckE0RVNsbkM4Rll4MnFTTHZkRVJoNHJmS0U1QXYvaQpHSXJ5ZE5RSXdVTkZ6OGtpdlBNQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZIMXhZM2FmNW1vSDFwZVRoWGRmVlFVSHdMZDBNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBd3VVOHpGKzBXb2szckxMTHZCOGw4ZUw5VEhSalVvVXRybW1ZdnBhckh6OVVrZmYwUQpQY29SbUwxSEVHVDNvUDJ3cnJoeDFnV1dtenJHUnc2S3JLNHdON1ZpVFZnSHpIdFNBR0tBSEpPSm9KQ0d6YjBTCnBkc0tZbGthazFxajJ3Tlo2NEg3OXM0RHFnd1h1citjS1pCY1Q0NkJ4UGE5dUU5WGkvNFV4ckNzN1BRbjdOL0gKNkdMTnVXQzY4L1BnRDdxNUgxQ1JvbVdZMlExQlQrcDNObkZTMkJRMWVqWkJyb2dERzByaE5SZkI0OHNmNnFZNwpra1h6aTlYdVp5QjRGa1EwRnpzR1c2aEF4c01XM0xnV2FueUZubTMyUEdxb1EzczlMSUIyV05kWEZudkQvSVkzCnVFc3NoVml6a2xpdGFna1UrblFuN2tQRE9hZVpvdDZpUUg1VwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+                        "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1URXlNakUzTlRjd05Gb1hEVE14TVRFeU1ERTNOVGN3TkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTUM0CkNPam03RTYvNFFUM294TVlOVGY5dUJuYlc0OTJWWVArY2Fqazdvam4rSTZtZUhkZ3dRclVxK0JhM2tIdk9CS28KWU1YREkvaGo0Q1A2YzBGSDNMcFM4ZzR1WGJGZTFUMCswUnI5MFpwY3NabVdadFVSdFZsL0VUdHB4ZW8vOStYeApENThVZmlBUUVFTStSYzZZc1VxRW9seFdrUHFzcCtEb1AyMlFnNXFLcFM1RGpGVTh1dkRTOVdSekIwejd0Z29RCmxIZkZydDJZSmNnYkYvRG5Xc25wNVZ1Qkdid1dZMmVQSjE5dHcrM09Kb3BiaW5vTGhUdnpMNHI3SEhlMjJTNnYKSmxHajJVV2FaaEVtMTFURmdoa1JPL3hPd0EvREtXTGlBVXMrelloYTR1SnROWWNiSTVhamh5QTIvQ3crRC9raApTSCtSWmU2Yk90NWtRSlFsdXRjQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZGQkR1U0pZZXVlU0VCNUcwRXJJOWQyRFFuYS9NQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFDb0RvdERvL2d2VUNUOVQzSlY2WGpRQmNmblFZRi9EVmorSFBRSXNTVUtDcndMbGhWUQpwZmhSWUMrLys0YXVnUjRzbGxRU1BNVEwzc2d0UThQQ09uZjNHOTRPRmVBRjg0d1pnVC85bUttM3hUenlsUFB4ClhPRDVCeDdKTU4xQ3Z3dmN1UGVKdjloV2Z1ZytlNWR3M2V4U1NFR1hpMFFGZDE3bWR3cWVFQjNxdDJTUE1RdTQKNDVhUExqNFRTTWxETkpzZ1dEMDZ4Tm5JcU5XVmhLRjduYk9DRkVZUlJJdGdqM3FQMU5qRDdzWTl4QVQ3ZnY1YgpPV3NXRlRhLzBPRVhGVFlpMGVLTk1kSHhNMWNxcmlyeFFZYWFlUlN2akVGemgvL0VpcUtpUWFHeTFqOEMrUHp1CjkwL1k1a1JPb0ptVEI0bGNCdGw0L1BrczFEdUZvU2NJeWkvMwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
                     }
                 ],
-                "created_at": "2021-06-09 18:51:25.242 +0000 UTC",
+                "created_at": "2021-11-22 17:50:07.095 +0000 UTC",
                 "enabled_cluster_log_types": null,
                 "encryption_config": [],
-                "endpoint": "https://D70C67F0CA5533EC6169BE7EEEF1F566.yl4.eu-central-1.eks.amazonaws.com",
+                "endpoint": "https://247CFCC7053319611C144FCD772BFA98.gr7.eu-central-1.eks.amazonaws.com",
                 "id": "example",
                 "identity": [
                     {
                         "oidc": [
                             {
-                                "issuer": "https://oidc.eks.eu-central-1.amazonaws.com/id/D70C67F0CA5533EC6169BE7EEEF1F566"
+                                "issuer": "https://oidc.eks.eu-central-1.amazonaws.com/id/247CFCC7053319611C144FCD772BFA98"
                             }
                         ]
                     }
@@ -79,15 +81,16 @@
                     }
                 ],
                 "name": "example",
-                "platform_version": "eks.5",
+                "platform_version": "eks.3",
                 "role_arn": "arn:aws:iam::644160558196:role/eks-cluster-example",
                 "status": "ACTIVE",
                 "tags": null,
+                "tags_all": {},
                 "timeouts": null,
-                "version": "1.19",
+                "version": "1.21",
                 "vpc_config": [
                     {
-                        "cluster_security_group_id": "sg-01a195a3755018b3f",
+                        "cluster_security_group_id": "sg-01c2beacef2c2b69d",
                         "endpoint_private_access": false,
                         "endpoint_public_access": true,
                         "public_access_cidrs": [
@@ -95,10 +98,10 @@
                         ],
                         "security_group_ids": null,
                         "subnet_ids": [
-                            "subnet-0a228654ec7e42459",
-                            "subnet-0b743fe5e4b41ff30"
+                            "subnet-04548b1aef0820aa6",
+                            "subnet-0771b430ef73a6480"
                         ],
-                        "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+                        "vpc_id": "vpc-0b1f77811b823c7d8"
                     }
                 ]
             }
@@ -106,7 +109,7 @@
         "aws_eks_node_group": {
             "deleted_example": {
                 "ami_type": "AL2_x86_64",
-                "arn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/deleted-example/b4bcf913-32c7-2459-26d9-66ee6025e572",
+                "arn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/deleted-example/eebea468-5d13-36cd-0e22-6218f108e0a5",
                 "capacity_type": "ON_DEMAND",
                 "cluster_name": "example",
                 "disk_size": 20,
@@ -118,14 +121,15 @@
                 "labels": null,
                 "launch_template": [],
                 "node_group_name": "deleted-example",
+                "node_group_name_prefix": "",
                 "node_role_arn": "arn:aws:iam::644160558196:role/eks-node-group-example",
-                "release_version": "1.19.6-20210526",
+                "release_version": "1.21.5-20211117",
                 "remote_access": [],
                 "resources": [
                     {
                         "autoscaling_groups": [
                             {
-                                "name": "eks-b4bcf913-32c7-2459-26d9-66ee6025e572"
+                                "name": "eks-deleted-example-eebea468-5d13-36cd-0e22-6218f108e0a5"
                             }
                         ],
                         "remote_access_security_group_id": ""
@@ -140,19 +144,30 @@
                 ],
                 "status": "ACTIVE",
                 "subnet_ids": [
-                    "subnet-090b5147c5840ff04",
-                    "subnet-0a87c93ecb21f181f"
+                    "subnet-0154790166fea93b2",
+                    "subnet-0f2431b82b35be8b8"
                 ],
                 "tags": {
                     "ClusterName": "example",
                     "Name": "deleted-example"
                 },
+                "tags_all": {
+                    "ClusterName": "example",
+                    "Name": "deleted-example"
+                },
+                "taint": [],
                 "timeouts": null,
-                "version": "1.19"
+                "update_config": [
+                    {
+                        "max_unavailable": 1,
+                        "max_unavailable_percentage": 0
+                    }
+                ],
+                "version": "1.21"
             },
             "not_deleted_example": {
                 "ami_type": "AL2_x86_64",
-                "arn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/not_deleted_example/54bcf913-32c5-0470-56a4-57858068f5dd",
+                "arn": "arn:aws:eks:eu-central-1:644160558196:nodegroup/example/not_deleted_example/96bea468-5d0d-9f94-ffad-b0a32314d44e",
                 "capacity_type": "ON_DEMAND",
                 "cluster_name": "example",
                 "disk_size": 20,
@@ -164,14 +179,15 @@
                 "labels": null,
                 "launch_template": [],
                 "node_group_name": "not_deleted_example",
+                "node_group_name_prefix": "",
                 "node_role_arn": "arn:aws:iam::644160558196:role/eks-node-group-example",
-                "release_version": "1.19.6-20210526",
+                "release_version": "1.21.5-20211117",
                 "remote_access": [],
                 "resources": [
                     {
                         "autoscaling_groups": [
                             {
-                                "name": "eks-54bcf913-32c5-0470-56a4-57858068f5dd"
+                                "name": "eks-not_deleted_example-96bea468-5d0d-9f94-ffad-b0a32314d44e"
                             }
                         ],
                         "remote_access_security_group_id": ""
@@ -186,22 +202,33 @@
                 ],
                 "status": "ACTIVE",
                 "subnet_ids": [
-                    "subnet-090b5147c5840ff04",
-                    "subnet-0a87c93ecb21f181f"
+                    "subnet-0154790166fea93b2",
+                    "subnet-0f2431b82b35be8b8"
                 ],
                 "tags": {
                     "ClusterName": "example",
                     "Name": "not-deleted-example"
                 },
+                "tags_all": {
+                    "ClusterName": "example",
+                    "Name": "not-deleted-example"
+                },
+                "taint": [],
                 "timeouts": null,
-                "version": "1.19"
+                "update_config": [
+                    {
+                        "max_unavailable": 1,
+                        "max_unavailable_percentage": 0
+                    }
+                ],
+                "version": "1.21"
             }
         },
         "aws_iam_role": {
             "cluster_example": {
                 "arn": "arn:aws:iam::644160558196:role/eks-cluster-example",
                 "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
-                "create_date": "2021-06-09T18:50:49Z",
+                "create_date": "2021-11-22T17:49:42Z",
                 "description": "",
                 "force_detach_policies": false,
                 "id": "eks-cluster-example",
@@ -214,16 +241,17 @@
                 "managed_policy_arns": [],
                 "max_session_duration": 3600,
                 "name": "eks-cluster-example",
-                "name_prefix": null,
+                "name_prefix": "",
                 "path": "/",
                 "permissions_boundary": null,
                 "tags": null,
-                "unique_id": "AROA43SAJ7OOP5YLNW3LI"
+                "tags_all": {},
+                "unique_id": "AROAXYCHC33B5I5I7LWPI"
             },
             "node_group_example": {
                 "arn": "arn:aws:iam::644160558196:role/eks-node-group-example",
                 "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
-                "create_date": "2021-06-09T18:50:49Z",
+                "create_date": "2021-11-22T17:49:42Z",
                 "description": "",
                 "force_detach_policies": false,
                 "id": "eks-node-group-example",
@@ -236,58 +264,60 @@
                 "managed_policy_arns": [],
                 "max_session_duration": 3600,
                 "name": "eks-node-group-example",
-                "name_prefix": null,
+                "name_prefix": "",
                 "path": "/",
                 "permissions_boundary": null,
                 "tags": null,
-                "unique_id": "AROA43SAJ7OODDQFYMOIB"
+                "tags_all": {},
+                "unique_id": "AROAXYCHC33BVWHI6WUVX"
             }
         },
         "aws_iam_role_policy_attachment": {
             "example-AmazonEC2ContainerRegistryReadOnly": {
-                "id": "eks-node-group-example-20210609185057653700000002",
+                "id": "eks-node-group-example-20211122174943970000000002",
                 "policy_arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
                 "role": "eks-node-group-example"
             },
             "example-AmazonEKSClusterPolicy": {
-                "id": "eks-cluster-example-20210609185057670700000005",
+                "id": "eks-cluster-example-20211122174943979800000004",
                 "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
                 "role": "eks-cluster-example"
             },
             "example-AmazonEKSVPCResourceController": {
-                "id": "eks-cluster-example-20210609185057306000000001",
+                "id": "eks-cluster-example-20211122174943980300000005",
                 "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController",
                 "role": "eks-cluster-example"
             },
             "example-AmazonEKSWorkerNodePolicy": {
-                "id": "eks-node-group-example-20210609185057669800000004",
+                "id": "eks-node-group-example-20211122174943972500000003",
                 "policy_arn": "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
                 "role": "eks-node-group-example"
             },
             "example-AmazonEKS_CNI_Policy": {
-                "id": "eks-node-group-example-20210609185057660500000003",
+                "id": "eks-node-group-example-20211122174943962700000001",
                 "policy_arn": "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
                 "role": "eks-node-group-example"
             }
         },
         "aws_internet_gateway": {
             "example": {
-                "arn": "arn:aws:ec2:eu-central-1:644160558196:internet-gateway/igw-0e5d436a368635698",
-                "id": "igw-0e5d436a368635698",
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:internet-gateway/igw-099fb28beca5a804b",
+                "id": "igw-099fb28beca5a804b",
                 "owner_id": "644160558196",
                 "tags": null,
-                "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+                "tags_all": {},
+                "vpc_id": "vpc-0b1f77811b823c7d8"
             }
         },
         "aws_subnet": {
             "cluster_example": {
-                "arn": "arn:aws:ec2:eu-central-1:644160558196:subnet/subnet-0b743fe5e4b41ff30",
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:subnet/subnet-0771b430ef73a6480",
                 "assign_ipv6_address_on_creation": false,
                 "availability_zone": "eu-central-1a",
                 "availability_zone_id": "euc1-az2",
                 "cidr_block": "10.0.0.0/24",
                 "customer_owned_ipv4_pool": "",
-                "id": "subnet-0b743fe5e4b41ff30",
+                "id": "subnet-0771b430ef73a6480",
                 "ipv6_cidr_block": "",
                 "ipv6_cidr_block_association_id": "",
                 "map_customer_owned_ip_on_launch": false,
@@ -297,16 +327,16 @@
                 "tags": null,
                 "tags_all": {},
                 "timeouts": null,
-                "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+                "vpc_id": "vpc-0b1f77811b823c7d8"
             },
             "node_group_example": {
-                "arn": "arn:aws:ec2:eu-central-1:644160558196:subnet/subnet-090b5147c5840ff04",
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:subnet/subnet-0f2431b82b35be8b8",
                 "assign_ipv6_address_on_creation": false,
                 "availability_zone": "eu-central-1a",
                 "availability_zone_id": "euc1-az2",
                 "cidr_block": "10.0.2.0/24",
                 "customer_owned_ipv4_pool": "",
-                "id": "subnet-090b5147c5840ff04",
+                "id": "subnet-0f2431b82b35be8b8",
                 "ipv6_cidr_block": "",
                 "ipv6_cidr_block_association_id": "",
                 "map_customer_owned_ip_on_launch": false,
@@ -320,27 +350,27 @@
                     "kubernetes.io/cluster/example": "shared"
                 },
                 "timeouts": null,
-                "vpc_id": "vpc-0192b1f9a4d0dbeb4"
+                "vpc_id": "vpc-0b1f77811b823c7d8"
             }
         },
         "aws_vpc": {
             "example": {
-                "arn": "arn:aws:ec2:eu-central-1:644160558196:vpc/vpc-0192b1f9a4d0dbeb4",
+                "arn": "arn:aws:ec2:eu-central-1:644160558196:vpc/vpc-0b1f77811b823c7d8",
                 "assign_generated_ipv6_cidr_block": false,
                 "cidr_block": "10.0.0.0/16",
-                "default_network_acl_id": "acl-042eff2fea9196d03",
-                "default_route_table_id": "rtb-0bd6a3614c5bfc10d",
-                "default_security_group_id": "sg-07c8a96d6e06c8dd9",
-                "dhcp_options_id": "dopt-d74e4fbc",
+                "default_network_acl_id": "acl-0560026251e7a0c9a",
+                "default_route_table_id": "rtb-09e8b3b482f368cd6",
+                "default_security_group_id": "sg-0ead292a4fd0c44f5",
+                "dhcp_options_id": "dopt-0a29ab60",
                 "enable_classiclink": null,
                 "enable_classiclink_dns_support": null,
                 "enable_dns_hostnames": false,
                 "enable_dns_support": true,
-                "id": "vpc-0192b1f9a4d0dbeb4",
+                "id": "vpc-0b1f77811b823c7d8",
                 "instance_tenancy": "default",
                 "ipv6_association_id": "",
                 "ipv6_cidr_block": "",
-                "main_route_table_id": "rtb-0bd6a3614c5bfc10d",
+                "main_route_table_id": "rtb-09e8b3b482f368cd6",
                 "owner_id": "644160558196",
                 "tags": null,
                 "tags_all": {}

--- a/tests/terraform/s3_access_point/tf_resources.json
+++ b/tests/terraform/s3_access_point/tf_resources.json
@@ -5,30 +5,37 @@
         "aws_caller_identity": {
             "current": {
                 "account_id": "644160558196",
-                "arn": "arn:aws:sts::644160558196:assumed-role/AWSReservedSSO_AWSAdministratorAccess_f277a3f2424192e7/kapil",
+                "arn": "arn:aws:sts::644160558196:assumed-role/AWSReservedSSO_AWSAdministratorAccess_32be95b7471a99e1/sonny@stacklet.io",
                 "id": "644160558196",
-                "user_id": "AROAXEGRT7KTSDWIMAUBP:kapil"
+                "user_id": "AROAXYCHC33BTMJIK3JOU:sonny@stacklet.io"
             }
         },
         "aws_region": {
             "current": {
-                "description": "US East (N. Virginia)",
-                "endpoint": "ec2.us-east-1.amazonaws.com",
-                "id": "us-east-1",
-                "name": "us-east-1"
+                "description": "US East (Ohio)",
+                "endpoint": "ec2.us-east-2.amazonaws.com",
+                "id": "us-east-2",
+                "name": "us-east-2"
             }
         },
         "aws_s3_access_point": {
             "example": {
                 "account_id": "644160558196",
-                "arn": "arn:aws:s3:us-east-1:644160558196:accesspoint/c7n-ap-moving-doe",
-                "bucket": "c7n-ap-moving-doe",
-                "domain_name": "c7n-ap-moving-doe-644160558196.s3-accesspoint.us-east-1.amazonaws.com",
+                "alias": "c7n-ap-liberal-anemo-rxgz4p36p5rx5dfpkqespgeuexicause2b-s3alias",
+                "arn": "arn:aws:s3:us-east-2:644160558196:accesspoint/c7n-ap-liberal-anemone",
+                "bucket": "c7n-ap-liberal-anemone",
+                "domain_name": "c7n-ap-liberal-anemone-644160558196.s3-accesspoint.us-east-2.amazonaws.com",
+                "endpoints": {
+                    "dualstack": "s3-accesspoint.dualstack.us-east-2.amazonaws.com",
+                    "fips": "s3-accesspoint-fips.us-east-2.amazonaws.com",
+                    "fips_dualstack": "s3-accesspoint-fips.dualstack.us-east-2.amazonaws.com",
+                    "ipv4": "s3-accesspoint.us-east-2.amazonaws.com"
+                },
                 "has_public_access_policy": true,
-                "id": "644160558196:c7n-ap-moving-doe",
-                "name": "c7n-ap-moving-doe",
+                "id": "644160558196:c7n-ap-liberal-anemone",
+                "name": "c7n-ap-liberal-anemone",
                 "network_origin": "Internet",
-                "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\"],\"Resource\":\"arn:aws:s3:us-east-1:644160558196:accesspoint/c7n-ap-moving-doe/object/*\"}]}",
+                "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\"],\"Resource\":\"arn:aws:s3:us-east-2:644160558196:accesspoint/c7n-ap-liberal-anemone/object/*\"}]}",
                 "public_access_block_configuration": [
                     {
                         "block_public_acls": true,
@@ -44,21 +51,21 @@
             "example": {
                 "acceleration_status": "",
                 "acl": "private",
-                "arn": "arn:aws:s3:::c7n-ap-moving-doe",
-                "bucket": "c7n-ap-moving-doe",
-                "bucket_domain_name": "c7n-ap-moving-doe.s3.amazonaws.com",
+                "arn": "arn:aws:s3:::c7n-ap-liberal-anemone",
+                "bucket": "c7n-ap-liberal-anemone",
+                "bucket_domain_name": "c7n-ap-liberal-anemone.s3.amazonaws.com",
                 "bucket_prefix": null,
-                "bucket_regional_domain_name": "c7n-ap-moving-doe.s3.amazonaws.com",
+                "bucket_regional_domain_name": "c7n-ap-liberal-anemone.s3.us-east-2.amazonaws.com",
                 "cors_rule": [],
                 "force_destroy": false,
                 "grant": [],
-                "hosted_zone_id": "Z3AQBSTGFYJSTF",
-                "id": "c7n-ap-moving-doe",
+                "hosted_zone_id": "Z2O1EMRO9K5GLX",
+                "id": "c7n-ap-liberal-anemone",
                 "lifecycle_rule": [],
                 "logging": [],
                 "object_lock_configuration": [],
                 "policy": null,
-                "region": "us-east-1",
+                "region": "us-east-2",
                 "replication_configuration": [],
                 "request_payer": "BucketOwner",
                 "server_side_encryption_configuration": [],
@@ -81,7 +88,7 @@
         },
         "random_pet": {
             "bucket": {
-                "id": "moving-doe",
+                "id": "liberal-anemone",
                 "keepers": null,
                 "length": 2,
                 "prefix": null,

--- a/tests/test_s3control.py
+++ b/tests/test_s3control.py
@@ -10,6 +10,8 @@ from pytest_terraform import terraform
 def test_s3_access_point(test, s3_access_point):
     factory = test.replay_flight_data('s3_access_point_query')
     client = factory().client('s3control')
+    sts_client = factory().client('sts')
+    account_id = sts_client.get_caller_identity()['Account']
     p = test.load_policy(
         {
             'name': 'ap',
@@ -18,7 +20,7 @@ def test_s3_access_point(test, s3_access_point):
             'actions': ['delete'],
         },
         session_factory=factory,
-        config={'account_id': '644160558196'},
+        config={'account_id': account_id}
     )
 
     resources = p.run()


### PR DESCRIPTION
This PR fixes a few issues in the functional tests:
1. Getting AccessDenied on the s3 access point test when running an account that isn't `644160558196`
2. The s3-access-point augment wasn't including the AccessPointArn (it's not returned in the `get_access_point` api call: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3control.html#S3Control.Client.get_access_point)
2. eks test was using eu-central-1 in the policy config but the provider wasn't set to eu-central-1 so depending on your local `AWS_REGION` environment variable the test would return 0 resources