### PR TITLE
feat: add ec2 filter for disableApiStop attribute

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -8,6 +8,7 @@ import itertools
 import logging
 import os
 import sys
+from typing import List
 
 import yaml
 from yaml.constructor import ConstructorError
@@ -283,7 +284,7 @@ def validate(options):
 
 
 @policy_command
-def run(options, policies):
+def run(options, policies: List[Policy]) -> None:
     exit_code = 0
 
     # AWS - Sanity check that we have an assumable role before executing policies
@@ -295,7 +296,7 @@ def run(options, policies):
             log.exception("Unable to assume role %s", options.assume_role)
             sys.exit(1)
 
-    errored_policies = []
+    errored_policies: List[str] = []
     for policy in policies:
         try:
             policy()

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import os
 import time
+from typing import List
 
 from dateutil import parser, tz as tzutil
 import jmespath
@@ -66,12 +67,12 @@ class PolicyCollection:
 
     log = logging.getLogger('c7n.policies')
 
-    def __init__(self, policies, options):
+    def __init__(self, policies: 'List[Policy]', options):
         self.options = options
         self.policies = policies
 
     @classmethod
-    def from_data(cls, data, options, session_factory=None):
+    def from_data(cls, data: dict, options, session_factory=None):
         # session factory param introduction needs an audit and review
         # on tests.
         sf = session_factory if session_factory else cls.session_factory()
@@ -1100,15 +1101,15 @@ class Policy:
             self.resource_type, self.name, self.options.region)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.data['name']
 
     @property
-    def resource_type(self):
+    def resource_type(self) -> str:
         return self.data['resource']
 
     @property
-    def provider_name(self):
+    def provider_name(self) -> str:
         if '.' in self.resource_type:
             provider_name, resource_type = self.resource_type.split('.', 1)
         else:

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -9,6 +9,7 @@ from concurrent.futures import as_completed
 import functools
 import itertools
 import json
+from typing import List
 
 import jmespath
 import os
@@ -503,7 +504,7 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
             'q': query
         }
 
-    def resources(self, query=None, augment=True):
+    def resources(self, query=None, augment=True) -> List[dict]:
         query = self.source.get_query_params(query)
         cache_key = self.get_cache_key(query)
         resources = None

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -7,6 +7,7 @@ import random
 import re
 import zlib
 from typing import List
+from distutils.version import LooseVersion
 
 import botocore
 from botocore.exceptions import ClientError
@@ -350,8 +351,7 @@ class DisableApiStop(Filter):
     def validate(self) -> None:
         botocore_min_version = '1.26.7'
 
-        from pkg_resources import parse_version
-        if parse_version(botocore.__version__) < parse_version(botocore_min_version):
+        if LooseVersion(botocore.__version__) < LooseVersion(botocore_min_version):
             raise PolicyValidationError(
                 "'stop-protected' filter requires botocore version "
                 f'{botocore_min_version} or above. '

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -329,11 +329,6 @@ class DisableApiStop(Filter):
     schema = type_schema('stop-protected')
     permissions = ('ec2:DescribeInstanceAttribute',)
 
-    def get_permissions(self) -> List[str]:
-        perms = list(self.permissions)
-        perms.extend(self.manager.get_permissions())
-        return perms
-
     def process(self, resources: List[dict], event=None) -> List[dict]:
         client = utils.local_session(
             self.manager.session_factory).client('ec2')

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -8,6 +8,7 @@ import re
 import zlib
 from typing import List
 
+import botocore
 from botocore.exceptions import ClientError
 from dateutil.parser import parse
 from concurrent.futures import as_completed
@@ -345,6 +346,17 @@ class DisableApiStop(Filter):
             InstanceId=instance['InstanceId']
         )
         return attr_val['DisableApiStop']['Value']
+
+    def validate(self) -> None:
+        botocore_min_version = '1.26.7'
+
+        from pkg_resources import parse_version
+        if parse_version(botocore.__version__) < parse_version(botocore_min_version):
+            raise PolicyValidationError(
+                "'stop-protected' filter requires botocore version "
+                f'{botocore_min_version} or above. '
+                f'Installed version is {botocore.__version__}.'
+            )
 
 
 @filters.register('termination-protected')

