### PR TITLE
feat: support s3 url for policy location

### DIFF
--- a/c7n/loader.py
+++ b/c7n/loader.py
@@ -7,19 +7,21 @@ except ImportError:
     from backports.functools_lru_cache import lru_cache
 
 import logging
-import re
 import os
+import re
 
 from c7n.exceptions import PolicyValidationError
 from c7n.policy import PolicyCollection
 from c7n.resources import load_resources
+
 try:
     from c7n import schema
 except ImportError:
     # serverless execution doesn't use jsonschema
     schema = None
+from c7n.policy import get_session_factory
 from c7n.structure import StructureParser
-from c7n.utils import load_file
+from c7n.utils import load_file as load_file_util
 
 
 class SchemaValidator:
@@ -88,10 +90,16 @@ class PolicyLoader:
         self.seen_types = set()
 
     def load_file(self, file_path, format=None):
-        # should we do os.path.expanduser here?
-        if not os.path.exists(file_path):
-            raise IOError("Invalid path for config %r" % file_path)
-        policy_data = load_file(file_path, format=format)
+        if file_path.startswith('s3://'):
+            session_factory = get_session_factory('aws', self.policy_config)
+            policy_data = load_file_util(
+                file_path, format=format, session_factory=session_factory
+            )
+        else:
+            # should we do os.path.expanduser here?
+            if not os.path.exists(file_path):
+                raise IOError("Invalid path for config %r" % file_path)
+            policy_data = load_file_util(file_path, format=format)
         return self.load_data(policy_data, file_path)
 
     def _handle_missing_resources(self, policy_data, missing):

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -1,26 +1,27 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from datetime import datetime
-import json
 import fnmatch
 import itertools
+import json
 import logging
 import os
 import time
+from datetime import datetime
 
-from dateutil import parser, tz as tzutil
 import jmespath
+from dateutil import parser
+from dateutil import tz as tzutil
 
-from c7n.cwe import CloudWatchEvents
+from c7n import deprecated, utils
 from c7n.ctx import ExecutionContext
-from c7n.exceptions import PolicyValidationError, ClientError, ResourceLimitExceeded
-from c7n.filters import FilterRegistry, And, Or, Not
+from c7n.cwe import CloudWatchEvents
+from c7n.exceptions import ClientError, PolicyValidationError, ResourceLimitExceeded
+from c7n.filters import And, FilterRegistry, Not, Or
 from c7n.manager import iter_filters
 from c7n.output import DEFAULT_NAMESPACE, NullBlobOutput
-from c7n.resources import load_resources
-from c7n.registry import PluginRegistry
 from c7n.provider import clouds, get_resource_class
-from c7n import deprecated, utils
+from c7n.registry import PluginRegistry
+from c7n.resources import load_resources
 from c7n.version import version
 
 log = logging.getLogger('c7n.policy')
@@ -32,7 +33,13 @@ def load(options, path, format=None, validate=True, vars=None):
         raise IOError("Invalid path for config %r" % path)
 
     from c7n.schema import validate, StructureParser
-    data = utils.load_file(path, format=format, vars=vars)
+    session_factory = None
+    if path.startswith('s3://'):
+        session_factory = get_session_factory('aws', options)
+
+    data = utils.load_file(
+        path, format=format, vars=vars, session_factory=session_factory
+    )
 
     structure = StructureParser()
     structure.validate(data)

--- a/poetry.lock
+++ b/poetry.lock
@@ -389,7 +389,7 @@ testing = ["coverage", "nose"]
 
 [[package]]
 name = "placebo"
-version = "0.9.0"
+version = "0.10.0"
 description = "Make boto3 calls that look real but have no effect"
 category = "dev"
 optional = false
