### PR TITLE
Add filter for S3 bucket ownership controls

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -3423,3 +3423,99 @@ class SetBucketEncryption(KMSKeyResolverMixin, BucketActionBase):
             Bucket=bucket['Name'],
             ServerSideEncryptionConfiguration=config
         )
+
+
+OWNERSHIP_CONTROLS = ['BucketOwnerEnforced', 'BucketOwnerPreferred', 'ObjectWriter']
+VALUE_FILTER_MAGIC_VALUES = ['absent', 'present', 'not-null', 'empty']
+
+
+@filters.register('ownership')
+class BucketOwnershipControls(BucketFilterBase, ValueFilter):
+    """Filter for object ownership controls
+
+    Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
+
+    :example
+
+    Find buckets with ACLs disabled
+
+    .. code-block:: yaml
+
+            policies:
+              - name: s3-bucket-acls-disabled
+                resource: aws.s3
+                region: us-east-1
+                filters:
+                  - type: ownership
+                    value: BucketOwnerEnforced
+
+    :example
+
+    Find buckets with object ownership preferred or enforced
+
+    .. code-block:: yaml
+
+            policies:
+              - name: s3-bucket-ownership-preferred
+                resource: aws.s3
+                region: us-east-1
+                filters:
+                  - type: ownership
+                    op: in
+                    value:
+                      - BucketOwnerEnforced
+                      - BucketOwnerPreferred
+
+    :example
+
+    Find buckets with no object ownership controls
+
+    .. code-block:: yaml
+
+            policies:
+              - name: s3-bucket-no-ownership-controls
+                resource: aws.s3
+                region: us-east-1
+                filters:
+                  - type: ownership
+                    value: empty
+    """
+    schema = type_schema('ownership', rinherit=ValueFilter.schema, value={'oneOf': [
+        {'type': 'string', 'enum': OWNERSHIP_CONTROLS + VALUE_FILTER_MAGIC_VALUES},
+        {'type': 'array', 'items': {
+            'type': 'string', 'enum': OWNERSHIP_CONTROLS + VALUE_FILTER_MAGIC_VALUES}}]})
+    permissions = ('s3:GetBucketOwnershipControls',)
+    annotation_key = 'c7n:ownership'
+
+    def __init__(self, data, manager=None):
+        super(BucketOwnershipControls, self).__init__(data, manager)
+
+        # Ownership controls appear as an array of rules. There can only be one
+        # ObjectOwnership rule defined for a bucket, so we can automatically
+        # match against that if it exists.
+        self.data['key'] = f'("{self.annotation_key}".Rules[].ObjectOwnership)[0]'
+
+    def process(self, buckets, event=None):
+        with self.executor_factory(max_workers=2) as w:
+            futures = {w.submit(self.process_bucket, b): b for b in buckets}
+            for future in as_completed(futures):
+                b = futures[future]
+                if future.exception():
+                    self.log.error("Message: %s Bucket: %s", future.exception(),
+                                   b['Name'])
+                    continue
+        return super(BucketOwnershipControls, self).process(buckets, event)
+
+    def process_bucket(self, b):
+        client = bucket_client(local_session(self.manager.session_factory), b)
+        if self.annotation_key not in b:
+            try:
+                controls = client.get_bucket_ownership_controls(Bucket=b['Name'])
+                controls.pop('ResponseMetadata', None)
+            except ClientError as e:
+                if e.response['Error']['Code'] != 'OwnershipControlsNotFoundError':
+                    raise
+                controls = {}
+            b[self.annotation_key] = controls.get('OwnershipControls')
+        else:
+            controls = b[self.annotation_key]

