### PR TITLE
azure - add initial defender resources

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/defender.py
+++ b/tools/c7n_azure/c7n_azure/resources/defender.py
@@ -8,8 +8,12 @@ from c7n_azure.provider import resources
 from c7n_azure.query import QueryResourceManager, QueryMeta, TypeInfo
 
 
-class SecurityResourceManager(QueryResourceManager):
-    """Manager for Security Center resources
+class DefenderResourceManager(QueryResourceManager):
+    """Manager for Microsoft Defender resources
+
+    Note: The "Microsoft Defender for Cloud" name replaces and
+    consolidates products previously called Azure Security Center
+    and Azure Defender.
 
     The Azure Security SDK takes different arguments for its
     SecurityCenter client than other service SDKs use.
@@ -41,13 +45,13 @@ class SecurityResourceManager(QueryResourceManager):
 
 
 @resources.register("defender-pricing")
-class DefenderPricing(SecurityResourceManager, metaclass=QueryMeta):
-    """Active Azure Defender pricing details for supported resources.
+class DefenderPricing(DefenderResourceManager, metaclass=QueryMeta):
+    """Active Microsoft Defender pricing details for supported resources.
 
     :example:
 
     Check if the Key Vaults resource is operating under the Standard
-    pricing tier. This equates to Azure Defender being "On" in some
+    pricing tier. This equates to Microsoft Defender being "On" in some
     security assessments.
 
     .. code-block:: yaml
@@ -73,12 +77,12 @@ class DefenderPricing(SecurityResourceManager, metaclass=QueryMeta):
 
 
 @resources.register("defender-setting")
-class DefenderSetting(SecurityResourceManager, metaclass=QueryMeta):
-    """Top-level Azure Defender settings for a subscription.
+class DefenderSetting(DefenderResourceManager, metaclass=QueryMeta):
+    """Top-level Microsoft Defender settings for a subscription.
 
     :example:
 
-    Check that the MCAS integration with Azure Defender is enabled.
+    Check that the MCAS integration with Microsoft Defender is enabled.
 
     .. code-block:: yaml
 
@@ -104,12 +108,12 @@ class DefenderSetting(SecurityResourceManager, metaclass=QueryMeta):
 
 
 @resources.register("defender-autoprovisioning")
-class DefenderAutoProvisioningSetting(SecurityResourceManager, metaclass=QueryMeta):
-    """Auto-provisioning settings for Azure Defender agents.
+class DefenderAutoProvisioningSetting(DefenderResourceManager, metaclass=QueryMeta):
+    """Auto-provisioning settings for Microsoft Defender agents.
 
     :example:
 
-    Check that auto-provisioning is enabled for the Azure Defender monitoring agent.
+    Check that auto-provisioning is enabled for the Microsoft Defender monitoring agent.
 
     .. code-block:: yaml
 

