### PR TITLE
aws - cloudfront - update formatting for post-finding

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -878,7 +878,7 @@ class UniversalTag(Tag):
     def get_client(self):
         # For global resources, manage tags from us-east-1
         region = (getattr(self.manager.resource_type, 'global_resource', None)
-            and 'us-east-1' or self.region)
+            and 'us-east-1' or self.manager.region)
         return utils.local_session(self.manager.session_factory).client(
             'resourcegroupstaggingapi', region_name=region)
 
@@ -894,7 +894,7 @@ class UniversalUntag(RemoveTag):
     def get_client(self):
         # For global resources, manage tags from us-east-1
         region = (getattr(self.manager.resource_type, 'global_resource', None)
-            and 'us-east-1' or self.region)
+            and 'us-east-1' or self.manager.region)
         return utils.local_session(self.manager.session_factory).client(
             'resourcegroupstaggingapi', region_name=region)
 
@@ -968,7 +968,7 @@ class UniversalTagDelayedAction(TagDelayedAction):
     def get_client(self):
         # For global resources, manage tags from us-east-1
         region = (getattr(self.manager.resource_type, 'global_resource', None)
-            and 'us-east-1' or self.region)
+            and 'us-east-1' or self.manager.region)
         return utils.local_session(self.manager.session_factory).client(
             'resourcegroupstaggingapi', region_name=region)
 

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -876,8 +876,11 @@ class UniversalTag(Tag):
             client.tag_resources, ResourceARNList=arns, Tags=tags)
 
     def get_client(self):
-        return utils.local_session(
-            self.manager.session_factory).client('resourcegroupstaggingapi')
+        # For global resources, manage tags from us-east-1
+        region = (getattr(self.manager.resource_type, 'global_resource', None)
+            and 'us-east-1' or self.region)
+        return utils.local_session(self.manager.session_factory).client(
+            'resourcegroupstaggingapi', region_name=region)
 
 
 class UniversalUntag(RemoveTag):
@@ -889,8 +892,11 @@ class UniversalUntag(RemoveTag):
     permissions = ('tag:UntagResources',)
 
     def get_client(self):
-        return utils.local_session(
-            self.manager.session_factory).client('resourcegroupstaggingapi')
+        # For global resources, manage tags from us-east-1
+        region = (getattr(self.manager.resource_type, 'global_resource', None)
+            and 'us-east-1' or self.region)
+        return utils.local_session(self.manager.session_factory).client(
+            'resourcegroupstaggingapi', region_name=region)
 
     def process_resource_set(self, client, resource_set, tag_keys):
         arns = self.manager.get_arns(resource_set)
@@ -960,8 +966,11 @@ class UniversalTagDelayedAction(TagDelayedAction):
             client.tag_resources, ResourceARNList=arns, Tags=tags)
 
     def get_client(self):
-        return utils.local_session(
-            self.manager.session_factory).client('resourcegroupstaggingapi')
+        # For global resources, manage tags from us-east-1
+        region = (getattr(self.manager.resource_type, 'global_resource', None)
+            and 'us-east-1' or self.region)
+        return utils.local_session(self.manager.session_factory).client(
+            'resourcegroupstaggingapi', region_name=region)
 
 
 class CopyRelatedResourceTag(Tag):

