### PR TITLE
ebs snapshot with description

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1332,7 +1332,8 @@ class CreateSnapshot(BaseAction):
         'snapshot',
         **{'copy-tags': {'type': 'array', 'items': {'type': 'string'}},
            'copy-volume-tags': {'type': 'boolean'},
-           'tags': {'type': 'object'}})
+           'tags': {'type': 'object'},
+           'description': {'type': 'string'}})
     permissions = ('ec2:CreateSnapshot', 'ec2:CreateTags',)
 
     def validate(self):
@@ -1352,8 +1353,16 @@ class CreateSnapshot(BaseAction):
             retry(self.process_volume, client=client, volume=vol_id, tags=tags)
 
     def process_volume(self, client, volume, tags):
+        description = self.data.get('description')
+        if not description:
+            description = "Automated snapshot by c7n of %s" % (volume)
+
         try:
-            client.create_snapshot(VolumeId=volume, TagSpecifications=tags)
+            client.create_snapshot(
+                VolumeId=volume,
+                Description=description,
+                TagSpecifications=tags
+            )
         except ClientError as e:
             if e.response['Error']['Code'] == 'InvalidVolume.NotFound':
                 return

--- a/tests/data/placebo/test_ebs_snapshot_default_description/ec2.CreateSnapshot_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_default_description/ec2.CreateSnapshot_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Description": "Automated snapshot by c7n of vol-0cc137cb158adbc32",
+        "Encrypted": true,
+        "OwnerId": "644160558196",
+        "Progress": "",
+        "SnapshotId": "snap-034e3ccff9379ed58",
+        "StartTime": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 28,
+            "hour": 18,
+            "minute": 56,
+            "second": 17,
+            "microsecond": 80000
+        },
+        "State": "pending",
+        "VolumeId": "vol-0cc137cb158adbc32",
+        "VolumeSize": 100,
+        "Tags": [
+            {
+                "Key": "custodian_snapshot",
+                "Value": ""
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_default_description/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_default_description/ec2.DescribeSnapshots_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "Snapshots": [
+            {
+                "Description": "Automated snapshot by c7n of vol-0cc137cb158adbc32",
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/f6d98445-ca15-466d-8552-95397d4ab83d",
+                "OwnerId": "644160558196",
+                "Progress": "100%",
+                "SnapshotId": "snap-034e3ccff9379ed58",
+                "StartTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 2,
+                    "day": 28,
+                    "hour": 18,
+                    "minute": 56,
+                    "second": 17,
+                    "microsecond": 80000
+                },
+                "State": "completed",
+                "VolumeId": "vol-0cc137cb158adbc32",
+                "VolumeSize": 100,
+                "Tags": [
+                    {
+                        "Key": "custodian_snapshot",
+                        "Value": ""
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_default_description/ec2.DescribeVolumes_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_default_description/ec2.DescribeVolumes_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "Volumes": [
+            {
+                "Attachments": [],
+                "AvailabilityZone": "us-east-1a",
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 2,
+                    "day": 28,
+                    "hour": 18,
+                    "minute": 47,
+                    "second": 57,
+                    "microsecond": 281000
+                },
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/f6d98445-ca15-466d-8552-95397d4ab83d",
+                "Size": 100,
+                "SnapshotId": "",
+                "State": "available",
+                "VolumeId": "vol-0cc137cb158adbc32",
+                "Iops": 300,
+                "VolumeType": "gp2",
+                "MultiAttachEnabled": false
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_description/ec2.CreateSnapshot_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_description/ec2.CreateSnapshot_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "Description": "snapshot description",
+        "Encrypted": true,
+        "OwnerId": "644160558196",
+        "Progress": "",
+        "SnapshotId": "snap-00551541dada3dacd",
+        "StartTime": {
+            "__class__": "datetime",
+            "year": 2022,
+            "month": 2,
+            "day": 28,
+            "hour": 18,
+            "minute": 51,
+            "second": 32,
+            "microsecond": 245000
+        },
+        "State": "pending",
+        "VolumeId": "vol-0cc137cb158adbc32",
+        "VolumeSize": 100,
+        "Tags": [
+            {
+                "Key": "custodian_snapshot",
+                "Value": ""
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_description/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_description/ec2.DescribeSnapshots_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "Snapshots": [
+            {
+                "Description": "snapshot description",
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/f6d98445-ca15-466d-8552-95397d4ab83d",
+                "OwnerId": "644160558196",
+                "Progress": "100%",
+                "SnapshotId": "snap-00551541dada3dacd",
+                "StartTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 2,
+                    "day": 28,
+                    "hour": 18,
+                    "minute": 51,
+                    "second": 32,
+                    "microsecond": 245000
+                },
+                "State": "completed",
+                "VolumeId": "vol-0cc137cb158adbc32",
+                "VolumeSize": 100,
+                "Tags": [
+                    {
+                        "Key": "custodian_snapshot",
+                        "Value": ""
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_description/ec2.DescribeVolumes_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_description/ec2.DescribeVolumes_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "Volumes": [
+            {
+                "Attachments": [],
+                "AvailabilityZone": "us-east-1a",
+                "CreateTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 2,
+                    "day": 28,
+                    "hour": 18,
+                    "minute": 47,
+                    "second": 57,
+                    "microsecond": 281000
+                },
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/f6d98445-ca15-466d-8552-95397d4ab83d",
+                "Size": 100,
+                "SnapshotId": "",
+                "State": "available",
+                "VolumeId": "vol-0cc137cb158adbc32",
+                "Iops": 300,
+                "VolumeType": "gp2",
+                "MultiAttachEnabled": false
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -658,6 +658,44 @@ class VolumeSnapshotTest(BaseTest):
         for s in snapshot_data['Snapshots']:
             self.assertEqual({'test-tag': 'custodian'}, {t['Key']: t['Value'] for t in s['Tags']})
 
+    def test_volume_snapshot_description(self):
+        factory = self.replay_flight_data("test_ebs_snapshot_description")
+        policy = self.load_policy(
+            {
+                "name": "ebs-test-snapshot",
+                "resource": "ebs",
+                "filters": [{"VolumeId": "vol-0cc137cb158adbc32"}],
+                "actions": [{"type": "snapshot",
+                             "description": "snapshot description"}]
+            },
+            session_factory=factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        snapshot_data = factory().client("ec2").describe_snapshots(
+            Filters=[{"Name": "volume-id", "Values": ["vol-0cc137cb158adbc32"]}]
+        )
+        for s in snapshot_data['Snapshots']:
+            self.assertEqual('snapshot description', s['Description'])
+
+    def test_volume_snapshot_default_description(self):
+        factory = self.replay_flight_data("test_ebs_snapshot_default_description")
+        policy = self.load_policy(
+            {
+                "name": "ebs-test-snapshot",
+                "resource": "ebs",
+                "filters": [{"VolumeId": "vol-0cc137cb158adbc32"}],
+                "actions": [{"type": "snapshot"}]
+            },
+            session_factory=factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        snapshot_data = factory().client("ec2").describe_snapshots(
+            Filters=[{"Name": "volume-id", "Values": ["vol-0cc137cb158adbc32"]}]
+        )
+        for s in snapshot_data['Snapshots']:
+            self.assertEqual('Automated snapshot by c7n of vol-0cc137cb158adbc32', s['Description'])
 
 class VolumeDeleteTest(BaseTest):
 


### PR DESCRIPTION
Updated ebs snapshot action to allow user to specify a description for the snapshot or if not provided, then use a default description that has a reference to the volume id from which the snapshot was created from