@@ -857,7 +857,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "363e4bcaf1d1dc49670628674ebcd243c0f5a43da98629d9e148ade6d7d0fa3a"
+content-hash = "1082619b1f733f6325d37f72e5178ad1df0e12032f01917281579099d18b3775"
 
 [metadata.files]
 argcomplete = [
@@ -1178,7 +1178,7 @@ pkginfo = [
     {file = "pkginfo-1.8.2.tar.gz", hash = "sha256:542e0d0b6750e2e21c20179803e40ab50598d8066d51097a0e382cba9eb02bff"},
 ]
 placebo = [
-    {file = "placebo-0.9.0.tar.gz", hash = "sha256:03157f8527bbc2965b71b88f4a139ef8038618b346787f20d63e3c5da541b047"},
+    {file = "placebo-0.10.0.tar.gz", hash = "sha256:390db04f3f3486790b583dc18cb0bc116f195f196d4e58195adb4bb543ebe0bd"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ docutils = ">=0.14,<0.18"
 [tool.poetry.dev-dependencies]
 pytest = "^6.0.0"
 coverage = "^5.0.3"
-placebo = "^0.9.0"
+placebo = "^0.10.0"
 pytest-xdist = "^2.0"
 pytest-cov = "^2.8.1"
 pytest-terraform = "^0.6.0"

--- a/tests/data/placebo/test_ec2_with_policy_in_s3/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_with_policy_in_s3/ec2.DescribeInstances_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ec2_with_policy_in_s3/s3.GetObject_1.json
+++ b/tests/data/placebo/test_ec2_with_policy_in_s3/s3.GetObject_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 14,
+            "hour": 3,
+            "minute": 38,
+            "second": 37,
+            "microsecond": 0
+        },
+        "ContentLength": 131,
+        "ETag": "\"7516c7bd4df5d768d340c67068b3c123\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGZpbHRlcnM6CiAgLSBTdGF0ZS5OYW1lOiBydW5uaW5nCiAgLSBkYXlzOiAzMAogICAgdHlwZTogc3RhdGUtYWdlCiAgbmFtZTogZWMyLXN0YXRlLXRyYW5zaXRpb24tYWdlCiAgcmVzb3VyY2U6IGVjMgo="
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_with_policy_in_s3/s3.GetObject_2.json
+++ b/tests/data/placebo/test_ec2_with_policy_in_s3/s3.GetObject_2.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 14,
+            "hour": 3,
+            "minute": 38,
+            "second": 37,
+            "microsecond": 0
+        },
+        "ContentLength": 131,
+        "ETag": "\"7516c7bd4df5d768d340c67068b3c123\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGZpbHRlcnM6CiAgLSBTdGF0ZS5OYW1lOiBydW5uaW5nCiAgLSBkYXlzOiAzMAogICAgdHlwZTogc3RhdGUtYWdlCiAgbmFtZTogZWMyLXN0YXRlLXRyYW5zaXRpb24tYWdlCiAgcmVzb3VyY2U6IGVjMgo="
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_with_policy_in_s3/s3.GetObject_3.json
+++ b/tests/data/placebo/test_ec2_with_policy_in_s3/s3.GetObject_3.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 14,
+            "hour": 3,
+            "minute": 38,
+            "second": 38,
+            "microsecond": 0
+        },
+        "ContentLength": 355,
+        "ETag": "\"b404039af88232af6bae77b167544a07\"",
+        "ContentType": "application/json",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "ewogICAgInBvbGljaWVzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImZpbHRlcnMiOiBbCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgIlN0YXRlLk5hbWUiOiAicnVubmluZyIKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgImRheXMiOiAzMCwKICAgICAgICAgICAgICAgICAgICAidHlwZSI6ICJzdGF0ZS1hZ2UiCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIF0sCiAgICAgICAgICAgICJuYW1lIjogImVjMi1zdGF0ZS10cmFuc2l0aW9uLWFnZSIsCiAgICAgICAgICAgICJyZXNvdXJjZSI6ICJlYzIiCiAgICAgICAgfQogICAgXQp9Cg=="
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_1.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 22,
+            "minute": 28,
+            "second": 23,
+            "microsecond": 0
+        },
+        "ContentLength": 156,
+        "ETag": "\"afb43d368d88ec8ad82c8b93847c5850\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGFjdGlvbnM6CiAgLSB0YWdzOgogICAgICBjdXN0b2RpYW5fY2xlYW51cDogJ3llcycKICAgIHR5cGU6IHVudGFnCiAgZmlsdGVyczoKICAtIHRhZzpjdXN0b2RpYW5fdGFnZ2luZzogbm90LW51bGwKICBuYW1lOiBmb28KICByZXNvdXJjZTogczMK"
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_10.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_10.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 23,
+            "minute": 0,
+            "second": 38,
+            "microsecond": 0
+        },
+        "ContentLength": 154,
+        "ETag": "\"3b1121a5e657decc073ccc5c1555f16e\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGFjdGlvbnM6CiAgLSB0YWdzOgogICAgICBjdXN0b2RpYW5fY2xlYW51cDogJ3llcycKICAgIHR5cGU6IHRhZwogIGZpbHRlcnM6CiAgLSB0YWc6Y3VzdG9kaWFuX3RhZ2dpbmc6IG5vdC1udWxsCiAgbmFtZTogZm9vCiAgcmVzb3VyY2U6IHMzCg=="
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_11.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_11.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 23,
+            "minute": 0,
+            "second": 38,
+            "microsecond": 0
+        },
+        "ContentLength": 154,
+        "ETag": "\"3b1121a5e657decc073ccc5c1555f16e\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGFjdGlvbnM6CiAgLSB0YWdzOgogICAgICBjdXN0b2RpYW5fY2xlYW51cDogJ3llcycKICAgIHR5cGU6IHRhZwogIGZpbHRlcnM6CiAgLSB0YWc6Y3VzdG9kaWFuX3RhZ2dpbmc6IG5vdC1udWxsCiAgbmFtZTogZm9vCiAgcmVzb3VyY2U6IHMzCg=="
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_2.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_2.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 22,
+            "minute": 28,
+            "second": 22,
+            "microsecond": 0
+        },
+        "ContentLength": 156,
+        "ETag": "\"afb43d368d88ec8ad82c8b93847c5850\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGFjdGlvbnM6CiAgLSB0YWdzOgogICAgICBjdXN0b2RpYW5fY2xlYW51cDogJ3llcycKICAgIHR5cGU6IHVudGFnCiAgZmlsdGVyczoKICAtIHRhZzpjdXN0b2RpYW5fdGFnZ2luZzogbm90LW51bGwKICBuYW1lOiBmb28KICByZXNvdXJjZTogczMK"
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_3.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_3.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 21,
+            "minute": 31,
+            "second": 43,
+            "microsecond": 0
+        },
+        "ContentLength": 452,
+        "ETag": "\"eac8b948a10434c0c23456ab2c60d6ea\"",
+        "ContentType": "application/json",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "ewogICAgInBvbGljaWVzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImFjdGlvbnMiOiBbCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgInRhZ3MiOiB7CiAgICAgICAgICAgICAgICAgICAgICAgICJjdXN0b2RpYW5fY2xlYW51cCI6ICJ5ZXMiCiAgICAgICAgICAgICAgICAgICAgfSwKICAgICAgICAgICAgICAgICAgICAidHlwZSI6ICJ1bnRhZyIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgXSwKICAgICAgICAgICAgImZpbHRlcnMiOiBbCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgInRhZzpjdXN0b2RpYW5fdGFnZ2luZyI6ICJub3QtbnVsbCIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgXSwKICAgICAgICAgICAgIm5hbWUiOiAiZm9vIiwKICAgICAgICAgICAgInJlc291cmNlIjogInMzIgogICAgICAgIH0KICAgIF0KfQo="
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_4.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_4.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Code": "NoSuchKey",
+            "Message": "The specified key does not exist.",
+            "Key": "fake.yaml"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_5.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_5.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Code": "NoSuchBucket",
+            "Message": "The specified bucket does not exist",
+            "BucketName": "not-a-custodian-source-s3"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_6.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_6.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 23,
+            "minute": 0,
+            "second": 38,
+            "microsecond": 0
+        },
+        "ContentLength": 154,
+        "ETag": "\"3b1121a5e657decc073ccc5c1555f16e\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGFjdGlvbnM6CiAgLSB0YWdzOgogICAgICBjdXN0b2RpYW5fY2xlYW51cDogJ3llcycKICAgIHR5cGU6IHRhZwogIGZpbHRlcnM6CiAgLSB0YWc6Y3VzdG9kaWFuX3RhZ2dpbmc6IG5vdC1udWxsCiAgbmFtZTogZm9vCiAgcmVzb3VyY2U6IHMzCg=="
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_7.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_7.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 23,
+            "minute": 0,
+            "second": 38,
+            "microsecond": 0
+        },
+        "ContentLength": 154,
+        "ETag": "\"3b1121a5e657decc073ccc5c1555f16e\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGFjdGlvbnM6CiAgLSB0YWdzOgogICAgICBjdXN0b2RpYW5fY2xlYW51cDogJ3llcycKICAgIHR5cGU6IHRhZwogIGZpbHRlcnM6CiAgLSB0YWc6Y3VzdG9kaWFuX3RhZ2dpbmc6IG5vdC1udWxsCiAgbmFtZTogZm9vCiAgcmVzb3VyY2U6IHMzCg=="
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_8.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_8.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 23,
+            "minute": 0,
+            "second": 38,
+            "microsecond": 0
+        },
+        "ContentLength": 450,
+        "ETag": "\"8ac44610f8b4fb1c620e1b230c3ab31a\"",
+        "ContentType": "application/json",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "ewogICAgInBvbGljaWVzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImFjdGlvbnMiOiBbCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgInRhZ3MiOiB7CiAgICAgICAgICAgICAgICAgICAgICAgICJjdXN0b2RpYW5fY2xlYW51cCI6ICJ5ZXMiCiAgICAgICAgICAgICAgICAgICAgfSwKICAgICAgICAgICAgICAgICAgICAidHlwZSI6ICJ0YWciCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIF0sCiAgICAgICAgICAgICJmaWx0ZXJzIjogWwogICAgICAgICAgICAgICAgewogICAgICAgICAgICAgICAgICAgICJ0YWc6Y3VzdG9kaWFuX3RhZ2dpbmciOiAibm90LW51bGwiCiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIF0sCiAgICAgICAgICAgICJuYW1lIjogImZvbyIsCiAgICAgICAgICAgICJyZXNvdXJjZSI6ICJzMyIKICAgICAgICB9CiAgICBdCn0K"
+        }
+    }
+}

