### PR TITLE
[Issue #6152] Error while executing policy flow-logs-enabled

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -134,7 +134,7 @@ class FlowLogFilter(Filter):
                 for fl in flogs:
                     dest_type_match = (destination_type is None) or op(
                         fl['LogDestinationType'], destination_type)
-                    dest_match = (destination is None) or op(
+                    dest_match = (destination is None) or (not hasattr(fl, 'LogDestination')) or op(
                         fl['LogDestination'], destination)
                     status_match = (status is None) or op(fl['FlowLogStatus'], status.upper())
                     delivery_status_match = (delivery_status is None) or op(


### PR DESCRIPTION
Vpc flow log destination comes back empty resulting in a KeyError.

![Screenshot 2022-04-08 at 11 03 02](https://user-images.githubusercontent.com/84714582/162414067-eb177e98-a5c9-468c-9a3b-948c646ea17c.png)


```
2022-04-08 10:53:31,343: custodian.output:ERROR Error while executing policy
Traceback (most recent call last):
  File "/Users/Alexandru.Popa/dev/tmp/custodian/lib/python3.9/site-packages/c7n/policy.py", line 285, in run
    resources = self.policy.resource_manager.resources()
  File "/Users/Alexandru.Popa/dev/tmp/custodian/lib/python3.9/site-packages/c7n/query.py", line 523, in resources
    resources = self.filter_resources(resources)
  File "/Users/Alexandru.Popa/dev/tmp/custodian/lib/python3.9/site-packages/c7n/manager.py", line 111, in filter_resources
    resources = f.process(resources, event)
  File "/Users/Alexandru.Popa/dev/tmp/custodian/lib/python3.9/site-packages/c7n/filters/core.py", line 340, in process
    return self.process_set(resources, event)
  File "/Users/Alexandru.Popa/dev/tmp/custodian/lib/python3.9/site-packages/c7n/filters/core.py", line 359, in process_set
    resources = f.process(resources, event)
  File "/Users/Alexandru.Popa/dev/tmp/custodian/lib/python3.9/site-packages/c7n/resources/vpc.py", line 139, in process
    fl['LogDestination'], destination)
KeyError: 'LogDestination'
```


```
Custodian:   0.9.11
Python:      3.9.10 (main, Jan 15 2022, 11:48:04) 
             [Clang 13.0.0 (clang-1300.0.29.3)]
Platform:    posix.uname_result(sysname='Darwin', nodename='C02FN00MML88.local', release='21.4.0', version='Darwin Kernel Version 21.4.0: Mon Feb 21 20:34:37 PST 2022; root:xnu-8020.101.4~2/RELEASE_X86_64', machine='x86_64')
Using venv:  True
Docker: False
Installed: 

argcomplete==1.12.2
attrs==20.3.0
boto3==1.17.33
botocore==1.20.33
importlib-metadata==3.7.3
jmespath==0.10.0
jsonpickle==1.3
jsonschema==3.2.0
pyrsistent==0.17.3
python-dateutil==2.8.1
pyyaml==5.4.1
s3transfer==0.3.6
setuptools==56.0.0
six==1.15.0
tabulate==0.8.9
typing-extensions==3.7.4.3
urllib3==1.26.4
zipp==3.4.1
```