--- a/tests/data/placebo/test_distribution_post_finding/cloudfront.GetDistributionConfig_1.json
+++ b/tests/data/placebo/test_distribution_post_finding/cloudfront.GetDistributionConfig_1.json
@@ -1,0 +1,241 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ETag": "E2AH945EEEKMEH",
+        "DistributionConfig": {
+            "CallerReference": "terraform-20220614160821318100000001",
+            "Aliases": {
+                "Quantity": 1,
+                "Items": [
+                    "cftesting.ajsbx.stacklet.dev"
+                ]
+            },
+            "DefaultRootObject": "index.html",
+            "Origins": {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "Id": "CloudFrontTestingOrigin",
+                        "DomainName": "cloudfront-testing20220614155949388400000001.s3.us-east-2.amazonaws.com",
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "ConnectionAttempts": 3,
+                        "ConnectionTimeout": 10,
+                        "OriginShield": {
+                            "Enabled": false
+                        }
+                    }
+                ]
+            },
+            "OriginGroups": {
+                "Quantity": 0
+            },
+            "DefaultCacheBehavior": {
+                "TargetOriginId": "CloudFrontTestingOrigin",
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "TrustedKeyGroups": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "ViewerProtocolPolicy": "allow-all",
+                "AllowedMethods": {
+                    "Quantity": 7,
+                    "Items": [
+                        "HEAD",
+                        "DELETE",
+                        "POST",
+                        "GET",
+                        "OPTIONS",
+                        "PUT",
+                        "PATCH"
+                    ],
+                    "CachedMethods": {
+                        "Quantity": 2,
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ]
+                    }
+                },
+                "SmoothStreaming": false,
+                "Compress": false,
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FieldLevelEncryptionId": "",
+                "ForwardedValues": {
+                    "QueryString": false,
+                    "Cookies": {
+                        "Forward": "none"
+                    },
+                    "Headers": {
+                        "Quantity": 0
+                    },
+                    "QueryStringCacheKeys": {
+                        "Quantity": 0
+                    }
+                },
+                "MinTTL": 0,
+                "DefaultTTL": 3600,
+                "MaxTTL": 86400
+            },
+            "CacheBehaviors": {
+                "Quantity": 2,
+                "Items": [
+                    {
+                        "PathPattern": "/content/immutable/*",
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 3,
+                            "Items": [
+                                "HEAD",
+                                "GET",
+                                "OPTIONS"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 3,
+                                "Items": [
+                                    "HEAD",
+                                    "GET",
+                                    "OPTIONS"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 1,
+                                "Items": [
+                                    "Origin"
+                                ]
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 86400,
+                        "MaxTTL": 31536000
+                    },
+                    {
+                        "PathPattern": "/content/*",
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 3,
+                            "Items": [
+                                "HEAD",
+                                "GET",
+                                "OPTIONS"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 3600,
+                        "MaxTTL": 86400
+                    }
+                ]
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
+            "Comment": "",
+            "Logging": {
+                "Enabled": false,
+                "IncludeCookies": false,
+                "Bucket": "",
+                "Prefix": ""
+            },
+            "PriceClass": "PriceClass_200",
+            "Enabled": true,
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": false,
+                "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                "SSLSupportMethod": "sni-only",
+                "MinimumProtocolVersion": "TLSv1_2016",
+                "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                "CertificateSource": "acm"
+            },
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "whitelist",
+                    "Quantity": 1,
+                    "Items": [
+                        "US"
+                    ]
+                }
+            },
+            "WebACLId": "",
+            "HttpVersion": "http2",
+            "IsIPV6Enabled": false
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_post_finding/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_distribution_post_finding/cloudfront.ListDistributions_1.json
@@ -1,0 +1,260 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DistributionList": {
+            "Marker": "",
+            "MaxItems": 100,
+            "IsTruncated": false,
+            "Quantity": 2,
+            "Items": [
+                {
+                    "Id": "E1XRY7J5866V6G",
+                    "ARN": "arn:aws:cloudfront::644160558196:distribution/E1XRY7J5866V6G",
+                    "Status": "Deployed",
+                    "LastModifiedTime": {
+                        "__class__": "datetime",
+                        "year": 2022,
+                        "month": 6,
+                        "day": 15,
+                        "hour": 13,
+                        "minute": 7,
+                        "second": 42,
+                        "microsecond": 936000
+                    },
+                    "DomainName": "dal78uzs60406.cloudfront.net",
+                    "Aliases": {
+                        "Quantity": 1,
+                        "Items": [
+                            "cftesting.ajsbx.stacklet.dev"
+                        ]
+                    },
+                    "Origins": {
+                        "Quantity": 1,
+                        "Items": [
+                            {
+                                "Id": "CloudFrontTestingOrigin",
+                                "DomainName": "cloudfront-testing20220614155949388400000001.s3.us-east-2.amazonaws.com",
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": ""
+                                },
+                                "ConnectionAttempts": 3,
+                                "ConnectionTimeout": 10,
+                                "OriginShield": {
+                                    "Enabled": false
+                                }
+                            }
+                        ]
+                    },
+                    "OriginGroups": {
+                        "Quantity": 0
+                    },
+                    "DefaultCacheBehavior": {
+                        "TargetOriginId": "CloudFrontTestingOrigin",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "allow-all",
+                        "AllowedMethods": {
+                            "Quantity": 7,
+                            "Items": [
+                                "HEAD",
+                                "DELETE",
+                                "POST",
+                                "GET",
+                                "OPTIONS",
+                                "PUT",
+                                "PATCH"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": false,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "MinTTL": 0,
+                        "DefaultTTL": 3600,
+                        "MaxTTL": 86400
+                    },
+                    "CacheBehaviors": {
+                        "Quantity": 2,
+                        "Items": [
+                            {
+                                "PathPattern": "/content/immutable/*",
+                                "TargetOriginId": "CloudFrontTestingOrigin",
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "TrustedKeyGroups": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "ViewerProtocolPolicy": "redirect-to-https",
+                                "AllowedMethods": {
+                                    "Quantity": 3,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET",
+                                        "OPTIONS"
+                                    ],
+                                    "CachedMethods": {
+                                        "Quantity": 3,
+                                        "Items": [
+                                            "HEAD",
+                                            "GET",
+                                            "OPTIONS"
+                                        ]
+                                    }
+                                },
+                                "SmoothStreaming": false,
+                                "Compress": true,
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FieldLevelEncryptionId": "",
+                                "ForwardedValues": {
+                                    "QueryString": false,
+                                    "Cookies": {
+                                        "Forward": "none"
+                                    },
+                                    "Headers": {
+                                        "Quantity": 1,
+                                        "Items": [
+                                            "Origin"
+                                        ]
+                                    },
+                                    "QueryStringCacheKeys": {
+                                        "Quantity": 0
+                                    }
+                                },
+                                "MinTTL": 0,
+                                "DefaultTTL": 86400,
+                                "MaxTTL": 31536000
+                            },
+                            {
+                                "PathPattern": "/content/*",
+                                "TargetOriginId": "CloudFrontTestingOrigin",
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "TrustedKeyGroups": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "ViewerProtocolPolicy": "redirect-to-https",
+                                "AllowedMethods": {
+                                    "Quantity": 3,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET",
+                                        "OPTIONS"
+                                    ],
+                                    "CachedMethods": {
+                                        "Quantity": 2,
+                                        "Items": [
+                                            "HEAD",
+                                            "GET"
+                                        ]
+                                    }
+                                },
+                                "SmoothStreaming": false,
+                                "Compress": true,
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FieldLevelEncryptionId": "",
+                                "ForwardedValues": {
+                                    "QueryString": false,
+                                    "Cookies": {
+                                        "Forward": "none"
+                                    },
+                                    "Headers": {
+                                        "Quantity": 0
+                                    },
+                                    "QueryStringCacheKeys": {
+                                        "Quantity": 0
+                                    }
+                                },
+                                "MinTTL": 0,
+                                "DefaultTTL": 3600,
+                                "MaxTTL": 86400
+                            }
+                        ]
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "Comment": "",
+                    "PriceClass": "PriceClass_200",
+                    "Enabled": true,
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": false,
+                        "ACMCertificateArn": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                        "SSLSupportMethod": "sni-only",
+                        "MinimumProtocolVersion": "TLSv1_2016",
+                        "Certificate": "arn:aws:acm:us-east-1:644160558196:certificate/e72fac97-0663-46bd-9b4b-d140709955c0",
+                        "CertificateSource": "acm"
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "whitelist",
+                            "Quantity": 1,
+                            "Items": [
+                                "US"
+                            ]
+                        }
+                    },
+                    "WebACLId": "",
+                    "HttpVersion": "HTTP2",
+                    "IsIPV6Enabled": false,
+                    "AliasICPRecordals": [
+                        {
+                            "CNAME": "cftesting.ajsbx.stacklet.dev",
+                            "ICPRecordalStatus": "APPROVED"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_post_finding/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_distribution_post_finding/tagging.GetResources_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudfront::644160558196:distribution/E1XRY7J5866V6G",
+                "Tags": [
+                    {
+                        "Key": "App",
+                        "Value": "cloudfront-testing"
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": "aj@stacklet.io"
+                    },
+                    {
+                        "Key": "c7n:FindingId:cloudfront-post-finding",
+                        "Value": "us-east-2/644160558196/bade9762d7fe23d7d78dc22fd454723b/bed93b6f658e0d0bf475f0e56d0d9d50:2022-06-15T17:18:30.146987+00:00"
+                    },
+                    {
+                        "Key": "Env",
+                        "Value": "dev"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -1,7 +1,9 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import jmespath
+
 from .common import BaseTest
+from c7n.resources.aws import shape_validate
 from c7n.utils import local_session
 from unittest.mock import MagicMock
 
@@ -563,6 +565,48 @@ class CloudFront(BaseTest):
         self.assertEqual(
             resp['StreamingDistributionConfig']['Logging']['Enabled'], True
         )
+
+    def test_cloudfront_post_finding(self):
+        factory = self.replay_flight_data(
+            "test_distribution_post_finding",
+            region="us-east-2")
+        p = self.load_policy(
+            {
+                "name": "cloudfront-post-finding",
+                "resource": "distribution",
+                "filters": [
+                    {
+                        "DomainName": "dal78uzs60406.cloudfront.net",
+                    },
+                    {
+                        "type": "distribution-config",
+                        "key": "ViewerCertificate.MinimumProtocolVersion",
+                        "op": "in",
+                        "value": ["TLSv1.1_2016", "TLSv1_2016", "TLSv1", "SSLv3"],
+                    },
+                ],
+                "actions": [
+                    {
+                        "type": "post-finding",
+                        "compliance_status": "FAILED",
+                        "description": "Deprecated TLS version support",
+                        "types": [
+                            "Software and Configuration Checks/AWS Security Best Practices"
+                        ],
+                    },
+                ],
+            },
+            config={'region': 'us-east-2'},
+            session_factory=factory,
+        )
+
+        resources = p.resource_manager.resources()
+        self.assertEqual(len(resources), 1)
+        formatted_resource = p.resource_manager.actions[0].format_resource(resources[0])
+        shape_validate(
+            formatted_resource['Details']['AwsCloudFrontDistribution'],
+            'AwsCloudFrontDistributionDetails',
+            'securityhub')
 
 
 class CloudFrontWafV2(BaseTest):


### PR DESCRIPTION
The primary change here is fixing and validating the shape of a formatted `aws.distribution` resource during a `post-finding` action. That stems from a discussion [in Gitter](https://gitter.im/cloud-custodian/cloud-custodian?at=62a88e614aa6c31dca4fa82f).

Separately, this ensures that universal tag actions use `us-east-1` clients for global resources. We already used `us-east-1` clients for _reading_ global resources tags [in universal_augment](https://github.com/cloud-custodian/cloud-custodian/blob/b620a7ef82c8b2964586521824044acba203df0b/c7n/tags.py#L74-L76), but didn't use the same logic for actions.

The immediate need for the tag change was ensuring that the `post-finding` action could tag `aws.distribution` resources with finding IDs. But as a happy accident this will fix issues like the one involving Route53 auto-tagging discussed [here](https://gitter.im/cloud-custodian/cloud-custodian?at=62a8c759c61b987d33fb322a).

_Note that there's some repetition/duplication in the `get_client()` definitions, but that seems cheaper than extracting the us-east-1 client logic into a common base class._