### PR TITLE
aws - filters - add `aws:SourceAccount` support to cross-account filter

### DIFF
--- a/c7n/filters/iamaccess.py
+++ b/c7n/filters/iamaccess.py
@@ -22,6 +22,9 @@ References
 - IAM Policy Reference
   https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
 
+- IAM Global Condition Context Keys
+  https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html
+
 """
 import fnmatch
 import logging
@@ -213,6 +216,10 @@ class PolicyChecker:
 
     # sns default policy
     def handle_aws_sourceowner(self, s, c):
+        return bool(set(map(_account, c['values'])).difference(self.allowed_accounts))
+
+    # AWS Connect default policy on Lex
+    def handle_aws_sourceaccount(self, s, c):
         return bool(set(map(_account, c['values'])).difference(self.allowed_accounts))
 
     # s3 logging

--- a/tests/data/iam/iam-policies.json
+++ b/tests/data/iam/iam-policies.json
@@ -69,5 +69,41 @@
         }
       }
     ]
+  },
+  {
+    "Id": "Cross-Account-Trust-Policy-Service-SourceAccount-Positive",
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "sns:Publish"
+        ],
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "*"
+        },
+        "Condition": {
+          "StringEquals": {"AWS:SourceAccount": "111111111111"}
+        }
+      }
+    ]
+  },
+  {
+    "Id": "Cross-Account-Trust-Policy-Service-SourceAccount-Negative",
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "sns:Publish"
+        ],
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "*"
+        },
+        "Condition": {
+          "StringEquals": {"AWS:SourceAccount": "111111111112"}
+        }
+      }
+    ]
   }
 ]

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -2000,7 +2000,7 @@ class CrossAccountChecker(TestCase):
             ]
         })
         for p, expected in zip(
-            policies, [False, True, True, False]
+            policies, [False, True, True, False, False, True]
         ):
             violations = checker.check(p)
             self.assertEqual(bool(violations), expected)


### PR DESCRIPTION
Adding support for Global Conditional key `aws:SourceAccount` to the cross-account filter. 

We found that AWS Connect creates a resource policy on a Lex bot alias with the source account context key. Like `aws:SourceOwner` this is an AWS account.