### PR TITLE
Added action to toggle metrics collection on glue jobs

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -165,9 +165,9 @@ class DeleteJob(BaseAction):
                 continue
 
 
-@GlueJob.action_registry.register('enable-metrics')
-class GlueJobEnableMetrics(BaseAction):
-    """Enable CloudWatch metrics for a Glue job
+@GlueJob.action_registry.register('toggle-metrics')
+class GlueJobToggleMetrics(BaseAction):
+    """Enable or disable CloudWatch metrics for a Glue job
 
     :example:
 
@@ -181,33 +181,41 @@ class GlueJobEnableMetrics(BaseAction):
                 key: 'DefaultArguments."--enable-metrics"'
                 value: absent
             actions:
-              - type: enable-metrics
+              - type: toggle-metrics
+                enabled: true
     """
-    schema = type_schema('enable-metrics')
+    schema = type_schema(
+        'toggle-metrics',
+        enabled={'type': 'boolean'},
+        required=['enabled'],
+    )
     permissions = ('glue:UpdateJob',)
 
-    def cleanup_params(self, r):
-        del_keys = [
-            "Name", "CreatedOn", "LastModifiedOn",
-            "AllocatedCapacity", "Tags", "c7n:MatchedFilters"
-        ]
-        for key in del_keys:
-            del r[key]
+    def prepare_params(self, r):
+        client = local_session(self.manager.session_factory).client('glue')
+        update_keys = client.meta._service_model.shape_for('JobUpdate').members
+        want_keys = set(r).intersection(update_keys) - {'AllocatedCapacity'}
+        params = {k: r[k] for k in want_keys}
 
         # Can't specify MaxCapacity when updating/creating a job if
         # job configuration includes WorkerType or NumberOfWorkers
-        if 'WorkerType' in r or 'NumberOfWorkers' in r:
-            del r['MaxCapacity']
+        if 'WorkerType' in params or 'NumberOfWorkers' in params:
+            del params['MaxCapacity']
 
-        return r
+        if self.data.get('enabled'):
+            params["DefaultArguments"]["--enable-metrics"] = ""
+        else:
+            del params["DefaultArguments"]["--enable-metrics"]
+
+        return params
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('glue')
+
         for r in resources:
             try:
                 job_name = r["Name"]
-                r["DefaultArguments"]["--enable-metrics"] = ""
-                updated_resource = self.cleanup_params(r)
+                updated_resource = self.prepare_params(r)
                 client.update_job(JobName=job_name, JobUpdate=updated_resource)
             except Exception as e:
                 self.log.error('Error updating glue job: {}'.format(e))

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -166,7 +166,23 @@ class DeleteJob(BaseAction):
 
 
 @GlueJob.action_registry.register('enable-metrics')
-class UpdateGlueJob(BaseAction):
+class GlueJobEnableMetrics(BaseAction):
+    """Enable CloudWatch metrics for a Glue job
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: gluejob-enable-metrics
+            resource: glue-job
+            filters:
+              - type: value
+                key: 'DefaultArguments."--enable-metrics"'
+                value: absent
+            actions:
+              - type: enable-metrics
+    """
     schema = type_schema('enable-metrics')
     permissions = ('glue:UpdateJob',)
 

--- a/tests/data/placebo/test_glue_job_disable_metrics/glue.GetJobs_1.json
+++ b/tests/data/placebo/test_glue_job_disable_metrics/glue.GetJobs_1.json
@@ -1,0 +1,154 @@
+{
+    "status_code": 200,
+    "data": {
+        "Jobs": [
+            {
+                "Name": "my-testing-job",
+                "Description": "",
+                "Role": "AWSGlueServiceRoleDefault",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 14,
+                    "minute": 57,
+                    "second": 39,
+                    "microsecond": 289000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 9,
+                    "hour": 11,
+                    "minute": 32,
+                    "second": 12,
+                    "microsecond": 188000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "gluestreaming",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/script",
+                    "PythonVersion": "2"
+                },
+                "DefaultArguments": {
+                    "--class": "GlueApp",
+                    "--enable-metrics": "true",
+                    "--job-bookmark-option": "job-bookmark-disable",
+                    "--job-language": "scala"
+                },
+                "MaxRetries": 0,
+                "AllocatedCapacity": 10,
+                "MaxCapacity": 10.0,
+                "GlueVersion": "0.9"
+            },
+            {
+                "Name": "testjob",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/agi-admin-svc-exec-role",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 2,
+                    "second": 48,
+                    "microsecond": 768000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 9,
+                    "hour": 11,
+                    "minute": 32,
+                    "second": 21,
+                    "microsecond": 577000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "PythonVersion": "3"
+                },
+                "DefaultArguments": {
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
+                    "--class": "GlueApp",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-job-insights": "true",
+                    "--enable-metrics": "true",
+                    "--enable-spark-ui": "true",
+                    "--job-bookmark-option": "job-bookmark-enable",
+                    "--job-language": "python",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                },
+                "MaxRetries": 3,
+                "AllocatedCapacity": 10,
+                "Timeout": 2880,
+                "MaxCapacity": 10.0,
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "3.0"
+            },
+            {
+                "Name": "testjob2",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/AccountProvisioningRoleForPaas",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 7,
+                    "second": 57,
+                    "microsecond": 551000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 9,
+                    "hour": 11,
+                    "minute": 32,
+                    "second": 30,
+                    "microsecond": 422000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "PythonVersion": "3"
+                },
+                "DefaultArguments": {
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
+                    "--class": "GlueApp",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-metrics": "true",
+                    "--enable-spark-ui": "true",
+                    "--job-bookmark-option": "job-bookmark-enable",
+                    "--job-language": "python",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                },
+                "MaxRetries": 3,
+                "AllocatedCapacity": 11,
+                "Timeout": 2880,
+                "MaxCapacity": 11.0,
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "1.0"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_disable_metrics/glue.GetJobs_2.json
+++ b/tests/data/placebo/test_glue_job_disable_metrics/glue.GetJobs_2.json
@@ -1,0 +1,151 @@
+{
+    "status_code": 200,
+    "data": {
+        "Jobs": [
+            {
+                "Name": "my-testing-job",
+                "Description": "",
+                "Role": "AWSGlueServiceRoleDefault",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 14,
+                    "minute": 57,
+                    "second": 39,
+                    "microsecond": 289000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 9,
+                    "hour": 11,
+                    "minute": 36,
+                    "second": 14,
+                    "microsecond": 95000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "gluestreaming",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/script",
+                    "PythonVersion": "2"
+                },
+                "DefaultArguments": {
+                    "--class": "GlueApp",
+                    "--job-bookmark-option": "job-bookmark-disable",
+                    "--job-language": "scala"
+                },
+                "MaxRetries": 0,
+                "AllocatedCapacity": 10,
+                "MaxCapacity": 10.0,
+                "GlueVersion": "0.9"
+            },
+            {
+                "Name": "testjob",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/agi-admin-svc-exec-role",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 2,
+                    "second": 48,
+                    "microsecond": 768000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 9,
+                    "hour": 11,
+                    "minute": 36,
+                    "second": 14,
+                    "microsecond": 274000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "PythonVersion": "3"
+                },
+                "DefaultArguments": {
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
+                    "--class": "GlueApp",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-job-insights": "true",
+                    "--enable-spark-ui": "true",
+                    "--job-bookmark-option": "job-bookmark-enable",
+                    "--job-language": "python",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                },
+                "MaxRetries": 3,
+                "AllocatedCapacity": 10,
+                "Timeout": 2880,
+                "MaxCapacity": 10.0,
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "3.0"
+            },
+            {
+                "Name": "testjob2",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/AccountProvisioningRoleForPaas",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 7,
+                    "second": 57,
+                    "microsecond": 551000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 9,
+                    "hour": 11,
+                    "minute": 36,
+                    "second": 14,
+                    "microsecond": 456000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "PythonVersion": "3"
+                },
+                "DefaultArguments": {
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
+                    "--class": "GlueApp",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-spark-ui": "true",
+                    "--job-bookmark-option": "job-bookmark-enable",
+                    "--job-language": "python",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                },
+                "MaxRetries": 3,
+                "AllocatedCapacity": 11,
+                "Timeout": 2880,
+                "MaxCapacity": 11.0,
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "1.0"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_disable_metrics/glue.UpdateJob_1.json
+++ b/tests/data/placebo/test_glue_job_disable_metrics/glue.UpdateJob_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "JobName": "my-testing-job",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_disable_metrics/glue.UpdateJob_2.json
+++ b/tests/data/placebo/test_glue_job_disable_metrics/glue.UpdateJob_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "JobName": "testjob",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_disable_metrics/glue.UpdateJob_3.json
+++ b/tests/data/placebo/test_glue_job_disable_metrics/glue.UpdateJob_3.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "JobName": "testjob2",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_disable_metrics/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_glue_job_disable_metrics/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.GetJobs_1.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.GetJobs_1.json
@@ -1,0 +1,151 @@
+{
+    "status_code": 200,
+    "data": {
+        "Jobs": [
+            {
+                "Name": "my-testing-job",
+                "Description": "",
+                "Role": "AWSGlueServiceRoleDefault",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 14,
+                    "minute": 57,
+                    "second": 39,
+                    "microsecond": 289000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 20,
+                    "second": 47,
+                    "microsecond": 458000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "gluestreaming",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/script",
+                    "PythonVersion": "2"
+                },
+                "DefaultArguments": {
+                    "--class": "GlueApp",
+                    "--job-bookmark-option": "job-bookmark-disable",
+                    "--job-language": "scala"
+                },
+                "MaxRetries": 0,
+                "AllocatedCapacity": 10,
+                "MaxCapacity": 10.0,
+                "GlueVersion": "0.9"
+            },
+            {
+                "Name": "testjob",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/agi-admin-svc-exec-role",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 2,
+                    "second": 48,
+                    "microsecond": 768000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 15,
+                    "second": 14,
+                    "microsecond": 198000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "PythonVersion": "3"
+                },
+                "DefaultArguments": {
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
+                    "--class": "GlueApp",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-job-insights": "true",
+                    "--enable-spark-ui": "true",
+                    "--job-bookmark-option": "job-bookmark-enable",
+                    "--job-language": "python",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                },
+                "MaxRetries": 3,
+                "AllocatedCapacity": 10,
+                "Timeout": 2880,
+                "MaxCapacity": 10.0,
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "3.0"
+            },
+            {
+                "Name": "testjob2",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/AccountProvisioningRoleForPaas",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 7,
+                    "second": 57,
+                    "microsecond": 551000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 17,
+                    "second": 59,
+                    "microsecond": 699000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "PythonVersion": "3"
+                },
+                "DefaultArguments": {
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
+                    "--class": "GlueApp",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-spark-ui": "true",
+                    "--job-bookmark-option": "job-bookmark-enable",
+                    "--job-language": "python",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                },
+                "MaxRetries": 3,
+                "AllocatedCapacity": 11,
+                "Timeout": 2880,
+                "MaxCapacity": 11.0,
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "1.0"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.GetJobs_2.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.GetJobs_2.json
@@ -1,0 +1,154 @@
+{
+    "status_code": 200,
+    "data": {
+        "Jobs": [
+            {
+                "Name": "my-testing-job",
+                "Description": "",
+                "Role": "AWSGlueServiceRoleDefault",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 14,
+                    "minute": 57,
+                    "second": 39,
+                    "microsecond": 289000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 22,
+                    "second": 36,
+                    "microsecond": 569000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "gluestreaming",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/script",
+                    "PythonVersion": "2"
+                },
+                "DefaultArguments": {
+                    "--class": "GlueApp",
+                    "--enable-metrics": "",
+                    "--job-bookmark-option": "job-bookmark-disable",
+                    "--job-language": "scala"
+                },
+                "MaxRetries": 0,
+                "AllocatedCapacity": 10,
+                "MaxCapacity": 10.0,
+                "GlueVersion": "0.9"
+            },
+            {
+                "Name": "testjob",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/agi-admin-svc-exec-role",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 2,
+                    "second": 48,
+                    "microsecond": 768000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 22,
+                    "second": 36,
+                    "microsecond": 772000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "PythonVersion": "3"
+                },
+                "DefaultArguments": {
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
+                    "--class": "GlueApp",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-job-insights": "true",
+                    "--enable-metrics": "",
+                    "--enable-spark-ui": "true",
+                    "--job-bookmark-option": "job-bookmark-enable",
+                    "--job-language": "python",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                },
+                "MaxRetries": 3,
+                "AllocatedCapacity": 10,
+                "Timeout": 2880,
+                "MaxCapacity": 10.0,
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "3.0"
+            },
+            {
+                "Name": "testjob2",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/AccountProvisioningRoleForPaas",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 7,
+                    "second": 57,
+                    "microsecond": 551000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 8,
+                    "hour": 15,
+                    "minute": 22,
+                    "second": 36,
+                    "microsecond": 965000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "PythonVersion": "3"
+                },
+                "DefaultArguments": {
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
+                    "--class": "GlueApp",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-metrics": "",
+                    "--enable-spark-ui": "true",
+                    "--job-bookmark-option": "job-bookmark-enable",
+                    "--job-language": "python",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                },
+                "MaxRetries": 3,
+                "AllocatedCapacity": 11,
+                "Timeout": 2880,
+                "MaxCapacity": 11.0,
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "1.0"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_1.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "JobName": "my-testing-job",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_2.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "JobName": "testjob",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_3.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_3.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "JobName": "testjob2",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_job_enable_metrics/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -289,6 +289,30 @@ class TestGlueJobs(BaseTest):
         jobs = client.get_jobs()["Jobs"]
         self.assertFalse(jobs)
 
+    def test_enable_metrics(self):
+        session_factory = self.replay_flight_data("test_glue_job_enable_metrics")
+        p = self.load_policy(
+            {
+                "name": "glue-job-enable-metrics",
+                "resource": "glue-job",
+                "filters": [
+                    {
+                        "type": "value",
+                        "key": 'DefaultArguments."--enable-metrics"',
+                        "value": "absent",
+                    }
+                ],
+                "actions": [{"type": "enable-metrics"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 3)
+        client = session_factory().client("glue")
+        jobs = client.get_jobs()["Jobs"]
+        for job in jobs:
+            self.assertIn("--enable-metrics", job["DefaultArguments"])
+
 
 class TestGlueCrawlers(BaseTest):
 


### PR DESCRIPTION
This PR adds a new action `toggle-metrics` to resource `glue-job`.  Our company relies on glue job metrics to identify cost-saving opportunities. This new action allows us to ensure that metrics collection is turned on for all jobs.

Sample policy
```
        policies:
          - name: gluejob-enable-metrics
            resource: glue-job
            filters:
              - type: value
                key: 'DefaultArguments."--enable-metrics"'
                value: absent
            actions:
              - type: toggle-metrics
                 enabled: true
```