### PR TITLE
aws - account - support config poll rule evaluations

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -48,6 +48,7 @@ class Account(ResourceManager):
     filter_registry = filters
     action_registry = actions
     retry = staticmethod(QueryResourceManager.retry)
+    source_type = 'describe'
 
     class resource_type(TypeInfo):
         id = 'account_id'
@@ -56,6 +57,8 @@ class Account(ResourceManager):
         global_resource = True
         # fake this for doc gen
         service = "account"
+        # for posting config rule evaluations
+        cfn_type = 'AWS::::Account'
 
     @classmethod
     def get_permissions(cls):


### PR DESCRIPTION
Specifying `AWS::::Account` as the `cfn_type` for `aws.account` allows folks to evaluate account-level Config rules on a schedule.

Addresses #7462

The `aws.account` resource is neither [natively supported by Config](https://github.com/awslabs/aws-config-resource-schema/tree/master/config/properties/resource-types) nor listed as a [supported resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html) for custom rules. Still, there are [working examples](https://docs.aws.amazon.com/config/latest/developerguide/example-config-rule-compliance-notification.html) of Config rules using the `AWS::::Account` resource type.

I also considered a broader change here, having Config rule policies fall back to `AWS::::Account` so we can theoretically support any resource type even if its Custodian resource doesn't have `config_type` or `cfn_type` specified. That's a farther-reaching change though and I'm not sure it's a good idea. This narrowly-scoped change seems more clearly useful.