### PR TITLE
gcp - also get project id from GCP_PROJECT env

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -68,7 +68,7 @@ RETRYABLE_EXCEPTIONS = (
 
 
 def get_default_project():
-    for k in ('GOOGLE_PROJECT', 'GCLOUD_PROJECT',
+    for k in ('GCP_PROJECT', 'GOOGLE_PROJECT', 'GCLOUD_PROJECT',
               'GOOGLE_CLOUD_PROJECT', 'CLOUDSDK_CORE_PROJECT'):
         if k in os.environ:
             return os.environ[k]


### PR DESCRIPTION
According to https://cloud.google.com/functions/docs/configuring/env-var#python_37_and_go_111 , the `GCP_PROJECT` is one of the runtime environment variables.