### PR TITLE
aws - sns - added "has-statement" filter

### DIFF
--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -87,7 +87,7 @@ class HasStatementFilter(Filter):
 
             policies:
               - name: sns-topic-has-statement
-                resource: s3
+                resource: sns
                 filters:
                   - type: has-statement
                     statement_ids:
@@ -96,7 +96,7 @@ class HasStatementFilter(Filter):
 
             policies:
               - name: sns-block-non-ssl
-                resource: s3
+                resource: sns
                 filters:
                   - type: has-statement
                     statements:

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -3,7 +3,7 @@
 import json
 
 from c7n.actions import RemovePolicyBase, ModifyPolicyBase, BaseAction
-from c7n.filters import CrossAccountAccessFilter, PolicyChecker
+from c7n.filters import CrossAccountAccessFilter, PolicyChecker, Filter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
 from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
@@ -75,6 +75,87 @@ class SNSPostFinding(PostFinding):
                 'Owner': r['Owner'],
                 'TopicName': r['TopicArn'].rsplit(':', 1)[-1]}))
         return envelope
+
+
+@SNS.filter_registry.register('has-statement')
+class HasStatementFilter(Filter):
+    """Find SNS topics with set of access policy statements.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: sns-topic-has-statement
+                resource: s3
+                filters:
+                  - type: has-statement
+                    statement_ids:
+                      - AllowSSLRequestsOnly
+
+
+            policies:
+              - name: sns-block-non-ssl
+                resource: s3
+                filters:
+                  - type: has-statement
+                    statements:
+                      - Effect: Deny
+                        Action: 'SNS:*'
+                        Principal: '*'
+    """
+    schema = type_schema(
+        'has-statement',
+        statement_ids={'type': 'array', 'items': {'type': 'string'}},
+        statements={
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'Sid': {'type': 'string'},
+                    'Effect': {'type': 'string', 'enum': ['Allow', 'Deny']},
+                    'Principal': {'anyOf': [
+                        {'type': 'string'},
+                        {'type': 'object'}, {'type': 'array'}]},
+                    'NotPrincipal': {
+                        'anyOf': [{'type': 'object'}, {'type': 'array'}]},
+                    'Action': {
+                        'anyOf': [{'type': 'string'}, {'type': 'array'}]},
+                    'NotAction': {
+                        'anyOf': [{'type': 'string'}, {'type': 'array'}]},
+                    'Resource': {
+                        'anyOf': [{'type': 'string'}, {'type': 'array'}]},
+                    'NotResource': {
+                        'anyOf': [{'type': 'string'}, {'type': 'array'}]},
+                    'Condition': {'type': 'object'}
+                },
+                'required': ['Effect']
+            }
+        })
+
+    def process(self, topics, event=None):
+        return list(filter(None, map(self.process_topic, topics)))
+
+    def process_topic(self, t):
+        p = t.get('Policy')
+        if p is None:
+            return None
+        p = json.loads(p)
+        statements = p.get('Statement', [])
+        required_statements = list(self.data.get('statements', []))
+        for required_statement in required_statements:
+            for statement in statements:
+                found = 0
+                for key, value in required_statement.items():
+                    if key in statement and value == statement[key]:
+                        found += 1
+                if found and found == len(required_statement):
+                    required_statements.remove(required_statement)
+                    break
+
+        if (self.data.get('statements', []) and not required_statements):
+            return t
+        return None
 
 
 @SNS.action_registry.register('tag')

