### PR TITLE
fix: terminate only 'batch' number of instances a request

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1543,7 +1543,7 @@ class Terminate(BaseAction):
         for batch in utils.chunks(instances, 100):
             self.manager.retry(
                 client.terminate_instances,
-                InstanceIds=[i['InstanceId'] for i in instances])
+                InstanceIds=[i['InstanceId'] for i in batch])
 
     def disable_deletion_protection(self, client, instances):
 


### PR DESCRIPTION
If I'm not mistaken, there is incorrect behaviour that
instead of terminating 'batch' number of instances a request, we try to
terminate all instances 'batch' times.