### PR TITLE
chore: cleanup the blob output handlers.

### DIFF
--- a/c7n/ctx.py
+++ b/c7n/ctx.py
@@ -11,7 +11,8 @@ from c7n.output import (
     log_outputs,
     metrics_outputs,
     sys_stats_outputs,
-    tracer_outputs)
+    tracer_outputs,
+)
 
 from c7n.utils import reset_session_cache, dumps, local_session
 from c7n.version import version
@@ -91,8 +92,7 @@ class ExecutionContext:
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
         if exc_type is not None and self.metrics:
             self.metrics.put_metric('PolicyException', 1, "Count")
-        self.policy._write_file(
-            'metadata.json', dumps(self.get_metadata(), indent=2))
+        self.output.write_file('metadata.json', dumps(self.get_metadata(), indent=2))
         self.api_stats.__exit__(exc_type, exc_value, exc_traceback)
 
         with self.tracer.subsegment('output'):
@@ -121,8 +121,9 @@ class ExecutionContext:
                 'id': self.execution_id,
                 'start': self.start_time,
                 'end_time': t,
-                'duration': t - self.start_time},
-            'config': dict(self.options)
+                'duration': t - self.start_time,
+            },
+            'config': dict(self.options),
         }
 
         if 'sys-stats' in include and self.sys_stats:

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -323,15 +323,15 @@ class AzureModeCommon:
             resources = policy.resource_manager.filter_resources(
                 resources, event)
 
-        with policy.ctx:
+        with policy.ctx as ctx:
             rt = time.time() - s
 
-            policy.ctx.metrics.put_metric(
+            ctx.metrics.put_metric(
                 'ResourceCount', len(resources), 'Count', Scope="Policy",
                 buffer=False)
-            policy.ctx.metrics.put_metric(
+            ctx.metrics.put_metric(
                 "ResourceTime", rt, "Seconds", Scope="Policy")
-            policy._write_file(
+            ctx.output.write_file(
                 'resources.json', utils.dumps(resources, indent=2))
 
             if not resources:
@@ -345,13 +345,13 @@ class AzureModeCommon:
                 policy.log.info(
                     "policy: %s invoking action: %s resources: %d",
                     policy.name, action.name, len(resources))
-                with policy.ctx.tracer.subsegment('action:%s' % action.type):
+                with ctx.tracer.subsegment('action:%s' % action.type):
                     if isinstance(action, EventAction):
                         results = action.process(resources, event)
                     else:
                         results = action.process(resources)
                 try:
-                    policy._write_file(
+                    ctx.output.write_file(
                         "action-%s" % action.name, utils.dumps(results))
                 except (TypeError, OverflowError):
                     pass


### PR DESCRIPTION
A policy shouldn't have a `_write_file` method. This job belongs to the output file handlers.
This PR introduces an abstract base that has the explicit interface expected of the classes registered with the blob_outputs registry.
