### PR TITLE
Removing multiple principal check condition

### DIFF
--- a/c7n/filters/iamaccess.py
+++ b/c7n/filters/iamaccess.py
@@ -51,6 +51,7 @@ class PolicyChecker:
       - whitelist_conditions: a list of conditions that are considered
             sufficient enough to whitelist the statement.
     """
+
     def __init__(self, checker_config):
         self.checker_config = checker_config
 
@@ -126,8 +127,6 @@ class PolicyChecker:
             s['Principal'].pop('Service')
             if not s['Principal']:
                 return False
-
-        assert len(s['Principal']) == 1, "Too many principals %s" % s
 
         if isinstance(s['Principal'], str):
             p = s['Principal']


### PR DESCRIPTION
Story: On running cross-account policy for s3  as per https://cloudcustodian.io/docs/aws/resources/s3.html#aws-s3-filters-cross-account getting an error "Too many principals %s"

Changes: Removed condition which will check the multiple principals

Error (Reason for change):

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/c7n_org/cli.py", line 563, in run_account
    resources = p.run()
  File "/usr/local/lib/python3.9/site-packages/c7n/policy.py", line 1175, in __call__
    resources = PullMode(self).run()
  File "/usr/local/lib/python3.9/site-packages/c7n/policy.py", line 284, in run
    resources = self.policy.resource_manager.resources()
  File "/usr/local/lib/python3.9/site-packages/c7n/query.py", line 522, in resources
    resources = self.filter_resources(resources)
  File "/usr/local/lib/python3.9/site-packages/c7n/manager.py", line 111, in filter_resources
    resources = f.process(resources, event)
  File "/usr/local/lib/python3.9/site-packages/c7n/filters/iamaccess.py", line 292, in process
    return super(CrossAccountAccessFilter, self).process(resources, event)
  File "/usr/local/lib/python3.9/site-packages/c7n/filters/core.py", line 190, in process
    return list(filter(self, resources))
  File "/usr/local/lib/python3.9/site-packages/c7n/filters/iamaccess.py", line 331, in __call__
    violations = self.checker.check(p)
  File "/usr/local/lib/python3.9/site-packages/c7n/filters/iamaccess.py", line 95, in check
    if self.handle_statement(s):
  File "/usr/local/lib/python3.9/site-packages/c7n/filters/iamaccess.py", line 100, in handle_statement
    if (all((self.handle_principal(s),
  File "/usr/local/lib/python3.9/site-packages/c7n/filters/iamaccess.py", line 130, in handle_principal
    assert len(s['Principal']) == 1, "Too many principals %s" % s
AssertionError: Too many principals {'Sid': 'DelegateS3Access', 'Effect': 'Allow', 'Principal': {'AWS': [‘XXXXXXXX]}
> /usr/local/lib/python3.9/site-packages/c7n/filters/iamaccess.py(130)handle_principal()
-> assert len(s['Principal']) == 1, "Too many principals %s" % s

Testing: removed the condition locally and rerun the policy which was successful 