--- a/tests/data/placebo/validate_with_s3/s3.GetObject_9.json
+++ b/tests/data/placebo/validate_with_s3/s3.GetObject_9.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "AcceptRanges": "bytes",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 13,
+            "hour": 23,
+            "minute": 0,
+            "second": 38,
+            "microsecond": 0
+        },
+        "ContentLength": 154,
+        "ETag": "\"3b1121a5e657decc073ccc5c1555f16e\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "LS0tCnBvbGljaWVzOgotIGFjdGlvbnM6CiAgLSB0YWdzOgogICAgICBjdXN0b2RpYW5fY2xlYW51cDogJ3llcycKICAgIHR5cGU6IHRhZwogIGZpbHRlcnM6CiAgLSB0YWc6Y3VzdG9kaWFuX3RhZ2dpbmc6IG5vdC1udWxsCiAgbmFtZTogZm9vCiAgcmVzb3VyY2U6IHMzCg=="
+        }
+    }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,15 +3,16 @@
 import json
 import os
 import sys
-
 from argparse import ArgumentTypeError
 from datetime import datetime, timedelta
 
-from c7n import cli, version, commands
+import pytest
+from c7n import cli, commands, version
 from c7n.resolver import ValuesFrom
 from c7n.resources import aws
+from c7n.resources.aws import AWS
 from c7n.schema import ElementSchema, generate
