### PR TITLE
tools/c7n-mailer - fix null exception of notify_action_to

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/azure_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/azure_queue_processor.py
@@ -68,13 +68,13 @@ class MailerAzureQueueProcessor:
             queue_message['policy']['resource'],
             len(queue_message['resources']),
             queue_message['policy']['name'],
-            ', '.join(queue_message['action'].get('to'))))
+            ', '.join(queue_message['action'].get('to', []))))
 
         if any(e.startswith('slack') or e.startswith('https://hooks.slack.com/')
-                for e in queue_message.get('action', ()).get('to')):
+                for e in queue_message.get('action', ()).get('to', [])):
             self._deliver_slack_message(queue_message)
 
-        if any(e.startswith('datadog') for e in queue_message.get('action', ()).get('to')):
+        if any(e.startswith('datadog') for e in queue_message.get('action', ()).get('to', [])):
             self._deliver_datadog_message(queue_message)
 
         email_result = self._deliver_email(queue_message)

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/sendgrid_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/sendgrid_delivery.py
@@ -40,7 +40,7 @@ class SendGridDelivery:
     # are sent, while only ever sending emails to the respective parties.
     def get_email_to_addrs_to_resources_map(self, queue_message):
         email_to_addrs_to_resources_map = {}
-        targets = queue_message['action']['to']
+        targets = queue_message['action'].get('to', [])
 
         for resource in queue_message['resources']:
             # this is the list of emails that will be sent for this resource

--- a/tools/c7n_mailer/c7n_mailer/datadog_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/datadog_delivery.py
@@ -91,7 +91,7 @@ class DataDogDelivery:
         metric_config_map = []
         if sqs_message and sqs_message.get(
                 'action', False) and sqs_message['action'].get('to', False):
-            for to in sqs_message['action']['to']:
+            for to in sqs_message['action'].get('to', []):
                 if to.startswith('datadog://'):
                     parsed = urlparse(to)
                     metric_config_map.append(dict(parse_qsl(parsed.query)))

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -86,7 +86,7 @@ class EmailDelivery:
         return ldap_uid_emails
 
     def get_resource_owner_emails_from_resource(self, sqs_message, resource):
-        if 'resource-owner' not in sqs_message['action']['to']:
+        if 'resource-owner' not in sqs_message['action'].get('to', []):
             return []
         resource_owner_tag_keys = self.config.get('contact_tags', [])
         resource_owner_tag_values = get_resource_tag_targets(resource, resource_owner_tag_keys)
@@ -111,7 +111,7 @@ class EmailDelivery:
     def get_account_emails(self, sqs_message):
         email_list = []
 
-        if 'account-emails' not in sqs_message['action']['to']:
+        if 'account-emails' not in sqs_message['action'].get('to', []):
             return []
 
         account_id = sqs_message.get('account_id', None)
@@ -134,7 +134,7 @@ class EmailDelivery:
         # these were manually set by the policy writer in notify to section
         # or it's an email from an aws event username from an ldap_lookup
         email_to_addrs_to_resources_map = {}
