### PR TITLE
aws - workspaces - fix connection-status filter when there is no status

### DIFF
--- a/c7n/resources/workspaces.py
+++ b/c7n/resources/workspaces.py
@@ -85,15 +85,23 @@ class WorkspaceConnectionStatusFilter(ValueFilter):
 
     def process(self, resources, event=None):
         client = local_session(self.manager.session_factory).client('workspaces')
-        annotate_map = {r['WorkspaceId']: r for r in resources if self.annotation_key not in r}
+        unannotated = {r['WorkspaceId']: r for r in resources if self.annotation_key not in r}
+        status_map = {}
         with self.executor_factory(max_workers=2) as w:
             self.log.debug(
-                'Querying connection status for %d workspaces' % len(annotate_map))
+                'Querying connection status for %d workspaces' % len(unannotated))
             for status in itertools.chain(*w.map(
                 functools.partial(self.get_connection_status, client),
-                chunks(annotate_map.keys(), 25)
+                chunks(unannotated.keys(), 25)
             )):
-                annotate_map[status['WorkspaceId']][self.annotation_key] = status
+                status_map[status['WorkspaceId']] = status
+
+        # Note: In some cases (e.g. workspaces that just launched or reached ERROR state during
+        # initialization) there will be no connection status information. Here we'll make
+        # sure that every workspace gets _some_ status annotation, even if it's empty.
+        for ws_id, r in unannotated.items():
+            r[self.annotation_key] = status_map.get(ws_id, {})
+
         return list(filter(self, resources))
 
     def get_resource_value(self, k, i):

--- a/tests/data/placebo/test_workspaces_connection_status/workspaces.DescribeWorkspaces_1.json
+++ b/tests/data/placebo/test_workspaces_connection_status/workspaces.DescribeWorkspaces_1.json
@@ -93,6 +93,26 @@
                     "ComputeTypeName": "POWER"
                 },
                 "ModificationStates": []
+            },
+            {
+                "WorkspaceId": "ws-5fm1ykjjj",
+                "DirectoryId": "d-5183055e94",
+                "UserName": "rburnham",
+                "State": "ERROR",
+                "BundleId": "wsb-c4dc00cc1",
+                "ErrorMessage": "There was an issue joining the WorkSpace to your domain.  Verify that your service account is allowed to complete domain join operations.  If you continue to see an issue, contact AWS Support.",
+                "ErrorCode": "ConfigureWorkspace.DomainJoin",
+                "VolumeEncryptionKey": "arn:aws:kms:us-east-1:644160558196:key/14a03569-d26b-4496-92e5-dfe8cb1855fe",
+                "UserVolumeEncryptionEnabled": true,
+                "RootVolumeEncryptionEnabled": true,
+                "WorkspaceProperties": {
+                    "RunningMode": "AUTO_STOP",
+                    "RunningModeAutoStopTimeoutInMinutes": 120,
+                    "RootVolumeSizeGib": 80,
+                    "UserVolumeSizeGib": 100,
+                    "ComputeTypeName": "POWER"
+                },
+                "ModificationStates": []
             }
         ],
         "NextToken": "",


### PR DESCRIPTION
In some cases the [DescribeWorkspacesConnectionStatus](https://docs.aws.amazon.com/workspaces/latest/api/API_DescribeWorkspacesConnectionStatus.html) call won't return data for a given workspace. Cases I've found so far:

- Workspaces that were just launched and haven't hit a status check cycle yet
- Workspaces that hit an ERROR state during initialization (because of failing to join a domain, for example)

In those cases we can make sure to leave an empty `c7n:ConnectionStatus` annotation, rather than skipping them which causes a `KeyError` later.

Closes #7248 