### PR TITLE
core - structural validate handle explicit null filters or actions

### DIFF
--- a/c7n/structure.py
+++ b/c7n/structure.py
@@ -66,7 +66,7 @@ class StructureParser:
                 'policy:%s must use a list for filters found:%s' % (
                     p['name'], type(p['filters']).__name__)))
         element_types = (dict, str)
-        for f in p.get('filters', ()):
+        for f in p.get('filters', ()) or []:
             if not isinstance(f, element_types):
                 raise PolicyValidationError((
                     'policy:%s filter must be a mapping/dict found:%s' % (
@@ -75,7 +75,7 @@ class StructureParser:
             raise PolicyValidationError((
                 'policy:%s must use a list for actions found:%s' % (
                     p.get('name', 'unknown'), type(p['actions']).__name__)))
-        for a in p.get('actions', ()):
+        for a in p.get('actions', ()) or []:
             if not isinstance(a, element_types):
                 raise PolicyValidationError((
                     'policy:%s action must be a mapping/dict found:%s' % (

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -73,6 +73,14 @@ class StructureParserTest(BaseTest):
         self.assertTrue(str(ecm.exception).startswith(
             'policy:foo action must be a mapping/dict found:list'))
 
+    def test_null_actions(self):
+        p = StructureParser()
+        p.validate({'policies': [{'name': 'foo', 'resource': 'ec2', 'actions': None}]})
+
+    def test_null_filters(self):
+        p = StructureParser()
+        p.validate({'policies': [{'name': 'foo', 'resource': 'ec2', 'filters': None}]})
+
     def test_invalid_filter(self):
         p = StructureParser()
         with self.assertRaises(PolicyValidationError) as ecm:


### PR DESCRIPTION
closes #7567

we'll let the jsonschema validate handle these

