### PR TITLE
AWS - Workspaces - deregister action

### DIFF
--- a/tests/data/placebo/test_workspaces_directory_deregister/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_workspaces_directory_deregister/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:workspaces:us-east-1:644160558196:directory/d-906748ece0",
+                "Tags": [
+                    {
+                        "Key": "Deregister",
+                        "Value": "true"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_workspaces_directory_deregister/workspaces.DeregisterWorkspaceDirectory_1.json
+++ b/tests/data/placebo/test_workspaces_directory_deregister/workspaces.DeregisterWorkspaceDirectory_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_workspaces_directory_deregister/workspaces.DescribeWorkspaceDirectories_1.json
+++ b/tests/data/placebo/test_workspaces_directory_deregister/workspaces.DescribeWorkspaceDirectories_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "Directories": [
+            {
+                "DirectoryId": "d-906748ece0",
+                "Alias": "c7ntesting",
+                "DirectoryName": "c7ntesting.com",
+                "RegistrationCode": "SLiad+N74PUL",
+                "SubnetIds": [
+                    "subnet-0bd18cd4df2d0d3b9",
+                    "subnet-0472841b16adf7476"
+                ],
+                "DnsIpAddresses": [
+                    "10.0.25.80",
+                    "10.0.1.72"
+                ],
+                "CustomerUserName": "Administrator",
+                "IamRoleId": "arn:aws:iam::644160558196:role/workspaces_DefaultRole",
+                "DirectoryType": "SIMPLE_AD",
+                "WorkspaceSecurityGroupId": "sg-0a570fceece0a9615",
+                "State": "REGISTERED",
+                "WorkspaceCreationProperties": {
+                    "EnableWorkDocs": false,
+                    "EnableInternetAccess": false,
+                    "UserEnabledAsLocalAdministrator": true,
+                    "EnableMaintenanceMode": true
+                },
+                "WorkspaceAccessProperties": {
+                    "DeviceTypeWindows": "ALLOW",
+                    "DeviceTypeOsx": "ALLOW",
+                    "DeviceTypeWeb": "DENY",
+                    "DeviceTypeIos": "ALLOW",
+                    "DeviceTypeAndroid": "ALLOW",
+                    "DeviceTypeChromeOs": "ALLOW",
+                    "DeviceTypeZeroClient": "ALLOW",
+                    "DeviceTypeLinux": "DENY"
+                },
+                "Tenancy": "SHARED",
+                "SelfservicePermissions": {
+                    "RestartWorkspace": "ENABLED",
+                    "IncreaseVolumeSize": "DISABLED",
+                    "ChangeComputeType": "DISABLED",
+                    "SwitchRunningMode": "DISABLED",
+                    "RebuildWorkspace": "DISABLED"
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_workspaces_directory_deregister/workspaces.DescribeWorkspaceDirectories_2.json
+++ b/tests/data/placebo/test_workspaces_directory_deregister/workspaces.DescribeWorkspaceDirectories_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Directories": [],
+        "ResponseMetadata": {}
+    }
+}


### PR DESCRIPTION
Addressing issue #7225 

Adding a new action for Workspaces directory resources to deregister directories. 