-from c7n.utils import yaml_dump, yaml_load
+from c7n.utils import NoSuchS3Bucket, NoSuchS3Key, yaml_dump, yaml_load
 
 from .common import BaseTest, TextTestIO
 
@@ -97,8 +98,12 @@ class VersionTest(CliTest):
         self.assertIn('python-dateutil==', output)
 
 
-class ValidateTest(CliTest):
+@pytest.fixture
+def set_aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_PROFILE", "myalt")
 
+
+class ValidateTest(CliTest):
     def test_invalidate_structure_exit(self):
         invalid_policies = {"policies": [{"name": "foo"}]}
         yaml_file = self.write_policy_file(invalid_policies)
@@ -153,6 +158,72 @@ class ValidateTest(CliTest):
 
         # duplicate policy names
         self.run_and_expect_failure(["custodian", "validate", yaml_file, yaml_file], 1)
+
+    @pytest.mark.usefixtures("set_aws")
+    def test_validate_with_policies_in_s3(self):
+
+        session_factory = self.replay_flight_data("validate_with_s3")
+
+        self.patch(
+            AWS,
+            "get_session_factory",
+            staticmethod(lambda x=None: session_factory),
+        )
+
+        # YAML validation
+        self.run_and_expect_exception(
+            ["custodian", "validate", "s3://custodian-source-s3/policy1.yaml"],
+            SystemExit,
+        )
+
+        self.run_and_expect_exception(
+            ["custodian", "validate", "s3://custodian-source-s3/policy1.yml"],
+            SystemExit,
+        )
+
+        # JSON validation
+        self.run_and_expect_failure(
+            ["custodian", "validate", "s3://custodian-source-s3/policy1.json"], 1
+        )
+
+        # nonexistent file given
+        self.run_and_expect_exception(
+            ["custodian", "validate", "s3://custodian-source-s3/fake.yaml"], NoSuchS3Key
+        )
+
+        # nonexistent bucket given
+        self.run_and_expect_exception(
+            ["custodian", "validate", "s3://not-a-custodian-source-s3/fake.yaml"],
+            NoSuchS3Bucket,
+        )
+
+        self.run_and_expect_success(
+            ["custodian", "validate", "s3://custodian-source-s3/policy2.yaml"]
+        )
+
+        self.run_and_expect_success(
+            ["custodian", "validate", "s3://custodian-source-s3/policy2.yml"]
+        )
+
+        self.run_and_expect_success(
+            ["custodian", "validate", "s3://custodian-source-s3/policy2.json"]
+        )
+
+        # legacy -c option
+        self.run_and_expect_success(
+            ["custodian", "validate", "-c", "s3://custodian-source-s3/policy2.yaml"]
+        )
+
+        # duplicate policy names
+        self.run_and_expect_failure(
+            [
+                "custodian",
+                "validate",
+                "s3://custodian-source-s3/policy2.yaml",
+                "s3://custodian-source-s3/policy2.yaml",
+            ],
+            1,
+        )
 
     def test_deprecated(self):
 
