### PR TITLE
aws - rds - add consecutive daily snapshot count filter

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -31,12 +31,14 @@ Find rds instances that are not encrypted
            op: ne
 
 """
+from __future__ import annotations
 import functools
 import itertools
 import logging
 import operator
 import jmespath
 import re
+from datetime import datetime, timedelta
 from decimal import Decimal as D, ROUND_HALF_UP
 
 from distutils.version import LooseVersion
@@ -52,7 +54,8 @@ from c7n.filters import (
 from c7n.filters.offhours import OffHour, OnHour
 import c7n.filters.vpc as net_filters
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, DescribeSource, ConfigSource, TypeInfo
+from c7n.query import (
+    QueryResourceManager, DescribeSource, ConfigSource, TypeInfo, RetryPageIterator)
 from c7n import deprecated, tags
 from c7n.tags import universal_augment
 
@@ -1819,3 +1822,61 @@ class ReservedRDS(QueryResourceManager):
         universal_taggable = object()
 
     augment = universal_augment
+
+
+@filters.register('consecutive-snapshots')
+class ConsecutiveSnapshots(Filter):
+    """Returns instances where number of consective daily snapshots is equal to/or greater than n days.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: rds-daily-snapshot-count
+                resource: rds
+                filters:
+                  - type: consecutive-snapshots
+                    days: 7
+    """
+    schema = type_schema('consecutive-snapshots', days={'type': 'number', 'minimum': 1},
+        required=['days'])
+    permissions = ('rds:DescribeDBSnapshots', 'rds:DescribeDBInstances')
+    annotation = 'c7n:DBSnapshots'
+
+    def process_resource_set(self, client, resources):
+        rds_instances = [r['DBInstanceIdentifier'] for r in resources]
+        paginator = client.get_paginator('describe_db_snapshots')
+        paginator.PAGE_ITERATOR_CLS = RetryPageIterator
+        db_snapshots = paginator.paginate(Filters=[{'Name': 'db-instance-id',
+          'Values': rds_instances}]).build_full_result().get('DBSnapshots', [])
+
+        inst_map = {}
+        for snapshot in db_snapshots:
+            if snapshot['DBInstanceIdentifier'] not in inst_map:
+                inst_map[snapshot['DBInstanceIdentifier']] = []
+            inst_map[snapshot['DBInstanceIdentifier']].append(snapshot)
+        for r in resources:
+            r[self.annotation] = inst_map.get(r['DBInstanceIdentifier'], [])
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('rds')
+        results = []
+        retention = self.data.get('days')
+        utcnow = datetime.utcnow()
+        expected_dates = set()
+        for days in range(1, retention + 1):
+            expected_dates.add((utcnow - timedelta(days=days)).strftime('%Y-%m-%d'))
+
+        for resource_set in chunks(
+                [r for r in resources if self.annotation not in r], 50):
+            self.process_resource_set(client, resource_set)
+
+        for r in resources:
+            snapshot_dates = []
+            for snapshot in r[self.annotation]:
+                if snapshot['Status'] == 'available':
+                    snapshot_dates.append(snapshot['SnapshotCreateTime'].strftime('%Y-%m-%d'))
+            if set(expected_dates).issubset(snapshot_dates):
+                results.append(r)
+        return results

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -3,13 +3,15 @@
 import logging
 
 from concurrent.futures import as_completed
+from datetime import datetime, timedelta
 
 from c7n.actions import BaseAction
-from c7n.filters import AgeFilter, CrossAccountAccessFilter
+from c7n.filters import AgeFilter, CrossAccountAccessFilter, Filter
 from c7n.filters.offhours import OffHour, OnHour
 import c7n.filters.vpc as net_filters
 from c7n.manager import resources
-from c7n.query import ConfigSource, QueryResourceManager, TypeInfo, DescribeSource
+from c7n.query import (
+    ConfigSource, QueryResourceManager, TypeInfo, DescribeSource, RetryPageIterator)
 from c7n.resources import rds
 from c7n.filters.kms import KmsRelatedFilter
 from .aws import shape_validate
@@ -599,3 +601,62 @@ class RDSClusterSnapshotDelete(BaseAction):
             except (client.exceptions.DBSnapshotNotFoundFault,
                     client.exceptions.InvalidDBSnapshotStateFault):
                 continue
+
+
+@RDSCluster.filter_registry.register('consecutive-snapshots')
+class ConsecutiveSnapshots(Filter):
+    """Returns RDS clusters where number of consective daily snapshots is equal to/or greater
+     than n days.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: rdscluster-daily-snapshot-count
+                resource: rds-cluster
+                filters:
+                  - type: consecutive-snapshots
+                    days: 7
+    """
+    schema = type_schema('consecutive-snapshots', days={'type': 'number', 'minimum': 1},
+        required=['days'])
+    permissions = ('rds:DescribeDBClusterSnapshots', 'rds:DescribeDBClusters')
+    annotation = 'c7n:DBClusterSnapshots'
+
+    def process_resource_set(self, client, resources):
+        rds_clusters = [r['DBClusterIdentifier'] for r in resources]
+        paginator = client.get_paginator('describe_db_cluster_snapshots')
+        paginator.PAGE_ITERATOR_CLS = RetryPageIterator
+        cluster_snapshots = paginator.paginate(Filters=[{'Name': 'db-instance-id',
+          'Values': rds_clusters}]).build_full_result().get('DBClusterSnapshots', [])
+
+        cluster_map = {}
+        for snapshot in cluster_snapshots:
+            if snapshot['DBClusterIdentifier'] not in cluster_map:
+                cluster_map[snapshot['DBClusterIdentifier']] = []
+            cluster_map[snapshot['DBClusterIdentifier']].append(snapshot)
+        for r in resources:
+            r[self.annotation] = cluster_map.get(r['DBClusterIdentifier'], [])
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('rds')
+        results = []
+        retention = self.data.get('days')
+        utcnow = datetime.utcnow()
+        expected_dates = set()
+        for days in range(1, retention + 1):
+            expected_dates.add((utcnow - timedelta(days=days)).strftime('%Y-%m-%d'))
+
+        for resource_set in chunks(
+                [r for r in resources if self.annotation not in r], 50):
+            self.process_resource_set(client, resource_set)
+
+        for r in resources:
+            snapshot_dates = []
+            for snapshot in r[self.annotation]:
+                if snapshot['Status'] == 'available':
+                    snapshot_dates.append(snapshot['SnapshotCreateTime'].strftime('%Y-%m-%d'))
+            if set(expected_dates).issubset(snapshot_dates):
+                results.append(r)
+        return results

--- a/tests/data/placebo/test_rds_snapshot_count_filter/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_snapshot_count_filter/rds.DescribeDBInstances_1.json
@@ -1,0 +1,249 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200
+        },
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "abc-restore",
+                "DBInstanceClass": "string",
+                "Engine": "postgres",
+                "DBInstanceStatus": "available",
+                "AutomaticRestartTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2016,
+                    "day": 21,
+                    "minute": 4
+                },
+                "MasterUsername": "dbadmin",
+                "DBName": "abc-restore",
+                "Endpoint": {
+                    "Address": "string",
+                    "Port": 123,
+                    "HostedZoneId": "string"
+                },
+                "AllocatedStorage": 100,
+                "InstanceCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "PreferredBackupWindow": "string",
+                "BackupRetentionPeriod": 7,
+                "DBSecurityGroups": [
+                    {
+                        "DBSecurityGroupName": "string",
+                        "Status": "string"
+                    }
+                ],
+                "VpcSecurityGroups": [
+                    {
+                        "VpcSecurityGroupId": "string",
+                        "Status": "string"
+                    }
+                ],
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "string",
+                        "ParameterApplyStatus": "string"
+                    }
+                ],
+                "AvailabilityZone": "us-east-1b",
+                "DBSubnetGroup": {
+                    "DBSubnetGroupName": "string",
+                    "DBSubnetGroupDescription": "string",
+                    "VpcId": "string",
+                    "SubnetGroupStatus": "string",
+                    "Subnets": [
+                        {
+                            "SubnetIdentifier": "string",
+                            "SubnetAvailabilityZone": {
+                                "Name": "string"
+                            },
+                            "SubnetOutpost": {
+                                "Arn": "string"
+                            },
+                            "SubnetStatus": "string"
+                        }
+                    ],
+                    "DBSubnetGroupArn": "string"
+                },
+                "PreferredMaintenanceWindow": "string",
+                "PendingModifiedValues": {
+                    "DBInstanceClass": "string",
+                    "AllocatedStorage": 123,
+                    "MasterUserPassword": "string",
+                    "Port": 5432,
+                    "BackupRetentionPeriod": 123,
+                    "MultiAZ": true,
+                    "EngineVersion": "9.4.5",
+                    "LicenseModel": "string",
+                    "Iops": 123,
+                    "DBInstanceIdentifier": "abc-restore",
+                    "StorageType": "string",
+                    "CACertificateIdentifier": "string",
+                    "DBSubnetGroupName": "string",
+                    "PendingCloudwatchLogsExports": {
+                        "LogTypesToEnable": [
+                            "string"
+                        ],
+                        "LogTypesToDisable": [
+                            "string"
+                        ]
+                    },
+                    "ProcessorFeatures": [
+                        {
+                            "Name": "string",
+                            "Value": "string"
+                        }
+                    ],
+                    "IAMDatabaseAuthenticationEnabled": true,
+                    "AutomationMode": "full",
+                    "ResumeFullAutomationModeTime": {
+                        "hour": 19,
+                        "__class__": "datetime",
+                        "month": 4,
+                        "second": 52,
+                        "microsecond": 776000,
+                        "year": 2016,
+                        "day": 21,
+                        "minute": 4
+                    }
+                },
+                "LatestRestorableTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2016,
+                    "day": 21,
+                    "minute": 4
+                },
+                "MultiAZ": true,
+                "EngineVersion": "postgres",
+                "AutoMinorVersionUpgrade": true,
+                "ReadReplicaSourceDBInstanceIdentifier": "string",
+                "ReadReplicaDBInstanceIdentifiers": [
+                    "string"
+                ],
+                "ReadReplicaDBClusterIdentifiers": [
+                    "string"
+                ],
+                "ReplicaMode": "open-read-only",
+                "LicenseModel": "string",
+                "Iops": 123,
+                "OptionGroupMemberships": [
+                    {
+                        "OptionGroupName": "default:postgres-9-4",
+                        "Status": "string"
+                    }
+                ],
+                "CharacterSetName": "string",
+                "NcharCharacterSetName": "string",
+                "SecondaryAvailabilityZone": "string",
+                "PubliclyAccessible": true,
+                "StatusInfos": [
+                    {
+                        "StatusType": "string",
+                        "Normal": true,
+                        "Status": "string",
+                        "Message": "string"
+                    }
+                ],
+                "StorageType": "string",
+                "TdeCredentialArn": "string",
+                "DbInstancePort": 123,
+                "DBClusterIdentifier": "string",
+                "StorageEncrypted": true,
+                "KmsKeyId": "string",
+                "DbiResourceId": "string",
+                "CACertificateIdentifier": "string",
+                "DomainMemberships": [
+                    {
+                        "Domain": "string",
+                        "Status": "string",
+                        "FQDN": "string",
+                        "IAMRoleName": "string"
+                    }
+                ],
+                "CopyTagsToSnapshot": true,
+                "MonitoringInterval": 123,
+                "EnhancedMonitoringResourceArn": "string",
+                "MonitoringRoleArn": "string",
+                "PromotionTier": 123,
+                "DBInstanceArn": "string",
+                "Timezone": "string",
+                "IAMDatabaseAuthenticationEnabled": true,
+                "PerformanceInsightsEnabled": true,
+                "PerformanceInsightsKMSKeyId": "string",
+                "PerformanceInsightsRetentionPeriod": 123,
+                "EnabledCloudwatchLogsExports": [
+                    "string"
+                ],
+                "ProcessorFeatures": [
+                    {
+                        "Name": "string",
+                        "Value": "string"
+                    }
+                ],
+                "DeletionProtection": true,
+                "AssociatedRoles": [
+                    {
+                        "RoleArn": "string",
+                        "FeatureName": "string",
+                        "Status": "string"
+                    }
+                ],
+                "ListenerEndpoint": {
+                    "Address": "string",
+                    "Port": 123,
+                    "HostedZoneId": "string"
+                },
+                "MaxAllocatedStorage": 123,
+                "TagList": [
+                    {
+                        "Key": "string",
+                        "Value": "string"
+                    }
+                ],
+                "DBInstanceAutomatedBackupsReplications": [
+                    {
+                        "DBInstanceAutomatedBackupsArn": "string"
+                    }
+                ],
+                "CustomerOwnedIpEnabled": true,
+                "AwsBackupRecoveryPointArn": "string",
+                "ActivityStreamStatus": "stopped",
+                "ActivityStreamKmsKeyId": "string",
+                "ActivityStreamKinesisStreamName": "string",
+                "ActivityStreamMode": "sync",
+                "ActivityStreamEngineNativeAuditFieldsIncluded": true,
+                "AutomationMode": "full",
+                "ResumeFullAutomationModeTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2016,
+                    "day": 21,
+                    "minute": 4
+                },
+                "CustomIamInstanceProfile": "string",
+                "BackupTarget": "string"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rds_snapshot_count_filter/rds.DescribeDBSnapshots_1.json
+++ b/tests/data/placebo/test_rds_snapshot_count_filter/rds.DescribeDBSnapshots_1.json
@@ -1,0 +1,155 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "9ec20898-2cce-11e6-9e53-995121fda0e7"
+        },
+        "DBSnapshots": [
+            {
+                "Engine": "postgres",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 29,
+                    "minute": 4
+                },
+                "AvailabilityZone": "us-east-1b",
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "Encrypted": true,
+                "LicenseModel": "postgresql-license",
+                "StorageType": "gp2",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBSnapshotIdentifier": "abc-restore-final-snapshot-1",
+                "InstanceCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "OptionGroupName": "default:postgres-9-4",
+                "AllocatedStorage": 100,
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBInstanceIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-1",
+                        "Key": "test-key"
+                    }
+                ]
+            },
+            {
+                "Engine": "postgres",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 28,
+                    "minute": 4
+                },
+                "AvailabilityZone": "us-east-1b",
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "Encrypted": true,
+                "LicenseModel": "postgresql-license",
+                "StorageType": "gp2",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBSnapshotIdentifier": "abc-restore-final-snapshot-2",
+                "InstanceCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "OptionGroupName": "default:postgres-9-4",
+                "AllocatedStorage": 100,
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBInstanceIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-2",
+                        "Key": "test-key"
+                    }
+                ]
+            },
+            {
+                "Engine": "postgres",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 27,
+                    "minute": 4
+                },
+                "AvailabilityZone": "us-east-1b",
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "Encrypted": true,
+                "LicenseModel": "postgresql-license",
+                "StorageType": "gp2",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBSnapshotIdentifier": "abc-restore-final-snapshot-3",
+                "InstanceCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "OptionGroupName": "default:postgres-9-4",
+                "AllocatedStorage": 100,
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBInstanceIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-3",
+                        "Key": "test-key"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_count_filter/rds.DescribeDBClusterSnapshots_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_count_filter/rds.DescribeDBClusterSnapshots_1.json
@@ -1,0 +1,146 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "9ec20898-2cce-11e6-9e53-995121fda0e7"
+        },
+        "DBClusterSnapshots": [
+            {
+                "Engine": "aurora-mysql",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 29,
+                    "minute": 4
+                },
+                "AvailabilityZones": ["us-east-1b"],
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "StorageEncrypted": true,
+                "LicenseModel": "aurora-mysql-license",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBClusterSnapshotIdentifier": "abc-restore-final-snapshot-1",
+                "ClusterCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBClusterIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-1",
+                        "Key": "test-key"
+                    }
+                ]
+            },
+            {
+                "Engine": "aurora-mysql",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 28,
+                    "minute": 4
+                },
+                "AvailabilityZones": ["us-east-1b"],
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "StorageEncrypted": true,
+                "LicenseModel": "aurora-mysql-license",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBClusterSnapshotIdentifier": "abc-restore-final-snapshot-2",
+                "ClusterCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBClusterIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-2",
+                        "Key": "test-key"
+                    }
+                ]
+            },
+            {
+                "Engine": "aurora-mysql",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 27,
+                    "minute": 4
+                },
+                "AvailabilityZones": ["us-east-1b"],
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "StorageEncrypted": true,
+                "LicenseModel": "postgresql-license",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBClusterSnapshotIdentifier": "abc-restore-final-snapshot-3",
+                "ClusterCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBClusterIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-3",
+                        "Key": "test-key"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_count_filter/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_count_filter/rds.DescribeDBClusters_1.json
@@ -1,0 +1,152 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200
+        },
+        "DBClusters": [
+            {
+                "DBClusterIdentifier": "abc-restore",
+                "DBInstanceClass": "string",
+                "Engine": "postgres",
+                "MasterUsername": "dbadmin",
+                "Endpoint": {
+                    "Address": "string",
+                    "Port": 123,
+                    "HostedZoneId": "string"
+                },
+                "ClusterCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "AvailabilityZones": [
+                    "us-east-1b"
+                ],
+                "BackupRetentionPeriod": 123,
+                "CharacterSetName": "string",
+                "DatabaseName": "abc-restore",
+                "DBClusterParameterGroup": "string",
+                "DBSubnetGroup": "string",
+                "Status": "string",
+                "PercentProgress": "string",
+                "ReaderEndpoint": "string",
+                "CustomEndpoints": [
+                    "string"
+                ],
+                "MultiAZ": true,
+                "EngineVersion": "string",
+                "Port": 123,
+                "DBClusterOptionGroupMemberships": [
+                    {
+                        "DBClusterOptionGroupName": "string",
+                        "Status": "string"
+                    }
+                ],
+                "PreferredBackupWindow": "string",
+                "PreferredMaintenanceWindow": "string",
+                "ReplicationSourceIdentifier": "string",
+                "ReadReplicaIdentifiers": [
+                    "string"
+                ],
+                "DBClusterMembers": [
+                    {
+                        "DBInstanceIdentifier": "string",
+                        "IsClusterWriter": true,
+                        "DBClusterParameterGroupStatus": "string",
+                        "PromotionTier": 123
+                    }
+                ],
+                "VpcSecurityGroups": [
+                    {
+                        "VpcSecurityGroupId": "string",
+                        "Status": "string"
+                    }
+                ],
+                "HostedZoneId": "string",
+                "StorageEncrypted": true,
+                "KmsKeyId": "string",
+                "DbClusterResourceId": "string",
+                "DBClusterArn": "string",
+                "AssociatedRoles": [
+                    {
+                        "RoleArn": "string",
+                        "Status": "string",
+                        "FeatureName": "string"
+                    }
+                ],
+                "IAMDatabaseAuthenticationEnabled": true,
+                "CloneGroupId": "string",
+                "BacktrackWindow": 123,
+                "BacktrackConsumedChangeRecords": 123,
+                "EnabledCloudwatchLogsExports": [
+                    "string"
+                ],
+                "Capacity": 123,
+                "EngineMode": "string",
+                "ScalingConfigurationInfo": {
+                    "MinCapacity": 123,
+                    "MaxCapacity": 123,
+                    "AutoPause": true,
+                    "SecondsUntilAutoPause": 123,
+                    "TimeoutAction": "string",
+                    "SecondsBeforeTimeout": 123
+                },
+                "DeletionProtection": true,
+                "HttpEndpointEnabled": true,
+                "ActivityStreamMode": "sync",
+                "ActivityStreamStatus": "stopped",
+                "ActivityStreamKmsKeyId": "string",
+                "ActivityStreamKinesisStreamName": "string",
+                "CopyTagsToSnapshot": true,
+                "CrossAccountClone": true,
+                "DomainMemberships": [
+                    {
+                        "Domain": "string",
+                        "Status": "string",
+                        "FQDN": "string",
+                        "IAMRoleName": "string"
+                    }
+                ],
+                "TagList": [
+                    {
+                        "Key": "string",
+                        "Value": "string"
+                    }
+                ],
+                "GlobalWriteForwardingStatus": "enabled",
+                "GlobalWriteForwardingRequested": true,
+                "PendingModifiedValues": {
+                    "PendingCloudwatchLogsExports": {
+                        "LogTypesToEnable": [
+                            "string"
+                        ],
+                        "LogTypesToDisable": [
+                            "string"
+                        ]
+                    },
+                    "DBClusterIdentifier": "string",
+                    "MasterUserPassword": "string",
+                    "IAMDatabaseAuthenticationEnabled": true,
+                    "EngineVersion": "string"
+                },
+                "DBClusterInstanceClass": "string",
+                "StorageType": "string",
+                "Iops": 123,
+                "PubliclyAccessible": true,
+                "AutoMinorVersionUpgrade": true,
+                "MonitoringInterval": 123,
+                "MonitoringRoleArn": "string",
+                "PerformanceInsightsEnabled": true,
+                "PerformanceInsightsKMSKeyId": "string",
+                "PerformanceInsightsRetentionPeriod": 123
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_count_filter/test_rds_snapshot_count_filter/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_count_filter/test_rds_snapshot_count_filter/rds.DescribeDBInstances_1.json
@@ -1,0 +1,249 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200
+        },
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "abc-restore",
+                "DBInstanceClass": "string",
+                "Engine": "postgres",
+                "DBInstanceStatus": "available",
+                "AutomaticRestartTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2016,
+                    "day": 21,
+                    "minute": 4
+                },
+                "MasterUsername": "dbadmin",
+                "DBName": "abc-restore",
+                "Endpoint": {
+                    "Address": "string",
+                    "Port": 123,
+                    "HostedZoneId": "string"
+                },
+                "AllocatedStorage": 100,
+                "InstanceCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "PreferredBackupWindow": "string",
+                "BackupRetentionPeriod": 7,
+                "DBSecurityGroups": [
+                    {
+                        "DBSecurityGroupName": "string",
+                        "Status": "string"
+                    }
+                ],
+                "VpcSecurityGroups": [
+                    {
+                        "VpcSecurityGroupId": "string",
+                        "Status": "string"
+                    }
+                ],
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "string",
+                        "ParameterApplyStatus": "string"
+                    }
+                ],
+                "AvailabilityZone": "us-east-1b",
+                "DBSubnetGroup": {
+                    "DBSubnetGroupName": "string",
+                    "DBSubnetGroupDescription": "string",
+                    "VpcId": "string",
+                    "SubnetGroupStatus": "string",
+                    "Subnets": [
+                        {
+                            "SubnetIdentifier": "string",
+                            "SubnetAvailabilityZone": {
+                                "Name": "string"
+                            },
+                            "SubnetOutpost": {
+                                "Arn": "string"
+                            },
+                            "SubnetStatus": "string"
+                        }
+                    ],
+                    "DBSubnetGroupArn": "string"
+                },
+                "PreferredMaintenanceWindow": "string",
+                "PendingModifiedValues": {
+                    "DBInstanceClass": "string",
+                    "AllocatedStorage": 123,
+                    "MasterUserPassword": "string",
+                    "Port": 5432,
+                    "BackupRetentionPeriod": 123,
+                    "MultiAZ": true,
+                    "EngineVersion": "9.4.5",
+                    "LicenseModel": "string",
+                    "Iops": 123,
+                    "DBInstanceIdentifier": "abc-restore",
+                    "StorageType": "string",
+                    "CACertificateIdentifier": "string",
+                    "DBSubnetGroupName": "string",
+                    "PendingCloudwatchLogsExports": {
+                        "LogTypesToEnable": [
+                            "string"
+                        ],
+                        "LogTypesToDisable": [
+                            "string"
+                        ]
+                    },
+                    "ProcessorFeatures": [
+                        {
+                            "Name": "string",
+                            "Value": "string"
+                        }
+                    ],
+                    "IAMDatabaseAuthenticationEnabled": true,
+                    "AutomationMode": "full",
+                    "ResumeFullAutomationModeTime": {
+                        "hour": 19,
+                        "__class__": "datetime",
+                        "month": 4,
+                        "second": 52,
+                        "microsecond": 776000,
+                        "year": 2016,
+                        "day": 21,
+                        "minute": 4
+                    }
+                },
+                "LatestRestorableTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2016,
+                    "day": 21,
+                    "minute": 4
+                },
+                "MultiAZ": true,
+                "EngineVersion": "postgres",
+                "AutoMinorVersionUpgrade": true,
+                "ReadReplicaSourceDBInstanceIdentifier": "string",
+                "ReadReplicaDBInstanceIdentifiers": [
+                    "string"
+                ],
+                "ReadReplicaDBClusterIdentifiers": [
+                    "string"
+                ],
+                "ReplicaMode": "open-read-only",
+                "LicenseModel": "string",
+                "Iops": 123,
+                "OptionGroupMemberships": [
+                    {
+                        "OptionGroupName": "default:postgres-9-4",
+                        "Status": "string"
+                    }
+                ],
+                "CharacterSetName": "string",
+                "NcharCharacterSetName": "string",
+                "SecondaryAvailabilityZone": "string",
+                "PubliclyAccessible": true,
+                "StatusInfos": [
+                    {
+                        "StatusType": "string",
+                        "Normal": true,
+                        "Status": "string",
+                        "Message": "string"
+                    }
+                ],
+                "StorageType": "string",
+                "TdeCredentialArn": "string",
+                "DbInstancePort": 123,
+                "DBClusterIdentifier": "string",
+                "StorageEncrypted": true,
+                "KmsKeyId": "string",
+                "DbiResourceId": "string",
+                "CACertificateIdentifier": "string",
+                "DomainMemberships": [
+                    {
+                        "Domain": "string",
+                        "Status": "string",
+                        "FQDN": "string",
+                        "IAMRoleName": "string"
+                    }
+                ],
+                "CopyTagsToSnapshot": true,
+                "MonitoringInterval": 123,
+                "EnhancedMonitoringResourceArn": "string",
+                "MonitoringRoleArn": "string",
+                "PromotionTier": 123,
+                "DBInstanceArn": "string",
+                "Timezone": "string",
+                "IAMDatabaseAuthenticationEnabled": true,
+                "PerformanceInsightsEnabled": true,
+                "PerformanceInsightsKMSKeyId": "string",
+                "PerformanceInsightsRetentionPeriod": 123,
+                "EnabledCloudwatchLogsExports": [
+                    "string"
+                ],
+                "ProcessorFeatures": [
+                    {
+                        "Name": "string",
+                        "Value": "string"
+                    }
+                ],
+                "DeletionProtection": true,
+                "AssociatedRoles": [
+                    {
+                        "RoleArn": "string",
+                        "FeatureName": "string",
+                        "Status": "string"
+                    }
+                ],
+                "ListenerEndpoint": {
+                    "Address": "string",
+                    "Port": 123,
+                    "HostedZoneId": "string"
+                },
+                "MaxAllocatedStorage": 123,
+                "TagList": [
+                    {
+                        "Key": "string",
+                        "Value": "string"
+                    }
+                ],
+                "DBInstanceAutomatedBackupsReplications": [
+                    {
+                        "DBInstanceAutomatedBackupsArn": "string"
+                    }
+                ],
+                "CustomerOwnedIpEnabled": true,
+                "AwsBackupRecoveryPointArn": "string",
+                "ActivityStreamStatus": "stopped",
+                "ActivityStreamKmsKeyId": "string",
+                "ActivityStreamKinesisStreamName": "string",
+                "ActivityStreamMode": "sync",
+                "ActivityStreamEngineNativeAuditFieldsIncluded": true,
+                "AutomationMode": "full",
+                "ResumeFullAutomationModeTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 4,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2016,
+                    "day": 21,
+                    "minute": 4
+                },
+                "CustomIamInstanceProfile": "string",
+                "BackupTarget": "string"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_count_filter/test_rds_snapshot_count_filter/rds.DescribeDBSnapshots_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_count_filter/test_rds_snapshot_count_filter/rds.DescribeDBSnapshots_1.json
@@ -1,0 +1,155 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "9ec20898-2cce-11e6-9e53-995121fda0e7"
+        },
+        "DBSnapshots": [
+            {
+                "Engine": "postgres",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 29,
+                    "minute": 4
+                },
+                "AvailabilityZone": "us-east-1b",
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "Encrypted": true,
+                "LicenseModel": "postgresql-license",
+                "StorageType": "gp2",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBSnapshotIdentifier": "abc-restore-final-snapshot-1",
+                "InstanceCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "OptionGroupName": "default:postgres-9-4",
+                "AllocatedStorage": 100,
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBInstanceIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-1",
+                        "Key": "test-key"
+                    }
+                ]
+            },
+            {
+                "Engine": "postgres",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 28,
+                    "minute": 4
+                },
+                "AvailabilityZone": "us-east-1b",
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "Encrypted": true,
+                "LicenseModel": "postgresql-license",
+                "StorageType": "gp2",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBSnapshotIdentifier": "abc-restore-final-snapshot-2",
+                "InstanceCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "OptionGroupName": "default:postgres-9-4",
+                "AllocatedStorage": 100,
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBInstanceIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-2",
+                        "Key": "test-key"
+                    }
+                ]
+            },
+            {
+                "Engine": "postgres",
+                "SnapshotCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 52,
+                    "microsecond": 776000,
+                    "year": 2022,
+                    "day": 27,
+                    "minute": 4
+                },
+                "AvailabilityZone": "us-east-1b",
+                "PercentProgress": 100,
+                "MasterUsername": "dbadmin",
+                "Encrypted": true,
+                "LicenseModel": "postgresql-license",
+                "StorageType": "gp2",
+                "Status": "available",
+                "VpcId": "vpc-f3581498",
+                "DBSnapshotIdentifier": "abc-restore-final-snapshot-3",
+                "InstanceCreateTime": {
+                    "hour": 3,
+                    "__class__": "datetime",
+                    "month": 3,
+                    "second": 42,
+                    "microsecond": 265000,
+                    "year": 2022,
+                    "day": 8,
+                    "minute": 33
+                },
+                "OptionGroupName": "default:postgres-9-4",
+                "AllocatedStorage": 100,
+                "EngineVersion": "9.4.5",
+                "SnapshotType": "manual",
+                "Port": 5432,
+                "DBInstanceIdentifier": "abc-restore",
+                "TagList": [
+                    {
+                        "Value": "other",
+                        "Key": "workload-type"
+                    },
+                    {
+                        "Value": "test-value-3",
+                        "Key": "test-key"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -867,6 +867,19 @@ class RDSTest(BaseTest):
         db_info = client.describe_db_instances(DBInstanceIdentifier="database-4")
         self.assertTrue(db_info["DBInstances"][0]["PerformanceInsightsEnabled"])
 
+    def test_rds_snapshot_count_filter(self):
+        factory = self.replay_flight_data("test_rds_snapshot_count_filter")
+        p = self.load_policy(
+            {
+                "name": "rds-snapshot-count-filter",
+                "resource": "rds",
+                "filters": [{"type": "consecutive-snapshots", "days": 2}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
 
 class RDSSnapshotTest(BaseTest):
 

--- a/tests/test_rdscluster.py
+++ b/tests/test_rdscluster.py
@@ -424,6 +424,19 @@ class RDSClusterTest(BaseTest):
             DBClusterIdentifier='mytest').get('DBClusters')[0]
         self.assertEqual(cluster['Status'], 'starting')
 
+    def test_rdscluster_snapshot_count_filter(self):
+        factory = self.replay_flight_data("test_rdscluster_snapshot_count_filter")
+        p = self.load_policy(
+            {
+                "name": "rdscluster-snapshot-count-filter",
+                "resource": "rds-cluster",
+                "filters": [{"type": "consecutive-snapshots", "days": 2}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
 
 class RDSClusterSnapshotTest(BaseTest):
 


### PR DESCRIPTION
Adding a new filter for 'consecutive-snapshots' daily snapshots to rds and rdscluster resources so that we can determine the number of consecutive daily snapshot each resource of above mentioned type has . The compliance reporting requires that all RDS ( cluster and instance ) resources should have at least 7 days worth of backups. This filter allows to calculate the number of daily consecutive snapshots.

Sample policy
```
     - name: rds-backup-test-daily
       resource: rds
       filters:
             - type: consecutive-snapshots
               days: 7
             - DBInstanceStatus: available
       actions:
          - type: notify
```
I had to close the previous PR (referenced below ) and recreate this PR to resolve the CLA issues with commit ids. Please see the following CR for notes /review by @ajkerrigan  and @darrendao.

https://github.com/cloud-custodian/cloud-custodian/pull/7165