### PR TITLE
fix: skip incorrect action_date instead of failing c7n

### DIFF
--- a/c7n/resources/opsworks.py
+++ b/c7n/resources/opsworks.py
@@ -64,7 +64,7 @@ class DeleteStack(BaseAction):
             instances = client.describe_instances(StackId=stack_id)['Instances']
             orig_length = len(instances)
             instances = self.filter_resources(instances, 'Status', self.valid_origin_states)
-            if(len(instances) != orig_length):
+            if len(instances) != orig_length:
                 self.log.exception(
                     "All instances must be stopped before deletion. Stack Id: %s Name: %s." %
                     (stack_id, stack['Name']))

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1825,7 +1825,8 @@ class ReservedRDS(QueryResourceManager):
 
 @filters.register('consecutive-snapshots')
 class ConsecutiveSnapshots(Filter):
-    """Returns instances where number of consective daily snapshots is equal to/or greater than n days.
+    """Returns instances where number of consective daily snapshots is
+    equal to/or greater than n days.
 
     :example:
 

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -719,7 +719,7 @@ class RemoveSharingSSMDocument(Action):
                         AccountIdsToRemove=r['c7n:CrossAccountViolations']
                     )
                 except client.exceptions.InvalidDocumentOperation as e:
-                    raise(e)
+                    raise e
         else:
             for r in resources:
                 try:
@@ -730,7 +730,7 @@ class RemoveSharingSSMDocument(Action):
                         AccountIdsToRemove=remove_accounts
                     )
                 except client.exceptions.InvalidDocumentOperation as e:
-                    raise(e)
+                    raise e
 
 
 @SSMDocument.action_registry.register('delete')
@@ -783,7 +783,7 @@ class DeleteSSMDocument(Action):
                         Force=True
                     )
                 else:
-                    raise(e)
+                    raise e
 
 
 @resources.register('ssm-data-sync')

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2078,7 +2078,7 @@ class AddressRelease(BaseAction):
                 client.disassociate_address(AssociationId=aa['AssociationId'])
             except ClientError as e:
                 # If its already been diassociated ignore, else raise.
