### PR TITLE
ISSUE-7107 - allow for policy name in AWS IAM set-policy action

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1091,6 +1091,10 @@ class SetPolicy(BaseAction):
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('iam')
         policy_arn = self.data['arn']
+        if policy_arn != "*" and not policy_arn.startswith('arn'):
+            policy_arn = 'arn:{}:iam::{}:policy/{}'.format(
+                get_partition(self.manager.config.region),
+                self.manager.account_id, policy_arn)
         state = self.data['state']
         for r in resources:
             if state == 'attached':

--- a/tests/data/placebo/test_set_policy_arn_construction/config.SelectResourceConfig_1.json
+++ b/tests/data/placebo/test_set_policy_arn_construction/config.SelectResourceConfig_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "Results": [
+            "{\"resourceId\":\"AROAY5Y4D45RMKKKBXNQ3\",\"configuration\":{\"path\":\"/\",\"assumeRolePolicyDocument\":\"%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22lambda.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D\",\"instanceProfileList\":[],\"roleId\":\"AROAY5Y4D45RMKKKBXNQ3\",\"attachedManagedPolicies\":[{\"policyArn\":\"arn:aws:iam::644160558196:policy/DeleteMe\",\"policyName\":\"DeleteMe\"}],\"roleName\":\"custodian-testing\",\"arn\":\"arn:aws:iam::644160558196:role/custodian-testing\",\"createDate\":\"2021-12-16T18:06:50.000Z\",\"rolePolicyList\":[],\"tags\":[]},\"supplementaryConfiguration\":{}}"
+        ],
+        "QueryInfo": {
+            "SelectFields": [
+                {
+                    "Name": "resourceId"
+                },
+                {
+                    "Name": "configuration"
+                },
+                {
+                    "Name": "supplementaryConfiguration"
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_set_policy_arn_construction/config.SelectResourceConfig_2.json
+++ b/tests/data/placebo/test_set_policy_arn_construction/config.SelectResourceConfig_2.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "Results": [
+            "{\"resourceId\":\"AROAY5Y4D45RMKKKBXNQ3\",\"configuration\":{\"path\":\"/\",\"assumeRolePolicyDocument\":\"%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22lambda.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D\",\"instanceProfileList\":[],\"roleId\":\"AROAY5Y4D45RMKKKBXNQ3\",\"attachedManagedPolicies\":[{\"policyArn\":\"arn:aws:iam::644160558196:policy/DeleteMe\",\"policyName\":\"DeleteMe\"}],\"roleName\":\"custodian-testing\",\"arn\":\"arn:aws:iam::644160558196:role/custodian-testing\",\"createDate\":\"2021-12-16T18:06:50.000Z\",\"rolePolicyList\":[],\"tags\":[]},\"supplementaryConfiguration\":{}}"
+        ],
+        "QueryInfo": {
+            "SelectFields": [
+                {
+                    "Name": "resourceId"
+                },
+                {
+                    "Name": "configuration"
+                },
+                {
+                    "Name": "supplementaryConfiguration"
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_set_policy_arn_construction/iam.AttachRolePolicy_1.json
+++ b/tests/data/placebo/test_set_policy_arn_construction/iam.AttachRolePolicy_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_set_policy_arn_construction/iam.DetachRolePolicy_1.json
+++ b/tests/data/placebo/test_set_policy_arn_construction/iam.DetachRolePolicy_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_set_policy_arn_construction/iam.ListAttachedRolePolicies_1.json
+++ b/tests/data/placebo/test_set_policy_arn_construction/iam.ListAttachedRolePolicies_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "AttachedPolicies": [
+            {
+                "PolicyName": "DeleteMe",
+                "PolicyArn": "arn:aws:iam::644160558196:policy/DeleteMe"
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -2157,6 +2157,46 @@ class DeleteRoleAction(BaseTest):
             }
         )
 
+    def test_set_policy_arn_construction(self):
+        factory = self.replay_flight_data("test_set_policy_arn_construction")
+
+        # Use set-policy with an explicit ARN
+        p = self.load_policy(
+            {
+                "name": "iam-policy-error",
+                "resource": "iam-role",
+                "source": "config",
+                "query": [{"clause": "resourceName = 'custodian-testing'"}],
+                "actions": [{
+                    "type": "set-policy",
+                    "state": "attached",
+                    "arn": "arn:aws:iam::{account_id}:policy/DeleteMe"
+                }],
+            },
+            session_factory=factory
+        )
+        p.expand_variables(p.get_variables())
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        if self.recording:
+            time.sleep(1)
+
+        # Use a policy name
+        p = self.load_policy(
+            {
+                "name": "iam-policy-error",
+                "resource": "iam-role",
+                "source": "config",
+                "query": [{"clause": "resourceName = 'custodian-testing'"}],
+                "filters": [{"type": "has-specific-managed-policy", "value": "DeleteMe"}],
+                "actions": [{"type": "set-policy", "state": "detached", "arn": "DeleteMe"}],
+            },
+            session_factory=factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_force_delete_role(self):
         factory = self.replay_flight_data("test_force_delete_role")
         policy = self.load_policy(


### PR DESCRIPTION
Fix for issue #7107 - copy logic from AWS IAM set-boundary action to set-policy to allow for policy name instead of full ARN.