### PR TITLE
aws - account - return empty list if check-macie doesn't match

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -121,6 +121,8 @@ class MacieEnabled(ValueFilter):
         if super().process([resources[0][self.annotation_key]]):
             return resources
 
+        return []
+
     def get_macie_info(self, account):
         client = local_session(
             self.manager.session_factory).client('macie2')

--- a/tests/data/placebo/test_account_check_macie_disabled/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_check_macie_disabled/iam.ListAccountAliases_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountAliases": [
+            "ajsbx"
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_account_check_macie_disabled/macie2.GetMacieSession_1.json
+++ b/tests/data/placebo/test_account_check_macie_disabled/macie2.GetMacieSession_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 403,
+    "data": {
+        "Error": {
+            "Message": "Macie is not enabled",
+            "Code": "AccessDeniedException"
+        },
+        "ResponseMetadata": {},
+        "message": "Macie is not enabled"
+    }
+}

--- a/tests/data/placebo/test_account_check_macie_disabled/macie2.GetMasterAccount_1.json
+++ b/tests/data/placebo/test_account_check_macie_disabled/macie2.GetMasterAccount_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 403,
+    "data": {
+        "Error": {
+            "Message": "Macie is not enabled",
+            "Code": "AccessDeniedException"
+        },
+        "ResponseMetadata": {},
+        "message": "Macie is not enabled"
+    }
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -52,6 +52,21 @@ class AccountTests(BaseTest):
                 2020, 12, 3, 16, 22, 14, 821000, tzinfo=tz.tzutc()),
         }
 
+    def test_macie_disabled(self):
+        factory = self.replay_flight_data(
+            'test_account_check_macie_disabled')
+        p = self.load_policy({
+            'name': 'macie-check-disabled',
+            'resource': 'aws.account',
+            'filters': [{
+                'not': [
+                    {'type': 'check-macie',
+                     'key': 'status',
+                     'value': 'ENABLED'}]}]
+        }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_missing(self):
         session_factory = self.replay_flight_data(
             'test_account_missing_resource_ec2')


### PR DESCRIPTION
If the `check-macie` filter for `aws.account` doesn't match, return an empty list rather than defaulting to `None`. Otherwise we can trigger exceptions when combining this filter with others, or nesting it under a `not` block:

```
./tests/test_account.py::AccountTests::test_macie_disabled Failed: [undefined]TypeError: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/home/aj/code/cloud-custodian/tests/test_account.py", line 67, in test_macie_disabled
    resources = p.run()
  File "/home/aj/code/cloud-custodian/c7n/policy.py", line 1242, in __call__
    resources = mode.run()
  File "/home/aj/code/cloud-custodian/c7n/policy.py", line 290, in run
    resources = self.policy.resource_manager.resources()
  File "/home/aj/code/cloud-custodian/c7n/resources/account.py", line 78, in resources
    return self.filter_resources([get_account(self.session_factory, self.config)])
  File "/home/aj/code/cloud-custodian/c7n/manager.py", line 111, in filter_resources
    resources = f.process(resources, event)
  File "/home/aj/code/cloud-custodian/c7n/filters/core.py", line 378, in process
    return self.process_set(resources, event)
  File "/home/aj/code/cloud-custodian/c7n/filters/core.py", line 402, in process_set
    after = {r[rtype_id] for r in resources}
TypeError: 'NoneType' object is not iterable
```