### PR TITLE
Added waiter for set-public-access action before modifying instance.

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -902,6 +902,8 @@ class RDSSetPublicAvailability(BaseAction):
 
     def set_accessibility(self, r):
         client = local_session(self.manager.session_factory).client('rds')
+        waiter = client.get_waiter('db_instance_available')
+        waiter.wait(DBInstanceIdentifier=r['DBInstanceIdentifier'])
         client.modify_db_instance(
             DBInstanceIdentifier=r['DBInstanceIdentifier'],
             PubliclyAccessible=self.data.get('state', False))


### PR DESCRIPTION
set-public-access is getting failed if RDS instance is not in available state, added waiter for RDS instance available state before modifying instance. 