### PR TITLE
aws - cloudfront - recursively merge config during set-attributes

### DIFF
--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -7,7 +7,7 @@ from c7n.filters import MetricsFilter, ShieldMetrics, Filter
 from c7n.manager import resources
 from c7n.query import ConfigSource, QueryResourceManager, DescribeSource, TypeInfo
 from c7n.tags import universal_augment
-from c7n.utils import local_session, type_schema, get_retry
+from c7n.utils import local_session, merge_dict, type_schema, get_retry
 from c7n.filters import ValueFilter
 from .aws import shape_validate
 from c7n.exceptions import PolicyValidationError
@@ -707,7 +707,10 @@ class DistributionUpdateAction(BaseUpdateAction):
                 Id=distribution[self.manager.get_model().id])
             default_config = self.validation_config
             config = {**default_config, **res['DistributionConfig']}
-            updatedConfig = {**config, **self.data['attributes']}
+
+            # Recursively merge config to allow piecemeal updates of
+            # nested structures
+            updatedConfig = merge_dict(config, self.data['attributes'])
             if config == updatedConfig:
                 return
             res = client.update_distribution(

--- a/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.GetDistributionConfig_1.json
+++ b/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.GetDistributionConfig_1.json
@@ -1,0 +1,241 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ETag": "E1PLC1MK2SZ98S",
+        "DistributionConfig": {
+            "CallerReference": "terraform-20220614160821318100000001",
+            "Aliases": {
+                "Quantity": 1,
+                "Items": [
+                    "cftesting.ajsbx.stacklet.dev"
+                ]
+            },
+            "DefaultRootObject": "index.html",
+            "Origins": {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "Id": "CloudFrontTestingOrigin",
+                        "DomainName": "cloudfront-testing20220614155949388400000001.s3.us-east-2.amazonaws.com",
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "ConnectionAttempts": 3,
+                        "ConnectionTimeout": 10,
+                        "OriginShield": {
+                            "Enabled": false
+                        }
+                    }
+                ]
+            },
+            "OriginGroups": {
+                "Quantity": 0
+            },
+            "DefaultCacheBehavior": {
+                "TargetOriginId": "CloudFrontTestingOrigin",
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "TrustedKeyGroups": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "ViewerProtocolPolicy": "allow-all",
+                "AllowedMethods": {
+                    "Quantity": 7,
+                    "Items": [
+                        "HEAD",
+                        "DELETE",
+                        "POST",
+                        "GET",
+                        "OPTIONS",
+                        "PUT",
+                        "PATCH"
+                    ],
+                    "CachedMethods": {
+                        "Quantity": 2,
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ]
+                    }
+                },
+                "SmoothStreaming": false,
+                "Compress": false,
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FieldLevelEncryptionId": "",
+                "ForwardedValues": {
+                    "QueryString": false,
+                    "Cookies": {
+                        "Forward": "none"
+                    },
+                    "Headers": {
+                        "Quantity": 0
+                    },
+                    "QueryStringCacheKeys": {
+                        "Quantity": 0
+                    }
+                },
+                "MinTTL": 0,
+                "DefaultTTL": 3600,
+                "MaxTTL": 86400
+            },
+            "CacheBehaviors": {
+                "Quantity": 2,
+                "Items": [
+                    {
+                        "PathPattern": "/content/immutable/*",
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 3,
+                            "Items": [
+                                "HEAD",
+                                "GET",
+                                "OPTIONS"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 3,
+                                "Items": [
+                                    "HEAD",
+                                    "GET",
+                                    "OPTIONS"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 1,
+                                "Items": [
+                                    "Origin"
+                                ]
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 86400,
+                        "MaxTTL": 31536000
+                    },
+                    {
+                        "PathPattern": "/content/*",
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 3,
+                            "Items": [
+                                "HEAD",
+                                "GET",
+                                "OPTIONS"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 3600,
+                        "MaxTTL": 86400
+                    }
+                ]
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
+            "Comment": "",
+            "Logging": {
+                "Enabled": false,
+                "IncludeCookies": false,
+                "Bucket": "",
+                "Prefix": ""
+            },
+            "PriceClass": "PriceClass_200",
+            "Enabled": true,
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": false,
+                "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                "SSLSupportMethod": "sni-only",
+                "MinimumProtocolVersion": "TLSv1_2016",
+                "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                "CertificateSource": "acm"
+            },
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "whitelist",
+                    "Quantity": 1,
+                    "Items": [
+                        "US"
+                    ]
+                }
+            },
+            "WebACLId": "",
+            "HttpVersion": "http2",
+            "IsIPV6Enabled": false
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.GetDistributionConfig_2.json
+++ b/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.GetDistributionConfig_2.json
@@ -1,0 +1,241 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ETag": "E1PLC1MK2SZ98S",
+        "DistributionConfig": {
+            "CallerReference": "terraform-20220614160821318100000001",
+            "Aliases": {
+                "Quantity": 1,
+                "Items": [
+                    "cftesting.ajsbx.stacklet.dev"
+                ]
+            },
+            "DefaultRootObject": "index.html",
+            "Origins": {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "Id": "CloudFrontTestingOrigin",
+                        "DomainName": "cloudfront-testing20220614155949388400000001.s3.us-east-2.amazonaws.com",
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "ConnectionAttempts": 3,
+                        "ConnectionTimeout": 10,
+                        "OriginShield": {
+                            "Enabled": false
+                        }
+                    }
+                ]
+            },
+            "OriginGroups": {
+                "Quantity": 0
+            },
+            "DefaultCacheBehavior": {
+                "TargetOriginId": "CloudFrontTestingOrigin",
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "TrustedKeyGroups": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "ViewerProtocolPolicy": "allow-all",
+                "AllowedMethods": {
+                    "Quantity": 7,
+                    "Items": [
+                        "HEAD",
+                        "DELETE",
+                        "POST",
+                        "GET",
+                        "OPTIONS",
+                        "PUT",
+                        "PATCH"
+                    ],
+                    "CachedMethods": {
+                        "Quantity": 2,
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ]
+                    }
+                },
+                "SmoothStreaming": false,
+                "Compress": false,
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FieldLevelEncryptionId": "",
+                "ForwardedValues": {
+                    "QueryString": false,
+                    "Cookies": {
+                        "Forward": "none"
+                    },
+                    "Headers": {
+                        "Quantity": 0
+                    },
+                    "QueryStringCacheKeys": {
+                        "Quantity": 0
+                    }
+                },
+                "MinTTL": 0,
+                "DefaultTTL": 3600,
+                "MaxTTL": 86400
+            },
+            "CacheBehaviors": {
+                "Quantity": 2,
+                "Items": [
+                    {
+                        "PathPattern": "/content/immutable/*",
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 3,
+                            "Items": [
+                                "HEAD",
+                                "GET",
+                                "OPTIONS"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 3,
+                                "Items": [
+                                    "HEAD",
+                                    "GET",
+                                    "OPTIONS"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 1,
+                                "Items": [
+                                    "Origin"
+                                ]
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 86400,
+                        "MaxTTL": 31536000
+                    },
+                    {
+                        "PathPattern": "/content/*",
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 3,
+                            "Items": [
+                                "HEAD",
+                                "GET",
+                                "OPTIONS"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 3600,
+                        "MaxTTL": 86400
+                    }
+                ]
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
+            "Comment": "",
+            "Logging": {
+                "Enabled": false,
+                "IncludeCookies": false,
+                "Bucket": "",
+                "Prefix": ""
+            },
+            "PriceClass": "PriceClass_200",
+            "Enabled": true,
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": false,
+                "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                "SSLSupportMethod": "sni-only",
+                "MinimumProtocolVersion": "TLSv1_2016",
+                "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                "CertificateSource": "acm"
+            },
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "whitelist",
+                    "Quantity": 1,
+                    "Items": [
+                        "US"
+                    ]
+                }
+            },
+            "WebACLId": "",
+            "HttpVersion": "http2",
+            "IsIPV6Enabled": false
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.GetDistributionConfig_3.json
+++ b/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.GetDistributionConfig_3.json
@@ -1,0 +1,241 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ETag": "E33H5IXGBMSC6D",
+        "DistributionConfig": {
+            "CallerReference": "terraform-20220614160821318100000001",
+            "Aliases": {
+                "Quantity": 1,
+                "Items": [
+                    "cftesting.ajsbx.stacklet.dev"
+                ]
+            },
+            "DefaultRootObject": "index.html",
+            "Origins": {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "Id": "CloudFrontTestingOrigin",
+                        "DomainName": "cloudfront-testing20220614155949388400000001.s3.us-east-2.amazonaws.com",
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "ConnectionAttempts": 3,
+                        "ConnectionTimeout": 10,
+                        "OriginShield": {
+                            "Enabled": false
+                        }
+                    }
+                ]
+            },
+            "OriginGroups": {
+                "Quantity": 0
+            },
+            "DefaultCacheBehavior": {
+                "TargetOriginId": "CloudFrontTestingOrigin",
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "TrustedKeyGroups": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "ViewerProtocolPolicy": "allow-all",
+                "AllowedMethods": {
+                    "Quantity": 7,
+                    "Items": [
+                        "HEAD",
+                        "DELETE",
+                        "POST",
+                        "GET",
+                        "OPTIONS",
+                        "PUT",
+                        "PATCH"
+                    ],
+                    "CachedMethods": {
+                        "Quantity": 2,
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ]
+                    }
+                },
+                "SmoothStreaming": false,
+                "Compress": false,
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FieldLevelEncryptionId": "",
+                "ForwardedValues": {
+                    "QueryString": false,
+                    "Cookies": {
+                        "Forward": "none"
+                    },
+                    "Headers": {
+                        "Quantity": 0
+                    },
+                    "QueryStringCacheKeys": {
+                        "Quantity": 0
+                    }
+                },
+                "MinTTL": 0,
+                "DefaultTTL": 3600,
+                "MaxTTL": 86400
+            },
+            "CacheBehaviors": {
+                "Quantity": 2,
+                "Items": [
+                    {
+                        "PathPattern": "/content/immutable/*",
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 3,
+                            "Items": [
+                                "HEAD",
+                                "GET",
+                                "OPTIONS"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 3,
+                                "Items": [
+                                    "HEAD",
+                                    "GET",
+                                    "OPTIONS"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 1,
+                                "Items": [
+                                    "Origin"
+                                ]
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 86400,
+                        "MaxTTL": 31536000
+                    },
+                    {
+                        "PathPattern": "/content/*",
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 3,
+                            "Items": [
+                                "HEAD",
+                                "GET",
+                                "OPTIONS"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 3600,
+                        "MaxTTL": 86400
+                    }
+                ]
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
+            "Comment": "",
+            "Logging": {
+                "Enabled": false,
+                "IncludeCookies": false,
+                "Bucket": "",
+                "Prefix": ""
+            },
+            "PriceClass": "PriceClass_200",
+            "Enabled": true,
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": false,
+                "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                "SSLSupportMethod": "sni-only",
+                "MinimumProtocolVersion": "TLSv1.2_2018",
+                "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                "CertificateSource": "acm"
+            },
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "whitelist",
+                    "Quantity": 1,
+                    "Items": [
+                        "US"
+                    ]
+                }
+            },
+            "WebACLId": "",
+            "HttpVersion": "http2",
+            "IsIPV6Enabled": false
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.ListDistributions_1.json
@@ -1,0 +1,260 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DistributionList": {
+            "Marker": "",
+            "MaxItems": 100,
+            "IsTruncated": false,
+            "Quantity": 2,
+            "Items": [
+                {
+                    "Id": "E1XRY7J5866V6G",
+                    "ARN": "arn:aws:cloudfront::644160558196:distribution/E1XRY7J5866V6G",
+                    "Status": "Deployed",
+                    "LastModifiedTime": {
+                        "__class__": "datetime",
+                        "year": 2022,
+                        "month": 6,
+                        "day": 15,
+                        "hour": 13,
+                        "minute": 5,
+                        "second": 13,
+                        "microsecond": 218000
+                    },
+                    "DomainName": "dal78uzs60406.cloudfront.net",
+                    "Aliases": {
+                        "Quantity": 1,
+                        "Items": [
+                            "cftesting.ajsbx.stacklet.dev"
+                        ]
+                    },
+                    "Origins": {
+                        "Quantity": 1,
+                        "Items": [
+                            {
+                                "Id": "CloudFrontTestingOrigin",
+                                "DomainName": "cloudfront-testing20220614155949388400000001.s3.us-east-2.amazonaws.com",
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": ""
+                                },
+                                "ConnectionAttempts": 3,
+                                "ConnectionTimeout": 10,
+                                "OriginShield": {
+                                    "Enabled": false
+                                }
+                            }
+                        ]
+                    },
+                    "OriginGroups": {
+                        "Quantity": 0
+                    },
+                    "DefaultCacheBehavior": {
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "allow-all",
+                        "AllowedMethods": {
+                            "Quantity": 7,
+                            "Items": [
+                                "HEAD",
+                                "DELETE",
+                                "POST",
+                                "GET",
+                                "OPTIONS",
+                                "PUT",
+                                "PATCH"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": false,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 3600,
+                        "MaxTTL": 86400
+                    },
+                    "CacheBehaviors": {
+                        "Quantity": 2,
+                        "Items": [
+                            {
+                                "PathPattern": "/content/immutable/*",
+                                "TargetOriginId": "CloudFrontTestingOrigin",
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "TrustedKeyGroups": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "ViewerProtocolPolicy": "redirect-to-https",
+                                "AllowedMethods": {
+                                    "Quantity": 3,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET",
+                                        "OPTIONS"
+                                    ],
+                                    "CachedMethods": {
+                                        "Quantity": 3,
+                                        "Items": [
+                                            "HEAD",
+                                            "GET",
+                                            "OPTIONS"
+                                        ]
+                                    }
+                                },
+                                "SmoothStreaming": false,
+                                "Compress": true,
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FieldLevelEncryptionId": "",
+                                "ForwardedValues": {
+                                    "QueryString": false,
+                                    "Cookies": {
+                                        "Forward": "none"
+                                    },
+                                    "Headers": {
+                                        "Quantity": 1,
+                                        "Items": [
+                                            "Origin"
+                                        ]
+                                    },
+                                    "QueryStringCacheKeys": {
+                                        "Quantity": 0
+                                    }
+                                },
+                                "MinTTL": 0,
+                                "DefaultTTL": 86400,
+                                "MaxTTL": 31536000
+                            },
+                            {
+                                "PathPattern": "/content/*",
+                                "TargetOriginId": "CloudFrontTestingOrigin",
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "TrustedKeyGroups": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "ViewerProtocolPolicy": "redirect-to-https",
+                                "AllowedMethods": {
+                                    "Quantity": 3,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET",
+                                        "OPTIONS"
+                                    ],
+                                    "CachedMethods": {
+                                        "Quantity": 2,
+                                        "Items": [
+                                            "HEAD",
+                                            "GET"
+                                        ]
+                                    }
+                                },
+                                "SmoothStreaming": false,
+                                "Compress": true,
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FieldLevelEncryptionId": "",
+                                "ForwardedValues": {
+                                    "QueryString": false,
+                                    "Cookies": {
+                                        "Forward": "none"
+                                    },
+                                    "Headers": {
+                                        "Quantity": 0
+                                    },
+                                    "QueryStringCacheKeys": {
+                                        "Quantity": 0
+                                    }
+                                },
+                                "MinTTL": 0,
+                                "DefaultTTL": 3600,
+                                "MaxTTL": 86400
+                            }
+                        ]
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "Comment": "",
+                    "PriceClass": "PriceClass_200",
+                    "Enabled": true,
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": false,
+                        "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                        "SSLSupportMethod": "sni-only",
+                        "MinimumProtocolVersion": "TLSv1_2016",
+                        "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                        "CertificateSource": "acm"
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "whitelist",
+                            "Quantity": 1,
+                            "Items": [
+                                "US"
+                            ]
+                        }
+                    },
+                    "WebACLId": "",
+                    "HttpVersion": "HTTP2",
+                    "IsIPV6Enabled": false,
+                    "AliasICPRecordals": [
+                        {
+                            "CNAME": "cftesting.ajsbx.stacklet.dev",
+                            "ICPRecordalStatus": "APPROVED"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.UpdateDistribution_1.json
+++ b/tests/data/placebo/test_distribution_update_deep_attribute/cloudfront.UpdateDistribution_1.json
@@ -1,0 +1,272 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ETag": "E33H5IXGBMSC6D",
+        "Distribution": {
+            "Id": "E1XRY7J5866V6G",
+            "ARN": "arn:aws:cloudfront::644160558196:distribution/E1XRY7J5866V6G",
+            "Status": "InProgress",
+            "LastModifiedTime": {
+                "__class__": "datetime",
+                "year": 2022,
+                "month": 6,
+                "day": 15,
+                "hour": 13,
+                "minute": 5,
+                "second": 45,
+                "microsecond": 753000
+            },
+            "InProgressInvalidationBatches": 0,
+            "DomainName": "dal78uzs60406.cloudfront.net",
+            "ActiveTrustedSigners": {
+                "Enabled": false,
+                "Quantity": 0
+            },
+            "ActiveTrustedKeyGroups": {
+                "Enabled": false,
+                "Quantity": 0
+            },
+            "DistributionConfig": {
+                "CallerReference": "terraform-20220614160821318100000001",
+                "Aliases": {
+                    "Quantity": 1,
+                    "Items": [
+                        "cftesting.ajsbx.stacklet.dev"
+                    ]
+                },
+                "DefaultRootObject": "index.html",
+                "Origins": {
+                    "Quantity": 1,
+                    "Items": [
+                        {
+                            "Id": "CloudFrontTestingOrigin",
+                            "DomainName": "cloudfront-testing20220614155949388400000001.s3.us-east-2.amazonaws.com",
+                            "OriginPath": "",
+                            "CustomHeaders": {
+                                "Quantity": 0
+                            },
+                            "S3OriginConfig": {
+                                "OriginAccessIdentity": ""
+                            },
+                            "ConnectionAttempts": 3,
+                            "ConnectionTimeout": 10,
+                            "OriginShield": {
+                                "Enabled": false
+                            }
+                        }
+                    ]
+                },
+                "OriginGroups": {
+                    "Quantity": 0
+                },
+                "DefaultCacheBehavior": {
+                    "TargetOriginId": "CloudFrontTestingOrigin",
+                    "TrustedSigners": {
+                        "Enabled": false,
+                        "Quantity": 0
+                    },
+                    "TrustedKeyGroups": {
+                        "Enabled": false,
+                        "Quantity": 0
+                    },
+                    "ViewerProtocolPolicy": "allow-all",
+                    "AllowedMethods": {
+                        "Quantity": 7,
+                        "Items": [
+                            "HEAD",
+                            "DELETE",
+                            "POST",
+                            "GET",
+                            "OPTIONS",
+                            "PUT",
+                            "PATCH"
+                        ],
+                        "CachedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ]
+                        }
+                    },
+                    "SmoothStreaming": false,
+                    "Compress": false,
+                    "LambdaFunctionAssociations": {
+                        "Quantity": 0
+                    },
+                    "FunctionAssociations": {
+                        "Quantity": 0
+                    },
+                    "FieldLevelEncryptionId": "",
+                    "ForwardedValues": {
+                        "QueryString": false,
+                        "Cookies": {
+                            "Forward": "none"
+                        },
+                        "Headers": {
+                            "Quantity": 0
+                        },
+                        "QueryStringCacheKeys": {
+                            "Quantity": 0
+                        }
+                    },
+                    "MinTTL": 0,
+                    "DefaultTTL": 3600,
+                    "MaxTTL": 86400
+                },
+                "CacheBehaviors": {
+                    "Quantity": 2,
+                    "Items": [
+                        {
+                            "PathPattern": "/content/immutable/*",
+                            "TargetOriginId": "CloudFrontTestingOrigin",
+                            "TrustedSigners": {
+                                "Enabled": false,
+                                "Quantity": 0
+                            },
+                            "TrustedKeyGroups": {
+                                "Enabled": false,
+                                "Quantity": 0
+                            },
+                            "ViewerProtocolPolicy": "redirect-to-https",
+                            "AllowedMethods": {
+                                "Quantity": 3,
+                                "Items": [
+                                    "HEAD",
+                                    "GET",
+                                    "OPTIONS"
+                                ],
+                                "CachedMethods": {
+                                    "Quantity": 3,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET",
+                                        "OPTIONS"
+                                    ]
+                                }
+                            },
+                            "SmoothStreaming": false,
+                            "Compress": true,
+                            "LambdaFunctionAssociations": {
+                                "Quantity": 0
+                            },
+                            "FunctionAssociations": {
+                                "Quantity": 0
+                            },
+                            "FieldLevelEncryptionId": "",
+                            "ForwardedValues": {
+                                "QueryString": false,
+                                "Cookies": {
+                                    "Forward": "none"
+                                },
+                                "Headers": {
+                                    "Quantity": 1,
+                                    "Items": [
+                                        "Origin"
+                                    ]
+                                },
+                                "QueryStringCacheKeys": {
+                                    "Quantity": 0
+                                }
+                            },
+                            "MinTTL": 0,
+                            "DefaultTTL": 86400,
+                            "MaxTTL": 31536000
+                        },
+                        {
+                            "PathPattern": "/content/*",
+                            "TargetOriginId": "CloudFrontTestingOrigin",
+                            "TrustedSigners": {
+                                "Enabled": false,
+                                "Quantity": 0
+                            },
+                            "TrustedKeyGroups": {
+                                "Enabled": false,
+                                "Quantity": 0
+                            },
+                            "ViewerProtocolPolicy": "redirect-to-https",
+                            "AllowedMethods": {
+                                "Quantity": 3,
+                                "Items": [
+                                    "HEAD",
+                                    "GET",
+                                    "OPTIONS"
+                                ],
+                                "CachedMethods": {
+                                    "Quantity": 2,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ]
+                                }
+                            },
+                            "SmoothStreaming": false,
+                            "Compress": true,
+                            "LambdaFunctionAssociations": {
+                                "Quantity": 0
+                            },
+                            "FunctionAssociations": {
+                                "Quantity": 0
+                            },
+                            "FieldLevelEncryptionId": "",
+                            "ForwardedValues": {
+                                "QueryString": false,
+                                "Cookies": {
+                                    "Forward": "none"
+                                },
+                                "Headers": {
+                                    "Quantity": 0
+                                },
+                                "QueryStringCacheKeys": {
+                                    "Quantity": 0
+                                }
+                            },
+                            "MinTTL": 0,
+                            "DefaultTTL": 3600,
+                            "MaxTTL": 86400
+                        }
+                    ]
+                },
+                "CustomErrorResponses": {
+                    "Quantity": 0
+                },
+                "Comment": "",
+                "Logging": {
+                    "Enabled": false,
+                    "IncludeCookies": false,
+                    "Bucket": "",
+                    "Prefix": ""
+                },
+                "PriceClass": "PriceClass_200",
+                "Enabled": true,
+                "ViewerCertificate": {
+                    "CloudFrontDefaultCertificate": false,
+                    "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                    "SSLSupportMethod": "sni-only",
+                    "MinimumProtocolVersion": "TLSv1.2_2018",
+                    "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                    "CertificateSource": "acm"
+                },
+                "Restrictions": {
+                    "GeoRestriction": {
+                        "RestrictionType": "whitelist",
+                        "Quantity": 1,
+                        "Items": [
+                            "US"
+                        ]
+                    }
+                },
+                "WebACLId": "",
+                "HttpVersion": "http2",
+                "IsIPV6Enabled": false
+            },
+            "AliasICPRecordals": [
+                {
+                    "CNAME": "cftesting.ajsbx.stacklet.dev",
+                    "ICPRecordalStatus": "APPROVED"
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_update_deep_attribute/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_distribution_update_deep_attribute/tagging.GetResources_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudfront::644160558196:distribution/E1XRY7J5866V6G",
+                "Tags": [
+                    {
+                        "Key": "App",
+                        "Value": "cloudfront-testing"
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": "aj@stacklet.io"
+                    },
+                    {
+                        "Key": "Env",
+                        "Value": "dev"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -419,6 +419,62 @@ class CloudFront(BaseTest):
 
         self.assertEqual(east_resources, west_resources)
 
+    def test_cloudfront_update_deep_attribute(self):
+        factory = self.replay_flight_data("test_distribution_update_deep_attribute", region="us-east-2")
+        p = self.load_policy(
+            {
+                "name": "cloudfront-update-tls",
+                "resource": "distribution",
+                "filters": [
+                    {
+                        "DomainName": "dal78uzs60406.cloudfront.net",
+                    },
+                    {
+                        "type": "distribution-config",
+                        "key": "ViewerCertificate.MinimumProtocolVersion",
+                        "op": "in",
+                        "value": ["TLSv1.1_2016", "TLSv1_2016", "TLSv1", "SSLv3"],
+                    },
+                    {
+                        "type": "distribution-config",
+                        "key": "ViewerCertificate.CertificateSource",
+                        "op": "in",
+                        "value": ["acm", "iam"],
+                    },
+                ],
+                "actions": [
+                    {
+                        "type": "set-attributes",
+                        "attributes": {
+                            "ViewerCertificate": {
+                                "MinimumProtocolVersion": "TLSv1.2_2018",
+                            }
+                        },
+                    },
+                ],
+            },
+            config=dict(region='us-east-2'),
+            session_factory=factory,
+        )
+
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+
+        client = local_session(factory).client("cloudfront")
+        dist_id = resources[0]['Id']
+        resp = client.get_distribution_config(Id=dist_id)
+
+        # Check attribute updated by policy action
+        self.assertEqual(
+            resp['DistributionConfig']['ViewerCertificate']['MinimumProtocolVersion'], 'TLSv1.2_2018'
+        )
+
+        # Check deep attribute from original configuration
+        self.assertEqual(
+            resp['DistributionConfig']['ViewerCertificate']['CertificateSource'], 'acm'
+        )
+
     def test_cloudfront_update_distribution(self):
         factory = self.replay_flight_data("test_distribution_update_distribution")
         p = self.load_policy(

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -420,7 +420,9 @@ class CloudFront(BaseTest):
         self.assertEqual(east_resources, west_resources)
 
     def test_cloudfront_update_deep_attribute(self):
-        factory = self.replay_flight_data("test_distribution_update_deep_attribute", region="us-east-2")
+        factory = self.replay_flight_data(
+            "test_distribution_update_deep_attribute",
+            region="us-east-2")
         p = self.load_policy(
             {
                 "name": "cloudfront-update-tls",
@@ -467,12 +469,14 @@ class CloudFront(BaseTest):
 
         # Check attribute updated by policy action
         self.assertEqual(
-            resp['DistributionConfig']['ViewerCertificate']['MinimumProtocolVersion'], 'TLSv1.2_2018'
+            resp['DistributionConfig']['ViewerCertificate']['MinimumProtocolVersion'],
+            'TLSv1.2_2018'
         )
 
         # Check deep attribute from original configuration
         self.assertEqual(
-            resp['DistributionConfig']['ViewerCertificate']['CertificateSource'], 'acm'
+            resp['DistributionConfig']['ViewerCertificate']['CertificateSource'],
+            'acm'
         )
 
     def test_cloudfront_update_distribution(self):


### PR DESCRIPTION
Addresses #6975 

Use a recursive merge during the `set-attributes` action for `aws.distribution` resources, to allow incremental updates to deep configuration items.

That is, given a distribution configuration that contains:

```
{
    ...,
    "ViewerCertificate": {
        "CloudFrontDefaultCertificate": false,
        "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
        "SSLSupportMeth dod": "sni-only",
        "MinimumProtocolVersion": "TLSv1_2016",
        "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
        "CertificateSource": "acm"
    },
    ...
}
```

A policy action like this:

```
  actions:
      - type: set-attributes
        attributes:
          ViewerCertificate:
              MinimumProtocolVersion: "TLSv1.2_2018"
```

Should succeed without needing to specify the full `ViewerCertificate` block, and result in a configuration with only the minimum protocol version changed:

```
{
    ...,
    "ViewerCertificate": {
        "CloudFrontDefaultCertificate": false,
        "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
        "SSLSupportMeth dod": "sni-only",
        "MinimumProtocolVersion": "TLSv1.2_2018",
        "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
        "CertificateSource": "acm"
    },
    ...
}
```