### PR TITLE
aws - ssm-data-sync - update id, name and arn_type

### DIFF
--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -795,9 +795,8 @@ class SSMDataSync(QueryResourceManager):
 
         enum_spec = ('list_resource_data_sync', 'ResourceDataSyncItems', None)
         service = 'ssm'
-        arn_type = 'datasync'
-        id = 'DataSync'
-        name = 'Title'
+        arn_type = 'resource-data-sync'
+        id = name = 'SyncName'
 
     permissions = ('ssm:ListResourceDataSync',)
 


### PR DESCRIPTION
Update some resource attributes of the `aws.ssm-data-sync` resource to match the docs and API responses. I'm pulling the arn type from `SourceArn` examples [here](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-inventory-datasync.html#systems-manager-inventory-resource-data-sync-AWS-Organizations).

The `id` update addresses #7169 .

