### PR TITLE
aws - key-pair - remove id_prefix to fix cloudtrail mode policies

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2324,7 +2324,9 @@ class KeyPair(query.QueryResourceManager):
         enum_spec = ('describe_key_pairs', 'KeyPairs', None)
         name = 'KeyName'
         id = 'KeyPairId'
-        id_prefix = 'key-'
+        # Removing id_prefix "key-" here to address #7089 in the short
+        # term without breaking backward compatibility with existing
+        # cloudtrail mode policies based on key name.
         filter_name = 'KeyNames'
         filter_type = 'list'
 


### PR DESCRIPTION
Remove `id_prefix` from the `aws.key-pair` resource type. Otherwise there is a mismatch between an `id_prefix` based on key pair ID and a `filter_name` based on key name, which prevents event mode policies from resolving resources.

Closes #7089 

### More Detail / Discussion

This is a really tiny change but perhaps worth kicking around, because I could think of two fixes and neither felt like the clear right answer:

1. Switch `filter_name` from `KeyNames` --> `KeyPairIds`
2. Remove `id_prefix`

#### Switch Filter Name

**Good:** This option seemed more "right", in that it would bring `id`, `id_prefix` and `filter_name` all into alignment without removing anything.

**Bad:** Until 0.9.12.0, CloudTrail mode policies using `ids: requestParameters.keyName` were working. They've been broken for the past few releases (in that they would run but always match 0 resources), but this would _keep_ them broken.

#### Remove ID Prefix

**Good:** Gets both new and old CloudTrail mode policies working again for EC2 key pairs.

**Bad:** Prevents [this check](https://github.com/cloud-custodian/cloud-custodian/blob/ce76027a2af6e21a9df3fcea65f0cb0781ab1aff/c7n/query.py#L482-L488) from filtering out non-key-pair resources. I _think_ the actual impact of this is pretty small, but that may be because I'm missing something. (The event rules for CloudTrail mode policies include the event name, which would seem to provide some focus unless a policy included an event shared by multiple EC2 resource types, like tagging operations)

_Of these two, I lean toward the option that preserves/restores backward compatibility. But I'm happy to be persuaded, and if someone has a good "why not both?!" suggestion I'm all ears!_