### PR TITLE
aws.vpc - traffic mirror session and target

### DIFF
--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -132,6 +132,8 @@ ResourceMap = {
     "aws.log-metric": "c7n.resources.cw.LogMetric",
     "aws.message-broker": "c7n.resources.mq.MessageBroker",
     "aws.message-config": "c7n.resources.mq.MessageConfig",
+    "aws.mirror-session": "c7n.resources.vpc.TrafficMirrorSession",
+    "aws.mirror-target": "c7n.resources.vpc.TrafficMirrorTarget",
     "aws.ml-model": "c7n.resources.ml.MLModel",
     "aws.nat-gateway": "c7n.resources.vpc.NATGateway",
     "aws.network-acl": "c7n.resources.vpc.NetworkAcl",

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2575,3 +2575,51 @@ class Entry(Filter):
                 results.append(r)
                 r[self.match_annotation_key] = matched
         return results
+
+
+@resources.register('mirror-session')
+class TrafficMirrorSession(query.QueryResourceManager):
+
+    class resource_type(query.TypeInfo):
+        service = 'ec2'
+        enum_spec = ('describe_traffic_mirror_sessions', 'TrafficMirrorSessions', None)
+        name = id = 'TrafficMirrorSessionId'
+        cfn_type = 'AWS::EC2::TrafficMirrorSession'
+
+
+@TrafficMirrorSession.action_registry.register('delete')
+class Delete(BaseAction):
+    """Action to delete traffic mirror session(s)
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: traffic-mirror-session-paclength
+                resource: mirror-session
+                filters:
+                  - type: value
+                    key: tag:Owner
+                    value: xyz
+                actions:
+                  - delete
+    """
+
+    schema = type_schema('delete')
+    permissions = ('ec2:DeleteTrafficMirrorSession',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('ec2')
+        for r in resources:
+            client.delete_traffic_mirror_session(TrafficMirrorSessionId=r['TrafficMirrorSessionId'])
+
+
+@resources.register('mirror-target')
+class TrafficMirrorTarget(query.QueryResourceManager):
+
+    class resource_type(query.TypeInfo):
+        service = 'ec2'
+        enum_spec = ('describe_traffic_mirror_targets', 'TrafficMirrorTargets', None)
+        name = id = 'TrafficMirrorTargetId'
+        cfn_type = 'AWS::EC2::TrafficMirrorTarget'

--- a/tests/data/placebo/test_traffic_mirror_session_delete/ec2.DeleteTrafficMirrorSession_1.json
+++ b/tests/data/placebo/test_traffic_mirror_session_delete/ec2.DeleteTrafficMirrorSession_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TrafficMirrorSessionId": "tms-084dc356a819e99ae",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_traffic_mirror_session_delete/ec2.DescribeTrafficMirrorSessions_1.json
+++ b/tests/data/placebo/test_traffic_mirror_session_delete/ec2.DescribeTrafficMirrorSessions_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200,
+    "data": {
+        "TrafficMirrorSessions": [
+            {
+                "TrafficMirrorSessionId": "tms-084dc356a819e99ae",
+                "TrafficMirrorTargetId": "tmt-02cc3955d41358894",
+                "TrafficMirrorFilterId": "tmf-003b318669f29b788",
+                "NetworkInterfaceId": "eni-0054f909285935030",
+                "OwnerId": "644160558196",
+                "PacketLength": 19,
+                "SessionNumber": 1,
+                "VirtualNetworkId": 5918387,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "test-session"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_traffic_mirror_session_delete/ec2.DescribeTrafficMirrorSessions_2.json
+++ b/tests/data/placebo/test_traffic_mirror_session_delete/ec2.DescribeTrafficMirrorSessions_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TrafficMirrorSessions": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_traffic_mirror_target/ec2.DescribeTrafficMirrorTargets_1.json
+++ b/tests/data/placebo/test_traffic_mirror_target/ec2.DescribeTrafficMirrorTargets_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "TrafficMirrorTargets": [
+            {
+                "TrafficMirrorTargetId": "tmt-02cc3955d41358894",
+                "NetworkInterfaceId": "eni-06dd77d6d23aa41e5",
+                "Type": "network-interface",
+                "OwnerId": "644160558196",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "pratyush"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -3167,3 +3167,45 @@ class TestPrefixList(BaseTest):
         resources = p.run()
         assert 'c7n:matched-entries' in resources[0]
         assert 'c7n:prefix-entries' in resources[0]
+
+
+class TrafficMirror(BaseTest):
+
+    def test_traffic_mirror_session_delete(self):
+        session_factory = self.replay_flight_data('test_traffic_mirror_session_delete')
+        p = self.load_policy({
+            'name': 'traffic-mirror-session-delete',
+            'resource': 'mirror-session',
+            "filters": [
+                {"tag:Owner": "absent"}
+            ],
+            "actions": [
+                {
+                    "type": "delete"
+                }
+            ],
+        },
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["TrafficMirrorSessionId"], "tms-084dc356a819e99ae")
+        client = session_factory(region="us-east-1").client("ec2")
+        if self.recording:
+            time.sleep(5)
+        self.assertEqual(
+            client.describe_traffic_mirror_sessions().get('TrafficMirrorSessions'), [])
+
+    def test_traffic_mirror_target(self):
+        session_factory = self.replay_flight_data('test_traffic_mirror_target')
+        p = self.load_policy({
+            'name': 'traffic-mirror-target',
+            'resource': 'mirror-target',
+            "filters": [
+                {"tag:Owner": "present"}
+            ],
+        },
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["TrafficMirrorTargetId"], "tmt-02cc3955d41358894")
+        self.assertEqual(resources[0]['Tags'], [{"Key": "Owner", "Value": "pratyush"}])


### PR DESCRIPTION
Closes #5295

This PR adds 2 new resource type: mirror-session and mirror-target. 
The goal is to enforce tags and ownership of these resources. It also adds a delete action for mirror-session. 
Mirror-targets cannot be deleted when they are tied to a session which is why I skipped the delete action for it.

