### PR TITLE
improved the email and slack as unified modification

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/msg-templates/default.html.j2
+++ b/tools/c7n_mailer/c7n_mailer/msg-templates/default.html.j2
@@ -30,6 +30,7 @@ Additional parameters can be passed in from the policy - i.e. action_desc, viola
 
 {# You can set any mandatory tags here, and they will be formatted/outputted in the message #}
 {% set requiredTags = ['Application','Owner'] %}
+{% set expireDays = 90 %}
 
 {# The macros below format some resource attributes for better presentation #}
 {% macro getTag(resource, tagKey) -%}
@@ -40,12 +41,6 @@ Additional parameters can be passed in from the policy - i.e. action_desc, viola
 			{% endif %}
 		{% endfor %}
 	{% endif %}
-{%- endmacro %}
-
-{% macro extractList(resource, column) -%}
-		{% for p in resource.get(column) %}
-			{{ p }},
-		{% endfor %}
 {%- endmacro %}
 	
 {% macro columnHeading(columnNames, tableWidth) -%}
@@ -68,6 +63,21 @@ Additional parameters can be passed in from the policy - i.e. action_desc, viola
 				<td>{{ getTag(resource,'Name') }}</td>
 			{% elif columnName == 'InstanceCount' %}
 				<td align="center">{{ resource['Instances'] | length }}</td>		
+                        {% elif columnName == 'AccessKeys:RemainDays' %}
+                          {% set combinedkeys = dict() %}
+                          {% for accesskeydet in resource['c7n:AccessKeys'] %}
+                            {% set accesskeyid = accesskeydet['AccessKeyId'] %}
+                            {% set remaindays = ( expireDays - (accesskeydet['CreateDate'] | get_date_age)) %}
+                            {% set _dummy = combinedkeys.update({ accesskeyid:remaindays }) %}
+                          {% endfor %}
+                          <td>{{ combinedkeys }}</td>
+                        {% elif columnName == 'RoleLastUsed' %}
+                          {% if resource['RoleLastUsed'].get('LastUsedDate') %}
+                            {% set last_used_status = resource['RoleLastUsed'].get('LastUsedDate')  + ' (Last used ' ~ (resource['RoleLastUsed'].get('LastUsedDate')  | get_date_age)  + ' days ago)' %}
+                          {% else %}
+                            {% set last_used_status = "Never used -" + ' (Created ' ~ (resource['CreateDate'] | get_date_age)  + ' days ago)' %}
+                          {% endif %}
+                          <td>{{ last_used_status }}</td>
 			{% elif columnName == 'VolumeConsumedReadWriteOps' %}
 				<td>{{ resource['c7n.metrics']['AWS/EBS.VolumeConsumedReadWriteOps.Maximum'][0]['Maximum'] }}</td>
 			{% elif columnName == 'PublicIp' %}
@@ -184,7 +194,7 @@ Additional parameters can be passed in from the policy - i.e. action_desc, viola
 			{{ createTable(columnNames, resources, '80') }}					   
 			
 		{% elif policy['resource'] == "efs" %}
-			{% set columnNames = ['CreationToken','CreationTime','FileSystemId','OwnerId'] %}
+			{% set columnNames = ['CreationToken','CreationTime','FileSystemId','Owner'] %}
 			{{ createTable(columnNames, resources, '50') }}		
 			  				
 		{% elif policy['resource'] == "elasticsearch" %}
@@ -198,6 +208,14 @@ Additional parameters can be passed in from the policy - i.e. action_desc, viola
 		{% elif policy['resource'] == "emr" %}
 			{% set columnNames = ['Id','EmrState'] %}
 			{{ createTable(columnNames, resources, '50') }}					
+
+  	       {% elif policy['resource'] == "iam-user" %}
+    			{% set columnNames = ['UserName','AccessKeys:RemainDays','Application','CreateDate','Owner'] %}
+			{{ createTable(columnNames, resources, '80') }}					
+
+  	       {% elif policy['resource'] == "iam-role" %}
+    			{% set columnNames = ['RoleName','RoleLastUsed','Application','CreateDate','Owner'] %}
+			{{ createTable(columnNames, resources, '80') }}					
 
 		{% elif policy['resource'] == "kinesis" %}
 			{% set columnNames = ['StreamName'] %}

--- a/tools/c7n_mailer/c7n_mailer/msg-templates/slack_default.j2
+++ b/tools/c7n_mailer/c7n_mailer/msg-templates/slack_default.j2
@@ -1,3 +1,63 @@
+{# You can set any mandatory tags here, and they will be formatted/outputted in the message #}
+{% set requiredTags = ['Application','Owner'] %}
+{% set expireDays = 90 %}
+
+{# The macros below format some resource attributes for better presentation #}
+{%- macro getTag(resource, tagKey) -%}
+  {%- if resource.get('Tags') -%}
+    {%- for t in resource.get('Tags') -%}
+      {%-  if t.get('Key') == tagKey -%}
+        {{ t.get('Value') }}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endmacro -%}
+
+{% macro columnData(resources, columnNames) -%}
+  {%- for resource in resources %}
+    {%- for columnName in columnNames -%}
+    {% set inner_loop = loop %}
+      {%- if columnName in requiredTags -%}
+        {%- set value = getTag(resource,columnName) -%}
+      {%- elif columnName == 'tag.Name' -%}
+        {%- set value = getTag(resource,'Name') -%}
+      {%- elif columnName == 'InstanceCount' -%}
+        {%- set value = resource['Instances'] | length -%}
+      {%- elif columnName == 'AccessKeys:RemainDays' -%}
+        {%- set combinedkeys = dict() -%}
+        {%- for accesskeydet in resource['c7n:AccessKeys'] -%}
+          {%- set accesskeyid = accesskeydet['AccessKeyId'] -%}
+          {%- set remaindays = ( expireDays - (accesskeydet['CreateDate'] | get_date_age)) -%}
+          {%- set _dummy = combinedkeys.update({ accesskeyid:remaindays }) -%}
+        {%- endfor -%}
+        {%- set value = combinedkeys -%}
+      {%- elif columnName == 'RoleLastUsed' -%}
+        {%- if resource['RoleLastUsed'].get('LastUsedDate') -%}
+          {%- set value = resource['RoleLastUsed'].get('LastUsedDate')  + ' (Last used ' ~ (resource['RoleLastUsed'].get('LastUsedDate')  | get_date_age)  + ' days ago)' -%}
+        {%- else -%}
+          {%- set value = "Never used -" + ' (Created ' ~ (resource['CreateDate'] | get_date_age)  + ' days ago)' -%}
+        {%- endif -%}
+      {%- elif columnName == 'PublicIp' -%}
+        {%- set value = resource['NetworkInterfaces'][0].get('Association')['PublicIp'] -%}
+      {%- elif columnName == 'PublicIpAddress' -%}
+        {%- set value = resource['PublicIp'] -%}
+      {%- else -%}
+        {% set value = resource[columnName] %}
+      {%- endif -%}
+      {%- if  inner_loop.index == 1 -%}
+        {{"\n"}}*- {{ columnName }}*: {{ value }}
+      {%- else %}
+    {{"\n     "}}*{{ columnName }}*: {{ value }}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endfor -%}
+{% endmacro %}
+
+{# Main #}
+{%- macro createTable(columnNames, resources) -%}
+  {{ columnData(resources, columnNames) }}
+{%- endmacro -%}
+
 {
    "attachments":[
       {
@@ -7,9 +67,138 @@
          "fields":[
             {
                "title":"Resources",
-               "value":"{%- for resource in resources -%}
-                        {{ format_resource(resource, policy['resource']) | replace('\\"', '"') | replace('"', '\\"') }}\n
-                        {%- endfor -%}"
+               "value":"{% if policy['resource'] == "ami" %}
+				{% set columnNames = ['Name','ImageId','CreationDate'] %}
+				{{ createTable(columnNames, resources) }}				
+		  				
+		        {% elif policy['resource'] == "app-elb" %}
+		          	{% set columnNames = ['LoadBalancerName','CreatedTime','Application','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}					  				
+		        							
+		        {% elif policy['resource'] == "asg" %}
+		        	{% if resources[0]['Invalid'] is defined %}
+		          		{% set columnNames = ['AutoScalingGroupName','InstanceCount','Invalid'] %}
+		          	{% else %}
+		          		{% set columnNames = ['AutoScalingGroupName','InstanceCount','Application','Owner'] %}
+		          	{% endif %}
+		        	{{ createTable(columnNames, resources) }}			  				
+		        	    	
+		        {% elif policy['resource'] == "cache-cluster" %}
+		          	{% set columnNames = ['CacheClusterId','CacheClusterCreateTime','CacheClusterStatus','Application','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}			  				  										  				
+
+		        {% elif policy['resource'] == "cache-snapshot" %}
+		        	{% set columnNames = ['SnapshotName','CacheClusterId','SnapshotSource','Application','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}			  	
+
+		        {% elif policy['resource'] == "cfn" %}
+		        	{% set columnNames = ['StackName'] %}
+		        	{{ createTable(columnNames, resources) }}			     	
+		        	
+		        {% elif policy['resource'] == "cloudsearch" %}
+		        	{% set columnNames = ['DomainName'] %}
+		        	{{ createTable(columnNames, resources) }}		    								    	
+		        	
+		        {% elif policy['resource'] == "ebs" %}
+		        	{% set columnNames = ['VolumeId','CreateTime','State','Application','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}		 
+		        	
+		        {% elif policy['resource'] == "ebs-snapshot" %}
+		        	{% set columnNames = ['SnapshotId','StartTime','Application','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}			     		
+		        	
+		        {% elif policy['resource'] == "ec2" %}
+		        	{% if resources[0]['MatchedFilters'] == ['PublicIpAddress'] %}
+		        		{% set columnNames = ['tag.Name','PublicIp','InstanceId'] %}
+		        	{% else %}
+		        		{% set columnNames = ['tag.Name','PrivateIpAddress','InstanceId','ImageId','Application','Owner'] %}
+		        	{% endif %}
+		        	{{ createTable(columnNames, resources) }}					   
+		        	
+		        {% elif policy['resource'] == "efs" %}
+		        	{% set columnNames = ['CreationToken','CreationTime','FileSystemId','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}		
+		        	  				
+		        {% elif policy['resource'] == "elasticsearch" %}
+		        	{% set columnNames = ['DomainName','Endpoint'] %}
+		        	{{ createTable(columnNames, resources) }}		
+		        	  				
+		        {% elif policy['resource'] == "elb" %}
+	    	        {% set columnNames = ['LoadBalancerName','InstanceCount','AvailabilityZones','Application','Owner'] %}	    		
+		        	{{ createTable(columnNames, resources) }}			  
+
+		        {% elif policy['resource'] == "emr" %}
+		        	{% set columnNames = ['Id','EmrState'] %}
+		        	{{ createTable(columnNames, resources) }}					
+
+  	       		{% elif policy['resource'] == "iam-user" %}
+    		        	{% set columnNames = ['UserName','AccessKeys:RemainDays','Application','CreateDate','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}					
+
+  	       		{% elif policy['resource'] == "iam-role" %}
+    		        	{% set columnNames = ['RoleName','RoleLastUsed','Application','CreateDate','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}					
+
+		        {% elif policy['resource'] == "kinesis" %}
+		        	{% set columnNames = ['StreamName'] %}
+		        	{{ createTable(columnNames, resources) }}						
+
+		        {% elif policy['resource'] == "launch-config" %}
+		            {% set columnNames = ['LaunchConfigurationName'] %}
+		        	{{ createTable(columnNames, resources) }}		
+
+		        {% elif policy['resource'] == "log-group" %}
+		        	{% set columnNames = ['logGroupName'] %}
+		        	{{ createTable(columnNames, resources) }}			  				  				  	
+		        	
+		        {% elif policy['resource'] == "rds" %}
+		        	{% if resources[0]['PubliclyAccessible'] == true or resources[0]['StorageEncrypted'] == false %}
+		        		{% set columnNames = ['DBInstanceIdentifier','PubliclyAccessible','StorageEncrypted','DBSubnetGroup'] %}
+		        	{% else %}
+		        		{% set columnNames = ['DBInstanceIdentifier','Application','Owner'] %}
+		        	{% endif %}				
+		        	{{ createTable(columnNames, resources) }}	
+		        				
+		        {% elif policy['resource'] == "rds-snapshot" %}
+		        	{% set columnNames = ['DBSnapshotIdentifier','SnapshotCreateTime','DBInstanceIdentifier','SnapshotType','Application','Owner'] %}
+		        	{{ createTable(columnNames, resources) }}				
+
+		        {% elif policy['resource'] == "redshift" %}
+		        	{% if resources[0]['PubliclyAccessible'] == true or resources[0]['Encrypted'] == false %}
+		        		{% set columnNames = ['ClusterIdentifier','NodeCount','PubliclyAccessible','Encrypted'] %}
+		        	{% else %}
+		        		{% set columnNames = ['ClusterIdentifier','NodeCount','Application','Owner'] %}
+		        	{% endif %}
+		        	{{ createTable(columnNames, resources) }}
+		        		  				
+		        {% elif policy['resource'] == "redshift-snapshot" %}
+		        	{% set columnNames = ['SnapshotIdentifier','DBName','Application','Owner'] %}
+		        	{{ createTable(columnNames, resources) }} 					  				
+		        			
+		        {% elif policy['resource'] == "s3" %}
+		        	{% if resources[0]['GlobalPermissions'] is defined %}
+		        	 	{% set columnNames = ['Name','GlobalPermissions'] %}
+		        	{% else %}
+		        		{% set columnNames = ['Name','Application','Owner'] %}
+		        	{% endif %}
+		        	{{ createTable(columnNames, resources) }} 										  								
+
+		        {% elif policy['resource'] == "security-group" %}
+		        	{% set columnNames = ['GroupName','tag.Name','GroupId','VpcId'] %}
+		        	{{ createTable(columnNames, resources) }}
+		        {% elif policy['resource'] == "iam-role" %}
+                                {% set columnNames = ['RoleName','CreateDate','Arn'] %}
+                                {{ createTable(columnNames, resources) }}
+		        	
+		        {% elif policy['resource'] == "simpledb" %}
+		        	{% set columnNames = ['DomainName'] %}
+		        	{{ createTable(columnNames, resources) }}	
+	                {% else %}
+	                  	{% set columnNames = resources[0].keys() %}
+	                  	{{ createTable(columnNames, resources) }}
+	                {% endif %}"
+	
+
             },
             {
                "title":"Account",


### PR DESCRIPTION
Team, I had pushed the code which I worked for improving the **email and slack templates by making it as unify modifications** in the future.  Also one more feature added as a bonus with having **remaining days** in the output result of email and slack for user access keys rotation and and last used date for roles resources.  You need some modification on the both templates with setting the **expireDays** variable 90 as default one, if have not provide.  If you guys think its useful please have a look and review, merge the same.