### PR TITLE
Add CreateNotebookInstance shortcut

### DIFF
--- a/c7n/cwe.py
+++ b/c7n/cwe.py
@@ -72,7 +72,11 @@ class CloudWatchEvents:
 
         'RunInstances': {
             'ids': 'responseElements.instancesSet.items[].instanceId',
-            'source': 'ec2.amazonaws.com'}}
+            'source': 'ec2.amazonaws.com'},
+
+        'CreateNotebookInstance': {
+            'ids': 'requestParameters.notebookInstanceName',
+            'source': 'sagemaker.amazonaws.com'}}
 
     @classmethod
     def get(cls, event_name):


### PR DESCRIPTION
This adds a CloudTrail event shortcut for the `CreateNotebookInstance` action for Sagemaker Notebooks.

While experimenting with policies to manage Sagemaker resources, I used the following in a policy for `mode: cloudtrail`:

```
      events:
        - source: sagemaker.amazonaws.com
          event: CreateNotebookInstance
          ids: 'requestParameters.notebookInstanceName'
```

Creating a Notebook creates an event in CloudTrail, which contains the following:

```
    "requestParameters": {
        "notebookInstanceName": "c7n-conor-test-5",
        .....
    },
```

My Cloud Custodian policy successfully finds the resource, outputting this to CloudWatch logs:

```
[INFO]	2022-08-24T09:53:45.039Z	157f4a60-671e-4a08-9f1e-8e7587297905	Found resource ids:['c7n-conor-test-5']
```