### PR TITLE
[Issue #7185] Update c7n logging for base64 decode error for clarification

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -387,7 +387,7 @@ def kms_decrypt(config, logger, session, encrypted_field):
                     'Plaintext'].decode('utf8')
         except (TypeError, base64.binascii.Error) as e:
             logger.warning(
-                "Error: %s Unable to base64 decode %s, will assume plaintext." %
+                "Error: %s Unable to base64 decode %s, will assume plaintext. If plaintext was your intention, you can ignore this error." %
                 (e, encrypted_field))
         except ClientError as e:
             if e.response['Error']['Code'] != 'InvalidCiphertextException':

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -415,3 +415,14 @@ class OtherTests(unittest.TestCase):
         session_mock.get_session_for_resource.return_value = session_mock
 
         self.assertEqual(utils.kms_decrypt(config, Mock(), session_mock, 'test'), config['test'])
+        
+    def test_kms_decrypt_base64_decode_error_logging(self):
+        
+        logger = logging.getLogger('c7n_mailer.utils.email')
+        
+        config = {'test': {'secret': 'mysecretpassword'}}
+        session_mock = Mock()
+        
+        with self.assertLogs() as lc:
+            utils.kms_decrypt(config, logger, session_mock, 'test')
+        self.assertIn('If plaintext was your intention, you can ignore this error.', lc.output[0])


### PR DESCRIPTION
As detailed in [Issue #7185 Update c7n logging for base64 decode error for clarification](https://github.com/cloud-custodian/cloud-custodian/issues/7185):

**Context:**
c7n-mailer supports KMS encryption of Slack tokens and other mailer config secrets and will attempt to handle the secret accordingly. However, this is not always the user's intention and the error log that occurs as a result of a failed attempted unnecessary decryption lacks clarity.

So even though my intention is plaintext, the log reads as an error:

```
Error: Incorrect padding Unable to base64 decode slack_token, will assume plaintext.
```

**Objectives:**
- Update current logging to more accurately reflect what is occurring for greater clarity and better user experience

**Testing:**
- Updated pertinent unit test -- all c7n-mailer tests passing
- Working on testing forked version (let me know if this is overkill) 