--- a/tests/data/placebo/test_s3_ownership_defined/s3.GetBucketOwnershipControls_1.json
+++ b/tests/data/placebo/test_s3_ownership_defined/s3.GetBucketOwnershipControls_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Code": "OwnershipControlsNotFoundError",
+            "Message": "The bucket ownership controls were not found",
+            "BucketName": "c7ntest-20211227212502652800000001"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_ownership_defined/s3.GetBucketOwnershipControls_2.json
+++ b/tests/data/placebo/test_s3_ownership_defined/s3.GetBucketOwnershipControls_2.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "OwnershipControls": {
+            "Rules": [
+                {
+                    "ObjectOwnership": "BucketOwnerPreferred"
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_ownership_defined/s3.GetBucketOwnershipControls_3.json
+++ b/tests/data/placebo/test_s3_ownership_defined/s3.GetBucketOwnershipControls_3.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "OwnershipControls": {
+            "Rules": [
+                {
+                    "ObjectOwnership": "BucketOwnerEnforced"
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_ownership_defined/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_ownership_defined/s3.ListBuckets_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Buckets": [
+            {
+                "Name": "c7ntest-20211227212502652800000001",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 12,
+                    "day": 27,
+                    "hour": 21,
+                    "minute": 25,
+                    "second": 3,
+                    "microsecond": 0
+                }
+            },
+            {
+                "Name": "c7ntest-20211227212502652900000002",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 12,
+                    "day": 27,
+                    "hour": 21,
+                    "minute": 25,
+                    "second": 3,
+                    "microsecond": 0
+                }
+            },
+            {
+                "Name": "c7ntest-20211227212502652900000003",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 12,
+                    "day": 27,
+                    "hour": 21,
+                    "minute": 25,
+                    "second": 3,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "Owner": {
+            "DisplayName": "c7ntest",
+            "ID": "e46bca81657fdc9f58bc5bab457564bb66f16636bd724a9f51d212fa2185a2b0"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_ownership_empty/s3.GetBucketOwnershipControls_1.json
+++ b/tests/data/placebo/test_s3_ownership_empty/s3.GetBucketOwnershipControls_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Code": "OwnershipControlsNotFoundError",
+            "Message": "The bucket ownership controls were not found",
+            "BucketName": "c7ntest-20211227212502652800000001"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_ownership_empty/s3.GetBucketOwnershipControls_2.json
+++ b/tests/data/placebo/test_s3_ownership_empty/s3.GetBucketOwnershipControls_2.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "OwnershipControls": {
+            "Rules": [
+                {
+                    "ObjectOwnership": "BucketOwnerPreferred"
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_ownership_empty/s3.GetBucketOwnershipControls_3.json
+++ b/tests/data/placebo/test_s3_ownership_empty/s3.GetBucketOwnershipControls_3.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "OwnershipControls": {
+            "Rules": [
+                {
+                    "ObjectOwnership": "BucketOwnerEnforced"
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_ownership_empty/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_ownership_empty/s3.ListBuckets_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Buckets": [
+            {
+                "Name": "c7ntest-20211227212502652800000001",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 12,
+                    "day": 27,
+                    "hour": 21,
+                    "minute": 25,
+                    "second": 3,
+                    "microsecond": 0
+                }
+            },
+            {
+                "Name": "c7ntest-20211227212502652900000002",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 12,
+                    "day": 27,
+                    "hour": 21,
+                    "minute": 25,
+                    "second": 3,
+                    "microsecond": 0
+                }
+            },
+            {
+                "Name": "c7ntest-20211227212502652900000003",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 12,
+                    "day": 27,
+                    "hour": 21,
+                    "minute": 25,
+                    "second": 3,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "Owner": {
+            "DisplayName": "c7ntest",
+            "ID": "e46bca81657fdc9f58bc5bab457564bb66f16636bd724a9f51d212fa2185a2b0"
+        }
+    }
+}

--- a/tests/terraform/s3_ownership/main.tf
+++ b/tests/terraform/s3_ownership/main.tf
@@ -1,0 +1,27 @@
+resource "aws_s3_bucket" "no_ownership_controls" {
+  bucket_prefix = "c7ntest-"
+}
+
+resource "aws_s3_bucket" "owner_preferred" {
+  bucket_prefix = "c7ntest-"
+}
+
+resource "aws_s3_bucket" "owner_enforced" {
+  bucket_prefix = "c7ntest-"
+}
+
+resource "aws_s3_bucket_ownership_controls" "owner_preferred" {
+  bucket = aws_s3_bucket.owner_preferred.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "owner_enforced" {
+  bucket = aws_s3_bucket.owner_enforced.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/tests/terraform/s3_ownership/tf_resources.json
+++ b/tests/terraform/s3_ownership/tf_resources.json
@@ -1,0 +1,127 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_s3_bucket": {
+            "no_ownership_controls": {
+                "acceleration_status": "",
+                "acl": "private",
+                "arn": "arn:aws:s3:::c7ntest-20211227212502652800000001",
+                "bucket": "c7ntest-20211227212502652800000001",
+                "bucket_domain_name": "c7ntest-20211227212502652800000001.s3.amazonaws.com",
+                "bucket_prefix": "c7ntest-",
+                "bucket_regional_domain_name": "c7ntest-20211227212502652800000001.s3.amazonaws.com",
+                "cors_rule": [],
+                "force_destroy": false,
+                "grant": [],
+                "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                "id": "c7ntest-20211227212502652800000001",
+                "lifecycle_rule": [],
+                "logging": [],
+                "object_lock_configuration": [],
+                "policy": null,
+                "region": "us-east-1",
+                "replication_configuration": [],
+                "request_payer": "BucketOwner",
+                "server_side_encryption_configuration": [],
+                "tags": null,
+                "tags_all": {},
+                "versioning": [
+                    {
+                        "enabled": false,
+                        "mfa_delete": false
+                    }
+                ],
+                "website": [],
+                "website_domain": null,
+                "website_endpoint": null
+            },
+            "owner_enforced": {
+                "acceleration_status": "",
+                "acl": "private",
+                "arn": "arn:aws:s3:::c7ntest-20211227212502652900000003",
+                "bucket": "c7ntest-20211227212502652900000003",
+                "bucket_domain_name": "c7ntest-20211227212502652900000003.s3.amazonaws.com",
+                "bucket_prefix": "c7ntest-",
+                "bucket_regional_domain_name": "c7ntest-20211227212502652900000003.s3.amazonaws.com",
+                "cors_rule": [],
+                "force_destroy": false,
+                "grant": [],
+                "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                "id": "c7ntest-20211227212502652900000003",
+                "lifecycle_rule": [],
+                "logging": [],
+                "object_lock_configuration": [],
+                "policy": null,
+                "region": "us-east-1",
+                "replication_configuration": [],
+                "request_payer": "BucketOwner",
+                "server_side_encryption_configuration": [],
+                "tags": null,
+                "tags_all": {},
+                "versioning": [
+                    {
+                        "enabled": false,
+                        "mfa_delete": false
+                    }
+                ],
+                "website": [],
+                "website_domain": null,
+                "website_endpoint": null
+            },
+            "owner_preferred": {
+                "acceleration_status": "",
+                "acl": "private",
+                "arn": "arn:aws:s3:::c7ntest-20211227212502652900000002",
+                "bucket": "c7ntest-20211227212502652900000002",
+                "bucket_domain_name": "c7ntest-20211227212502652900000002.s3.amazonaws.com",
+                "bucket_prefix": "c7ntest-",
+                "bucket_regional_domain_name": "c7ntest-20211227212502652900000002.s3.amazonaws.com",
+                "cors_rule": [],
+                "force_destroy": false,
+                "grant": [],
+                "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                "id": "c7ntest-20211227212502652900000002",
+                "lifecycle_rule": [],
+                "logging": [],
+                "object_lock_configuration": [],
+                "policy": null,
+                "region": "us-east-1",
+                "replication_configuration": [],
+                "request_payer": "BucketOwner",
+                "server_side_encryption_configuration": [],
+                "tags": null,
+                "tags_all": {},
+                "versioning": [
+                    {
+                        "enabled": false,
+                        "mfa_delete": false
+                    }
+                ],
+                "website": [],
+                "website_domain": null,
+                "website_endpoint": null
+            }
+        },
+        "aws_s3_bucket_ownership_controls": {
+            "owner_enforced": {
+                "bucket": "c7ntest-20211227212502652900000003",
+                "id": "c7ntest-20211227212502652900000003",
+                "rule": [
+                    {
+                        "object_ownership": "BucketOwnerEnforced"
+                    }
+                ]
+            },
+            "owner_preferred": {
+                "bucket": "c7ntest-20211227212502652900000002",
+                "id": "c7ntest-20211227212502652900000002",
+                "rule": [
+                    {
+                        "object_ownership": "BucketOwnerPreferred"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -3724,3 +3724,62 @@ def test_s3_encryption_audit(test, aws_s3_encryption_audit):
     actual_names = sorted([r.get('Name') for r in resources])
 
     assert actual_names == expected_names
+
+
+@terraform('s3_ownership', scope='class')
+class TestBucketOwnership:
+    def test_s3_ownership_empty(self, test, s3_ownership):
+        test.patch(s3.S3, "executor_factory", MainThreadExecutor)
+        test.patch(s3.BucketOwnershipControls, "executor_factory", MainThreadExecutor)
+        test.patch(
+            s3, "S3_AUGMENT_TABLE", []
+        )
+        session_factory = test.replay_flight_data("test_s3_ownership_empty")
+        bucket_name = s3_ownership['aws_s3_bucket.no_ownership_controls.bucket']
+        p = test.load_policy(
+            {
+                "name": "s3-",
+                "resource": "s3",
+                "filters": [
+                    {"type": "value",
+                     "op": "glob",
+                     "key": "Name",
+                     "value": "c7ntest*"},
+                    {"type": "ownership",
+                     "value": "empty"},
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        assert len(resources) == 1
+        assert resources[0]["Name"] == bucket_name
+
+    def test_s3_ownership_defined(self, test, s3_ownership):
+        test.patch(s3.S3, "executor_factory", MainThreadExecutor)
+        test.patch(s3.BucketOwnershipControls, "executor_factory", MainThreadExecutor)
+        test.patch(
+            s3, "S3_AUGMENT_TABLE", []
+        )
+        session_factory = test.replay_flight_data("test_s3_ownership_defined")
+        bucket_names = {s3_ownership[f'aws_s3_bucket.{r}.bucket']
+                        for r in ('owner_preferred', 'owner_enforced')}
+        p = test.load_policy(
+            {
+                "name": "s3-",
+                "resource": "s3",
+                "filters": [
+                    {"type": "value",
+                     "op": "glob",
+                     "key": "Name",
+                     "value": "c7ntest*"},
+                    {"type": "ownership",
+                     "op": "in",
+                     "value": ["BucketOwnerPreferred", "BucketOwnerEnforced"]},
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        assert len(resources) == 2
+        assert {r["Name"] for r in resources} == bucket_names

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -3738,7 +3738,7 @@ class TestBucketOwnership:
         bucket_name = s3_ownership['aws_s3_bucket.no_ownership_controls.bucket']
         p = test.load_policy(
             {
-                "name": "s3-",
+                "name": "s3-ownership-empty",
                 "resource": "s3",
                 "filters": [
                     {"type": "value",
@@ -3766,7 +3766,7 @@ class TestBucketOwnership:
                         for r in ('owner_preferred', 'owner_enforced')}
         p = test.load_policy(
             {
-                "name": "s3-",
+                "name": "s3-ownership-defined",
                 "resource": "s3",
                 "filters": [
                     {"type": "value",


### PR DESCRIPTION
This is the first step in addressing #7019 - I'd expect to handle the action in a separate PR.

Some discussion points for a review:

- I want to make this filter friendly to use but also relatively typo-resistant. That's the motivation behind the awkward-looking combination of an ownership controls enum that allows `ValueFilter` magic values like `absent` and `present`. If anyone has suggestions for ways to make this cleaner on the dev side but still friendly to policy authors, please chime in!

- Peeking at the shape definitions ([ref 1], [ref 2]) for ownership control data, it looks like today we'll either have an empty object or one with a `Rules` array that has exactly 1 element. This filter doesn't rely on those expectations, but _does_ assume that only one rule will have an `ObjectOwnership` setting.

[ref 1]: https://github.com/boto/botocore/blob/63107d6f1fbf8a53b23dbf19f49ff849501c8ffd/botocore/data/s3/2006-03-01/service-2.json#L6629-L6637
[ref 2]: https://github.com/boto/botocore/blob/63107d6f1fbf8a53b23dbf19f49ff849501c8ffd/botocore/data/s3/2006-03-01/service-2.json#L6744-L6768