### PR TITLE
lint - fix E275 findings from pycodestyle 2.9.0

### DIFF
--- a/c7n/resources/opsworks.py
+++ b/c7n/resources/opsworks.py
@@ -64,7 +64,7 @@ class DeleteStack(BaseAction):
             instances = client.describe_instances(StackId=stack_id)['Instances']
             orig_length = len(instances)
             instances = self.filter_resources(instances, 'Status', self.valid_origin_states)
-            if(len(instances) != orig_length):
+            if len(instances) != orig_length:
                 self.log.exception(
                     "All instances must be stopped before deletion. Stack Id: %s Name: %s." %
                     (stack_id, stack['Name']))

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1825,7 +1825,8 @@ class ReservedRDS(QueryResourceManager):
 
 @filters.register('consecutive-snapshots')
 class ConsecutiveSnapshots(Filter):
-    """Returns instances where number of consective daily snapshots is equal to/or greater than n days.
+    """Returns instances where number of consective daily snapshots is equal to/or greater than n
+    days.
 
     :example:
 

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -719,7 +719,7 @@ class RemoveSharingSSMDocument(Action):
                         AccountIdsToRemove=r['c7n:CrossAccountViolations']
                     )
                 except client.exceptions.InvalidDocumentOperation as e:
-                    raise(e)
+                    raise e
         else:
             for r in resources:
                 try:
@@ -730,7 +730,7 @@ class RemoveSharingSSMDocument(Action):
                         AccountIdsToRemove=remove_accounts
                     )
                 except client.exceptions.InvalidDocumentOperation as e:
-                    raise(e)
+                    raise e
 
 
 @SSMDocument.action_registry.register('delete')
@@ -783,7 +783,7 @@ class DeleteSSMDocument(Action):
                         Force=True
                     )
                 else:
-                    raise(e)
+                    raise e
 
 
 @resources.register('ssm-data-sync')

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2078,8 +2078,8 @@ class AddressRelease(BaseAction):
                 client.disassociate_address(AssociationId=aa['AssociationId'])
             except ClientError as e:
                 # If its already been diassociated ignore, else raise.
-                if not(e.response['Error']['Code'] == 'InvalidAssocationID.NotFound' and
-                       aa['AssocationId'] in e.response['Error']['Message']):
+                if not (e.response['Error']['Code'] == 'InvalidAssocationID.NotFound' and
+                        aa['AssocationId'] in e.response['Error']['Message']):
                     raise e
                 associated_addrs.remove(aa)
         return associated_addrs

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -523,7 +523,7 @@ def reformat_schema(model):
     ret = copy.deepcopy(model.schema['properties'])
 
     if 'type' in ret:
-        del(ret['type'])
+        del ret['type']
 
     for key in model.schema.get('required', []):
         if key in ret:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -542,7 +542,7 @@ class AccountTests(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
-        assert(
+        assert (
             resources[0]['c7n:password_policy']['PasswordPolicyConfigured'] is False
         )
 
@@ -637,7 +637,7 @@ class AccountTests(BaseTest):
         self.assertEqual(len(resources), 1)
         client = local_session(factory).client('iam')
         policy = client.get_account_password_policy().get('PasswordPolicy')
-        assert(
+        assert (
             policy['MinimumPasswordLength'] == 12
         )
         # assert defaults being set

--- a/tests/test_elasticache.py
+++ b/tests/test_elasticache.py
@@ -494,7 +494,7 @@ class TestElastiCacheReplicationGroup(BaseTest):
 
         client = session_factory().client("elasticache")
         response = client.describe_replication_groups(ReplicationGroupId='c7n-tagging')
-        while(response.get('ReplicationGroups')[0].get('Status') == 'modifying'):
+        while response.get('ReplicationGroups')[0].get('Status') == 'modifying':
             response = client.describe_replication_groups(ReplicationGroupId='c7n-tagging')
         arn = p.resource_manager.get_arns(resources)[0]
         tags = client.list_tags_for_resource(ResourceName=arn)["TagList"]

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -730,7 +730,7 @@ class TestGlueDataCatalog(BaseTest):
         session = session_factory()
         client = session.client("glue")
         before_cat_setting = client.get_resource_policy()
-        assert('o-4amkskbcf3' in before_cat_setting.get('PolicyInJson'))
+        assert ('o-4amkskbcf3' in before_cat_setting.get('PolicyInJson'))
         p = self.load_policy(
             {
                 "name": "net-change-rbp-cross-account",
@@ -760,4 +760,4 @@ class TestGlueDataCatalog(BaseTest):
         )
         p.push(event_data("event-cloud-trail-catalog-put-resource-policy.json"), None)
         after_cat_setting = client.get_resource_policy()
-        assert('o-4amkskbcf3' not in after_cat_setting.get('PolicyInJson'))
+        assert ('o-4amkskbcf3' not in after_cat_setting.get('PolicyInJson'))

--- a/tools/c7n_azure/tests_azure/tools_tags.py
+++ b/tools/c7n_azure/tests_azure/tools_tags.py
@@ -47,8 +47,8 @@ def get_resource_group_resource(existing_tags):
 
 
 def get_tags_parameter(update_tags_mock):
-    assert(len(update_tags_mock.call_args_list) == 1)
-    assert(len(update_tags_mock.call_args_list[0][0]) == 3)
+    assert len(update_tags_mock.call_args_list) == 1
+    assert len(update_tags_mock.call_args_list[0][0]) == 3
     return update_tags_mock.call_args_list[0][0][2]
 
 

--- a/tools/c7n_openstack/c7n_openstack/resources/server.py
+++ b/tools/c7n_openstack/c7n_openstack/resources/server.py
@@ -227,5 +227,5 @@ def find_object_by_property(collection, k, v):
             result.append(d)
     if not result:
         return None
-    assert(len(result) == 1)
+    assert len(result) == 1
     return result[0]

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -420,7 +420,7 @@ def report(config, output, use, output_dir, accounts,
     formatter = Formatter(
         factory.resource_type,
         extra_fields=field,
-        include_default_fields=not(no_default_fields),
+        include_default_fields=(not no_default_fields),
         include_region=False,
         include_policy=False,
         fields=prefix_fields)


### PR DESCRIPTION
Address the `missing whitespace after keyword` findings that have become part of the default check list [in pycodestyle 2.9.0](https://github.com/PyCQA/pycodestyle/blob/44b3d2895b39b1eff8cb5048ae3464a033b4ede8/CHANGES.txt#L13).

The alternative would be to ignore this check, but it seems reasonable to me :shrug: 