### PR TITLE
tests - gracefully handle non-default aws/git config

### DIFF
--- a/test.env
+++ b/test.env
@@ -2,6 +2,7 @@ export AWS_DEFAULT_REGION=us-east-1
 export AWS_ACCESS_KEY_ID=foo
 export AWS_SECRET_ACCESS_KEY=bar
 export AWS_SESSION_TOKEN=fake
+unset AWS_PROFILE
 export C7N_TEST_RUN=true
 export AZURE_ACCESS_TOKEN=fake_token
 export AZURE_SUBSCRIPTION_ID=ea42f556-5106-4743-99b0-c129bfa71a47

--- a/tools/c7n_policystream/tests/test_policystream.py
+++ b/tools/c7n_policystream/tests/test_policystream.py
@@ -37,7 +37,7 @@ class GitRepo:
         self.git_config = git_config or DEFAULT_CONFIG
 
     def init(self):
-        subprocess.check_output(['git', 'init'], cwd=self.repo_path)
+        subprocess.check_output(['git', 'init', '--initial-branch', 'main'], cwd=self.repo_path)
         with open(os.path.join(self.repo_path, '.git', 'config'), 'w') as fh:
             fh.write(self.git_config)
 
@@ -110,12 +110,12 @@ class StreamTest(TestUtils):
         git.commit('switch')
         return git
 
-    def test_cli_diff_master(self):
+    def test_cli_diff_main(self):
         git = self.setup_basic_repo()
         runner = CliRunner()
         result = runner.invoke(
             policystream.cli,
-            ['diff', '-r', git.repo_path])
+            ['diff', '-r', git.repo_path, '--source', 'HEAD^', '--target', 'main'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(
             yaml.safe_load(result.stdout),
@@ -135,7 +135,7 @@ class StreamTest(TestUtils):
         runner = CliRunner()
         result = runner.invoke(
             policystream.cli,
-            ['diff', '-r', git.repo_path])
+            ['diff', '-r', git.repo_path, '--source', 'main'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(
             yaml.safe_load(result.stdout),


### PR DESCRIPTION
This addresses a couple minor test breakages I saw locally due to custom config options for the AWS CLI and git. The changes _should_ be transparent for CI/release but help avoid brittleness for other contributors. Alternative suggestions welcome though!

* `make test-poetry` sources `test.env` before running tests. Unset
an `AWS_PROFILE` environment variable if it exists.

* c7n-policystream tests initialize a local git repo and make
assumptions about the local git client's `init.defaultBranch` setting.
Explicitly use `main` during initialization and testing.