### PR TITLE
tools/c7n-org - warn and continue when failing to resolve regions

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -198,9 +198,16 @@ def init(config, use, debug, verbose, accounts, tags, policies, resource=None, p
 
 def resolve_regions(regions, account):
     if 'all' in regions:
-        session = get_session(account, 'c7n-org', "us-east-1")
-        client = session.client('ec2')
-        return [region['RegionName'] for region in client.describe_regions()['Regions']]
+        try:
+            session = get_session(account, 'c7n-org', 'us-east-1')
+            client = session.client('ec2')
+            return [region['RegionName'] for region in client.describe_regions()['Regions']]
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'AccessDenied':
+                log.warning('access denied listing available regions for account:%s',
+                             account['name'])
+                return []
+            raise
     if not regions:
         return ('us-east-1', 'us-west-2')
 


### PR DESCRIPTION
#6280 enhanced c7n-org to be more flexible with regard to resolving regions per account (to accommodate differences in opt-in regions per account).

As an unintended consequence, this can cause c7n-org to crash while resolving the special `all` region. This PR causes `--region all` to warn and return an empty region list rather than crashing, in cases where it hits `AccessDenied` listing available regions.

Resolves #7211 and #7478