### PR TITLE
aws - ec2 - fix typo in set-metadata-options example

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1060,7 +1060,7 @@ class SetMetadataServerAccess(BaseAction):
          - name: ec2-require-imdsv2
            resource: ec2
            filters:
-             - MetadataOptions.HttpToken: optional
+             - MetadataOptions.HttpTokens: optional
            actions:
              - type: set-metadata-access
                tokens: required


### PR DESCRIPTION
Yes, a one-character PR is silly. But that one character is sort of important here!