### PR TITLE
aws - output - allow for setting bucket region

### DIFF
--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -535,8 +535,11 @@ class S3Output(BlobOutput):
     def __init__(self, ctx, config):
         super().__init__(ctx, config)
         # can't use a local session as we dont want an unassumed session cached.
+        kwargs = {'assume': False}
+        if os.environ.get('C7N_BUCKET_REGION'):
+            kwargs['region'] = os.environ['C7N_BUCKET_REGION']
         self.transfer = S3Transfer(
-            self.ctx.session_factory(assume=False).client('s3'))
+            self.ctx.session_factory(**kwargs).client('s3'))
 
     def upload_file(self, path, key):
         self.transfer.upload_file(


### PR DESCRIPTION
When running a policy in a region like af-south-1, if the output bucket is in us-east-1 the output will fail:

```
custodian run asdf.yaml -s s3://bucket --region af-south-1
2022-06-24 14:27:25,087: custodian.policy:INFO policy:foo resource:lambda region:af-south-1 count:0 time:0.00
2022-06-24 14:27:26,993: custodian.commands:ERROR Error while executing policy foo, continuing
Traceback (most recent call last):
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/boto3/s3/transfer.py", line 287, in upload_file
    future.result()
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/s3transfer/futures.py", line 103, in result
    return self._coordinator.result()
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/s3transfer/futures.py", line 266, in result
    raise self._exception
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/s3transfer/tasks.py", line 139, in __call__
    return self._execute_main(kwargs)
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/s3transfer/tasks.py", line 162, in _execute_main
    return_value = self._main(**kwargs)
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/s3transfer/upload.py", line 758, in _main
    client.put_object(Bucket=bucket, Key=key, Body=body, **extra_args)
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/botocore/client.py", line 508, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/botocore/client.py", line 915, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (IllegalLocationConstraintException) when calling the PutObject operation: The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sonny/dev/thisisshi/cloud-custodian/c7n/commands.py", line 301, in run
    policy()
  File "/Users/sonny/dev/thisisshi/cloud-custodian/c7n/policy.py", line 1242, in __call__
    resources = mode.run()
  File "/Users/sonny/dev/thisisshi/cloud-custodian/c7n/policy.py", line 312, in run
    return []
  File "/Users/sonny/dev/thisisshi/cloud-custodian/c7n/ctx.py", line 103, in __exit__
    self.output.__exit__(exc_type, exc_value, exc_traceback)
  File "/Users/sonny/dev/thisisshi/cloud-custodian/c7n/output.py", line 486, in __exit__
    self.upload()
  File "/Users/sonny/dev/thisisshi/cloud-custodian/c7n/output.py", line 494, in upload
    self.upload_file(os.path.join(root, f), key)
  File "/Users/sonny/dev/thisisshi/cloud-custodian/c7n/resources/aws.py", line 542, in upload_file
    self.transfer.upload_file(
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.9/lib/python3.9/site-packages/boto3/s3/transfer.py", line 293, in upload_file
    raise S3UploadFailedError(
boto3.exceptions.S3UploadFailedError: Failed to upload /var/folders/97/ym_n9g9x1gggyhwqpppr6hjc0000gn/T/tmps6m5xrht/resources.json.gz to bucket/foo/2022/06/24/21/resources.json.gz: An error occurred (IllegalLocationConstraintException) when calling the PutObject operation: The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.
2022-06-24 14:27:27,006: custodian.commands:ERROR The following policies had errors while executing
 - foo
```