--- a/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeInstanceAttribute_1.json
+++ b/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeInstanceAttribute_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "InstanceId": "i-0ace8b3999421ba93",
+        "DisableApiStop": {
+            "Value": false
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeInstanceAttribute_2.json
+++ b/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeInstanceAttribute_2.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "InstanceId": "i-0916290676d3ede6a",
+        "DisableApiStop": {
+            "Value": false
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeInstanceAttribute_3.json
+++ b/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeInstanceAttribute_3.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "InstanceId": "i-00737300785a058f9",
+        "DisableApiStop": {
+            "Value": true
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeInstances_1.json
@@ -1,0 +1,494 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0ace8b3999421ba93",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 51,
+                            "second": 10,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1b",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-8.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.8",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-0097c16e28e99cd1f",
+                        "VpcId": "vpc-0bf64b04425b5bd8f",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 51,
+                                        "second": 11,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-069a6298487605445"
+                                }
+                            }
+                        ],
+                        "ClientToken": "CEAC0FD7-9EB9-42E1-AB7B-46DB7347B928",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 51,
+                                        "second": 10,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-0006e2995c35f7dfa",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-0b19c3cb919a3fe08"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:2e:58:2f:2c:43",
+                                "NetworkInterfaceId": "eni-038d5123afd6dee32",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.8",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.8"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-0097c16e28e99cd1f",
+                                "VpcId": "vpc-0bf64b04425b5bd8f",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-0b19c3cb919a3fe08"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 51,
+                            "second": 10,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-01611ca4e7520b17c"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0916290676d3ede6a",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 51,
+                            "second": 10,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1b",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-227.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.227",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-0097c16e28e99cd1f",
+                        "VpcId": "vpc-0bf64b04425b5bd8f",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 51,
+                                        "second": 11,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0f19e8a86522e29fa"
+                                }
+                            }
+                        ],
+                        "ClientToken": "460B0613-4782-4EA8-8B1C-2C60C1A219B1",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 51,
+                                        "second": 10,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-0e4110e67f1585b8b",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-0b19c3cb919a3fe08"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:87:d4:cd:9c:ff",
+                                "NetworkInterfaceId": "eni-0cf997427424304d4",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.227",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.227"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-0097c16e28e99cd1f",
+                                "VpcId": "vpc-0bf64b04425b5bd8f",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-0b19c3cb919a3fe08"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 51,
+                            "second": 10,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-08b33f8edee2c1956"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-00737300785a058f9",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 51,
+                            "second": 11,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1b",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-224.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.224",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-0097c16e28e99cd1f",
+                        "VpcId": "vpc-0bf64b04425b5bd8f",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 51,
+                                        "second": 11,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0911be7318df80a51"
+                                }
+                            }
+                        ],
+                        "ClientToken": "8E7C2B80-05F1-493B-8935-C3C57506015C",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 51,
+                                        "second": 11,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-01cd8b8d5574ea995",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-0b19c3cb919a3fe08"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:55:4b:96:45:c5",
+                                "NetworkInterfaceId": "eni-09bf69ce93aa23e6d",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.224",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.224"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-0097c16e28e99cd1f",
+                                "VpcId": "vpc-0bf64b04425b5bd8f",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-0b19c3cb919a3fe08"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 51,
+                            "second": 10,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-09a31d594eee1cb78"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeTags_1.json
+++ b/tests/data/placebo/ec2_stop_protection_disabled/ec2.DescribeTags_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeInstanceAttribute_1.json
+++ b/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeInstanceAttribute_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "InstanceId": "i-017e55c722d539f90",
+        "DisableApiStop": {
+            "Value": false
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeInstanceAttribute_2.json
+++ b/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeInstanceAttribute_2.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "InstanceId": "i-0daf36c03bf9c5e75",
+        "DisableApiStop": {
+            "Value": false
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeInstanceAttribute_3.json
+++ b/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeInstanceAttribute_3.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "InstanceId": "i-0ecfe7c50cf2f76b2",
+        "DisableApiStop": {
+            "Value": true
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeInstances_1.json
@@ -1,0 +1,494 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-017e55c722d539f90",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 33,
+                            "second": 49,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1f",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-168.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.168",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-0e172a55c20169303",
+                        "VpcId": "vpc-00255c1f52c0a88d6",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 33,
+                                        "second": 49,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0f1ee2360fa73f764"
+                                }
+                            }
+                        ],
+                        "ClientToken": "78C6248B-3FFA-4B29-874F-0AE73674F2C4",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 33,
+                                        "second": 49,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-0fded6ac2e059ed5d",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-09c6a03dec497a6b0"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "16:b2:be:00:93:87",
+                                "NetworkInterfaceId": "eni-004e46d428e6b695a",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.168",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.168"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-0e172a55c20169303",
+                                "VpcId": "vpc-00255c1f52c0a88d6",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-09c6a03dec497a6b0"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 33,
+                            "second": 49,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0cb1509e933be4992"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0daf36c03bf9c5e75",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 33,
+                            "second": 49,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1f",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-15.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.15",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-0e172a55c20169303",
+                        "VpcId": "vpc-00255c1f52c0a88d6",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 33,
+                                        "second": 49,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-07fccc8f6c75d1d1c"
+                                }
+                            }
+                        ],
+                        "ClientToken": "5671183C-7176-4D0F-93C7-E0703AA88F2B",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 33,
+                                        "second": 49,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-005f4b0f31ceb16b1",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-09c6a03dec497a6b0"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "16:2f:ca:48:69:fd",
+                                "NetworkInterfaceId": "eni-0d3a0342e5b7b9403",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.15",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.15"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-0e172a55c20169303",
+                                "VpcId": "vpc-00255c1f52c0a88d6",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-09c6a03dec497a6b0"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 33,
+                            "second": 49,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-076e7b153ee60b37a"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d7734f53f491186b",
+                        "InstanceId": "i-0ecfe7c50cf2f76b2",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 33,
+                            "second": 49,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1f",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-124.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.124",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-0e172a55c20169303",
+                        "VpcId": "vpc-00255c1f52c0a88d6",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 33,
+                                        "second": 49,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0d2b762057cf67207"
+                                }
+                            }
+                        ],
+                        "ClientToken": "1EB6F15E-842A-4A68-914B-818224E485B4",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2022,
+                                        "month": 8,
+                                        "day": 4,
+                                        "hour": 11,
+                                        "minute": 33,
+                                        "second": 49,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-025d5e6d9b9d22787",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "default",
+                                        "GroupId": "sg-09c6a03dec497a6b0"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "16:46:43:6b:2a:4d",
+                                "NetworkInterfaceId": "eni-0d6d13c72ac812cae",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.124",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.124"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-0e172a55c20169303",
+                                "VpcId": "vpc-00255c1f52c0a88d6",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default",
+                                "GroupId": "sg-09c6a03dec497a6b0"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2022,
+                            "month": 8,
+                            "day": 4,
+                            "hour": 11,
+                            "minute": 33,
+                            "second": 49,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        }
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0306be6c4abf309e0"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeTags_1.json
+++ b/tests/data/placebo/ec2_stop_protection_enabled/ec2.DescribeTags_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/ec2_stop_protection_disabled/ami.tf
+++ b/tests/terraform/ec2_stop_protection_disabled/ami.tf
@@ -1,0 +1,12 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+}

