### PR TITLE
aws - subnet filter - public option for igw route checking

### DIFF
--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -93,7 +93,7 @@ class SubnetFilter(MatchResourceValidator, RelatedResourceFilter):
                 return False
         return super().match(related)
 
-    def process(self, resources):
+    def process(self, resources, event=None):
         related = self.get_related(resources)
         if self.check_public in [True, False]:
             self.route_tables = self.get_route_tables(related)

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -101,11 +101,8 @@ class SubnetFilter(MatchResourceValidator, RelatedResourceFilter):
 
     def get_route_tables(self, subnets):
         rmanager = self.manager.get_resource_manager('aws.route-table')
-        rtables = rmanager.resources(
-            query={'association.subnet-id': sorted([
-                s['SubnetId'] for s in subnets])})
         route_tables = {}
-        for r in rtables:
+        for r in rmanager.resources():
             for a in r['Associations']:
                 if a['Main']:
                     route_tables[r['VpcId']] = r

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -28,15 +28,108 @@ class SecurityGroupFilter(MatchResourceValidator, RelatedResourceFilter):
 
 
 class SubnetFilter(MatchResourceValidator, RelatedResourceFilter):
-    """Filter a resource by its associated subnets."""
+    """Filter a resource by its associated subnets attributes.
+
+    This filter is generally available for network attached resources.
+
+    ie. to find lambda functions that are vpc attached to subnets with
+    a tag key Location and value Database.
+
+    :example:
+
+    .. code-block:: yaml
+
+      policies:
+        - name: lambda
+          resource: aws.lambda
+          filters:
+            - type: subnet
+              key: tag:Location
+              value: Database
+
+    It also supports finding resources on public or private subnets
+    via route table introspection to determine if its associated to an
+    internet gateway.
+
+    :example:
+
+    .. code-block:: yaml
+
+      policies:
+         - name: public-ec2
+           resource: aws.ec2
+           filters:
+             - type: subnet
+               public: True
+               key: SubnetId
+               value: present
+    """
+
     schema = type_schema(
         'subnet', rinherit=ValueFilter.schema,
         **{'match-resource': {'type': 'boolean'},
-           'operator': {'enum': ['and', 'or']}})
-    schema_alias = True
+           'operator': {'enum': ['and', 'or']},
+           'public': {'enum': [True, False]},
+           })
 
+    schema_alias = True
     RelatedResource = "c7n.resources.vpc.Subnet"
     AnnotationKey = "matched-subnets"
+
+    def get_permissions(self):
+        perms = super().get_permissions()
+        if self.data.get('public') in (True, False):
+            perms += self.manager.get_resource_manager(
+                'aws.route-table').get_permissions()
+        return perms
+
+    def validate(self):
+        super().validate()
+        self.check_public = self.data.get('public')
+
+    def match(self, related):
+        if self.check_public in [True, False]:
+            if not self.match_route(related):
+                return False
+        return super().match(related)
+
+    def process(self, resources):
+        related = self.get_related(resources)
+        if self.check_public in [True, False]:
+            self.route_tables = self.get_route_tables(related)
+        return [r for r in resources if self.process_resource(r, related)]
+
+    def get_route_tables(self, subnets):
+        rmanager = self.manager.get_resource_manager('aws.route-table')
+        rtables = rmanager.resources(
+            query={'association.subnet-id': sorted([
+                s['SubnetId'] for s in subnets])})
+        route_tables = {}
+        for r in rtables:
+            for a in r['Associations']:
+                if a['Main']:
+                    route_tables[r['VpcId']] = r
+                elif 'SubnetId' in a:
+                    route_tables[a['SubnetId']] = r
+        return route_tables
+
+    def match_route(self, subnet):
+        rtable = self.route_tables.get(
+            subnet['SubnetId'],
+            self.route_tables.get(subnet['VpcId']))
+        if rtable is None:
+            self.log.debug('route table for %s not found', subnet['SubnetId'])
+            return
+        found_igw = False
+        for route in rtable['Routes']:
+            if route.get('GatewayId') and route['GatewayId'].startswith('igw-'):
+                found_igw = True
+                break
+        if self.check_public and found_igw:
+            return True
+        elif not self.check_public and not found_igw:
+            return True
+        return False
 
 
 class VpcFilter(MatchResourceValidator, RelatedResourceFilter):

