### PR TITLE
aws - mu - add waiter to lambda creation to support AWS Lamdba states

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -458,7 +458,6 @@ class LambdaManager:
         assert role, "Lambda function role must be specified"
         archive = func.get_archive()
         existing = self.get(func.name, qualifier)
-        function_updated_waiter = self.client.get_waiter('function_updated')
 
         if s3_uri:
             # TODO: support versioned buckets
@@ -475,7 +474,8 @@ class LambdaManager:
                 params = dict(FunctionName=func.name, Publish=True)
                 params.update(code_ref)
                 result = self.client.update_function_code(**params)
-                function_updated_waiter.wait(FunctionName=func.name)
+                waiter = self.client.get_waiter('function_updated')
+                waiter.wait(FunctionName=func.name)
                 changed = True
 
             # TODO/Consider also set publish above to false, and publish
@@ -501,6 +501,8 @@ class LambdaManager:
             params.update({'Publish': True, 'Code': code_ref, 'Role': role})
             result = self.client.create_function(**params)
             self._update_concurrency(None, func)
+            waiter = self.client.get_waiter('function_active')
+            waiter.wait(FunctionName=func.name)
             changed = True
 
         return result, changed


### PR DESCRIPTION
We were seeing the following error when deploying config policy
```
$ custodian run -s /tmp --cache-period 0 policy-config-poll-rule.yaml
2022-06-28 14:21:55,034: custodian.policy:INFO Provisioning policy lambda: s3-encryption-test-3 region: us-west-2
2022-06-28 14:21:55,775: custodian.serverless:INFO Publishing custodian policy lambda function custodian-s3-encryption-test-3
2022-06-28 14:21:58,019: custodian.output:ERROR Error while executing policy
Traceback (most recent call last):
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/policy.py", line 518, in provision
    return manager.publish(
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/mu.py", line 397, in publish
    if e.add(func):
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/mu.py", line 1741, in add
    return LambdaRetry(self.client.put_config_rule, ConfigRule=params)
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/utils.py", line 446, in _retry
    return func(*args, **kw)
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/botocore/client.py", line 415, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/botocore/client.py", line 745, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidParameterValueException: An error occurred (InvalidParameterValueException) when calling the PutConfigRule operation: The specified AWS Lambda function is not in Active state. Please retry after sometime
2022-06-28 14:21:58,025: custodian.commands:ERROR Error while executing policy s3-encryption-test-3, continuing
Traceback (most recent call last):
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/commands.py", line 301, in run
    policy()
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/policy.py", line 1271, in __call__
    resources = mode.provision()
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/policy.py", line 518, in provision
    return manager.publish(
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/mu.py", line 397, in publish
    if e.add(func):
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/mu.py", line 1741, in add
    return LambdaRetry(self.client.put_config_rule, ConfigRule=params)
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/c7n/utils.py", line 446, in _retry
    return func(*args, **kw)
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/botocore/client.py", line 415, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/ddao/git/ddao-cloud-custodian/custodian/lib/python3.9/site-packages/botocore/client.py", line 745, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidParameterValueException: An error occurred (InvalidParameterValueException) when calling the PutConfigRule operation: The specified AWS Lambda function is not in Active state. Please retry after sometime
2022-06-28 14:21:58,042: custodian.commands:ERROR The following policies had errors while executing
 - s3-encryption-test-3
 ```

I believe that is caused by https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/

There was a PR for it: https://github.com/cloud-custodian/cloud-custodian/pull/6969/files. However, that PR only handled the "update" path and not the "create" path.

There was another PR that attempted to fix the issue by putting in a workaround of bumping up the retry: https://github.com/cloud-custodian/cloud-custodian/pull/7194/files#diff-624309be839883690fed68e43721e4e79911f95bd64ed760fc7e2295f4a3580eR41-R42. This PR however only fix the symptom and not the root cause.

I believe the real fix is to actually put in a waiter for the "create" path so that we wait for the lambda function to be in active state before we continue with the policy deployment.