--- a/tests/terraform/ec2_stop_protection_disabled/main.tf
+++ b/tests/terraform/ec2_stop_protection_disabled/main.tf
@@ -1,0 +1,19 @@
+resource "aws_instance" "no_protection" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.example.id
+}
+
+resource "aws_instance" "termination_protection" {
+  ami                     = data.aws_ami.amazon_linux.id
+  instance_type           = "t2.micro"
+  subnet_id               = aws_subnet.example.id
+  disable_api_termination = true
+}
+
+resource "aws_instance" "stop_protection" {
+  ami              = data.aws_ami.amazon_linux.id
+  instance_type    = "t2.micro"
+  subnet_id        = aws_subnet.example.id
+  disable_api_stop = true
+}

--- a/tests/terraform/ec2_stop_protection_disabled/network.tf
+++ b/tests/terraform/ec2_stop_protection_disabled/network.tf
@@ -1,0 +1,8 @@
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "example" {
+  vpc_id     = aws_vpc.example.id
+  cidr_block = "10.0.1.0/24"
+}

--- a/tests/terraform/ec2_stop_protection_disabled/tf_resources.json
+++ b/tests/terraform/ec2_stop_protection_disabled/tf_resources.json
@@ -1,0 +1,434 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_ami": {
+            "amazon_linux": {
+                "architecture": "x86_64",
+                "arn": "arn:aws:ec2:us-east-1::image/ami-0d7734f53f491186b",
+                "block_device_mappings": [
+                    {
+                        "device_name": "/dev/xvda",
+                        "ebs": {
+                            "delete_on_termination": "true",
+                            "encrypted": "false",
+                            "iops": "0",
+                            "snapshot_id": "snap-00e9c002a992550a7",
+                            "throughput": "0",
+                            "volume_size": "8",
+                            "volume_type": "gp2"
+                        },
+                        "no_device": "",
+                        "virtual_name": ""
+                    }
+                ],
+                "boot_mode": "",
+                "creation_date": "2022-07-16T02:39:01.000Z",
+                "deprecation_time": "2024-07-16T02:39:01.000Z",
+                "description": "Amazon Linux AMI 2018.03.0.20220705.1 x86_64 HVM gp2",
+                "ena_support": true,
+                "executable_users": null,
+                "filter": [
+                    {
+                        "name": "name",
+                        "values": [
+                            "amzn-ami-hvm-*-x86_64-gp2"
+                        ]
+                    }
+                ],
+                "hypervisor": "xen",
+                "id": "ami-0d7734f53f491186b",
+                "image_id": "ami-0d7734f53f491186b",
+                "image_location": "amazon/amzn-ami-hvm-2018.03.0.20220705.1-x86_64-gp2",
+                "image_owner_alias": "amazon",
+                "image_type": "machine",
+                "include_deprecated": false,
+                "kernel_id": "",
+                "most_recent": true,
+                "name": "amzn-ami-hvm-2018.03.0.20220705.1-x86_64-gp2",
+                "name_regex": null,
+                "owner_id": "644160558196",
+                "owners": [
+                    "amazon"
+                ],
+                "platform": "",
+                "platform_details": "Linux/UNIX",
+                "product_codes": [],
+                "public": true,
+                "ramdisk_id": "",
+                "root_device_name": "/dev/xvda",
+                "root_device_type": "ebs",
+                "root_snapshot_id": "snap-00e9c002a992550a7",
+                "sriov_net_support": "simple",
+                "state": "available",
+                "state_reason": {
+                    "code": "UNSET",
+                    "message": "UNSET"
+                },
+                "tags": {},
+                "tpm_support": "",
+                "usage_operation": "RunInstances",
+                "virtualization_type": "hvm"
+            }
+        },
+        "aws_instance": {
+            "no_protection": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0916290676d3ede6a",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1b",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-0916290676d3ede6a",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-0cf997427424304d4",
+                "private_dns": "ip-10-0-1-227.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.227",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": true,
+                        "iops": 100,
+                        "kms_key_id": "arn:aws:kms:us-east-1:644160558196:key/9ee2a815-01df-4571-9946-3464baabfacd",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0f19e8a86522e29fa",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0097c16e28e99cd1f",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0b19c3cb919a3fe08"
+                ]
+            },
+            "stop_protection": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-00737300785a058f9",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1b",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": true,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-00737300785a058f9",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-09bf69ce93aa23e6d",
+                "private_dns": "ip-10-0-1-224.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.224",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": true,
+                        "iops": 100,
+                        "kms_key_id": "arn:aws:kms:us-east-1:644160558196:key/9ee2a815-01df-4571-9946-3464baabfacd",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0911be7318df80a51",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0097c16e28e99cd1f",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0b19c3cb919a3fe08"
+                ]
+            },
+            "termination_protection": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0ace8b3999421ba93",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1b",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": true,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-0ace8b3999421ba93",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-038d5123afd6dee32",
+                "private_dns": "ip-10-0-1-8.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.8",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": true,
+                        "iops": 100,
+                        "kms_key_id": "arn:aws:kms:us-east-1:644160558196:key/9ee2a815-01df-4571-9946-3464baabfacd",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-069a6298487605445",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0097c16e28e99cd1f",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0b19c3cb919a3fe08"
+                ]
+            }
+        },
+        "aws_subnet": {
+            "example": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:subnet/subnet-0097c16e28e99cd1f",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "us-east-1b",
+                "availability_zone_id": "use1-az2",
+                "cidr_block": "10.0.1.0/24",
+                "customer_owned_ipv4_pool": "",
+                "enable_dns64": false,
+                "enable_resource_name_dns_a_record_on_launch": false,
+                "enable_resource_name_dns_aaaa_record_on_launch": false,
+                "id": "subnet-0097c16e28e99cd1f",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "ipv6_native": false,
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": false,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_hostname_type_on_launch": "ip-name",
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-0bf64b04425b5bd8f"
+            }
+        },
+        "aws_vpc": {
+            "example": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:vpc/vpc-0bf64b04425b5bd8f",
+                "assign_generated_ipv6_cidr_block": false,
+                "cidr_block": "10.0.0.0/16",
+                "default_network_acl_id": "acl-061af6d2449d2183f",
+                "default_route_table_id": "rtb-0b957138d7879cd8b",
+                "default_security_group_id": "sg-0b19c3cb919a3fe08",
+                "dhcp_options_id": "dopt-041fd1396ba62bfa4",
+                "enable_classiclink": false,
+                "enable_classiclink_dns_support": false,
+                "enable_dns_hostnames": false,
+                "enable_dns_support": true,
+                "id": "vpc-0bf64b04425b5bd8f",
+                "instance_tenancy": "default",
+                "ipv4_ipam_pool_id": null,
+                "ipv4_netmask_length": null,
+                "ipv6_association_id": "",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_network_border_group": "",
+                "ipv6_ipam_pool_id": "",
+                "ipv6_netmask_length": 0,
+                "main_route_table_id": "rtb-0b957138d7879cd8b",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}

