### PR TITLE
aws - vpc - flow-logs - bugfix LogDestination key error

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -134,6 +134,8 @@ class FlowLogFilter(Filter):
                 for fl in flogs:
                     dest_type_match = (destination_type is None) or op(
                         fl['LogDestinationType'], destination_type)
+                    if not hasattr(fl, 'LogDestination'):
+                        fl['LogDestination'] = ''
                     dest_match = (destination is None) or op(
                         fl['LogDestination'], destination)
                     status_match = (status is None) or op(fl['FlowLogStatus'], status.upper())

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -134,7 +134,7 @@ class FlowLogFilter(Filter):
                 for fl in flogs:
                     dest_type_match = (destination_type is None) or op(
                         fl['LogDestinationType'], destination_type)
-                    if not hasattr(fl, 'LogDestination'):
+                    if not 'LogDestination' in fl:
                         fl['LogDestination'] = ''
                     dest_match = (destination is None) or op(
                         fl['LogDestination'], destination)

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -134,7 +134,7 @@ class FlowLogFilter(Filter):
                 for fl in flogs:
                     dest_type_match = (destination_type is None) or op(
                         fl['LogDestinationType'], destination_type)
-                    if not 'LogDestination' in fl:
+                    if 'LogDestination' not in fl:
                         fl['LogDestination'] = ''
                     dest_match = (destination is None) or op(
                         fl['LogDestination'], destination)


### PR DESCRIPTION
Addresses issue #6152

The existing pull request (#7200) does not work when a user has a following policy because it will skip the whole filters when the `LogDestination` key is missing. No actions will be taken.

**example policy**
```yaml
    filters:
      - not:
        - type: flow-logs
          enabled: true
          destination: arn:aws:s3:::my-flow-log-destination-us-west-2
    actions:
      - type: set-flow-log
        TrafficType: ALL
        LogDestinationType: s3
        LogDestination: arn:aws:s3:::my-flow-log-destination-us-west-2
        LogFormat: ${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status} ${vpc-id} ${subnet-id} ${instance-id} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr} ${region} ${az-id} ${sublocation-type} ${sublocation-id} ${pkt-src-aws-service} ${pkt-dst-aws-service} ${flow-direction} ${traffic-path}
```