### PR TITLE
releng - docs build - update cache keys to address stale cache issue

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -74,7 +74,7 @@ jobs:
             docs/source/gcp/resources
             docs/source/azure/resources
             docs/source/awscc/resources
-          key: sphinx-docs-${{ runner.os }}-3.9-v2-${{ hashFiles('**/*.rst') }}-${{ hashFiles('**/*.md') }}-1
+          key: sphinx-docs-${{ runner.os }}-3.9-v2-${{ hashFiles('**/poetry.lock') }}
 
       - name: Update PATH
         shell: bash

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -74,7 +74,7 @@ jobs:
             docs/source/gcp/resources
             docs/source/azure/resources
             docs/source/awscc/resources
-          key: sphinx-docs-${{ runner.os }}-3.9-${{ hashFiles('**/*.rst') }}-${{ hashFiles('**/*.md') }}-1
+          key: sphinx-docs-${{ runner.os }}-3.9-v2-${{ hashFiles('**/*.rst') }}-${{ hashFiles('**/*.md') }}-1
 
       - name: Update PATH
         shell: bash

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Bootstrap poetry
         shell: bash
         run: |
@@ -62,7 +62,7 @@ jobs:
         id: cache
         with:
           path: .venv
-          key: venv-docs-${{ runner.os }}-3.9-${{ hashFiles('**/poetry.lock') }}
+          key: venv-docs-${{ runner.os }}-3.9-v2-${{ hashFiles('**/poetry.lock') }}
 
       - name: Set up doc cache
         uses: actions/cache@v2

--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -205,10 +205,12 @@ don't require quoting, i.e., "my_{charge_code}".
 
 ## Other commands
 
-c7n-org also supports running arbitrary scripts against accounts via the run-script command.
-For AWS the standard AWS SDK credential information is exported into the process environment before executing.
-For Azure and GCP, only the environment variables `AZURE_SUBSCRIPTION_ID` and `PROJECT_ID` are exported(in addition
-of the system env variables).
+c7n-org also supports running arbitrary scripts against accounts via
+the run-script command.  For AWS the standard AWS SDK credential
+information is exported into the process environment before executing.
+For Azure and GCP, only the environment variables
+`AZURE_SUBSCRIPTION_ID` and `PROJECT_ID` are exported(in addition of
+the system env variables).
 
 c7n-org also supports generating reports for a given policy execution
 across accounts via the `c7n-org report` subcommand.


### PR DESCRIPTION
sphinx doc builds take about 23m sans any cache, but the virtualenv cache wasn't fully working
causing it to rebuild every time.