@@ -498,6 +569,57 @@ class RunTest(CliTest):
                 "-s",
                 temp_dir,
                 yaml_file,
+            ]
+        )
+
+    @pytest.mark.usefixtures("set_aws")
+    def test_ec2_with_policy_in_s3(self):
+
+        session_factory = self.replay_flight_data(
+            "test_ec2_with_policy_in_s3", region="us-east-1"
+        )
+
+        self.patch(
+            AWS,
+            "get_session_factory",
+            staticmethod(lambda x=None: session_factory),
+        )
+
+        temp_dir = self.get_temp_dir()
+
+        self.run_and_expect_success(
+            [
+                "custodian",
+                "run",
+                "--cache",
+                temp_dir + "/cache",
+                "-s",
+                temp_dir,
+                "s3://custodian-source-s3/policy3.yaml",
+            ]
+        )
+
+        self.run_and_expect_success(
+            [
+                "custodian",
+                "run",
+                "--cache",
+                temp_dir + "/cache",
+                "-s",
+                temp_dir,
+                "s3://custodian-source-s3/policy3.yml",
+            ]
+        )
+
+        self.run_and_expect_success(
+            [
+                "custodian",
+                "run",
+                "--cache",
+                temp_dir + "/cache",
+                "-s",
+                temp_dir,
+                "s3://custodian-source-s3/policy3.json",
             ]
         )
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -12,7 +12,8 @@ from .common import BaseTest, ACCOUNT_ID, Bag
 from .test_s3 import destroyBucket
 
 from c7n.config import Config
-from c7n.resolver import ValuesFrom, URIResolver
+from c7n.resolver import ValuesFrom
+from c7n.utils import URIResolver
 
 
 class FakeCache:

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -1,21 +1,22 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+import base64
 import fnmatch
-from io import StringIO
 import json
 import os
+import re
 import shutil
 import zipfile
-import re
 from datetime import datetime, timedelta, tzinfo
 from distutils.util import strtobool
+from io import BytesIO
 
 import boto3
 import placebo
 from botocore.response import StreamingBody
+from c7n.testing import CustodianTestCore
 from placebo import pill
 
-from c7n.testing import CustodianTestCore
 from .constants import ACCOUNT_ID
 
 # Custodian Test Account. This is used only for testing.