--- a/tools/c7n_azure/c7n_azure/resources/defender.py
+++ b/tools/c7n_azure/c7n_azure/resources/defender.py
@@ -1,0 +1,129 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+import jmespath
+import requests
+from azure.mgmt.security import SecurityCenter
+
+from c7n.utils import local_session
+from c7n_azure.constants import RESOURCE_GLOBAL_MGMT
+from c7n_azure.provider import resources
+from c7n_azure.query import QueryResourceManager, QueryMeta, TypeInfo
+
+
+class SecurityResourceManager(QueryResourceManager):
+    """Manager for Security Center resources
+
+    The Azure Security SDK takes different arguments for its
+    SecurityCenter client than other service SDKs use. Notably, it
+    takes an `asc_location` which comes from the `locations` API.
+
+    We can override client creation here to use a subscription's
+    home region, which should help simplify individual Defender
+    resource definitions.
+    """
+
+    def get_client(self):
+        session = local_session(self.session_factory)
+        credentials = session.get_credentials()
+        token = credentials.get_token(RESOURCE_GLOBAL_MGMT + '.default')
+        locations_path = f'/subscriptions/{session.subscription_id}/providers/Microsoft.Security/locations/'
+        api_version = session.resource_api_version(locations_path)
+        response = requests.get(
+            f'{RESOURCE_GLOBAL_MGMT}/{locations_path}?api-version={api_version}',
+            headers={'Authorization': f'Bearer {token.token}'})
+        home_region = jmespath.search('value[].properties.homeRegionName|[0]', response.json())
+        return SecurityCenter(credentials, session.subscription_id, home_region)
+
+
+@resources.register('defender-pricing')
+class DefenderPricing(SecurityResourceManager, metaclass=QueryMeta):
+    """Active Azure Defender pricing details for supported resources.
+
+    :example:
+
+    Check if the Key Vaults resource is operating under the Standard
+    pricing tier. This equates to Azure Defender being "On" in some
+    security assessments.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: azure-defender-keyvaults-enabled
+            resource: azure.defender-pricing
+            filters:
+              - name: KeyVaults
+              - properties.pricingTier: Standard
+    """
+
+    class resource_type(TypeInfo):
+        doc_groups = ['Security']
+
+        id = 'id'
+        name = 'name'
+        enum_spec = ('pricings', 'list', None)
+        client = 'SecurityCenter'
+        filter_name = None
+        service = 'security'
+        resource_type = 'Microsoft.Security/pricings'
+
+
+@resources.register('defender-setting')
+class DefenderSetting(SecurityResourceManager, metaclass=QueryMeta):
+    """Top-level Azure Defender settings for a subscription.
+
+    :example:
+
+    Check that the MCAS integration with Azure Defender is enabled.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: azure-defender-mcas-enabled
+            resource: azure.defender-setting
+            filters:
+            - name: MCAS
+            - kind: DataExportSettings
+            - properties.enabled: True
+    """
+
+    class resource_type(TypeInfo):
+        doc_groups = ['Security']
+
+        id = 'id'
+        name = 'name'
+        enum_spec = ('settings', 'list', None)
+        client = 'SecurityCenter'
+        filter_name = None
+        service = 'security'
+        resource_type = 'Microsoft.Security/settings'
+
+
+@resources.register('defender-autoprovisioning')
+class DefenderAutoProvisioningSetting(SecurityResourceManager, metaclass=QueryMeta):
+    """Auto-provisioning settings for Azure Defender agents.
+
+    :example:
+
+    Check that auto-provisioning is enabled for the Azure Defender monitoring agent.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: azure-defender-auto-provisioning-enabled
+            resource: azure.defender-autoprovisioning
+            filters:
+            - name: default
+            - properties.autoProvision: "On"
+    """
+
+    class resource_type(TypeInfo):
+        doc_groups = ['Security']
+
+        id = 'id'
+        name = 'name'
+        enum_spec = ('auto_provisioning_settings', 'list', None)
+        client = 'SecurityCenter'
+        filter_name = None
+        service = 'security'
+        resource_type = 'Microsoft.Security/autoProvisioningSettings'

--- a/tools/c7n_azure/c7n_azure/resources/defender.py
+++ b/tools/c7n_azure/c7n_azure/resources/defender.py
@@ -39,7 +39,8 @@ class SecurityResourceManager(QueryResourceManager):
         # [^3]: https://github.com/Azure/azure-cli/pull/7917#discussion_r238458818  # noqa
         return SecurityCenter(session.get_credentials(), session.subscription_id, "centralus")
 
-@resources.register('defender-pricing')
+
+@resources.register("defender-pricing")
 class DefenderPricing(SecurityResourceManager, metaclass=QueryMeta):
     """Active Azure Defender pricing details for supported resources.
 
@@ -60,18 +61,18 @@ class DefenderPricing(SecurityResourceManager, metaclass=QueryMeta):
     """
 
     class resource_type(TypeInfo):
-        doc_groups = ['Security']
+        doc_groups = ["Security"]
 
-        id = 'id'
-        name = 'name'
-        enum_spec = ('pricings', 'list', None)
-        client = 'SecurityCenter'
+        id = "id"
+        name = "name"
+        enum_spec = ("pricings", "list", None)
+        client = "SecurityCenter"
         filter_name = None
-        service = 'security'
-        resource_type = 'Microsoft.Security/pricings'
+        service = "security"
+        resource_type = "Microsoft.Security/pricings"
 
 
-@resources.register('defender-setting')
+@resources.register("defender-setting")
 class DefenderSetting(SecurityResourceManager, metaclass=QueryMeta):
     """Top-level Azure Defender settings for a subscription.
 
@@ -91,18 +92,18 @@ class DefenderSetting(SecurityResourceManager, metaclass=QueryMeta):
     """
 
     class resource_type(TypeInfo):