--- a/tests/data/placebo/test_sns_has_statement/sns.GetTopicAttributes_1.json
+++ b/tests/data/placebo/test_sns_has_statement/sns.GetTopicAttributes_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"Statement_1\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\"],\"Resource\":\"arn:aws:sns:us-west-2:644160558196:sns-test-has-statement\",\"Condition\":{\"StringEquals\":{\"aws:SourceOwner\":\"644160558196\"},\"Bool\":{\"aws:SecureTransport\":\"true\"}}},{\"Sid\":\"BlockNonSSL\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"SNS:Publish\",\"Resource\":\"arn:aws:sns:us-west-2:644160558196:sgunn-test-1\",\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"false\"}}}]}",
+            "LambdaSuccessFeedbackSampleRate": "0",
+            "Owner": "644160558196",
+            "SubscriptionsPending": "0",
+            "KmsMasterKeyId": "alias/aws/sns",
+            "TopicArn": "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement",
+            "EffectiveDeliveryPolicy": "{\"http\":{\"defaultHealthyRetryPolicy\":{\"minDelayTarget\":20,\"maxDelayTarget\":20,\"numRetries\":3,\"numMaxDelayRetries\":0,\"numNoDelayRetries\":0,\"numMinDelayRetries\":0,\"backoffFunction\":\"linear\"},\"disableSubscriptionOverrides\":false}}",
+            "FirehoseSuccessFeedbackSampleRate": "0",
+            "SubscriptionsConfirmed": "0",
+            "SQSSuccessFeedbackSampleRate": "0",
+            "HTTPSuccessFeedbackSampleRate": "0",
+            "ApplicationSuccessFeedbackSampleRate": "0",
+            "DisplayName": "",
+            "DeliveryPolicy": "{\"http\":{\"defaultHealthyRetryPolicy\":{\"minDelayTarget\":20,\"maxDelayTarget\":20,\"numRetries\":3,\"numMaxDelayRetries\":0,\"numNoDelayRetries\":0,\"numMinDelayRetries\":0,\"backoffFunction\":\"linear\"},\"disableSubscriptionOverrides\":false}}",
+            "SubscriptionsDeleted": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sns_has_statement/sns.GetTopicAttributes_2.json
+++ b/tests/data/placebo/test_sns_has_statement/sns.GetTopicAttributes_2.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\"],\"Resource\":\"arn:aws:sns:us-west-1:644160558196:sns-test-not-has-statement\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"644160558196\"}}}]}",
+            "Owner": "644160558196",
+            "SubscriptionsPending": "0",
+            "KmsMasterKeyId": "alias/aws/sns",
+            "TopicArn": "arn:aws:sns:us-west-1:644160558196:sns-test-not-has-statement",
+            "EffectiveDeliveryPolicy": "{\"http\":{\"defaultHealthyRetryPolicy\":{\"minDelayTarget\":20,\"maxDelayTarget\":20,\"numRetries\":3,\"numMaxDelayRetries\":0,\"numNoDelayRetries\":0,\"numMinDelayRetries\":0,\"backoffFunction\":\"linear\"},\"disableSubscriptionOverrides\":false}}",
+            "SubscriptionsConfirmed": "0",
+            "DisplayName": "",
+            "SubscriptionsDeleted": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sns_has_statement/sns.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_sns_has_statement/sns.ListTagsForResource_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [],
+        "ResponseMetadata": {
+            "RequestId": "399ed6c0-9ff9-5402-b66e-83aa9202b8f3",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "399ed6c0-9ff9-5402-b66e-83aa9202b8f3",
+                "content-type": "text/xml",
+                "content-length": "290",
+                "date": "Thu, 16 Jun 2022 16:58:35 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_sns_has_statement/sns.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_sns_has_statement/sns.ListTagsForResource_2.json
@@ -3,7 +3,7 @@
     "data": {
         "Tags": [],
         "ResponseMetadata": {
-            "RequestId": "399ed6c0-9ff9-5402-b66e-83aa9202b8f4",
+            "RequestId": "399ed6c0-9ff9-5402-b66e-83aa9202b8f5",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
                 "x-amzn-requestid": "399ed6c0-9ff9-5402-b66e-83aa9202b8f3",

--- a/tests/data/placebo/test_sns_has_statement/sns.ListTopics_1.json
+++ b/tests/data/placebo/test_sns_has_statement/sns.ListTopics_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "Topics": [
+            {
+                "TopicArn": "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sns_has_statement/sns.ListTopics_1.json
+++ b/tests/data/placebo/test_sns_has_statement/sns.ListTopics_1.json
@@ -4,6 +4,9 @@
         "Topics": [
             {
                 "TopicArn": "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement"
+            },
+            {
+                "TopicArn": "arn:aws:sns:us-west-1:644160558196:sns-test-not-has-statement"
             }
         ],
         "ResponseMetadata": {}

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -711,26 +711,13 @@ class TestSNS(BaseTest):
         self.assertEqual(len(resources), 2)
         self.assertEqual(resources[0]['Tags'][0]['Value'], 'false')
 
-    def test_sns_has_statement(self):
-        # session_factory = self.record_flight_data('test_sns_has_statement')
-        # policy = {
-        #     'name': 'list-sns-topics',
-        #     'resource': 'sns',
-        # }
-        # policy = self.load_policy(
-        #     policy,
-        #     session_factory=session_factory, config={'region': 'us-west-1'}
-        # )
-
-        # resources = policy.run()
-        # self.assertEqual(len(resources), 2)
-
+    def test_sns_has_statement_definition(self):
         session_factory = self.replay_flight_data(
             "test_sns_has_statement"
         )
         p = self.load_policy(
             {
-                "name": "test_sns_has_statement",
+                "name": "test_sns_has_statement_definition",
                 "resource": "sns",
                 "filters": [
                     {
@@ -739,7 +726,8 @@ class TestSNS(BaseTest):
                             {
                                 "Effect": "Deny",
                                 "Action": "SNS:Publish",
-                                "Principal": "*"
+                                "Principal": "*",
+                                "Condition": { "Bool": {"aws:SecureTransport": "false"} }
                             }
                         ]
                     }
@@ -749,6 +737,28 @@ class TestSNS(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["TopicArn"], "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement")
+
+    def test_sns_has_statement_id(self):
+        session_factory = self.replay_flight_data(
+            "test_sns_has_statement"
+        )
+        p = self.load_policy(
+            {
+                "name": "test_sns_has_statement_id",
+                "resource": "sns",
+                "filters": [
+                    {
+                        "type": "has-statement",
+                        "statement_ids": ["BlockNonSSL"]
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["TopicArn"], "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement")
 
 
 class TestSubscription(BaseTest):

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -724,6 +724,7 @@ class TestSNS(BaseTest):
 
         # resources = policy.run()
         # self.assertEqual(len(resources), 2)
+        
         session_factory = self.replay_flight_data(
             "test_sns_has_statement"
         )

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -727,7 +727,8 @@ class TestSNS(BaseTest):
                                 "Effect": "Deny",
                                 "Action": "SNS:Publish",
                                 "Principal": "*",
-                                "Condition": { "Bool": {"aws:SecureTransport": "false"} }
+                                "Condition":
+                                    {"Bool": {"aws:SecureTransport": "false"}}
                             }
                         ]
                     }
@@ -737,7 +738,8 @@ class TestSNS(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]["TopicArn"], "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement")
+        self.assertEqual(resources[0]["TopicArn"],
+        "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement")
 
     def test_sns_has_statement_id(self):
         session_factory = self.replay_flight_data(
@@ -758,7 +760,8 @@ class TestSNS(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]["TopicArn"], "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement")
+        self.assertEqual(resources[0]["TopicArn"],
+        "arn:aws:sns:us-west-1:644160558196:sns-test-has-statement")
 
 
 class TestSubscription(BaseTest):

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -711,6 +711,45 @@ class TestSNS(BaseTest):
         self.assertEqual(len(resources), 2)
         self.assertEqual(resources[0]['Tags'][0]['Value'], 'false')
 
+    def test_sns_has_statement(self):
+        # session_factory = self.record_flight_data('test_sns_has_statement')
+        # policy = {
+        #     'name': 'list-sns-topics',
+        #     'resource': 'sns',
+        # }
+        # policy = self.load_policy(
+        #     policy,
+        #     session_factory=session_factory, config={'region': 'us-west-1'}
+        # )
+
+        # resources = policy.run()
+        # self.assertEqual(len(resources), 2)
+
+        session_factory = self.replay_flight_data(
+            "test_sns_has_statement"
+        )
+        p = self.load_policy(
+            {
+                "name": "test_sns_has_statement",
+                "resource": "sns",
+                "filters": [
+                    {
+                        "type": "has-statement",
+                        "statements": [
+                            {
+                                "Effect": "Deny",
+                                "Action": "SNS:Publish",
+                                "Principal": "*"
+                            }
+                        ]
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
 
 class TestSubscription(BaseTest):
 

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -724,7 +724,7 @@ class TestSNS(BaseTest):
 
         # resources = policy.run()
         # self.assertEqual(len(resources), 2)
-        
+
         session_factory = self.replay_flight_data(
             "test_sns_has_statement"
         )

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -724,7 +724,6 @@ class TestSNS(BaseTest):
 
         # resources = policy.run()
         # self.assertEqual(len(resources), 2)
-
         session_factory = self.replay_flight_data(
             "test_sns_has_statement"
         )


### PR DESCRIPTION
Added the ability to filter by SNS access policy statements. 

With this, SNS access policy statements can either be filtered by statement IDs:

```
    filters:
      - not:
        - type: has-statement
          statement_ids:
            - BlockNonSSL
            - MyFavoriteStatement
```

Or by statement key-value definitions:

```
    filters:
      - not:
        - type: has-statement
          statements:
            - Effect: "Deny"
              Principal: "*"
              Action: "SNS:Publish"
              Condition:
                Bool:
                  "aws:SecureTransport": "false"
```