### PR TITLE
Get Bucket Encryption Fails When No Encryption Configuration Is Present but KMS Bucket Key is Enabled

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -3283,7 +3283,10 @@ class BucketEncryption(KMSKeyResolverMixin, Filter):
         key = self.get_key(b)
         crypto = self.data.get('crypto')
         rule = sse.get('ApplyServerSideEncryptionByDefault')
-        algo = rule.get('SSEAlgorithm')
+        try:
+            algo = rule.get('SSEAlgorithm')
+        except Exception:
+            return False
 
         if not crypto and algo in allowed:
             return True

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -3283,10 +3283,11 @@ class BucketEncryption(KMSKeyResolverMixin, Filter):
         key = self.get_key(b)
         crypto = self.data.get('crypto')
         rule = sse.get('ApplyServerSideEncryptionByDefault')
-        try:
-            algo = rule.get('SSEAlgorithm')
-        except Exception:
+
+        if not rule:
             return False
+        else:
+            algo = rule.get('SSEAlgorithm')
 
         if not crypto and algo in allowed:
             return True

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -3286,8 +3286,7 @@ class BucketEncryption(KMSKeyResolverMixin, Filter):
 
         if not rule:
             return False
-        else:
-            algo = rule.get('SSEAlgorithm')
+        algo = rule.get('SSEAlgorithm')
 
         if not crypto and algo in allowed:
             return True

--- a/tests/data/placebo/test_s3_filter_bucket_encryption_disabled_malformed_statement/s3.GetBucketEncryption_1.json
+++ b/tests/data/placebo/test_s3_filter_bucket_encryption_disabled_malformed_statement/s3.GetBucketEncryption_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ServerSideEncryptionConfiguration": {
+            "Rules": [
+                {
+                    "BucketKeyEnabled": true
+                }
+            ]
+        }
+    }
+}
+

--- a/tests/data/placebo/test_s3_filter_bucket_encryption_disabled_malformed_statement/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_filter_bucket_encryption_disabled_malformed_statement/s3.ListBuckets_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Buckets": [
+            {
+                "Name": "xcc-services-alb-access-logs-prod-eu-central-1",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 7,
+                    "day": 14,
+                    "hour": 12,
+                    "minute": 5,
+                    "second": 56,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "Owner": {
+            "DisplayName": "cctestaccount",
+            "ID": "14ceabf5195df217c82064f90b5d1914f4649c4039c4de18ddde72ffc35298fa"
+        }
+    }
+}
+

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -339,6 +339,28 @@ class BucketEncryption(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 0)
 
+    def test_s3_filter_bucket_encryption_disabled_malformed_statement(self):
+        bname = "xcc-services-alb-access-logs-prod-eu-central-1"
+        self.patch(s3.S3, "executor-factory", MainThreadExecutor)
+        self.patch(s3, "S3_AUGMENT_TABLE", [])
+
+        session_factory = self.replay_flight_data(
+            "test_s3_filter_bucket_encryption_disabled_malformed_statement"
+        )
+
+        p = self.load_policy(
+            {
+                "name": "s3-disabled-encryption-malformed-statement",
+                "resource": "s3",
+                "filters": [
+                    {"Name": bname}, {"type": "bucket-encryption", "state": False}
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_s3_bucket_encryption_bucket_key(self):
         session_factory = self.replay_flight_data("test_s3_bucket_encryption_bucket_key")
 


### PR DESCRIPTION
An account within one of our AWS Organizations has three buckets that are failing with the following error:

'NoneType' object has no attribute 'get' Bucket: <BUCKET_NAME>

After researching it, it appears that there is no encryption configuration, but the use of KMS bucket keys is enabled. Using the AWS CLI, the following output is displayed:

{
"ServerSideEncryptionConfiguration": {
"Rules": [
{
"BucketKeyEnabled": true
}
]
}
}

Currently there is no exception handling for this scenario, so the call by c7n fails. This PR is a simple fix to ensure that it fails gracefully and the resource is included as one that does not have a default encryption configuration.