### PR TITLE
releng - update policystream to use 22.04 and remove libgit compilation

### DIFF
--- a/docker/policystream
+++ b/docker/policystream
@@ -1,6 +1,6 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
-FROM ubuntu:21.10 as build-env
+FROM ubuntu:22.04 as build-env
 
 ENV DEBIAN_FRONTEND=noninteractive
 # pre-requisite distro deps, and build env setup
@@ -58,7 +58,7 @@ RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/
 #  - as a sanity check to distributing known good assets / we test here
 RUN . /usr/local/bin/activate && pytest -p "no:terraform" tools/c7n_policystream
 
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 
 LABEL name="policystream" \
       repository="http://github.com/cloud-custodian/cloud-custodian"

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -128,18 +128,6 @@ RUN . /usr/local/bin/activate && cd tools/c7n_mailer && $HOME/.poetry/bin/poetry
 """
 
 BUILD_POLICYSTREAM = """\
-# Compile libgit2
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget cmake libssl-dev libffi-dev git
-RUN mkdir build && \\
-    wget -q https://github.com/libgit2/libgit2/releases/download/v1.0.0/libgit2-1.0.0.tar.gz && \\
-    cd build && \\
-    tar xzf ../libgit2-1.0.0.tar.gz && \\
-    cd libgit2-1.0.0 && \\
-    mkdir build && cd build && \\
-    cmake .. && \\
-    make install && \\
-    rm -Rf /src/build
-
 # Install c7n-policystream
 ADD tools/c7n_policystream /src/tools/c7n_policystream
 RUN . /usr/local/bin/activate && cd tools/c7n_policystream && $HOME/.poetry/bin/poetry install


### PR DESCRIPTION


ci on main was failing due to policystream docker image usage of 21.10 which is out of support, update to use 22.04

also at the time the dockerfile was created pygit2 required a separate install/build of a recent libgit2, which is no longer
the case as the project distributes binary wheels with the library included now.


