### PR TITLE
7013 - gcp non customer managed encrypted snapshot

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/compute.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/compute.py
@@ -394,7 +394,7 @@ class Snapshot(QueryResourceManager):
         def get(client, resource_info):
             return client.execute_command(
                 'get', {'project': resource_info['project_id'],
-                        'snapshot_id': resource_info['snapshot_id']})
+                        'snapshot': resource_info['snapshot_id']})
 
 
 @Snapshot.action_registry.register('delete')


### PR DESCRIPTION
As long as protoPayload.resource.labels contains snapshot_id - i.e. resource_info['snapshot_id'] as seen below - then this guardrail (detailed in 7013) does it's job and deletes the snapshot. However v1.compute.disks.createSnapshot related events currently don't contain that data.

Note this issue came about from a synthetic test I wrote where I built the payload published to the policy's topic. And as I say - with a properly built payload and the fix in this PR - it works.