-        targets = sqs_message['action']['to'] + \
+        targets = sqs_message['action'].get('to', []) + \
             (sqs_message['action']['cc'] if 'cc' in sqs_message['action'] else [])
         no_owner_targets = self.get_valid_emails_from_list(
             sqs_message['action'].get('owner_absent_contact', [])

--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -31,7 +31,7 @@ class SlackDelivery:
         slack_messages = {}
 
         # Check for Slack targets in 'to' action and render appropriate template.
-        for target in sqs_message.get('action', ()).get('to'):
+        for target in sqs_message.get('action', ()).get('to', []):
             if target == 'slack://owners':
                 to_addrs_to_resources_map = \
                     self.email_handler.get_email_to_addrs_to_resources_map(sqs_message)

--- a/tools/c7n_mailer/c7n_mailer/splunk_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/splunk_delivery.py
@@ -265,7 +265,7 @@ class SplunkHecDelivery:
         """
         indices = set()
         if msg and msg.get('action', False) and msg['action'].get('to', False):
-            for to in msg['action']['to']:
+            for to in msg['action'].get('to', []):
                 if not to.startswith('splunkhec://'):
                     continue
                 parsed = urlparse(to)

--- a/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
@@ -142,7 +142,7 @@ class MailerSqsQueueProcessor:
             sqs_message['policy']['resource'],
             len(sqs_message['resources']),
             sqs_message['policy']['name'],
-            ', '.join(sqs_message['action'].get('to'))))
+            ', '.join(sqs_message['action'].get('to', []))))
 
         # get the map of email_to_addresses to mimetext messages (with resources baked in)
         # and send any emails (to SES or SMTP) if there are email addresses found
@@ -176,7 +176,7 @@ class MailerSqsQueueProcessor:
                 pass
 
         # this section gets the map of metrics to send to datadog and delivers it
-        if any(e.startswith('datadog') for e in sqs_message.get('action', ()).get('to')):
+        if any(e.startswith('datadog') for e in sqs_message.get('action', ()).get('to', [])):
             from .datadog_delivery import DataDogDelivery
             datadog_delivery = DataDogDelivery(self.config, self.session, self.logger)
             datadog_message_packages = datadog_delivery.get_datadog_message_packages(sqs_message)
@@ -190,7 +190,7 @@ class MailerSqsQueueProcessor:
         # this section sends the full event to a Splunk HTTP Event Collector (HEC)
         if any(
             e.startswith('splunkhec://')
-            for e in sqs_message.get('action', ()).get('to')
+            for e in sqs_message.get('action', ()).get('to', [])
         ):
             from .splunk_delivery import SplunkHecDelivery
             splunk_delivery = SplunkHecDelivery(self.config, self.session, self.logger)

--- a/tools/c7n_mailer/tests/test_email.py
+++ b/tools/c7n_mailer/tests/test_email.py
@@ -253,7 +253,7 @@ class EmailTest(unittest.TestCase):
 
     def test_no_mapping_if_no_valid_emails(self):
         SQS_MESSAGE = copy.deepcopy(SQS_MESSAGE_1)
-        SQS_MESSAGE['action']['to'].remove('ldap_uid_tags')
+        SQS_MESSAGE['action'].get('to', []).remove('ldap_uid_tags')
         SQS_MESSAGE['resources'][0].pop('Tags', None)
         emails_to_resources_map = self.email_delivery.get_email_to_addrs_to_resources_map(
             SQS_MESSAGE

--- a/tools/c7n_mailer/tests/test_sns.py
+++ b/tools/c7n_mailer/tests/test_sns.py
@@ -27,6 +27,6 @@ class SnsTest(unittest.TestCase):
 
     def test_get_sns_to_resources_map(self):
         SQS_MESSAGE = copy.deepcopy(SQS_MESSAGE_1)
-        SQS_MESSAGE['action']['to'].append(self.sns_topic_example)
+        SQS_MESSAGE['action'].get('to', []).append(self.sns_topic_example)
         sns_to_resources = self.sns_delivery.get_sns_addrs_to_resources_map(SQS_MESSAGE)
         self.assertEqual(sns_to_resources, {self.sns_topic_example: [RESOURCE_1]})


### PR DESCRIPTION
- Description
  - If 'to' is missed for notify action, an error is raised and no progress.
- Changed (in case of 'to' is missed) :
    - AS-IS : error -> sqs queue stack up -> problems with handling other sqs queue
    - TO-BE : not send notify message anywhere -> sqs queue not stack up
- Tracelog
```
python3.8/site-packages/c7n_mailer/sqs_queue_processor.py", line 145, in process_sqs_message
    ', '.join(sqs_message['action'].get('to'))))
TypeError: can only join an iterable
```