@@ -64,7 +65,10 @@ def deserialize(obj):
     if class_name == "datetime":
         return datetime(tzinfo=utc, **target)
     if class_name == "StreamingBody":
-        return StringIO(target["body"])
+        # https://github.com/garnaat/placebo/pull/79/files
+        b64_body = target['body']
+        decoded_body = base64.b64decode(b64_body)
+        StreamingBody(decoded_body, len(decoded_body))
     # Return unrecognized structures as-is
     return obj
 
@@ -90,11 +94,14 @@ def serialize(obj):
         return result
     if isinstance(obj, StreamingBody):
         result["body"] = obj.read()
-        obj._raw_stream = StringIO(result["body"])
+        # https://github.com/garnaat/placebo/pull/79/files
+        # https://github.com/garnaat/placebo/releases/tag/0.10.0
+        obj._raw_stream = BytesIO(result['body'])
         obj._amount_read = 0
         return result
     if isinstance(obj, bytes):
-        return obj.decode('utf8')
+        encoded = base64.b64encode(obj)
+        return encoded.decode('utf-8')
 
     # Raise a TypeError if the object isn't recognized
     raise TypeError("Type not serializable")
@@ -109,7 +116,6 @@ placebo.pill.deserialize = deserialize
 
 
 class BluePill(pill.Pill):
-
     def playback(self):
         super(BluePill, self).playback()
         self._avail = self.get_available()
@@ -137,7 +143,6 @@ class BluePill(pill.Pill):
 
 
 class ZippedPill(pill.Pill):
-
     def __init__(self, path, prefix=None, debug=False):
         super(ZippedPill, self).__init__(prefix, debug)
         self.path = path
@@ -196,7 +201,8 @@ class ZippedPill(pill.Pill):
             self.archive.read(response_file), object_hook=pill.deserialize
         )
         return (
-            pill.FakeHttpResponse(response_data["status_code"]), response_data["data"]
+            pill.FakeHttpResponse(response_data["status_code"]),
+            response_data["data"],
         )
 
     def get_new_file_path(self, service, operation):
@@ -246,13 +252,11 @@ def attach(session, data_path, prefix=None, debug=False):
 
 
 class RedPill(pill.Pill):
-
     def datetime_converter(self, obj):
         if isinstance(obj, datetime):
             return obj.isoformat()
 
-    def save_response(self, service, operation, response_data,
-                    http_response=200):
+    def save_response(self, service, operation, response_data, http_response=200):
         """
         Override to sanitize response metadata and account_ids
         """
@@ -267,8 +271,9 @@ class RedPill(pill.Pill):
         response_data = re.sub(r"\b\d{12}\b", ACCOUNT_ID, response_data)  # noqa
         response_data = json.loads(response_data, object_hook=deserialize)
 
-        super(RedPill, self).save_response(service, operation, response_data,
-                    http_response)
+        super(RedPill, self).save_response(
+            service, operation, response_data, http_response
+        )
 
 
 class PillTest(CustodianTestCore):
@@ -312,7 +317,6 @@ class PillTest(CustodianTestCore):
         self.addCleanup(self.cleanUp)
 
         class FakeFactory:
-
             def __call__(fake, region=None, assume=None):
                 new_session = None
                 # slightly experimental for test recording, using
@@ -323,13 +327,14 @@ class PillTest(CustodianTestCore):
                 if 0 and (assume is not False and fake.assume_role):
                     client = session.client('sts')
                     creds = client.assume_role(
-                        RoleArn=fake.assume_role,
-                        RoleSessionName='CustodianTest')['Credentials']
+                        RoleArn=fake.assume_role, RoleSessionName='CustodianTest'
+                    )['Credentials']
                     new_session = boto3.Session(
                         aws_access_key_id=creds['AccessKeyId'],
                         aws_secret_access_key=creds['SecretAccessKey'],
                         aws_session_token=creds['SessionToken'],
-                        region_name=region or fake.region or default_region)
+                        region_name=region or fake.region or default_region,
+                    )
                 elif region and region != default_region:
                     new_session = boto3.Session(region_name=region)
 


### PR DESCRIPTION
Aiming to use S3 URLs as a valid location for a policy.

So far includes support for validation and run CLI paths.

The tests pass through `pytest` but are currently failing through `tox` for reasons that aren't immediately clear.