### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ setup_kwargs = {
     'maintainer': None,
     'maintainer_email': None,
     'url': 'https://cloudcustodian.io',
+    'project_urls': {
+        'Source': 'https://github.com/cloud-custodian/cloud-custodian',
+    },
     'packages': packages,
     'package_data': package_data,
     'install_requires': install_requires,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)