--- a/tests/terraform/ec2_stop_protection_enabled/ami.tf
+++ b/tests/terraform/ec2_stop_protection_enabled/ami.tf
@@ -1,0 +1,12 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+}

--- a/tests/terraform/ec2_stop_protection_enabled/main.tf
+++ b/tests/terraform/ec2_stop_protection_enabled/main.tf
@@ -1,0 +1,19 @@
+resource "aws_instance" "no_protection" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.example.id
+}
+
+resource "aws_instance" "termination_protection" {
+  ami                     = data.aws_ami.amazon_linux.id
+  instance_type           = "t2.micro"
+  subnet_id               = aws_subnet.example.id
+  disable_api_termination = true
+}
+
+resource "aws_instance" "stop_protection" {
+  ami              = data.aws_ami.amazon_linux.id
+  instance_type    = "t2.micro"
+  subnet_id        = aws_subnet.example.id
+  disable_api_stop = true
+}

--- a/tests/terraform/ec2_stop_protection_enabled/network.tf
+++ b/tests/terraform/ec2_stop_protection_enabled/network.tf
@@ -1,0 +1,8 @@
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "example" {
+  vpc_id     = aws_vpc.example.id
+  cidr_block = "10.0.1.0/24"
+}

--- a/tests/terraform/ec2_stop_protection_enabled/tf_resources.json
+++ b/tests/terraform/ec2_stop_protection_enabled/tf_resources.json
@@ -1,0 +1,434 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_ami": {
+            "amazon_linux": {
+                "architecture": "x86_64",
+                "arn": "arn:aws:ec2:us-east-1::image/ami-0d7734f53f491186b",
+                "block_device_mappings": [
+                    {
+                        "device_name": "/dev/xvda",
+                        "ebs": {
+                            "delete_on_termination": "true",
+                            "encrypted": "false",
+                            "iops": "0",
+                            "snapshot_id": "snap-00e9c002a992550a7",
+                            "throughput": "0",
+                            "volume_size": "8",
+                            "volume_type": "gp2"
+                        },
+                        "no_device": "",
+                        "virtual_name": ""
+                    }
+                ],
+                "boot_mode": "",
+                "creation_date": "2022-07-16T02:39:01.000Z",
+                "deprecation_time": "2024-07-16T02:39:01.000Z",
+                "description": "Amazon Linux AMI 2018.03.0.20220705.1 x86_64 HVM gp2",
+                "ena_support": true,
+                "executable_users": null,
+                "filter": [
+                    {
+                        "name": "name",
+                        "values": [
+                            "amzn-ami-hvm-*-x86_64-gp2"
+                        ]
+                    }
+                ],
+                "hypervisor": "xen",
+                "id": "ami-0d7734f53f491186b",
+                "image_id": "ami-0d7734f53f491186b",
+                "image_location": "amazon/amzn-ami-hvm-2018.03.0.20220705.1-x86_64-gp2",
+                "image_owner_alias": "amazon",
+                "image_type": "machine",
+                "include_deprecated": false,
+                "kernel_id": "",
+                "most_recent": true,
+                "name": "amzn-ami-hvm-2018.03.0.20220705.1-x86_64-gp2",
+                "name_regex": null,
+                "owner_id": "644160558196",
+                "owners": [
+                    "amazon"
+                ],
+                "platform": "",
+                "platform_details": "Linux/UNIX",
+                "product_codes": [],
+                "public": true,
+                "ramdisk_id": "",
+                "root_device_name": "/dev/xvda",
+                "root_device_type": "ebs",
+                "root_snapshot_id": "snap-00e9c002a992550a7",
+                "sriov_net_support": "simple",
+                "state": "available",
+                "state_reason": {
+                    "code": "UNSET",
+                    "message": "UNSET"
+                },
+                "tags": {},
+                "tpm_support": "",
+                "usage_operation": "RunInstances",
+                "virtualization_type": "hvm"
+            }
+        },
+        "aws_instance": {
+            "no_protection": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0daf36c03bf9c5e75",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1f",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-0daf36c03bf9c5e75",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-0d3a0342e5b7b9403",
+                "private_dns": "ip-10-0-1-15.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.15",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-07fccc8f6c75d1d1c",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0e172a55c20169303",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-09c6a03dec497a6b0"
+                ]
+            },
+            "stop_protection": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0ecfe7c50cf2f76b2",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1f",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": true,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-0ecfe7c50cf2f76b2",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-0d6d13c72ac812cae",
+                "private_dns": "ip-10-0-1-124.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.124",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0d2b762057cf67207",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0e172a55c20169303",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-09c6a03dec497a6b0"
+                ]
+            },
+            "termination_protection": {
+                "ami": "ami-0d7734f53f491186b",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-017e55c722d539f90",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1f",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": true,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "",
+                "id": "i-017e55c722d539f90",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-004e46d428e6b695a",
+                "private_dns": "ip-10-0-1-168.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.168",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0f1ee2360fa73f764",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0e172a55c20169303",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-09c6a03dec497a6b0"
+                ]
+            }
+        },
+        "aws_subnet": {
+            "example": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:subnet/subnet-0e172a55c20169303",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "us-east-1f",
+                "availability_zone_id": "use1-az5",
+                "cidr_block": "10.0.1.0/24",
+                "customer_owned_ipv4_pool": "",
+                "enable_dns64": false,
+                "enable_resource_name_dns_a_record_on_launch": false,
+                "enable_resource_name_dns_aaaa_record_on_launch": false,
+                "id": "subnet-0e172a55c20169303",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "ipv6_native": false,
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": false,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_hostname_type_on_launch": "ip-name",
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-00255c1f52c0a88d6"
+            }
+        },
+        "aws_vpc": {
+            "example": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:vpc/vpc-00255c1f52c0a88d6",
+                "assign_generated_ipv6_cidr_block": false,
+                "cidr_block": "10.0.0.0/16",
+                "default_network_acl_id": "acl-00281436354a0a4f2",
+                "default_route_table_id": "rtb-0c7d1e90e3c8ce222",
+                "default_security_group_id": "sg-09c6a03dec497a6b0",
+                "dhcp_options_id": "dopt-0965473f41c19ccbd",
+                "enable_classiclink": false,
+                "enable_classiclink_dns_support": false,
+                "enable_dns_hostnames": false,
+                "enable_dns_support": true,
+                "id": "vpc-00255c1f52c0a88d6",
+                "instance_tenancy": "default",
+                "ipv4_ipam_pool_id": null,
+                "ipv4_netmask_length": null,
+                "ipv6_association_id": "",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_network_border_group": "",
+                "ipv6_ipam_pool_id": "",
+                "ipv6_netmask_length": 0,
+                "main_route_table_id": "rtb-0c7d1e90e3c8ce222",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -17,6 +17,82 @@ from c7n import tags, utils
 
 from .common import BaseTest
 
+from pytest_terraform import terraform
+
+
+@terraform('ec2_stop_protection_enabled')
+def test_ec2_stop_protection_enabled(test, ec2_stop_protection_enabled):
+    aws_region = 'us-east-1'
+    session_factory = test.replay_flight_data('ec2_stop_protection_enabled', region=aws_region)
+
+    p = test.load_policy(
+        {
+            'name': 'ec2_stop_protection_enabled',
+            'resource': 'ec2',
+            'filters': [
+                {'State.Name': 'running'},
+                {'type': 'stop-protected'},
+            ],
+        },
+        session_factory=session_factory,
+        config={'region': aws_region},
+    )
+
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+    test.assertEqual(
+        resources[0]['InstanceId'],
+        ec2_stop_protection_enabled['aws_instance.stop_protection.id'])
+
+
+@terraform('ec2_stop_protection_disabled')
+def test_ec2_stop_protection_disabled(test, ec2_stop_protection_disabled):
+    aws_region = 'us-east-1'
+    session_factory = test.replay_flight_data('ec2_stop_protection_disabled', region=aws_region)
+
+    p = test.load_policy(
+        {
+            'name': 'ec2_stop_protection_disabled',
+            'resource': 'ec2',
+            'filters': [
+                {'State.Name': 'running'},
+                {'not': [{'type': 'stop-protected'}]},
+            ],
+        },
+        session_factory=session_factory,
+        config={'region': aws_region},
+    )
+
+    resources = p.run()
+    test.assertEqual(len(resources), 2)
+
+    resource_ids = [i['InstanceId'] for i in resources]
+    test.assertIn(
+        ec2_stop_protection_disabled['aws_instance.termination_protection.id'],
+        resource_ids)
+    test.assertIn(
+        ec2_stop_protection_disabled['aws_instance.no_protection.id'],
+        resource_ids)
+
+
+def test_ec2_stop_protection_filter_permissions(test):
+    policy = test.load_policy(
+        {
+            'name': 'ec2-stop-protection',
+            'resource': 'ec2',
+            'filters': [{'type': 'stop-protected'}],
+        },
+    )
+    permissions = policy.get_permissions()
+    test.assertEqual(
+        permissions,
+        {
+            'ec2:DescribeInstances',
+            'ec2:DescribeTags',
+            'ec2:DescribeInstanceAttribute',
+        },
+    )
+
 
 class TestEc2NetworkLocation(BaseTest):
     def test_ec2_network_location_terminated(self):


### PR DESCRIPTION
This filter helps users filter EC2 instance with _stop protection_ so users are able to stop/terminate EC2 instances using their organization rules and not affect _protected_ instances (if _force_ stop/terminate action is not allowed in their case).

Also add type hints for some methods to simplify reading code. If this is okay, I will add type hints in the future if I work on part of codes without them and be able to understand variable type. Otherwise, let me know and I remove my _refactor_ commit here.