### PR TITLE
releng - update generated requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete==2.0.0; python_version >= "3.6"
-atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0"
-attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
+atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_version < "4.0" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_version < "4.0"
+attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.7" and python_version < "4.0"
 aws-xray-sdk==2.9.0
 bleach==4.1.0; python_version >= "3.6"
 boto3==1.20.37; python_version >= "3.6"
@@ -9,7 +9,7 @@ certifi==2021.10.8; python_version >= "3.6" and python_full_version < "3.0.0" or
 cffi==1.15.0; sys_platform == "linux" and python_version >= "3.7"
 charset-normalizer==2.0.10; python_full_version >= "3.6.0" and python_version >= "3.6"
 click==8.0.3; python_version >= "3.6"
-colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and platform_system == "Windows" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0" and platform_system == "Windows"
+colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and platform_system == "Windows" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_version < "4.0" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0" and platform_system == "Windows" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_version < "4.0"
 coverage==5.5; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
 cryptography==36.0.1; sys_platform == "linux" and python_version >= "3.7"
 docutils==0.17.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
@@ -17,9 +17,9 @@ execnet==1.9.0; python_version >= "3.6" and python_full_version < "3.0.0" and py
 flake8==4.0.1; python_version >= "3.6"
 future==0.18.2; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 idna==3.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-importlib-metadata==4.2.0; python_version == "3.7"
+importlib-metadata==4.2.0; python_version == "3.7" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
 importlib-resources==5.4.0; python_version < "3.9" and python_version >= "3.7"
-iniconfig==1.1.1; python_version >= "3.6"
+iniconfig==1.1.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.6" and python_version < "4.0"
 jeepney==0.7.1; sys_platform == "linux" and python_version >= "3.7"
 jmespath==0.10.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.3.0" and python_version >= "3.6" and python_version < "4.0"
 jsonpatch==1.32; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
@@ -29,13 +29,13 @@ keyring==23.5.0; python_version >= "3.7"
 mccabe==0.6.1; python_version >= "3.6"
 mock==4.0.3; python_version >= "3.6"
 multidict==5.2.0; python_version >= "3.6"
-packaging==21.3; python_version >= "3.6"
+packaging==21.3; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.6" and python_version < "4.0"
 pkginfo==1.8.2; python_version >= "3.6"
 placebo==0.9.0
-pluggy==1.0.0; python_version >= "3.6"
+pluggy==1.0.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.6" and python_version < "4.0"
 portalocker==2.3.2; python_version >= "3.6" and python_version < "4.0"
 psutil==5.9.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-py==1.11.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+py==1.11.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.6" and python_version < "4.0"
 pycodestyle==2.8.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 pycparser==2.21; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "linux" or sys_platform == "linux" and python_version >= "3.7" and python_full_version >= "3.4.0"
 pyflakes==2.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
@@ -61,13 +61,13 @@ secretstorage==3.3.1; sys_platform == "linux" and python_version >= "3.7"
 six==1.16.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 tabulate==0.8.9
 termcolor==1.1.0
-toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.6" and python_version < "4.0"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 twine==3.7.1; python_version >= "3.6"
-typing-extensions==4.0.1; python_version < "3.8" and python_version >= "3.7"
+typing-extensions==4.0.1; python_version == "3.7"
 urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 vcrpy==4.1.1; python_version >= "3.5"
 webencodings==0.5.1; python_version >= "3.6"
 wrapt==1.13.3; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
 yarl==1.7.2; python_version >= "3.6"
-zipp==3.7.0; python_version < "3.8" and python_version >= "3.7"
+zipp==3.7.0; python_version == "3.7"

--- a/tools/c7n_azure/requirements.txt
+++ b/tools/c7n_azure/requirements.txt
@@ -79,12 +79,12 @@ msrestazure==0.6.4
 netaddr==0.7.20
 oauthlib==3.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 portalocker==2.3.2
-pycparser==2.21; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+pycparser==2.21; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
 pyjwt==1.7.1
 python-dateutil==2.8.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 pytz==2021.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
-pywin32==303
+pywin32==303; python_version >= "3.5" and platform_system == "Windows"
 requests-oauthlib==1.3.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 six==1.16.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"

--- a/tools/c7n_gcp/requirements.txt
+++ b/tools/c7n_gcp/requirements.txt
@@ -1,6 +1,6 @@
 cachetools==4.2.4; python_version >= "3.5" and python_version < "4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
-certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
-charset-normalizer==2.0.10; python_full_version >= "3.6.0" and python_version >= "3"
+certifi==2021.10.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+charset-normalizer==2.0.10; python_full_version >= "3.6.0" and python_version >= "3.6"
 google-api-core==2.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 google-api-python-client==2.35.0; python_version >= "3.6"
 google-auth-httplib2==0.1.0; python_version >= "3.6"
@@ -13,15 +13,15 @@ google-cloud-monitoring==2.8.0; python_version >= "3.6"
 google-cloud-storage==1.44.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 google-crc32c==1.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 google-resumable-media==2.1.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-googleapis-common-protos==1.54.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+googleapis-common-protos==1.54.0; python_version >= "3.6" and python_full_version < "3.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") or python_full_version >= "3.6.0" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 grpc-google-iam-v1==0.12.3; python_version >= "3.6"
-grpcio-status==1.43.0; python_version >= "3.6"
-grpcio==1.43.0; python_version >= "3.6"
+grpcio-status==1.43.0; python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
+grpcio==1.43.0; python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 httplib2==0.20.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
-idna==3.3; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.5"
+idna==3.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 packaging==21.3; python_version >= "3.6"
 proto-plus==1.19.8; python_version >= "3.6"
-protobuf==3.19.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+protobuf==3.19.3; python_version >= "3.6" and python_full_version < "3.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") or python_full_version >= "3.6.0" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 pyasn1-modules==0.2.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 pyasn1==0.4.8; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") or python_full_version >= "3.6.0" and python_version >= "3.6" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 pyparsing==3.0.6; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
@@ -30,6 +30,6 @@ ratelimiter==1.2.0.post0
 requests==2.27.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 retrying==1.3.3
 rsa==4.8; python_version >= "3.6" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
-six==1.16.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+six==1.16.0; python_version >= "3.6" and python_full_version < "3.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") or python_full_version >= "3.6.0" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 uritemplate==4.1.1; python_version >= "3.6"
-urllib3==1.26.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4"
+urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"

--- a/tools/c7n_sphinxext/poetry.lock
+++ b/tools/c7n_sphinxext/poetry.lock
@@ -194,7 +194,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 name = "importlib-resources"
 version = "5.4.0"
 description = "Read resources from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -622,7 +622,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "906cec7b692a35eca4ecb738ea5d6d971de1cf47fb5157e9cb5d2060c7b265fc"
+content-hash = "66195e57ed6b6e0b817d976ea88b9071b8ac50f633faf329bb8db5e7b0d48c67"
 
 [metadata.files]
 alabaster = [

--- a/tools/c7n_sphinxext/pyproject.toml
+++ b/tools/c7n_sphinxext/pyproject.toml
@@ -28,6 +28,7 @@ myst-parser = "^0.15.2"
 click = "^8.0"
 typing-extensions = "^3.7.4"
 docutils = ">=0.14,<0.18"
+importlib-resources = "^5.4.0"
 
 [tool.poetry.dev-dependencies]
 c7n = {path = "../..", develop = true}

--- a/tools/c7n_sphinxext/requirements.txt
+++ b/tools/c7n_sphinxext/requirements.txt
@@ -10,6 +10,7 @@ docutils==0.17.1; (python_version >= "2.7" and python_full_version < "3.0.0") or
 idna==3.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 imagesize==1.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 importlib-metadata==4.10.1; python_version < "3.8" and python_version >= "3.7" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6")
+importlib-resources==5.4.0; python_version >= "3.6"
 jinja2==3.0.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 markdown-it-py==1.1.0; python_version >= "3.6" and python_version < "4.0"
 markdown==3.0.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"

--- a/tools/c7n_sphinxext/requirements.txt
+++ b/tools/c7n_sphinxext/requirements.txt
@@ -35,4 +35,4 @@ sphinxcontrib-qthelp==1.0.3; python_version >= "3.6" and python_full_version < "
 sphinxcontrib-serializinghtml==1.1.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 typing-extensions==3.10.0.2
 urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
-zipp==3.7.0; python_version < "3.10" and python_version >= "3.7"
+zipp==3.7.0; python_version < "3.8" and python_version >= "3.7"


### PR DESCRIPTION
- Update generated `requirements.txt` files with the output of `make pkg-gen-requirements` using Poetry 1.1.12.
- Add `importlib-resources` to the c7n_sphinxext pyproject.toml

This may still need a couple tweaks or additions, but these changes were enough to get `tox -e docs` working again at least for me. Looking to get input from others...

Addresses #7097 