### PR TITLE
fix the efs without Name key by get attribute

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -321,7 +321,7 @@ def resource_format(resource, resource_type):
             resource['QueueArn'])
     elif resource_type == "efs":
         return "name: %s  id: %s  state: %s" % (
-            resource['Name'],
+            resource.get('Name', ''),
             resource['FileSystemId'],
             resource['LifeCycleState']
         )


### PR DESCRIPTION
If the user creating the AWS EFS resources without Name tag key, we got issues sometimes in results for slack/email messages.  Fixing by below code can help users in the future.