-                if not(e.response['Error']['Code'] == 'InvalidAssocationID.NotFound' and
+                if not (e.response['Error']['Code'] == 'InvalidAssocationID.NotFound' and
                        aa['AssocationId'] in e.response['Error']['Message']):
                     raise e
                 associated_addrs.remove(aa)

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -314,6 +314,7 @@ class TagActionFilter(Filter):
         except Exception:
             self.log.warning("could not parse tag:%s value:%s on %s" % (
                 tag, v, i['InstanceId']))
+            return False
 
         if self.current_date is None:
             self.current_date = datetime.now()

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -523,7 +523,7 @@ def reformat_schema(model):
     ret = copy.deepcopy(model.schema['properties'])
 
     if 'type' in ret:
-        del(ret['type'])
+        del ret['type']
 
     for key in model.schema.get('required', []):
         if key in ret:

--- a/tests/data/placebo/test_action_filter_call/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_action_filter_call/ec2.DescribeInstances_1.json
@@ -1,0 +1,1460 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0c293fd3707bf57cb",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 8,
+                            "minute": 17,
+                            "second": 55,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 08:32:37 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "047B5D40-B54C-496A-956F-644160558196",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/33/03"
+                            },
+                            {
+                                "Key": "apply_action",
+                                "Value": "false"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 8,
+                            "minute": 17,
+                            "second": 55,
+                            "microsecond": 0
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-010e8ce7fbdc1fa1b"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0ce0b4bca0e7f2931",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 8,
+                            "minute": 17,
+                            "second": 55,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 08:32:37 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "F0306BEA-B74B-46EC-A738-00587952567B",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/33"
+                            },
+                            {
+                                "Key": "apply_action",
+                                "Value": "false"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 8,
+                            "minute": 17,
+                            "second": 55,
+                            "microsecond": 0
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0ab328207310c5fcd"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0ffcc52a85413e79a",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 8,
+                            "minute": 17,
+                            "second": 55,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 08:32:37 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "7A9E1AAE-A292-4130-B25F-14CF1B2B15BE",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@9999/06/03"
+                            },
+                            {
+                                "Key": "apply_action",
+                                "Value": "false"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 8,
+                            "minute": 17,
+                            "second": 55,
+                            "microsecond": 0
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0b99f6d18e5b7bbd5"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-056828fa9a9b4215f",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 8,
+                            "minute": 17,
+                            "second": 54,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 08:32:37 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "E3C5659B-EB2E-4988-964F-04E3050C38D4",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "apply_action",
+                                "Value": "true"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 8,
+                            "minute": 17,
+                            "second": 54,
+                            "microsecond": 0
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0ff330a48c73a3423"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0f6b2909a39992759",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 5,
+                            "second": 0,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1e",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 09:06:05 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "F42A77E5-A26C-4628-8A69-A8E6E7DFE5A1",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/03"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 5,
+                            "second": 0,
+                            "microsecond": 0
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-075951fdde7a6a04e"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0c5892fa8bd10e29b",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 4,
+                            "second": 59,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1e",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 09:06:17 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "A447AE25-8334-4817-BF37-A0A0A4224BDD",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@9999/06/03"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 4,
+                            "second": 59,
+                            "microsecond": 0
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0ba9f17f99843b9df"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0fe7b22bd2bc2aacd",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 5,
+                            "second": 0,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1e",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 09:06:17 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "6AE4AE9B-69E6-4B18-8CCD-78BB6209B9CD",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/33/03"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 5,
+                            "second": 0,
+                            "microsecond": 0
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-09b896a248bc2411f"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0ecc2e6a8a5914814",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 4,
+                            "second": 59,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1e",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 09:06:17 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "D2CC816B-C374-4B5E-9B9B-42C6734B196F",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/33"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 4,
+                            "second": 59,
+                            "microsecond": 0
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0cc115c4ea20ecd3a"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0083db530bdebd00b",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 26,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1f",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-102.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.102",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-07ba30829a346804b",
+                        "VpcId": "vpc-00b6e6c52a13cf27e",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 26,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0d290970d417a3622"
+                                }
+                            }
+                        ],
+                        "ClientToken": "4D38AE58-0E4C-441A-9D87-DE0DFDF07CA7",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 26,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-04f2995ca1a4782fc",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-0b220ecaf50a178e0"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "16:ab:cd:39:3d:c3",
+                                "NetworkInterfaceId": "eni-0914aafff1079c827",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.102",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.102"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-07ba30829a346804b",
+                                "VpcId": "vpc-00b6e6c52a13cf27e",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-0b220ecaf50a178e0"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/33"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-060299041fca17afd"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-06131954c6f7e8d9d",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1f",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-36.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.36",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-07ba30829a346804b",
+                        "VpcId": "vpc-00b6e6c52a13cf27e",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 26,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0e032096d09c985d9"
+                                }
+                            }
+                        ],
+                        "ClientToken": "4971F406-FF16-4B92-93F9-BAA54912F8E6",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 25,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-0508de4aff881b100",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-0b220ecaf50a178e0"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "16:7d:9c:17:9d:03",
+                                "NetworkInterfaceId": "eni-07b90e67bc441830f",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.36",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.36"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-07ba30829a346804b",
+                                "VpcId": "vpc-00b6e6c52a13cf27e",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-0b220ecaf50a178e0"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/33/03"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0898960f237f04ffb"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-067c1978d00cacbf4",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1f",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-235.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.235",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-07ba30829a346804b",
+                        "VpcId": "vpc-00b6e6c52a13cf27e",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 26,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0fb0d0a1452b92196"
+                                }
+                            }
+                        ],
+                        "ClientToken": "8403EA97-5948-442B-AB3E-134DCDB23784",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 25,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-09a82d1058578c967",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-0b220ecaf50a178e0"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "16:68:7e:f5:81:49",
+                                "NetworkInterfaceId": "eni-0deae94fadf64ba35",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.235",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.235"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-07ba30829a346804b",
+                                "VpcId": "vpc-00b6e6c52a13cf27e",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-0b220ecaf50a178e0"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/03"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0e0a4863b551e4d3d"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0e704ca06c0cd4af8",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1f",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-133.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.133",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-07ba30829a346804b",
+                        "VpcId": "vpc-00b6e6c52a13cf27e",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 26,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-08d27c60f346e9190"
+                                }
+                            }
+                        ],
+                        "ClientToken": "F6FF547A-14BD-4133-A4ED-16CA2780808C",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 25,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-0dc97c650702504e7",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-0b220ecaf50a178e0"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "16:9a:34:0f:ce:25",
+                                "NetworkInterfaceId": "eni-0530c233ef25d4d8f",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.133",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.133"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-07ba30829a346804b",
+                                "VpcId": "vpc-00b6e6c52a13cf27e",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-0b220ecaf50a178e0"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@9999/06/03"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0ae0505df0174dd76"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_action_filter_call/ec2.DescribeInstances_2.json
+++ b/tests/data/placebo/test_action_filter_call/ec2.DescribeInstances_2.json
@@ -1,0 +1,180 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-067c1978d00cacbf4",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1f",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-235.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.235",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 64,
+                            "Name": "stopping"
+                        },
+                        "StateTransitionReason": "User initiated (2022-07-31 09:10:10 GMT)",
+                        "SubnetId": "subnet-07ba30829a346804b",
+                        "VpcId": "vpc-00b6e6c52a13cf27e",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 26,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0fb0d0a1452b92196"
+                                }
+                            }
+                        ],
+                        "ClientToken": "8403EA97-5948-442B-AB3E-134DCDB23784",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 7,
+                                        "day": 31,
+                                        "hour": 9,
+                                        "minute": 9,
+                                        "second": 25,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-09a82d1058578c967",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-0b220ecaf50a178e0"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "16:68:7e:f5:81:49",
+                                "NetworkInterfaceId": "eni-0deae94fadf64ba35",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.235",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.235"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-07ba30829a346804b",
+                                "VpcId": "vpc-00b6e6c52a13cf27e",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-0b220ecaf50a178e0"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [
+                            {
+                                "Key": "action_tag",
+                                "Value": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/03"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 7,
+                            "day": 31,
+                            "hour": 9,
+                            "minute": 9,
+                            "second": 25,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0e0a4863b551e4d3d"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_action_filter_call/ec2.StopInstances_1.json
+++ b/tests/data/placebo/test_action_filter_call/ec2.StopInstances_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "StoppingInstances": [
+            {
+                "CurrentState": {
+                    "Code": 64,
+                    "Name": "stopping"
+                },
+                "InstanceId": "i-067c1978d00cacbf4",
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/tag_action_filter_call/ami.tf
+++ b/tests/terraform/tag_action_filter_call/ami.tf
@@ -1,0 +1,12 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+}

--- a/tests/terraform/tag_action_filter_call/main.tf
+++ b/tests/terraform/tag_action_filter_call/main.tf
@@ -1,0 +1,39 @@
+resource "aws_instance" "past_stop" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.example.id
+
+  tags = {
+    "action_tag" = "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/03"
+  }
+}
+
+resource "aws_instance" "future_stop" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.example.id
+
+  tags = {
+    "action_tag" = "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@9999/06/03"
+  }
+}
+
+resource "aws_instance" "incorrect_month_stop" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.example.id
+
+  tags = {
+    "action_tag" = "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/33/03"
+  }
+}
+
+resource "aws_instance" "incorrect_day_stop" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.example.id
+
+  tags = {
+    "action_tag" = "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/33"
+  }
+}

