### PR TITLE
ci - deploy docs to gh-pages on push to main

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -109,6 +109,14 @@ jobs:
         run: |
           make sphinx
 
+      - name: Deploy Docs
+        if: ${{ github.event_name == 'push' }}
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        with:
+          branch: gh-pages
+          folder: docs/build/html
+          target-folder: docs
+
   Tests:
     runs-on: "${{ matrix.os }}"
     needs: Lint


### PR DESCRIPTION
During a push to main, we already build docs. This PR adds a step to publish those built docs to GitHub Pages using [this GitHub action](https://github.com/JamesIves/github-pages-deploy-action).

This came out of some discussion with @castrojo who came across the action and wondered if/where/how it would fit into our process. Looks like it can slot in nicely right after the build we already run, as long as we set the source & target folders appropriately. Tested in my fork [here](https://github.com/ajkerrigan/cloud-custodian/runs/6296787289?check_suite_focus=true).