### PR TITLE
AWS - Lambda - Add Lambda@Edge filter

### DIFF
--- a/tests/data/placebo/test_aws_lambda_edge/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_aws_lambda_edge/cloudfront.ListDistributions_1.json
@@ -1,0 +1,124 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DistributionList": {
+            "Marker": "",
+            "MaxItems": 100,
+            "IsTruncated": false,
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "E2SXWKJGGZ872U",
+                    "ARN": "arn:aws:cloudfront::644160558196:distribution/E2SXWKJGGZ872U",
+                    "Status": "Deployed",
+                    "LastModifiedTime": {
+                        "__class__": "datetime",
+                        "year": 2022,
+                        "month": 5,
+                        "day": 3,
+                        "hour": 16,
+                        "minute": 47,
+                        "second": 19,
+                        "microsecond": 426000
+                    },
+                    "DomainName": "djsor8e3s8pxf.cloudfront.net",
+                    "Aliases": {
+                        "Quantity": 0
+                    },
+                    "Origins": {
+                        "Quantity": 1,
+                        "Items": [
+                            {
+                                "Id": "demo-pratyush-s3-bucket-2022.s3.us-east-1.amazonaws.com",
+                                "DomainName": "demo-pratyush-s3-bucket-2022.s3.us-east-1.amazonaws.com",
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": "origin-access-identity/cloudfront/E1HDZBBD47I5Y5"
+                                },
+                                "ConnectionAttempts": 3,
+                                "ConnectionTimeout": 10,
+                                "OriginShield": {
+                                    "Enabled": false
+                                }
+                            }
+                        ]
+                    },
+                    "OriginGroups": {
+                        "Quantity": 0
+                    },
+                    "DefaultCacheBehavior": {
+                        "TargetOriginId": "demo-pratyush-s3-bucket-2022.s3.us-east-1.amazonaws.com",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "allow-all",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 1,
+                            "Items": [
+                                {
+                                    "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:edge-filter-test:5",
+                                    "EventType": "origin-response",
+                                    "IncludeBody": false
+                                }
+                            ]
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    },
+                    "CacheBehaviors": {
+                        "Quantity": 0
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "Comment": "",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": true,
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "SSLSupportMethod": "vip",
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "WebACLId": "",
+                    "HttpVersion": "HTTP2",
+                    "IsIPV6Enabled": true
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_aws_lambda_edge/lambda.ListFunctions_1.json
+++ b/tests/data/placebo/test_aws_lambda_edge/lambda.ListFunctions_1.json
@@ -1,0 +1,387 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Functions": [
+            {
+                "FunctionName": "custodian-post-ebs-snapshot-public",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-post-ebs-snapshot-public",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "custodian_policy.run",
+                "CodeSize": 495704,
+                "Description": "post findings if snapshot shared outside of org which includes if public",
+                "Timeout": 3,
+                "MemorySize": 128,
+                "LastModified": "2022-03-02T03:56:43.000+0000",
+                "CodeSha256": "P0oG/ciyGfgtB6C3MkOT1pKBkjejAGLHGuoCbs5pt5g=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [
+                        "subnet-05b58b4afe5124322"
+                    ],
+                    "SecurityGroupIds": [
+                        "sg-05c4bbdf77917f3d1"
+                    ],
+                    "VpcId": "vpc-0a59f94e3fca9fbc0"
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "9a63888a-b5ee-48c5-b9c0-bed12c8dd371",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "CloudActionModulePoc3Stac-LogRetentionaae0aa3c5b4d-st0bpU8m2cTo",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:CloudActionModulePoc3Stac-LogRetentionaae0aa3c5b4d-st0bpU8m2cTo",
+                "Runtime": "nodejs14.x",
+                "Role": "arn:aws:iam::644160558196:role/CloudActionModulePoc3Stac-LogRetentionaae0aa3c5b4d-17CJW3ASN7MT1",
+                "Handler": "index.handler",
+                "CodeSize": 5220,
+                "Description": "",
+                "Timeout": 3,
+                "MemorySize": 128,
+                "LastModified": "2022-04-08T14:47:18.564+0000",
+                "CodeSha256": "ojIag4IfVmMig/2aX2+qQAkJkpMYnbeB3T3wZPzoOfQ=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "20fcb08b-10e0-4f50-9926-a162da624c4a",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "custodian-test-ecs-td-last-used-timestamp",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-test-ecs-td-last-used-timestamp",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "custodian_policy.run",
+                "CodeSize": 498379,
+                "Description": "cloud-custodian lambda policy",
+                "Timeout": 900,
+                "MemorySize": 512,
+                "LastModified": "2022-03-09T21:05:34.144+0000",
+                "CodeSha256": "43g82vX3/xaNWC+xlzkFeQfGjRMIbQFFU1+84wjRkKY=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "a0127d9d-e1ed-48bb-a2fc-6dc542b2543d",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "CloudActionModulePoc3Stack-IngestionLambdaEF25F265-mRpHWGSq9jhn",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:CloudActionModulePoc3Stack-IngestionLambdaEF25F265-mRpHWGSq9jhn",
+                "Runtime": "python3.9",
+                "Role": "arn:aws:iam::644160558196:role/CloudActionModulePoc3Stac-IngestionLambdaExecution-1E8ETFQJKUZ02",
+                "Handler": "ingestion.lambda_handler",
+                "CodeSize": 1895,
+                "Description": "",
+                "Timeout": 3,
+                "MemorySize": 128,
+                "LastModified": "2022-04-12T21:09:16.000+0000",
+                "CodeSha256": "asilXcEp63oQE3zcpCzM8zPl0tScqxkGysef0BNA54Q=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "3329cb47-7768-43b7-8d65-e22795f2faa0",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "test-pratyush",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:test-pratyush",
+                "Runtime": "python3.9",
+                "Role": "arn:aws:iam::644160558196:role/service-role/test-pratyush-role-z8t69erp",
+                "Handler": "lambda_function.lambda_handler",
+                "CodeSize": 220,
+                "Description": "",
+                "Timeout": 3,
+                "MemorySize": 128,
+                "LastModified": "2022-04-20T21:50:01.000+0000",
+                "CodeSha256": "CgG1dtSripiTmFxTZ6uKHO3z+R0lW0/Zzws96pDHmHA=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "fe6d0ef5-a3fa-4c16-9838-46b30bdacfd4",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "custodian-enterprise-rds-clust-sg-sn-netloc-tags-newchange",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-enterprise-rds-clust-sg-sn-netloc-tags-newchange",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "custodian_policy.run",
+                "CodeSize": 494606,
+                "Description": "SC-7.AWS.23(v1): All RDS resource subnets must match the NetworkLocation tag of the attached Security Group.",
+                "Timeout": 900,
+                "MemorySize": 512,
+                "LastModified": "2021-12-08T04:56:06.037+0000",
+                "CodeSha256": "4kNBrNJzHIteV+bD3OG3FHIyg9t/qdkYIGnqJ3nk0Ss=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "8e7038df-b784-4c15-8246-0620cbd1757a",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "custodian-post-ebs-snapshot-public-passing",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-post-ebs-snapshot-public-passing",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "custodian_policy.run",
+                "CodeSize": 495689,
+                "Description": "post findings if snapshot shared outside of org which includes if public",
+                "Timeout": 900,
+                "MemorySize": 128,
+                "LastModified": "2022-01-20T02:45:03.042+0000",
+                "CodeSha256": "H1Ow10mdIOYm+nWdXigkiU2bQhLdMSZ5sBRhVEhdC9M=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "e805f14b-fba9-48c4-9212-d98b76a530fe",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "test-python",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:test-python",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/BrentTestCustodianRole",
+                "Handler": "lambda_function.lambda_handler",
+                "CodeSize": 300,
+                "Description": "",
+                "Timeout": 3,
+                "MemorySize": 128,
+                "LastModified": "2022-04-12T14:36:03.089+0000",
+                "CodeSha256": "YILsaYMROYwZjWFweT4yJ6tPf40OwvI9jKdrfshdVuA=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "17098892-91b8-4a21-8b40-7ee4d2753c98",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "CloudActionModulePoc3Stac-LambdaRemediationLambdaB-KgXaIyUdBPsP",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:CloudActionModulePoc3Stac-LambdaRemediationLambdaB-KgXaIyUdBPsP",
+                "Runtime": "python3.9",
+                "Role": "arn:aws:iam::644160558196:role/CloudActionModulePoc3Stac-LambdaRemediationLambdaS-19OYFO3I3LIQB",
+                "Handler": "remediation.lambda_handler",
+                "CodeSize": 1667,
+                "Description": "",
+                "Timeout": 3,
+                "MemorySize": 128,
+                "LastModified": "2022-04-12T19:12:32.000+0000",
+                "CodeSha256": "tkiz0xd1i+Pt1PtjjhLfp27f38MoFKRK1QzxgAZoYPA=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "c9de7a22-c4d2-4ca5-b3e5-a671b31a2f54",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "CloudActionModulePoc4Stack-IngestionLambda",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:CloudActionModulePoc4Stack-IngestionLambda",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/CloudActionModulePoc3Stac-IngestionLambdaExecution-1E8ETFQJKUZ02",
+                "Handler": "lambda_function.lambda_handler",
+                "CodeSize": 510,
+                "Description": "",
+                "Timeout": 3,
+                "MemorySize": 128,
+                "LastModified": "2022-04-21T19:54:47.000+0000",
+                "CodeSha256": "e8czSxK4l5zWCyXdYI/Cjmy4pNrYTUtKVKe8fT9nIdE=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "c2bac461-c478-4a34-9239-3e06bbe50eda",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "edge-filter-test",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:edge-filter-test",
+                "Runtime": "nodejs12.x",
+                "Role": "arn:aws:iam::644160558196:role/BrentTestCustodianRole",
+                "Handler": "index.handler",
+                "CodeSize": 350,
+                "Description": "Blueprint for modifying CloudFront response header implemented in NodeJS.",
+                "Timeout": 1,
+                "MemorySize": 128,
+                "LastModified": "2022-05-03T19:22:03.000+0000",
+                "CodeSha256": "fvlh5JTW8cCUyvD59KsCFwFo28SE5BDVkF0XBiA7AKQ=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "04491992-0fa8-4228-afe9-91ff79072cd7",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "custodian-ec2-sechub-remediate-severity-with-findings",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-ec2-sechub-remediate-severity-with-findings",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "custodian_policy.run",
+                "CodeSize": 500498,
+                "Description": "Security Finding imported filtering on Severity >= Medium, Name, and a previous report of a Vulnerability",
+                "Timeout": 900,
+                "MemorySize": 256,
+                "LastModified": "2022-04-05T18:09:26.000+0000",
+                "CodeSha256": "EE6hQg6jszJXNmh3cSyX1lAmDCJY8GP3GCooKE0CiHA=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "fda3324d-2d09-4a83-a36a-3ac7244c2a91",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "custodian-ec2-sechub-remediate-severity-with-findings-delete",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-ec2-sechub-remediate-severity-with-findings-delete",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "custodian_policy.run",
+                "CodeSize": 500608,
+                "Description": "Security Finding imported filtering on Severity >= Medium, Name, and a previous report of a Vulnerability",
+                "Timeout": 900,
+                "MemorySize": 256,
+                "LastModified": "2022-04-07T14:14:42.098+0000",
+                "CodeSha256": "SyucS4M9bI9eQaZuSOE0NXWKN4lULT3NbevobKi5Va8=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "5fb0a413-da6b-445e-b230-734094fc67a7",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "test-poc-4",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:test-poc-4",
+                "Runtime": "python3.9",
+                "Role": "arn:aws:iam::644160558196:role/test-poc-remediation",
+                "Handler": "lambda_function.lambda_handler",
+                "CodeSize": 500216,
+                "Description": "",
+                "Timeout": 843,
+                "MemorySize": 128,
+                "LastModified": "2022-04-21T19:35:51.000+0000",
+                "CodeSha256": "X9HQnz20i6UUJGYeZT141D1vh0zC8Yj00F1bBBBkh9c=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "0a603175-2d53-41ee-83e8-c25ecf2da095",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "custodian-lambda-sechub-lambda-remove-signature",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-lambda-sechub-lambda-remove-signature",
+                "Runtime": "python3.8",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "custodian_policy.run",
+                "CodeSize": 500650,
+                "Description": "Security Finding imported filtering on Severity >= Medium, Name, and a previous report of a Vulnerability",
+                "Timeout": 900,
+                "MemorySize": 256,
+                "LastModified": "2022-04-18T16:22:27.000+0000",
+                "CodeSha256": "e3GcAUT6fCehERSotxo76cxMbJyi3rQzlJ1VhaZZBOM=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "ae562c8e-0d87-422c-a510-360533f5566a",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_aws_lambda_edge/lambda.ListVersionsByFunction_1.json
+++ b/tests/data/placebo/test_aws_lambda_edge/lambda.ListVersionsByFunction_1.json
@@ -1,0 +1,79 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Versions": [
+            {
+                "FunctionName": "edge-filter-test",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:edge-filter-test:$LATEST",
+                "Runtime": "nodejs12.x",
+                "Role": "arn:aws:iam::644160558196:role/BrentTestCustodianRole",
+                "Handler": "index.handler",
+                "CodeSize": 350,
+                "Description": "Blueprint for modifying CloudFront response header implemented in NodeJS.",
+                "Timeout": 1,
+                "MemorySize": 128,
+                "LastModified": "2022-05-03T19:22:03.000+0000",
+                "CodeSha256": "fvlh5JTW8cCUyvD59KsCFwFo28SE5BDVkF0XBiA7AKQ=",
+                "Version": "$LATEST",
+                "VpcConfig": {
+                    "SubnetIds": [],
+                    "SecurityGroupIds": [],
+                    "VpcId": ""
+                },
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "04491992-0fa8-4228-afe9-91ff79072cd7",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "edge-filter-test",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:edge-filter-test:4",
+                "Runtime": "nodejs12.x",
+                "Role": "arn:aws:iam::644160558196:role/BrentTestCustodianRole",
+                "Handler": "index.handler",
+                "CodeSize": 339,
+                "Description": "Testing lambda edge filter",
+                "Timeout": 1,
+                "MemorySize": 128,
+                "LastModified": "2022-05-03T16:00:41.000+0000",
+                "CodeSha256": "ow6y7haF235HgJf6BUggCziWOE1bLnyRdnT39xtdJ5g=",
+                "Version": "4",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "f9b9fb9c-e2e8-4a11-afc5-be9f346cc701",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            },
+            {
+                "FunctionName": "edge-filter-test",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:edge-filter-test:5",
+                "Runtime": "nodejs12.x",
+                "Role": "arn:aws:iam::644160558196:role/BrentTestCustodianRole",
+                "Handler": "index.handler",
+                "CodeSize": 350,
+                "Description": "Blueprint for modifying CloudFront response header implemented in NodeJS.",
+                "Timeout": 1,
+                "MemorySize": 128,
+                "LastModified": "2022-05-03T16:47:19.563+0000",
+                "CodeSha256": "fvlh5JTW8cCUyvD59KsCFwFo28SE5BDVkF0XBiA7AKQ=",
+                "Version": "5",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "8fce2d02-1e97-43d4-9fdf-85b5dd9f9ea4",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_aws_lambda_edge/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_aws_lambda_edge/tagging.GetResources_1.json
@@ -1,0 +1,157 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:custodian-post-ebs-snapshot-public",
+                "Tags": [
+                    {
+                        "Key": "CreatedBy",
+                        "Value": "CloudCustodian"
+                    },
+                    {
+                        "Key": "custodian-info",
+                        "Value": "mode=cloudtrail:version=0.9.15"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:CloudActionModulePoc3Stac-LogRetentionaae0aa3c5b4d-st0bpU8m2cTo",
+                "Tags": [
+                    {
+                        "Key": "aws:cloudformation:stack-name",
+                        "Value": "CloudActionModulePoc3Stack"
+                    },
+                    {
+                        "Key": "aws:cloudformation:stack-id",
+                        "Value": "arn:aws:cloudformation:us-east-1:644160558196:stack/CloudActionModulePoc3Stack/a9ffcfa0-b74a-11ec-95ce-0ea7f09e1d49"
+                    },
+                    {
+                        "Key": "aws:cloudformation:logical-id",
+                        "Value": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:custodian-test-ecs-td-last-used-timestamp",
+                "Tags": [
+                    {
+                        "Key": "custodian-info",
+                        "Value": "mode=cloudtrail:version=0.9.15"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:CloudActionModulePoc3Stack-IngestionLambdaEF25F265-mRpHWGSq9jhn",
+                "Tags": [
+                    {
+                        "Key": "aws:cloudformation:stack-name",
+                        "Value": "CloudActionModulePoc3Stack"
+                    },
+                    {
+                        "Key": "aws:cloudformation:stack-id",
+                        "Value": "arn:aws:cloudformation:us-east-1:644160558196:stack/CloudActionModulePoc3Stack/a9ffcfa0-b74a-11ec-95ce-0ea7f09e1d49"
+                    },
+                    {
+                        "Key": "c7n:FindingId:lambda-force-vulnerabilities",
+                        "Value": "us-east-1/644160558196/8b34d68bb91a6355cb1f62e52cc471cc/b6e21b33259192f1efebaea71bf6a536:2022-04-12T20:55:33.185422+00:00"
+                    },
+                    {
+                        "Key": "aws:cloudformation:logical-id",
+                        "Value": "IngestionLambdaEF25F265"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:custodian-enterprise-rds-clust-sg-sn-netloc-tags-newchange",
+                "Tags": [
+                    {
+                        "Key": "custodian-info",
+                        "Value": "mode=cloudtrail:version=0.9.14"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:custodian-post-ebs-snapshot-public-passing",
+                "Tags": [
+                    {
+                        "Key": "CreatedBy",
+                        "Value": "CloudCustodian"
+                    },
+                    {
+                        "Key": "custodian-info",
+                        "Value": "mode=cloudtrail:version=0.9.15"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:test-python",
+                "Tags": [
+                    {
+                        "Key": "c7n:FindingId:lambda-force-vulnerabilities",
+                        "Value": "us-east-1/644160558196/a045b52dbdf3f1601befc59dd0c8526f/a317aa172505e9805fb207a8b22c1e72:2022-04-12T14:37:06.132664+00:00"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:CloudActionModulePoc3Stac-LambdaRemediationLambdaB-KgXaIyUdBPsP",
+                "Tags": [
+                    {
+                        "Key": "aws:cloudformation:stack-name",
+                        "Value": "CloudActionModulePoc3Stack"
+                    },
+                    {
+                        "Key": "aws:cloudformation:stack-id",
+                        "Value": "arn:aws:cloudformation:us-east-1:644160558196:stack/CloudActionModulePoc3Stack/a9ffcfa0-b74a-11ec-95ce-0ea7f09e1d49"
+                    },
+                    {
+                        "Key": "aws:cloudformation:logical-id",
+                        "Value": "LambdaRemediationLambdaBB234D1C"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:CloudActionModulePoc4Stack-IngestionLambda",
+                "Tags": []
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:edge-filter-test",
+                "Tags": [
+                    {
+                        "Key": "lambda-console:blueprint",
+                        "Value": "cloudfront-modify-response-header"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:custodian-ec2-sechub-remediate-severity-with-findings",
+                "Tags": [
+                    {
+                        "Key": "custodian-info",
+                        "Value": "mode=hub-finding:version=0.9.15"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:custodian-ec2-sechub-remediate-severity-with-findings-delete",
+                "Tags": [
+                    {
+                        "Key": "custodian-info",
+                        "Value": "mode=hub-finding:version=0.9.15"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:custodian-lambda-sechub-lambda-remove-signature",
+                "Tags": [
+                    {
+                        "Key": "custodian-info",
+                        "Value": "mode=hub-finding:version=0.9.15"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_aws_lambda_edge/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_aws_lambda_edge/tagging.GetResources_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -385,6 +385,39 @@ class LambdaTest(BaseTest):
         self.assertEqual(resources[0]["FunctionName"], "mys3")
         self.assertEqual(resources[0]["c7n:matched-security-groups"], ["sg-f9cc4d9f"])
 
+    def test_lambda_edge(self):
+        factory = self.replay_flight_data("test_aws_lambda_edge")
+        p = self.load_policy(
+            {
+                "name": "lambda-edge-filter",
+                "resource": "lambda",
+                "filters": [{"type": "lambda-edge",
+                            "state": True}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            {r["VersionedFunctionArn"] for r in resources},
+            {"arn:aws:lambda:us-east-1:644160558196:function:edge-filter-test:5"}
+        )
+
+    def test_lambda_edge_non_edge(self):
+        factory = self.replay_flight_data("test_aws_lambda_edge")
+        p = self.load_policy(
+            {
+                "name": "lambda-edge-filter",
+                "resource": "lambda",
+                "filters": [{"type": "lambda-edge",
+                            "state": False}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertNotEqual(len(resources), 1)
+        self.assertTrue({"VersionedFunctionArn" not in r.keys() for r in resources})
+
 
 class LambdaTagTest(BaseTest):
 


### PR DESCRIPTION
This PR is to address #6034 and an extension of #5999 which was an old PR that was never completed. 
I've attempted to address all the comments in #5999 in the implementation. 

When filtering with lambda-edge set to true, the filter will compare the versioned ARN of Lambda functions associated with Cloudfront distributions with every version of the particular Lambda function. If a match is found, filter will return the resource along with the versioned ARN and the DistributionID of the associated distribution. 

When filtering with lambda-edge set to false, the filter will return any resource that is not associated with a Cloudfront distribution found by Cloud Custodian as-is without any additional fields for versioned ARN or DistributionID.

@PratMis @kapilt let me know your thoughts, thanks!
