### PR TITLE
Add a roadmap.md that points to the proper GitHub board

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,11 @@
+# Roadmap
+
+The roadmap for Cloud Custodian is maintained at the org level at this board:
+
+- [Custodian Road Map](https://github.com/orgs/cloud-custodian/projects/1/)
+
+Custodian is an Open Source project primarily run on volunteer time, as such the Roadmap is aspirational and purposely not milestoned or guaranteed to be implemented within a certain amount of time.
+
+We welcome contributions to these items, and also welcome community feedback as to what kind of features/fixes and priority of these features users would like to see. 
+
+If you want to help out check the [contribution documentation](https://cloudcustodian.io/docs/contribute.html), file issues and dive in!


### PR DESCRIPTION
We're going to use the org level for a proper roadmap and deprecate the board used here, since ROADMAP.md is kinda of an expected convention we'll use it to point to the roadmap itself. Happy to make changes to the text to set expectations.