### PR TITLE
Add filter for efs to check for secure transport

### DIFF
--- a/c7n/resources/efs.py
+++ b/c7n/resources/efs.py
@@ -278,12 +278,13 @@ class CheckSecureTransport(Filter):
 
         for s in statements:
             try:
-                if ((s['Effect'] == 'Deny' and
-                         s['Condition']['Bool']['aws:SecureTransport'] == 'false') or
-                    (s['Effect'] == 'Allow' and
-                         s['Condition']['Bool']['aws:SecureTransport'] == 'true')):
+                effect = s['Effect']
+                secureTransportValue = s['Condition']['Bool']['aws:SecureTransport']
+                if ((effect == 'Deny' and secureTransportValue == 'false') or
+                        (effect == 'Allow' and secureTransportValue == 'true')):
                     return False
-            except (KeyError, TypeError): pass
+            except (KeyError, TypeError):
+                pass
 
         return True
 

--- a/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystemPolicy_1.json
+++ b/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystemPolicy_1.json
@@ -2,7 +2,7 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "FileSystemId": "fs-0d3f38476c955d214",
-        "Policy": "{\n  \"Version\" : \"2012-10-17\",\n  \"Id\" : \"efs-policy-wizard-c8abc7d0-22e5-4e0c-841f-76f97a96e1f2\",\n  \"Statement\" : [ {\n    \"Sid\" : \"efs-statement-b3f6b59b-d938-4001-9154-508f67707073\",\n    \"Effect\" : \"Deny\",\n    \"Principal\" : {\n      \"AWS\" : \"*\"\n    },\n    \"Action\" : \"*\",\n    \"Resource\" : \"arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-0d3f38476c955d214\",\n    \"Condition\" : {\n      \"Bool\" : {\n        \"aws:SecureTransport\" : \"false\"\n      }\n    }\n  } ]\n}"
+        "FileSystemId": "fs-06f6ce85b4976bd7f",
+        "Policy": "{\n  \"Version\" : \"2012-10-17\",\n  \"Id\" : \"EnforceSecureTransport\",\n  \"Statement\" : [ {\n    \"Sid\" : \"ExampleSatement01\",\n    \"Effect\" : \"Deny\",\n    \"Principal\" : {\n      \"AWS\" : \"*\"\n    },\n    \"Action\" : \"*\",\n    \"Resource\" : \"arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-06f6ce85b4976bd7f\",\n    \"Condition\" : {\n      \"Bool\" : {\n        \"aws:SecureTransport\" : \"false\"\n      }\n    }\n  } ]\n}"
     }
 }

--- a/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystemPolicy_1.json
+++ b/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystemPolicy_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "FileSystemId": "fs-0d3f38476c955d214",
+        "Policy": "{\n  \"Version\" : \"2012-10-17\",\n  \"Id\" : \"efs-policy-wizard-c8abc7d0-22e5-4e0c-841f-76f97a96e1f2\",\n  \"Statement\" : [ {\n    \"Sid\" : \"efs-statement-b3f6b59b-d938-4001-9154-508f67707073\",\n    \"Effect\" : \"Deny\",\n    \"Principal\" : {\n      \"AWS\" : \"*\"\n    },\n    \"Action\" : \"*\",\n    \"Resource\" : \"arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-0d3f38476c955d214\",\n    \"Condition\" : {\n      \"Bool\" : {\n        \"aws:SecureTransport\" : \"false\"\n      }\n    }\n  } ]\n}"
+    }
+}

--- a/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystemPolicy_2.json
+++ b/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystemPolicy_2.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": null,
+            "Code": "PolicyNotFound"
+        },
+        "ResponseMetadata": {},
+        "ErrorCode": "PolicyNotFound"
+    }
+}

--- a/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystems_1.json
+++ b/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystems_1.json
@@ -5,21 +5,21 @@
         "FileSystems": [
             {
                 "OwnerId": "644160558196",
-                "CreationToken": "quickCreated-b182bbc9-fecd-4503-9e3a-24bdb2733abb",
-                "FileSystemId": "fs-0d3f38476c955d214",
-                "FileSystemArn": "arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-0d3f38476c955d214",
+                "CreationToken": "some-token",
+                "FileSystemId": "fs-06f6ce85b4976bd7f",
+                "FileSystemArn": "arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-06f6ce85b4976bd7f",
                 "CreationTime": {
                     "__class__": "datetime",
                     "year": 2021,
                     "month": 12,
                     "day": 6,
-                    "hour": 13,
-                    "minute": 51,
-                    "second": 7,
+                    "hour": 15,
+                    "minute": 52,
+                    "second": 15,
                     "microsecond": 0
                 },
                 "LifeCycleState": "available",
-                "Name": "secured-efs",
+                "Name": "efs-with-secure-transport",
                 "NumberOfMountTargets": 0,
                 "SizeInBytes": {
                     "Value": 6144,
@@ -33,31 +33,27 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "secured-efs"
-                    },
-                    {
-                        "Key": "aws:elasticfilesystem:default-backup",
-                        "Value": "enabled"
+                        "Value": "efs-with-secure-transport"
                     }
                 ]
             },
             {
                 "OwnerId": "644160558196",
-                "CreationToken": "quickCreated-a1b107d5-bb3a-476c-bc9e-a4b3f00c8fdc",
-                "FileSystemId": "fs-07b922135ba1c9c9e",
-                "FileSystemArn": "arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-07b922135ba1c9c9e",
+                "CreationToken": "some-token-2",
+                "FileSystemId": "fs-005ab9082da5b0a27",
+                "FileSystemArn": "arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-005ab9082da5b0a27",
                 "CreationTime": {
                     "__class__": "datetime",
                     "year": 2021,
                     "month": 12,
                     "day": 6,
-                    "hour": 13,
-                    "minute": 50,
-                    "second": 30,
+                    "hour": 15,
+                    "minute": 52,
+                    "second": 15,
                     "microsecond": 0
                 },
                 "LifeCycleState": "available",
-                "Name": "non-secured-efs",
+                "Name": "efs-without-secure-transport",
                 "NumberOfMountTargets": 0,
                 "SizeInBytes": {
                     "Value": 6144,
@@ -71,11 +67,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "non-secured-efs"
-                    },
-                    {
-                        "Key": "aws:elasticfilesystem:default-backup",
-                        "Value": "enabled"
+                        "Value": "efs-without-secure-transport"
                     }
                 ]
             }

