### PR TITLE
Interpolate universal tags #6821 

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -871,6 +871,8 @@ class UniversalTag(Tag):
         if msg:
             tags[tag] = msg
 
+        self.interpolate_values(tags)
+
         batch_size = self.data.get('batch_size', self.batch_size)
         client = self.get_client()
 
@@ -882,6 +884,12 @@ class UniversalTag(Tag):
         arns = self.manager.get_arns(resource_set)
         return universal_retry(
             client.tag_resources, ResourceARNList=arns, Tags=tags)
+
+    def interpolate_values(self, tags):
+        """Interpolate in a list of tags - 'new' resourcegroupstaggingapi format
+        """
+        for key in list(tags.keys()):
+            tags[key] = self.interpolate_single_value(tags[key])
 
     def get_client(self):
         # For global resources, manage tags from us-east-1

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -425,13 +425,20 @@ class Tag(Action):
             Tags=tags,
             DryRun=self.manager.config.dryrun)
 
-    def interpolate_values(self, tags):
+    def interpolate_single_value(self, tag):
+        """Interpolate in a single tag value.
+        """
         params = {
             'account_id': self.manager.config.account_id,
             'now': utils.FormatDate.utcnow(),
             'region': self.manager.config.region}
+        return tag.format(**params)
+
+    def interpolate_values(self, tags):
+        """Interpolate in a list of tags - 'old' ec2 format
+        """
         for t in tags:
-            t['Value'] = t['Value'].format(**params)
+            t['Value'] = self.interpolate_single_value(t['Value'])
 
     def get_client(self):
         return utils.local_session(self.manager.session_factory).client(

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ cryptography==37.0.4; sys_platform == "linux" and python_version >= "3.7"
 docutils==0.17.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 execnet==1.9.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.6" and python_version < "4.0"
 flake8==3.9.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+freezegun==1.2.2; python_version >= "3.6"
 idna==3.3; python_version >= "3.7" and python_version < "4"
 importlib-metadata==4.12.0; python_version >= "3.7"
 importlib-resources==5.9.0; python_version < "3.9" and python_version >= "3.7"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -96,6 +96,34 @@ class TagInterpolationTest(BaseTest):
             DryRun=False,
         )
 
+    @freeze_time("2022-06-27 12:34:56")
+    def test_rds_tag_interpolation(self):
+        (_, tag_resources) = self.__tag_interpolation_helper(
+            'rds', [{'DBInstanceIdentifier': 'xxx', 'DBInstanceArn': 'arn:xxx'}]
+        )
+        tag_resources.assert_called_once_with(
+            ResourceARNList=['arn:xxx'],
+            Tags={
+                'tag_account_id': self.account_id,
+                'tag_now': '2022-06-27 12:34:56',
+                'tag_region': 'us-east-1',
+            },
+        )
+
+    @freeze_time("2022-06-27 12:34:56")
+    def test_kms_key_tag_interpolation(self):
+        (_, tag_resources) = self.__tag_interpolation_helper(
+            'kms-key', [{'KeyId': 'xxx', 'Arn': 'arn:xxx'}]
+        )
+        tag_resources.assert_called_once_with(
+            ResourceARNList=['arn:xxx'],
+            Tags={
+                'tag_account_id': self.account_id,
+                'tag_now': '2022-06-27 12:34:56',
+                'tag_region': 'us-east-1',
+            },
+        )
+
 
 class UniversalTagTest(BaseTest):
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -4,6 +4,7 @@
 module to test some universal tagging infrastructure not directly exposed.
 """
 import time
+from freezegun import freeze_time
 from mock import MagicMock, call
 
 from c7n.tags import universal_retry, coalesce_copy_user_tags
@@ -46,6 +47,54 @@ def test_tag_action_filter_call(test, tag_action_filter_call):
     ec2 = session_factory().resource('ec2')
     instance = ec2.Instance(stopped_ec2_instance_id)
     test.assertEqual(instance.state['Name'], 'stopping')
+
+
+class TagInterpolationTest(BaseTest):
+    def __tag_interpolation_helper(self, resource_name, resources):
+
+        mock_factory = MagicMock()
+        mock_factory.region = 'us-east-1'
+
+        create_tags = mock_factory().client(resource_name).create_tags
+
+        tag_resources = mock_factory().client('resourcegroupstaggingapi').tag_resources
+        tag_resources.return_value = {}
+
+        policy = self.load_policy(
+            {
+                "name": "test-tag-interpolation",
+                "resource": resource_name,
+                "actions": [
+                    {
+                        "type": "tag",
+                        "tags": {
+                            "tag_account_id": "{account_id}",
+                            "tag_now": "{now}",
+                            "tag_region": "{region}",
+                        },
+                    }
+                ],
+            },
+            session_factory=mock_factory,
+        )
+        policy.resource_manager.actions[0].process(resources)
+
+        return (create_tags, tag_resources)
+
+    @freeze_time("2022-06-27 12:34:56")
+    def test_ec2_tag_interpolation(self):
+        (create_tags, _) = self.__tag_interpolation_helper(
+            'ec2', [{'InstanceId': 'i-12345'}]
+        )
+        create_tags.assert_called_once_with(
+            Resources=['i-12345'],
+            Tags=[
+                {'Key': 'tag_account_id', 'Value': self.account_id},
+                {'Key': 'tag_now', 'Value': '2022-06-27 12:34:56'},
+                {'Key': 'tag_region', 'Value': 'us-east-1'},
+            ],
+            DryRun=False,
+        )
 
 
 class UniversalTagTest(BaseTest):


### PR DESCRIPTION
Implement interpolation for UniversalTag by reusing the implementation of ec2 tag interpolation.  
Tests are added - I was not able to properly use [`mock_datetime_now`](https://github.com/cloud-custodian/cloud-custodian/blob/50b1ee560dc833947176b1c094c9273317d9795b/c7n/testing.py#L272-L296) to freeze the time during the tests, so I'm using a [new dependency](https://github.com/spulec/freezegun) for this very need.
Do not hesitate to rewrite it with `mock_datetime_now` if you're luckier than I am.

Fixes #6821