### PR TITLE
fix(aws.glue-catalog): Use the QueryResourceManager.

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -3,7 +3,7 @@
 import json
 from botocore.exceptions import ClientError
 from concurrent.futures import as_completed
-from c7n.manager import resources, ResourceManager
+from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
 from c7n.utils import local_session, chunks, type_schema
 from c7n.actions import BaseAction, ActionRegistry, RemovePolicyBase
@@ -566,7 +566,7 @@ class GlueWorkflowSecurityConfigFilter(SecurityConfigFilter):
 
 
 @resources.register('glue-catalog')
-class GlueDataCatalog(ResourceManager):
+class GlueDataCatalog(QueryResourceManager):
 
     filter_registry = FilterRegistry('glue-catalog.filters')
     action_registry = ActionRegistry('glue-catalog.actions')


### PR DESCRIPTION
The resource manager says it `has_arn` but doesn't implement `get_arns`.
I'm fairly sure that this is because it doesn't inherit from the QueryResourceManager.

Not sure where or how to test, please advise.