--- a/tests/data/placebo/test_eni_public_subnet/ec2.DescribeNetworkInterfaces_1.json
+++ b/tests/data/placebo/test_eni_public_subnet/ec2.DescribeNetworkInterfaces_1.json
@@ -1,0 +1,64 @@
+{
+    "status_code": 200,
+    "data": {
+        "NetworkInterfaces": [
+            {
+                "AvailabilityZone": "us-east-1c",
+                "Description": "private",
+                "Groups": [
+                    {
+                        "GroupName": "bastion-access",
+                        "GroupId": "sg-f1850a95"
+                    }
+                ],
+                "InterfaceType": "interface",
+                "Ipv6Addresses": [],
+                "MacAddress": "06:b4:af:ec:65:ab",
+                "NetworkInterfaceId": "eni-0d47bf614f6182182",
+                "OwnerId": "644160558196",
+                "PrivateIpAddress": "10.0.1.152",
+                "PrivateIpAddresses": [
+                    {
+                        "Primary": true,
+                        "PrivateIpAddress": "10.0.1.152"
+                    }
+                ],
+                "RequesterManaged": false,
+                "SourceDestCheck": true,
+                "Status": "available",
+                "SubnetId": "subnet-b2cb8788",
+                "TagSet": [],
+                "VpcId": "vpc-65db9700"
+            },
+            {
+                "AvailabilityZone": "us-east-1c",
+                "Description": "public",
+                "Groups": [
+                    {
+                        "GroupName": "default",
+                        "GroupId": "sg-fe87089a"
+                    }
+                ],
+                "InterfaceType": "interface",
+                "Ipv6Addresses": [],
+                "MacAddress": "06:f9:25:64:72:2d",
+                "NetworkInterfaceId": "eni-0911a059630a4a75c",
+                "OwnerId": "644160558196",
+                "PrivateIpAddress": "10.0.5.143",
+                "PrivateIpAddresses": [
+                    {
+                        "Primary": true,
+                        "PrivateIpAddress": "10.0.5.143"
+                    }
+                ],
+                "RequesterManaged": false,
+                "SourceDestCheck": true,
+                "Status": "available",
+                "SubnetId": "subnet-cdcb87f7",
+                "TagSet": [],
+                "VpcId": "vpc-65db9700"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_eni_public_subnet/ec2.DescribeRouteTables_1.json
+++ b/tests/data/placebo/test_eni_public_subnet/ec2.DescribeRouteTables_1.json
@@ -1,0 +1,141 @@
+{
+    "status_code": 200,
+    "data": {
+        "RouteTables": [
+            {
+                "Associations": [
+                    {
+                        "Main": true,
+                        "RouteTableAssociationId": "rtbassoc-f8232c83",
+                        "RouteTableId": "rtb-0795cb7f",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-0795cb7f",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/28",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    }
+                ],
+                "Tags": [],
+                "VpcId": "vpc-39831640",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": true,
+                        "RouteTableAssociationId": "rtbassoc-5efeff3b",
+                        "RouteTableId": "rtb-dac896bf",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-dac896bf",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/16",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    }
+                ],
+                "Tags": [],
+                "VpcId": "vpc-65db9700",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-6026291b",
+                        "RouteTableId": "rtb-e997c991",
+                        "SubnetId": "subnet-8e261cb2",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-e997c991",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/28",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-d74339b1",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "fast-ai-route-table"
+                    }
+                ],
+                "VpcId": "vpc-39831640",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-fc848599",
+                        "RouteTableId": "rtb-5bc59b3e",
+                        "SubnetId": "subnet-381d864f",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    },
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-c88485ad",
+                        "RouteTableId": "rtb-5bc59b3e",
+                        "SubnetId": "subnet-b2cb8788",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-5bc59b3e",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/16",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-bda12fd8",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "cfndev-internet-route"
+                    }
+                ],
+                "VpcId": "vpc-65db9700",
+                "OwnerId": "644160558196"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_eni_public_subnet/ec2.DescribeSubnets_1.json
+++ b/tests/data/placebo/test_eni_public_subnet/ec2.DescribeSubnets_1.json
@@ -1,0 +1,66 @@
+{
+    "status_code": 200,
+    "data": {
+        "Subnets": [
+            {
+                "AvailabilityZone": "us-east-1c",
+                "AvailabilityZoneId": "use1-az3",
+                "AvailableIpAddressCount": 250,
+                "CidrBlock": "10.0.1.0/24",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": false,
+                "MapCustomerOwnedIpOnLaunch": false,
+                "State": "available",
+                "SubnetId": "subnet-b2cb8788",
+                "VpcId": "vpc-65db9700",
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "web-b"
+                    }
+                ],
+                "SubnetArn": "arn:aws:ec2:us-east-1:644160558196:subnet/subnet-b2cb8788",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                }
+            },
+            {
+                "AvailabilityZone": "us-east-1c",
+                "AvailabilityZoneId": "use1-az3",
+                "AvailableIpAddressCount": 250,
+                "CidrBlock": "10.0.5.0/24",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": false,
+                "MapCustomerOwnedIpOnLaunch": false,
+                "State": "available",
+                "SubnetId": "subnet-cdcb87f7",
+                "VpcId": "vpc-65db9700",
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "db-2"
+                    }
+                ],
+                "SubnetArn": "arn:aws:ec2:us-east-1:644160558196:subnet/subnet-cdcb87f7",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -10,6 +10,22 @@ from c7n.resources.aws import shape_validate
 from pytest_terraform import terraform
 
 
+def test_eni_public_subnet(test):
+    factory = test.replay_flight_data('test_eni_public_subnet')
+    p = test.load_policy({
+        'name': 'public-eni',
+        'resource': 'aws.eni',
+        'filters': [
+            {'type': 'subnet',
+             'key': 'SubnetId',
+             'value': 'present',
+             'public': True}
+        ]}, session_factory=factory)
+    resources = p.run()
+    assert len(resources) == 1
+    assert resources[0]['NetworkInterfaceId'] == 'eni-0d47bf614f6182182'
+
+
 @terraform('aws_code_build_vpc')
 def test_codebuild_unused(test, aws_code_build_vpc):
     factory = test.replay_flight_data("test_security_group_codebuild_unused")

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -10,7 +10,7 @@ from c7n.resources.aws import shape_validate
 from pytest_terraform import terraform
 
 
-def test_eni_public_subnet(test):
+def test_eni_igw_subnet(test):
     factory = test.replay_flight_data('test_eni_public_subnet')
     p = test.load_policy({
         'name': 'public-eni',
@@ -19,7 +19,7 @@ def test_eni_public_subnet(test):
             {'type': 'subnet',
              'key': 'SubnetId',
              'value': 'present',
-             'public': True}
+             'igw': True}
         ]}, session_factory=factory)
     resources = p.run()
     assert len(resources) == 1


### PR DESCRIPTION
filter resources by subnets with a route association to an igw.

related to a feature proposal originally in #7477 but instead
added to multi-resource subnet filter.

closes https://github.com/cloud-custodian/cloud-custodian/issues/1327