-        doc_groups = ['Security']
+        doc_groups = ["Security"]
 
-        id = 'id'
-        name = 'name'
-        enum_spec = ('settings', 'list', None)
-        client = 'SecurityCenter'
+        id = "id"
+        name = "name"
+        enum_spec = ("settings", "list", None)
+        client = "SecurityCenter"
         filter_name = None
-        service = 'security'
-        resource_type = 'Microsoft.Security/settings'
+        service = "security"
+        resource_type = "Microsoft.Security/settings"
 
 
-@resources.register('defender-autoprovisioning')
+@resources.register("defender-autoprovisioning")
 class DefenderAutoProvisioningSetting(SecurityResourceManager, metaclass=QueryMeta):
     """Auto-provisioning settings for Azure Defender agents.
 
@@ -121,12 +122,12 @@ class DefenderAutoProvisioningSetting(SecurityResourceManager, metaclass=QueryMe
     """
 
     class resource_type(TypeInfo):
-        doc_groups = ['Security']
+        doc_groups = ["Security"]
 
-        id = 'id'
-        name = 'name'
-        enum_spec = ('auto_provisioning_settings', 'list', None)
-        client = 'SecurityCenter'
+        id = "id"
+        name = "name"
+        enum_spec = ("auto_provisioning_settings", "list", None)
+        client = "SecurityCenter"
         filter_name = None
