### PR TITLE
aws - metrics - include days prop in cache key

### DIFF
--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -124,7 +124,7 @@ class MetricsFilter(Filter):
     }
 
     def process(self, resources, event=None):
-        days = self.data.get('days', 14)
+        self.days = days = self.data.get('days', 14)
         duration = timedelta(days)
 
         self.metric = self.data['name']
@@ -192,7 +192,7 @@ class MetricsFilter(Filter):
             # policies, still the lack of full qualification on the key
             # means multiple filters within a policy using the same metric
             # across different periods or dimensions would be problematic.
-            key = "%s.%s.%s" % (self.namespace, self.metric, self.statistics)
+            key = "%s.%s.%s.%s" % (self.namespace, self.metric, self.statistics, str(self.days))
             if key not in collected_metrics:
                 collected_metrics[key] = client.get_metric_statistics(
                     Namespace=self.namespace,

--- a/tests/test_appelb.py
+++ b/tests/test_appelb.py
@@ -467,7 +467,7 @@ class AppELBTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['LoadBalancerName'], 'nicnoc')
         self.assertTrue(
-            'AWS/NetworkELB.TCP_ELB_Reset_Count.Sum' in resources[
+            'AWS/NetworkELB.TCP_ELB_Reset_Count.Sum.0.25' in resources[
                 0]['c7n.metrics'])
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1055,12 +1055,12 @@ class TestMetricsFilter(BaseTest):
 
         self.assertEqual(len(resources), 2)
         self.assertEqual(all(
-            isinstance(res["c7n.metrics"]["AWS/ELB.RequestCount.Sum"], list)
+            isinstance(res["c7n.metrics"]["AWS/ELB.RequestCount.Sum.14"], list)
             for res in resources
         ), True)
         self.assertIn(
             "Fill value for missing data",
-            (res["c7n.metrics"]["AWS/ELB.RequestCount.Sum"][0].get("c7n:detail")
+            (res["c7n.metrics"]["AWS/ELB.RequestCount.Sum.14"][0].get("c7n:detail")
                 for res in resources)
         )
 
@@ -1092,7 +1092,7 @@ class TestMetricsFilter(BaseTest):
         # Set a fixed end time for the metrics filter with a non-zero minute component.
         with mock_datetime_now(parse_date("2020-12-03T04:45:00+00:00"), base_filters.metrics):
             resources = p.run()
-            datapoints = resources[0]["c7n.metrics"]["AWS/SQS.NumberOfMessagesSent.Sum"]
+            datapoints = resources[0]["c7n.metrics"]["AWS/SQS.NumberOfMessagesSent.Sum.90"]
 
         self.assertEqual(metrics_filter.start.strftime("%H:%M"), "04:00")
         self.assertEqual(len(resources), 1)

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -317,7 +317,7 @@ class LambdaTest(BaseTest):
                     {
                         "type": "set-concurrency",
                         "expr": True,
-                        "value": '"c7n.metrics"."AWS/Lambda.Invocations.Sum"[0].Sum',
+                        "value": '"c7n.metrics"."AWS/Lambda.Invocations.Sum.14"[0].Sum',
                     }
                 ],
             },

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -181,7 +181,7 @@ class BucketMetrics(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["Name"], "custodian-skunk-trails")
         self.assertTrue("c7n.metrics" in resources[0])
-        self.assertTrue("AWS/S3.NumberOfObjects.Average" in resources[0]["c7n.metrics"])
+        self.assertTrue("AWS/S3.NumberOfObjects.Average.14" in resources[0]["c7n.metrics"])
 
 
 class BucketEncryption(BaseTest):


### PR DESCRIPTION
As noted in c7n/filters/metrics.py 6 years ago, the key could be problematic.
```
            # Note this annotation cache is policy scoped, not across
            # policies, still the lack of full qualification on the key
            # means multiple filters within a policy using the same metric
            # across different periods or dimensions would be problematic.
            key = "%s.%s.%s.%s" % (self.namespace, self.metric, self.statistics, str(self.days))
```

When comes to filters like these, it's an issue. This PR is to make the below filters work.
```
  no-connections: &no-connections
    type: metrics
    name: DatabaseConnections
    value: 0
    op: le
    statistics: Maximum
    missing-value: 0

  no-connections-now: &no-connections-now
    <<: *no-connections
    days: 0.04 # 1 hour
    period: 300 # seconds

  no-connections-today: &no-connections-today
    <<: *no-connections
    days: 1
    period: 3600 # 1 hour
```