### PR TITLE
fix: only require pywin32 if running on Windows

### DIFF
--- a/tools/c7n_azure/requirements.txt
+++ b/tools/c7n_azure/requirements.txt
@@ -84,7 +84,7 @@ pyjwt==1.7.1
 python-dateutil==2.8.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 pytz==2021.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
-pywin32==303
+pywin32==303; python_version >= "3.6" and python_version < "4.0" and platform_system == "Windows"
 requests-oauthlib==1.3.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 six==1.16.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"


### PR DESCRIPTION
The file `tools/c7n_azure/requirements.txt` currently causes install failures when performing the recommended [developer install](https://cloudcustodian.io/docs/developer/installing.html#developer-installing) while using tox on a Mac. This change fixes the issue. 