### PR TITLE
aws - core - add TooManyRequestsException to list of main retry codes

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -441,6 +441,7 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
 
     retry = staticmethod(
         get_retry((
+            'TooManyRequestsException',
             'ThrottlingException',
             'RequestLimitExceeded',
             'Throttled',


### PR DESCRIPTION
This comes from reviewing #7138, but I didn't want to derail that PR which is useful on its own. The gist is that our common/default retry behavior considers a [number of error codes](https://github.com/cloud-custodian/cloud-custodian/blob/72534952f591e1536720dd868aa633c8d59bceb6/c7n/query.py#L442-L450) related to throttling.

We allow resources/filters/actions to define their own retryable errors too, and we've [done that for `TooManyRequestsException` a couple times already](https://github.com/cloud-custodian/cloud-custodian/search?q=extension%3Apy+TooManyRequestsException&type=code). Poking at botocore service data, this error code shows up [in a number of additional places](https://github.com/boto/botocore/search?q=path%3Abotocore%2Fdata+extension%3Ajson+toomanyrequestsexception&type=code). Custodian's main response in any of those cases would be to backoff/retry as far as I can tell, so covering that at a higher level seems reasonable.