### PR TITLE
aws - wafv2 - cloudfront's update distribution need webacl ARN. 

### DIFF
--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -423,7 +423,7 @@ class SetWafv2(BaseAction):
     def process(self, resources):
         query = {'Scope': 'CLOUDFRONT'}
         wafs = self.manager.get_resource_manager('wafv2').resources(query, augment=False)
-        waf_name_id_map = {w['Name']: w['Id'] for w in wafs}
+        waf_name_id_map = {w['Name']: w['ARN'] for w in wafs}
         target_acl = self.data.get('web-acl')
         target_acl_id = waf_name_id_map.get(target_acl, target_acl)
         if target_acl_id not in waf_name_id_map.values():

--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -155,7 +155,7 @@ class IsWafV2Enabled(Filter):
     def process(self, resources, event=None):
         query = {'Scope': 'CLOUDFRONT'}
         wafs = self.manager.get_resource_manager('wafv2').resources(query, augment=False)
-        waf_name_id_map = {w['Name']: w['Id'] for w in wafs}
+        waf_name_id_map = {w['Name']: w['ARN'] for w in wafs}
         state = self.data.get('state', False)
         target_acl = self.data.get('web-acl')
         target_acl_id = waf_name_id_map.get(target_acl, target_acl)

--- a/tests/data/placebo/test_distribution_wafv2/cloudfront.ListDistributions_2.json
+++ b/tests/data/placebo/test_distribution_wafv2/cloudfront.ListDistributions_2.json
@@ -32,7 +32,7 @@
                         "Quantity": 1
                     }, 
                     "DomainName": "d3naej5h8q7gej.cloudfront.net", 
-                    "WebACLId": "1ebe0b46-0fd2-4e07-a74c-27bf25adc0bf", 
+                    "WebACLId": "arn:aws:wafv2:us-east-1:1234567890:regional/webacl/test/791f9fc9-16bb-4d32-8f6a-b55e9b6f11c8", 
                     "PriceClass": "PriceClass_All", 
                     "Enabled": true, 
                     "DefaultCacheBehavior": {
@@ -188,7 +188,7 @@
                         "Quantity": 1
                     }, 
                     "DomainName": "d34vi31c0msjue.cloudfront.net", 
-                    "WebACLId": "1ebe0b46-0fd2-4e07-a74c-27bf25adc0bf", 
+                    "WebACLId": "arn:aws:wafv2:us-east-1:1234567890:regional/webacl/test/791f9fc9-16bb-4d32-8f6a-b55e9b6f11c8", 
                     "PriceClass": "PriceClass_All", 
                     "Enabled": true, 
                     "DefaultCacheBehavior": {

--- a/tests/data/placebo/test_distribution_wafv2/wafv2.ListWebACLs_3.json
+++ b/tests/data/placebo/test_distribution_wafv2/wafv2.ListWebACLs_3.json
@@ -16,7 +16,8 @@
         "WebACLs": [
             {
                 "Id": "1ebe0b46-0fd2-4e07-a74c-27bf25adc0bf",
-                "Name": "test"
+                "Name": "test",
+				"ARN": "arn:aws:wafv2:us-east-1:1234567890:regional/webacl/test/791f9fc9-16bb-4d32-8f6a-b55e9b6f11c8"
             }
         ]
     }


### PR DESCRIPTION
CloudFront's update distribution needs webacl ARN to update distribution with WebACL