--- a/tests/terraform/tag_action_filter_call/network.tf
+++ b/tests/terraform/tag_action_filter_call/network.tf
@@ -1,0 +1,8 @@
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "example" {
+  vpc_id     = aws_vpc.example.id
+  cidr_block = "10.0.1.0/24"
+}

--- a/tests/terraform/tag_action_filter_call/tf_resources.json
+++ b/tests/terraform/tag_action_filter_call/tf_resources.json
@@ -1,0 +1,551 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_ami": {
+            "amazon_linux": {
+                "architecture": "x86_64",
+                "arn": "arn:aws:ec2:us-east-1::image/ami-0d7734f53f491186b",
+                "block_device_mappings": [
+                    {
+                        "device_name": "/dev/xvda",
+                        "ebs": {
+                            "delete_on_termination": "true",
+                            "encrypted": "false",
+                            "iops": "0",
+                            "snapshot_id": "snap-00e9c002a992550a7",
+                            "throughput": "0",
+                            "volume_size": "8",
+                            "volume_type": "gp2"
+                        },
+                        "no_device": "",
+                        "virtual_name": ""
+                    }
+                ],
+                "boot_mode": "",
+                "creation_date": "2022-07-16T02:39:01.000Z",
+                "deprecation_time": "2024-07-16T02:39:01.000Z",
+                "description": "Amazon Linux AMI 2018.03.0.20220705.1 x86_64 HVM gp2",
+                "ena_support": true,
+                "executable_users": null,
+                "filter": [
+                    {
+                        "name": "name",
+                        "values": [
+                            "amzn-ami-hvm-*-x86_64-gp2"
+                        ]
+                    }
+                ],
+                "hypervisor": "xen",
+                "id": "ami-0d7734f53f491186b",
+                "image_id": "ami-0d7734f53f491186b",
+                "image_location": "amazon/amzn-ami-hvm-2018.03.0.20220705.1-x86_64-gp2",
+                "image_owner_alias": "amazon",
+                "image_type": "machine",
+                "include_deprecated": false,
+                "kernel_id": "",
+                "most_recent": true,
+                "name": "amzn-ami-hvm-2018.03.0.20220705.1-x86_64-gp2",
+                "name_regex": null,
+                "owner_id": "644160558196",
+                "owners": [
+                    "amazon"
+                ],
+                "platform": "",
+                "platform_details": "Linux/UNIX",
+                "product_codes": [],
+                "public": true,
+                "ramdisk_id": "",
+                "root_device_name": "/dev/xvda",
+                "root_device_type": "ebs",
+                "root_snapshot_id": "snap-00e9c002a992550a7",
+                "sriov_net_support": "simple",
+                "state": "available",
+                "state_reason": {
+                    "code": "UNSET",
+                    "message": "UNSET"
+                },
+                "tags": {},
+                "tpm_support": "",
+                "usage_operation": "RunInstances",
+                "virtualization_type": "hvm"
+            }
+        },
+        "aws_instance": {
+            "future_stop": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0e704ca06c0cd4af8",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1f",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-0e704ca06c0cd4af8",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-0530c233ef25d4d8f",
+                "private_dns": "ip-10-0-1-133.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.133",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-08d27c60f346e9190",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-07ba30829a346804b",
+                "tags": {
+                    "action_tag": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@9999/06/03"
+                },
+                "tags_all": {
+                    "action_tag": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@9999/06/03"
+                },
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0b220ecaf50a178e0"
+                ]
+            },
+            "incorrect_day_stop": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0083db530bdebd00b",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1f",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-0083db530bdebd00b",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-0914aafff1079c827",
+                "private_dns": "ip-10-0-1-102.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.102",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0d290970d417a3622",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-07ba30829a346804b",
+                "tags": {
+                    "action_tag": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/33"
+                },
+                "tags_all": {
+                    "action_tag": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/33"
+                },
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0b220ecaf50a178e0"
+                ]
+            },
+            "incorrect_month_stop": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-06131954c6f7e8d9d",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1f",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-06131954c6f7e8d9d",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-07b90e67bc441830f",
+                "private_dns": "ip-10-0-1-36.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.36",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0e032096d09c985d9",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-07ba30829a346804b",
+                "tags": {
+                    "action_tag": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/33/03"
+                },
+                "tags_all": {
+                    "action_tag": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/33/03"
+                },
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0b220ecaf50a178e0"
+                ]
+            },
+            "past_stop": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-067c1978d00cacbf4",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1f",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-067c1978d00cacbf4",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-0deae94fadf64ba35",
+                "private_dns": "ip-10-0-1-235.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.235",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0fb0d0a1452b92196",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-07ba30829a346804b",
+                "tags": {
+                    "action_tag": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/03"
+                },
+                "tags_all": {
+                    "action_tag": "This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/03"
+                },
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0b220ecaf50a178e0"
+                ]
+            }
+        },
+        "aws_subnet": {
+            "example": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:subnet/subnet-07ba30829a346804b",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "us-east-1f",
+                "availability_zone_id": "use1-az5",
+                "cidr_block": "10.0.1.0/24",
+                "customer_owned_ipv4_pool": "",
+                "enable_dns64": false,
+                "enable_resource_name_dns_a_record_on_launch": false,
+                "enable_resource_name_dns_aaaa_record_on_launch": false,
+                "id": "subnet-07ba30829a346804b",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "ipv6_native": false,
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": false,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_hostname_type_on_launch": "ip-name",
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-00b6e6c52a13cf27e"
+            }
+        },
+        "aws_vpc": {
+            "example": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:vpc/vpc-00b6e6c52a13cf27e",
+                "assign_generated_ipv6_cidr_block": false,
+                "cidr_block": "10.0.0.0/16",
+                "default_network_acl_id": "acl-0f884aa05ad937262",
+                "default_route_table_id": "rtb-0bc816f7ca32e237f",
+                "default_security_group_id": "sg-0b220ecaf50a178e0",
+                "dhcp_options_id": "dopt-08a1adfe48d210ed0",
+                "enable_classiclink": false,
+                "enable_classiclink_dns_support": false,
+                "enable_dns_hostnames": false,
+                "enable_dns_support": true,
+                "id": "vpc-00b6e6c52a13cf27e",
+                "instance_tenancy": "default",
+                "ipv4_ipam_pool_id": null,
+                "ipv4_netmask_length": null,
+                "ipv6_association_id": "",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_network_border_group": "",
+                "ipv6_ipam_pool_id": "",
+                "ipv6_netmask_length": 0,
+                "main_route_table_id": "rtb-0bc816f7ca32e237f",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -542,9 +542,7 @@ class AccountTests(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
-        assert(
-            resources[0]['c7n:password_policy']['PasswordPolicyConfigured'] is False
-        )
+        assert resources[0]['c7n:password_policy']['PasswordPolicyConfigured'] is False
 
     def test_account_password_policy_update(self):
         factory = self.replay_flight_data("test_account_password_policy_update")
@@ -637,9 +635,7 @@ class AccountTests(BaseTest):
         self.assertEqual(len(resources), 1)
         client = local_session(factory).client('iam')
         policy = client.get_account_password_policy().get('PasswordPolicy')
-        assert(
-            policy['MinimumPasswordLength'] == 12
-        )
+        assert policy['MinimumPasswordLength'] == 12
         # assert defaults being set
         self.assertEqual(
             [

--- a/tests/test_elasticache.py
+++ b/tests/test_elasticache.py
@@ -494,7 +494,7 @@ class TestElastiCacheReplicationGroup(BaseTest):
 
         client = session_factory().client("elasticache")
         response = client.describe_replication_groups(ReplicationGroupId='c7n-tagging')
-        while(response.get('ReplicationGroups')[0].get('Status') == 'modifying'):
+        while response.get('ReplicationGroups')[0].get('Status') == 'modifying':
             response = client.describe_replication_groups(ReplicationGroupId='c7n-tagging')
         arn = p.resource_manager.get_arns(resources)[0]
         tags = client.list_tags_for_resource(ResourceName=arn)["TagList"]

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -730,7 +730,7 @@ class TestGlueDataCatalog(BaseTest):
         session = session_factory()
         client = session.client("glue")
         before_cat_setting = client.get_resource_policy()
-        assert('o-4amkskbcf3' in before_cat_setting.get('PolicyInJson'))
+        assert 'o-4amkskbcf3' in before_cat_setting.get('PolicyInJson')
         p = self.load_policy(
             {
                 "name": "net-change-rbp-cross-account",
@@ -760,4 +760,4 @@ class TestGlueDataCatalog(BaseTest):
         )
         p.push(event_data("event-cloud-trail-catalog-put-resource-policy.json"), None)
         after_cat_setting = client.get_resource_policy()
-        assert('o-4amkskbcf3' not in after_cat_setting.get('PolicyInJson'))
+        assert 'o-4amkskbcf3' not in after_cat_setting.get('PolicyInJson')

--- a/tools/c7n_azure/tests_azure/tools_tags.py
+++ b/tools/c7n_azure/tests_azure/tools_tags.py
@@ -47,8 +47,8 @@ def get_resource_group_resource(existing_tags):
 
 
 def get_tags_parameter(update_tags_mock):
-    assert(len(update_tags_mock.call_args_list) == 1)
-    assert(len(update_tags_mock.call_args_list[0][0]) == 3)
+    assert len(update_tags_mock.call_args_list) == 1
+    assert len(update_tags_mock.call_args_list[0][0]) == 3
     return update_tags_mock.call_args_list[0][0][2]
 
 

--- a/tools/c7n_openstack/c7n_openstack/resources/server.py
+++ b/tools/c7n_openstack/c7n_openstack/resources/server.py
@@ -227,5 +227,5 @@ def find_object_by_property(collection, k, v):
             result.append(d)
     if not result:
         return None
-    assert(len(result) == 1)
+    assert len(result) == 1
     return result[0]

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -420,7 +420,7 @@ def report(config, output, use, output_dir, accounts,
     formatter = Formatter(
         factory.resource_type,
         extra_fields=field,
-        include_default_fields=not(no_default_fields),
+        include_default_fields=not no_default_fields,
         include_region=False,
         include_policy=False,
         fields=prefix_fields)


### PR DESCRIPTION
Since 'action_date' is parsed in try/except block, there is an issue
if parsing of 'action_date' fails, because Python 'action_date' variable
is used later

Error example:

UnboundLocalError: local variable 'action_date' referenced before assignment


Examples:

**Before:**
```console
$ custodian run --cache-period 0 --profile acloudguru -s policy -r us-east-1 policy.yaml 
2022-07-31 10:30:24,124: custodian.filters:WARNING could not parse tag:action_tag value:This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/33/03 on i-0c293fd3707bf57cb
2022-07-31 10:30:24,125: custodian.output:ERROR Error while executing policy
Traceback (most recent call last):
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/policy.py", line 290, in run
    resources = self.policy.resource_manager.resources()
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/resources/ec2.py", line 140, in resources
    return super(EC2, self).resources(query=query)
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/query.py", line 532, in resources
    resources = self.filter_resources(resources)
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/manager.py", line 111, in filter_resources
    resources = f.process(resources, event)
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/filters/core.py", line 190, in process
    return list(filter(self, resources))
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/tags.py", line 321, in __call__
    if action_date.tzinfo:
UnboundLocalError: local variable 'action_date' referenced before assignment
2022-07-31 10:30:24,126: custodian.commands:ERROR Error while executing policy action_date, continuing
Traceback (most recent call last):
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/commands.py", line 301, in run
    policy()
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/policy.py", line 1242, in __call__
    resources = mode.run()
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/policy.py", line 290, in run
    resources = self.policy.resource_manager.resources()
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/resources/ec2.py", line 140, in resources
    return super(EC2, self).resources(query=query)
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/query.py", line 532, in resources
    resources = self.filter_resources(resources)
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/manager.py", line 111, in filter_resources
    resources = f.process(resources, event)
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/filters/core.py", line 190, in process
    return list(filter(self, resources))
  File "/home/dranser/contribution/cloud-custodian/tests/terraform/tag_action_filter_call/venv/lib/python3.7/site-packages/c7n/tags.py", line 321, in __call__
    if action_date.tzinfo:
UnboundLocalError: local variable 'action_date' referenced before assignment
2022-07-31 10:30:24,126: custodian.commands:ERROR The following policies had errors while executing
 - action_date
```

**After:**
```console
$ poetry run custodian run --cache-period 0 --profile acloudguru -s policy -r us-east-1 policy.yaml 
2022-07-31 10:28:40,530: custodian.filters:WARNING could not parse tag:action_tag value:This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/33/03 on i-0c293fd3707bf57cb
2022-07-31 10:28:40,531: custodian.filters:WARNING could not parse tag:action_tag value:This EC2 instance has had less than 5 percent CPU utilization for over 5 days: stop@2022/06/33 on i-0ce0b4bca0e7f2931
2022-07-31 10:28:40,531: custodian.policy:INFO policy:action_date resource:ec2 region:us-east-1 count:1 time:0.85
2022-07-31 10:28:41,122: custodian.policy:INFO policy:action_date action:removetag resources:1 execution_time:0.59
```