--- a/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystems_1.json
+++ b/tests/data/placebo/test_efs_filter_check_secure_transport/elasticfilesystem.DescribeFileSystems_1.json
@@ -1,0 +1,84 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "FileSystems": [
+            {
+                "OwnerId": "644160558196",
+                "CreationToken": "quickCreated-b182bbc9-fecd-4503-9e3a-24bdb2733abb",
+                "FileSystemId": "fs-0d3f38476c955d214",
+                "FileSystemArn": "arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-0d3f38476c955d214",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 12,
+                    "day": 6,
+                    "hour": 13,
+                    "minute": 51,
+                    "second": 7,
+                    "microsecond": 0
+                },
+                "LifeCycleState": "available",
+                "Name": "secured-efs",
+                "NumberOfMountTargets": 0,
+                "SizeInBytes": {
+                    "Value": 6144,
+                    "ValueInIA": 0,
+                    "ValueInStandard": 6144
+                },
+                "PerformanceMode": "generalPurpose",
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/f1cbcbea-2ce1-4794-90b1-fe58da4ce954",
+                "ThroughputMode": "bursting",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "secured-efs"
+                    },
+                    {
+                        "Key": "aws:elasticfilesystem:default-backup",
+                        "Value": "enabled"
+                    }
+                ]
+            },
+            {
+                "OwnerId": "644160558196",
+                "CreationToken": "quickCreated-a1b107d5-bb3a-476c-bc9e-a4b3f00c8fdc",
+                "FileSystemId": "fs-07b922135ba1c9c9e",
+                "FileSystemArn": "arn:aws:elasticfilesystem:us-east-1:644160558196:file-system/fs-07b922135ba1c9c9e",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 12,
+                    "day": 6,
+                    "hour": 13,
+                    "minute": 50,
+                    "second": 30,
+                    "microsecond": 0
+                },
+                "LifeCycleState": "available",
+                "Name": "non-secured-efs",
+                "NumberOfMountTargets": 0,
+                "SizeInBytes": {
+                    "Value": 6144,
+                    "ValueInIA": 0,
+                    "ValueInStandard": 6144
+                },
+                "PerformanceMode": "generalPurpose",
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/f1cbcbea-2ce1-4794-90b1-fe58da4ce954",
+                "ThroughputMode": "bursting",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "non-secured-efs"
+                    },
+                    {
+                        "Key": "aws:elasticfilesystem:default-backup",
+                        "Value": "enabled"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/test_efs.py
+++ b/tests/test_efs.py
@@ -224,7 +224,7 @@ class ElasticFileSystem(BaseTest):
         self.assertEqual(resources[0]["FileSystemId"], "fs-5f61b0df")
 
     def test_filter_securetransport_check(self):
-        factory = self.record_flight_data("test_efs_filter_check_secure_transport")
+        factory = self.replay_flight_data("test_efs_filter_check_secure_transport")
         p = self.load_policy(
             {
                 "name": "efs-check-securetransport",
@@ -235,4 +235,4 @@ class ElasticFileSystem(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]["Name"], "non-secured-efs")
+        self.assertEqual(resources[0]["Name"], "efs-without-secure-transport")

--- a/tests/test_efs.py
+++ b/tests/test_efs.py
@@ -222,3 +222,17 @@ class ElasticFileSystem(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["FileSystemId"], "fs-5f61b0df")
+
+    def test_filter_securetransport_check(self):
+        factory = self.record_flight_data("test_efs_filter_check_secure_transport")
+        p = self.load_policy(
+            {
+                "name": "efs-check-securetransport",
+                "resource": "efs",
+                "filters": [{"type": "check-secure-transport"}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["Name"], "non-secured-efs")


### PR DESCRIPTION
Adding a new filter `check-secure-transport` to `efs` resource so we get EFS that don't have proper policy for requiring secure transport