### PR TITLE
aws - python 3.9 lambda policy support

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -351,7 +351,7 @@ class LambdaMode(ServerlessExecutionMode):
             'layers': {'type': 'array', 'items': {'type': 'string'}},
             'concurrency': {'type': 'integer'},
             'runtime': {'enum': ['python2.7', 'python3.6',
-                                 'python3.7', 'python3.8']},
+                                 'python3.7', 'python3.8', 'python3.9']},
             'role': {'type': 'string'},
             'pattern': {'type': 'object', 'minProperties': 1},
             'timeout': {'type': 'number'},


### PR DESCRIPTION
added support for python 3.9 in lambda without changing the default lambda runtime version