### PR TITLE
 gcp - sql - fix augment function in GCP SQL

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -60,7 +60,7 @@ class SqlInstance(QueryResourceManager):
     def augment(self, resources):
         for r in resources:
             if 'userLabels' in r['settings']:
-                r['labels'] = r['settings']['labels']
+                r['labels'] = r['settings']['userLabels']
         return resources
 
 


### PR DESCRIPTION
I have tested the previous change and got the following:
```
File "/src/tools/c7n_gcp/c7n_gcp/query.py", line 212, in _fetch_resources
    return self.augment(self.source.get_resources(query)) or []
  File "/src/tools/c7n_gcp/c7n_gcp/resources/sql.py", line 63, in augment
    r['labels'] = r['settings']['labels']
KeyError: 'labels'
```