### PR TITLE
azure - function runtime python 3.8

### DIFF
--- a/tools/c7n_azure/c7n_azure/provisioning/function_app.py
+++ b/tools/c7n_azure/c7n_azure/provisioning/function_app.py
@@ -49,6 +49,7 @@ class FunctionAppDeploymentUnit(DeploymentUnit):
         # consumption app plan
         if params['is_consumption_plan']:
             functionapp_def.kind = 'functionapp,linux'
+            site_config.linux_fx_version = FUNCTION_DOCKER_VERSION
         # dedicated app plan
         else:
             functionapp_def.kind = 'functionapp,linux,container'

--- a/tools/c7n_azure/tests_azure/azure-functions/templates/policies.yaml
+++ b/tools/c7n_azure/tests_azure/azure-functions/templates/policies.yaml
@@ -5,6 +5,9 @@ policies:
         type: azure-event-grid
         events: ['ResourceGroupWrite']
         provision-options:
+          identity:
+            type: UserAssigned
+            id: ${identity_name}
           servicePlan:
             resourceGroupName: ${rg_name}-consumption
     filters:
@@ -21,6 +24,9 @@ policies:
         type: azure-event-grid
         events: ['ResourceGroupWrite']
         provision-options:
+          identity:
+            type: UserAssigned
+            id: ${identity_name}
           servicePlan:
             resourceGroupName: ${rg_name}-dedicated
             skuName: S2
@@ -39,6 +45,9 @@ policies:
         type: azure-periodic
         schedule: '0 */5 * * * *'
         provision-options:
+          identity:
+            type: UserAssigned
+            id: ${identity_name}
           servicePlan:
             resourceGroupName: ${rg_name}-consumption
     filters:
@@ -55,6 +64,9 @@ policies:
         type: azure-periodic
         schedule: '0 */5 * * * *'
         provision-options:
+          identity:
+            type: UserAssigned
+            id: ${identity_name}
           servicePlan:
             resourceGroupName: ${rg_name}-dedicated
             skuName: S2

--- a/tools/c7n_azure/tests_azure/azure-functions/test_functions.sh
+++ b/tools/c7n_azure/tests_azure/azure-functions/test_functions.sh
@@ -3,6 +3,8 @@
 set -e
 
 rg_name=cloud-custodian-test-functions-$RANDOM
+rg_identity_name="${rg_name}-identity"
+identity_name="c7n-identity"
 
 function cleanup {
     set +e
@@ -11,12 +13,19 @@ function cleanup {
     $(az group delete -n ${rg_name} -y)
     $(az group delete -n ${rg_name}-dedicated -y)
     $(az group delete -n ${rg_name}-consumption -y)
+    $(az group delete -n ${rg_identity_name}-consumption -y)
 }
 trap cleanup EXIT
 
 echo "Logging to Azure"
 az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET -t $AZURE_TENANT_ID -o none
 az account set -s $AZURE_SUBSCRIPTION_ID -o none
+
+echo "Creating user managed identity"
+az group create -l westus -n ${rg_identity_name} -o none
+identity_principal=$(az identity create -g ${rg_identity_name} --name ${identity_name} --query clientId -o tsv)
+sleep 60
+az role assignment create --assignee-object-id ${identity_principal} --assignee-principal-type "ServicePrincipal" --role "Owner" --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}" -o None
 
 eval "echo \"$(cat templates/policies.yaml)\"" > policies.yaml
 


### PR DESCRIPTION
Seems like an issue from 2019 when Consumption plan was added. For some reason Python Runtime version was not specified and Azure Functions were using 3.6.

It was working fine until Dec 19 `importlib-metadata` dropped support for Py3.6 in 4.10 (https://pypi.org/project/importlib-metadata/4.10.0/)
So Consumption plan wasn't able to install dependencies.

This changes makes sure both consumption\dedicated are using the same 3.8.

Second part of the change is the update to functional test for Azure Functions - I'll wire up to run it daily so we can catch these regressions.

closes https://github.com/cloud-custodian/cloud-custodian/issues/7160
closes https://github.com/cloud-custodian/cloud-custodian/issues/7133