### PR TITLE
tools/c7n-org - warn on AuthFailure when listing regions

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -203,11 +203,13 @@ def resolve_regions(regions, account):
             client = session.client('ec2')
             return [region['RegionName'] for region in client.describe_regions()['Regions']]
         except ClientError as e:
-            if e.response['Error']['Code'] == 'AccessDenied':
-                log.warning('access denied listing available regions for account:%s',
-                    account['name'])
-                return []
-            raise
+            err = e.response['Error']
+            if err['Code'] not in ('AccessDenied', 'AuthFailure'):
+                raise
+            log.warning('error (%s) listing available regions for account:%s - %s',
+                err['Code'], account['name'], err['Message']
+            )
+            return []
     if not regions:
         return ('us-east-1', 'us-west-2')
 


### PR DESCRIPTION
#7494 allowed c7n-org to warn and continue in the case of `AccessDenied` error assuming target roles. #7685 raises a related error - an `AuthFailure` while describing regions. One way around that is to treat that the same way as an `AccessDenied` error during the role-assume step: warn, continue, and effectively ignore that account.

Some alternatives might be:
- Treat `AuthFailure` differently, either explicitly failing the policy on purpose or falling back to the default set of regions
- Allow the warn/continue behavior to accommodate _any_ boto errors we hit when listing regions, rather than picking and choosing specific exceptions

Closes #7685 