-        service = 'security'
-        resource_type = 'Microsoft.Security/autoProvisioningSettings'
+        service = "security"
+        resource_type = "Microsoft.Security/autoProvisioningSettings"

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -51,7 +51,7 @@ ResourceMap = {
     "azure.search": "c7n_azure.resources.search.SearchService",
     "azure.defender-pricing": "c7n_azure.resources.defender.DefenderPricing",
     "azure.defender-setting": "c7n_azure.resources.defender.DefenderSetting",
-    "azure.defender-autoprovisioning": "c7n_azure.resources.defender.DefenderAutoProvisioningSetting",
+    "azure.defender-autoprovisioning": "c7n_azure.resources.defender.DefenderAutoProvisioningSetting",  # noqa
     "azure.service-fabric-cluster": "c7n_azure.resources.service_fabric.ServiceFabricCluster",
     "azure.service-fabric-cluster-managed": "c7n_azure.resources.service_fabric.ServiceFabricClusterManaged",  # noqa
     "azure.sql-database": "c7n_azure.resources.sqldatabase.SqlDatabase",

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -21,6 +21,9 @@ ResourceMap = {
     "azure.databricks": "c7n_azure.resources.databricks.Databricks",
     "azure.datafactory": "c7n_azure.resources.data_factory.DataFactory",
     "azure.datalake": "c7n_azure.resources.datalake_store.DataLakeStore",
+    "azure.defender-autoprovisioning": "c7n_azure.resources.defender.DefenderAutoProvisioningSetting",  # noqa
+    "azure.defender-pricing": "c7n_azure.resources.defender.DefenderPricing",
+    "azure.defender-setting": "c7n_azure.resources.defender.DefenderSetting",
     "azure.disk": "c7n_azure.resources.disk.Disk",
     "azure.dnszone": "c7n_azure.resources.dns_zone.DnsZone",
     "azure.eventhub": "c7n_azure.resources.event_hub.EventHub",
@@ -49,9 +52,6 @@ ResourceMap = {
     "azure.roledefinition": "c7n_azure.resources.access_control.RoleDefinition",
     "azure.routetable": "c7n_azure.resources.route_table.RouteTable",
     "azure.search": "c7n_azure.resources.search.SearchService",
-    "azure.defender-pricing": "c7n_azure.resources.defender.DefenderPricing",
-    "azure.defender-setting": "c7n_azure.resources.defender.DefenderSetting",
-    "azure.defender-autoprovisioning": "c7n_azure.resources.defender.DefenderAutoProvisioningSetting",  # noqa
     "azure.service-fabric-cluster": "c7n_azure.resources.service_fabric.ServiceFabricCluster",
     "azure.service-fabric-cluster-managed": "c7n_azure.resources.service_fabric.ServiceFabricClusterManaged",  # noqa
     "azure.sql-database": "c7n_azure.resources.sqldatabase.SqlDatabase",

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -49,6 +49,9 @@ ResourceMap = {
     "azure.roledefinition": "c7n_azure.resources.access_control.RoleDefinition",
     "azure.routetable": "c7n_azure.resources.route_table.RouteTable",
     "azure.search": "c7n_azure.resources.search.SearchService",
+    "azure.defender-pricing": "c7n_azure.resources.defender.DefenderPricing",
+    "azure.defender-setting": "c7n_azure.resources.defender.DefenderSetting",
+    "azure.defender-autoprovisioning": "c7n_azure.resources.defender.DefenderAutoProvisioningSetting",
     "azure.service-fabric-cluster": "c7n_azure.resources.service_fabric.ServiceFabricCluster",
     "azure.service-fabric-cluster-managed": "c7n_azure.resources.service_fabric.ServiceFabricClusterManaged",  # noqa
     "azure.sql-database": "c7n_azure.resources.sqldatabase.SqlDatabase",

--- a/tools/c7n_azure/poetry.lock
+++ b/tools/c7n_azure/poetry.lock
@@ -679,6 +679,19 @@ azure-mgmt-core = ">=1.2.0,<2.0.0"
 msrest = ">=0.5.0"
 
 [[package]]
+name = "azure-mgmt-security"
+version = "1.0.0"
+description = "Microsoft Azure Security Center Management Client Library for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+azure-common = ">=1.1,<2.0"
+azure-mgmt-core = ">=1.2.0,<2.0.0"
+msrest = ">=0.5.0"
+
+[[package]]
 name = "azure-mgmt-servicefabric"
 version = "1.0.0"
 description = "Microsoft Azure Service Fabric Management Client Library for Python"
@@ -1423,7 +1436,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f5b2e8745a847ee4d1388ac04d155aa0b995303f99374124988a07fb45c0a565"
+content-hash = "6555ab1c2575e37b68fde3697e992bc23a0e9b5f70c125df6c2a965372bdff13"
 
 [metadata.files]
 adal = [
@@ -1633,6 +1646,10 @@ azure-mgmt-resourcegraph = [
 azure-mgmt-search = [
     {file = "azure-mgmt-search-8.0.0.zip", hash = "sha256:a96d50c88507233a293e757202deead980c67808f432b8e897c4df1ca088da7e"},
     {file = "azure_mgmt_search-8.0.0-py2.py3-none-any.whl", hash = "sha256:cfb9687d5c947a3287564980ac933bc2a566f212be73fb323e3278636b8e9751"},
+]
+azure-mgmt-security = [
+    {file = "azure-mgmt-security-1.0.0.zip", hash = "sha256:ae1cff598dfe80e93406e524c55c3f2cbffced9f9b7a5577e3375008a4c3bcad"},
+    {file = "azure_mgmt_security-1.0.0-py2.py3-none-any.whl", hash = "sha256:1f7d98e6c3c6623619bb57ff71105e6e8f2f2a82dc820028246a5bea5a915d38"},
 ]
 azure-mgmt-servicefabric = [
     {file = "azure-mgmt-servicefabric-1.0.0.zip", hash = "sha256:de35e117912832c1a9e93109a8d24cab94f55703a9087b2eb1c5b0655b3b1913"},

--- a/tools/c7n_azure/pyproject.toml
+++ b/tools/c7n_azure/pyproject.toml
@@ -82,6 +82,7 @@ jmespath = "^0.10.0"
 azure-mgmt-servicefabric = "^1.0.0"
 azure-mgmt-trafficmanager = "^0.51.0"
 azure-mgmt-frontdoor = "^1.0.0"
+azure-mgmt-security = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 # setup custodian as a dev dependency

--- a/tools/c7n_azure/tests_azure/cassettes/DefenderTest.test_azure_defender_autoprovisioning.json
+++ b/tools/c7n_azure/tests_azure/cassettes/DefenderTest.test_azure_defender_autoprovisioning.json
@@ -1,0 +1,53 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/autoProvisioningSettings?api-version=2017-08-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Wed, 23 Feb 2022 05:32:38 GMT"
+                    ],
+                    "api-supported-versions": [
+                        "1.0"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "749"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "240"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/autoProvisioningSettings/default",
+                                "name": "default",
+                                "type": "Microsoft.Security/autoProvisioningSettings",
+                                "properties": {
+                                    "autoProvision": "On"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/DefenderTest.test_azure_defender_pricing.json
+++ b/tools/c7n_azure/tests_azure/cassettes/DefenderTest.test_azure_defender_pricing.json
@@ -1,0 +1,161 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings?api-version=2018-06-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Wed, 23 Feb 2022 05:27:37 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "749"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "api-supported-versions": [
+                        "1.0"
+                    ],
+                    "content-length": [
+                        "3049"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/VirtualMachines",
+                                "name": "VirtualMachines",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/SqlServers",
+                                "name": "SqlServers",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/AppServices",
+                                "name": "AppServices",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/StorageAccounts",
+                                "name": "StorageAccounts",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/SqlServerVirtualMachines",
+                                "name": "SqlServerVirtualMachines",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/KubernetesService",
+                                "name": "KubernetesService",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S",
+                                    "deprecated": true,
+                                    "replacedBy": [
+                                        "Containers"
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/ContainerRegistry",
+                                "name": "ContainerRegistry",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S",
+                                    "deprecated": true,
+                                    "replacedBy": [
+                                        "Containers"
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/KeyVaults",
+                                "name": "KeyVaults",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/Dns",
+                                "name": "Dns",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/Arm",
+                                "name": "Arm",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Standard",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/OpenSourceRelationalDatabases",
+                                "name": "OpenSourceRelationalDatabases",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Free",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/pricings/Containers",
+                                "name": "Containers",
+                                "type": "Microsoft.Security/pricings",
+                                "properties": {
+                                    "pricingTier": "Free",
+                                    "freeTrialRemainingTime": "PT0S"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/DefenderTest.test_azure_defender_setting.json
+++ b/tools/c7n_azure/tests_azure/cassettes/DefenderTest.test_azure_defender_setting.json
@@ -1,0 +1,63 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/settings?api-version=2019-01-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Wed, 23 Feb 2022 05:32:41 GMT"
+                    ],
+                    "api-supported-versions": [
+                        "1.0"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "749"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "439"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/settings/MCAS",
+                                "name": "MCAS",
+                                "type": "Microsoft.Security/settings",
+                                "kind": "DataExportSettings",
+                                "properties": {
+                                    "enabled": true
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/settings/WDATP",
+                                "name": "WDATP",
+                                "type": "Microsoft.Security/settings",
+                                "kind": "DataExportSettings",
+                                "properties": {
+                                    "enabled": true
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_defender.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_defender.py
@@ -1,0 +1,47 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from ..azure_common import BaseTest
+
+
+class DefenderTest(BaseTest):
+    def test_azure_defender_pricing(self):
+        p = self.load_policy(
+            {
+                "name": "test-azure-defender-pricing",
+                "resource": "azure.defender-pricing",
+                "filters": [
+                    {"name": "KeyVaults"},
+                ],
+            }
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_azure_defender_setting(self):
+        p = self.load_policy(
+            {
+                "name": "test-azure-defender-setting",
+                "resource": "azure.defender-setting",
+                "filters": [
+                    {"name": "MCAS"},
+                    {"kind": "DataExportSettings"},
+                    {"properties.enabled": True},
+                ],
+            }
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_azure_defender_autoprovisioning(self):
+        p = self.load_policy(
+            {
+                "name": "test-azure-defender-autoprovisioning",
+                "resource": "azure.defender-autoprovisioning",
+                "filters": [
+                    {"name": "default"},
+                    {"properties.autoProvision": "On"},
+                ],
+            }
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
This is partly addressing #7116 , and partly me figuring out the flow of adding Azure resources. High-level:

- Add the package dependency we need to manage Defender (Security Center) resources
- Add resource types under the Defender umbrella
  - The SDK breaks these out into separate resource types (pricing, settings, auto-provisioning settings...). We may want to reorganize them, but for a first pass I tried to follow existing conventions.

The client creation for Defender resources looked different from any other Azure service client examples I saw. I'm not sure how much this is "Defender is different" and how much is "I haven't looked at enough Azure stuff". I stole the Azure CLI's approach though - it was much simpler than my first attempt.