### PR TITLE
Extend fms waf1

### DIFF
--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -554,8 +554,8 @@ class SetS3Logging(BaseAction):
         if self.data.get('state') == 'enabled':
             if 'bucket' not in self.data or 'prefix' not in self.data:
                 raise PolicyValidationError((
-                        "alb logging enablement requires `bucket` "
-                        "and `prefix` specification on %s" % (self.manager.data,)))
+                    "alb logging enablement requires `bucket` "
+                    "and `prefix` specification on %s" % (self.manager.data,)))
         return self
 
     def process(self, resources):
@@ -565,7 +565,7 @@ class SetS3Logging(BaseAction):
             attributes = [{
                 'Key': 'access_logs.s3.enabled',
                 'Value': (
-                        self.data.get('state') == 'enabled' and 'true' or 'value')}]
+                    self.data.get('state') == 'enabled' and 'true' or 'value')}]
 
             if self.data.get('state') == 'enabled':
                 attributes.append({
@@ -1220,7 +1220,7 @@ class AppELBTargetGroup(QueryResourceManager):
 
         def _describe_target_group_health(target_group):
             result = self.retry(client.describe_target_health,
-                                TargetGroupArn=target_group['TargetGroupArn'])
+                TargetGroupArn=target_group['TargetGroupArn'])
             target_group['TargetHealthDescriptions'] = result[
                 'TargetHealthDescriptions']
 

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -5,6 +5,7 @@ Application & Network Load Balancers
 """
 import json
 import logging
+import re
 
 from collections import defaultdict
 from c7n.actions import ActionRegistry, BaseAction, ModifyVpcSecurityGroupsAction
@@ -255,6 +256,8 @@ class WafEnabled(Filter):
 class WafV2Enabled(Filter):
     """Filter Application LoadBalancer by wafv2 web-acl
 
+    Supports regex expression for web-acl
+
     :example:
 
     .. code-block:: yaml
@@ -266,21 +269,35 @@ class WafV2Enabled(Filter):
                   - type: wafv2-enabled
                     state: false
                     web-acl: testv2
+
+              - name: filter-wafv2-elb-regex
+                resource: app-elb
+                filters:
+                  - type: wafv2-enabled
+                    state: false
+                    web-acl: .*FMManagedWebACLV2-?FMS-.*
     """
 
     schema = type_schema(
         'wafv2-enabled', **{
             'web-acl': {'type': 'string'},
             'state': {'type': 'boolean'}})
-
     permissions = ('wafv2:ListResourcesForWebACL', 'wafv2:ListWebACLs')
+
+    retry = staticmethod(get_retry((
+        'ThrottlingException',
+        'RequestLimitExceeded',
+        'Throttled',
+        'ThrottledException',
+        'Throttling',
+        'Client.RequestLimitExceeded')))
 
     # TODO verify name uniqueness within region/account
     # TODO consider associated resource fetch in augment
     def process(self, resources, event=None):
         client = local_session(self.manager.session_factory).client('wafv2')
 
-        target_acl = self.data.get('web-acl')
+        target_acl = self.data.get('web-acl', '')
         state = self.data.get('state', False)
 
         name_arn_map = {}
@@ -290,35 +307,35 @@ class WafV2Enabled(Filter):
 
         for w in wafs:
             if 'c7n:AssociatedResources' not in w:
-                arns = client.list_resources_for_web_acl(
-                    WebACLArn=w['ARN']).get('ResourceArns', [])
+                arns = self.retry(
+                    client.list_resources_for_web_acl,
+                    WebACLArn=w.get('ARN', ''),
+                    ResourceType='APPLICATION_LOAD_BALANCER').get('ResourceArns', [])
                 w['c7n:AssociatedResources'] = arns
             name_arn_map[w['Name']] = w['ARN']
             for r in w['c7n:AssociatedResources']:
                 resource_map[r] = w['ARN']
 
-        target_acl_id = name_arn_map.get(target_acl, target_acl)
+        target_acl_ids = [v for k, v in name_arn_map.items() if
+                          re.match(target_acl, k)]
+
         arn_key = self.manager.resource_type.id
         state_map = {}
         for r in resources:
             arn = r[arn_key]
-            if arn in resource_map:
-                # NLB & GLB doesn't support WAF. So, skip such resources
-                if r['Type'] == 'application':
-                    r['c7n_webacl'] = resource_map[arn]
-                    if not target_acl:
-                        state_map[arn] = True
-                        continue
-                    r_acl = resource_map[arn]
-                    if r_acl == target_acl_id:
-                        state_map[arn] = True
-                        continue
+            # NLB & GLB doesn't support WAF. So, skip such resources
+            if r['Type'] == 'application':
+                if arn not in resource_map:
                     state_map[arn] = False
-            else:
-                # NLB & GLB doesn't support WAF. So, skip such resources
-                if r['Type'] == 'application':
-                    state_map[arn] = False
-        return [r for r in resources if r[arn_key] in state_map and state_map[r[arn_key]] == state]
+                    continue
+                if not target_acl:
+                    state_map[arn] = True
+                    continue
+                if resource_map[arn] in target_acl_ids:
+                    state_map[arn] = True
+                    continue
+                state_map[arn] = False
+        return [r for r in resources if state_map[r[arn_key]] == state]
 
 
 @AppELB.action_registry.register('set-waf')
@@ -403,6 +420,8 @@ class SetWaf(BaseAction):
 class SetWafV2(BaseAction):
     """Enable wafv2 protection on Application LoadBalancer.
 
+    Supports regex expression for web-acl
+
     :example:
 
     .. code-block:: yaml
@@ -427,15 +446,36 @@ class SetWafV2(BaseAction):
                 actions:
                   - type: set-wafv2
                     state: true
-                    web-acl: testv2
+
+            policies:
+              - name: set-wafv2-for-elb-regex
+                resource: app-elb
+                filters:
+                  - type: wafv2-enabled
+                    state: false
+                    web-acl: .*FMManagedWebACLV2-?FMS-.*
+                actions:
+                  - type: set-wafv2
+                    state: true
+                    web-acl: FMManagedWebACLV2-?FMS-TestWebACL
 
     """
-    permissions = ('wafv2:AssociateWebACL', 'wafv2:ListWebACLs')
+    permissions = ('wafv2:AssociateWebACL',
+                   'wafv2:DisassociateWebACL',
+                   'wafv2:ListWebACLs')
 
     schema = type_schema(
-        'set-wafv2', required=['web-acl'], **{
+        'set-wafv2', **{
             'web-acl': {'type': 'string'},
             'state': {'type': 'boolean'}})
+
+    retry = staticmethod(get_retry((
+        'ThrottlingException',
+        'RequestLimitExceeded',
+        'Throttled',
+        'ThrottledException',
+        'Throttling',
+        'Client.RequestLimitExceeded')))
 
     def validate(self):
         found = False
@@ -453,12 +493,17 @@ class SetWafV2(BaseAction):
     def process(self, resources):
         wafs = self.manager.get_resource_manager('wafv2').resources(augment=False)
         name_id_map = {w['Name']: w['ARN'] for w in wafs}
-        target_acl = self.data.get('web-acl')
-        target_acl_id = name_id_map.get(target_acl, target_acl)
         state = self.data.get('state', True)
 
-        if state and target_acl_id not in name_id_map.values():
-            raise ValueError("invalid web acl: %s" % (target_acl_id))
+        target_acl_id = ''
+        if state:
+            target_acl = self.data.get('web-acl', '')
+            target_acl_ids = [v for k, v in name_id_map.items() if
+                              re.match(target_acl, k)]
+            if len(target_acl_ids) != 1:
+                raise ValueError(f'{target_acl} matching to none or '
+                                 f'multiple webacls')
+            target_acl_id = target_acl_ids[0]
 
         client = local_session(
             self.manager.session_factory).client('wafv2')
@@ -469,11 +514,12 @@ class SetWafV2(BaseAction):
         # TODO investigate limits on waf association.
         for r in resources:
             if state:
-                client.associate_web_acl(
-                    WebACLArn=target_acl_id, ResourceArn=r[arn_key])
+                self.retry(client.associate_web_acl,
+                           WebACLArn=target_acl_id,
+                           ResourceArn=r[arn_key])
             else:
-                client.disassociate_web_acl(
-                    WebACLArn=target_acl_id, ResourceArn=r[arn_key])
+                self.retry(client.disassociate_web_acl,
+                           ResourceArn=r[arn_key])
 
 
 @AppELB.action_registry.register('set-s3-logging')
@@ -508,8 +554,8 @@ class SetS3Logging(BaseAction):
         if self.data.get('state') == 'enabled':
             if 'bucket' not in self.data or 'prefix' not in self.data:
                 raise PolicyValidationError((
-                    "alb logging enablement requires `bucket` "
-                    "and `prefix` specification on %s" % (self.manager.data,)))
+                        "alb logging enablement requires `bucket` "
+                        "and `prefix` specification on %s" % (self.manager.data,)))
         return self
 
     def process(self, resources):
@@ -519,7 +565,7 @@ class SetS3Logging(BaseAction):
             attributes = [{
                 'Key': 'access_logs.s3.enabled',
                 'Value': (
-                    self.data.get('state') == 'enabled' and 'true' or 'value')}]
+                        self.data.get('state') == 'enabled' and 'true' or 'value')}]
 
             if self.data.get('state') == 'enabled':
                 attributes.append({
@@ -1174,7 +1220,7 @@ class AppELBTargetGroup(QueryResourceManager):
 
         def _describe_target_group_health(target_group):
             result = self.retry(client.describe_target_health,
-                TargetGroupArn=target_group['TargetGroupArn'])
+                                TargetGroupArn=target_group['TargetGroupArn'])
             target_group['TargetHealthDescriptions'] = result[
                 'TargetHealthDescriptions']
 

--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -157,7 +157,7 @@ class IsWafEnabled(Filter):
             if state and target_acl_id is None and r.get('WebACLId'):
                 results.append(r)
             elif not state and target_acl_id is None and (not r.get('WebACLId') or
-                                                          r.get('WebACLId') not in waf_name_id_map.values()):
+                    r.get('WebACLId') not in waf_name_id_map.values()):
                 results.append(r)
             elif state and target_acl_id and r['WebACLId'] == target_acl_id:
                 results.append(r)
@@ -752,8 +752,8 @@ class DistributionSSLAction(BaseAction):
 
 class BaseUpdateAction(BaseAction):
     schema = type_schema('set-attributes',
-                         attributes={"type": "object"},
-                         required=('attributes',))
+                        attributes={"type": "object"},
+                        required=('attributes',))
     schema_alias = False
 
     def validate(self, config_name, shape):

--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -157,7 +157,7 @@ class IsWafEnabled(Filter):
             if state and target_acl_id is None and r.get('WebACLId'):
                 results.append(r)
             elif not state and target_acl_id is None and (not r.get('WebACLId') or
-                    r.get('WebACLId') not in waf_name_id_map.values()):
+                                                          r.get('WebACLId') not in waf_name_id_map.values()):
                 results.append(r)
             elif state and target_acl_id and r['WebACLId'] == target_acl_id:
                 results.append(r)
@@ -181,6 +181,13 @@ class IsWafV2Enabled(Filter):
                   - type: wafv2-enabled
                     state: false
                     web-acl: testv2
+
+              - name: filter-distribution-wafv2-regex
+                resource: distribution
+                filters:
+                  - type: wafv2-enabled
+                    state: false
+                    web-acl: .*FMManagedWebACLV2-?FMS-.*
     """
 
     schema = type_schema(
@@ -194,24 +201,24 @@ class IsWafV2Enabled(Filter):
         query = {'Scope': 'CLOUDFRONT'}
         wafs = self.manager.get_resource_manager('wafv2').resources(query, augment=False)
         waf_name_id_map = {w['Name']: w['ARN'] for w in wafs}
+
+        target_acl = self.data.get('web-acl', '')
         state = self.data.get('state', False)
-        target_acl = self.data.get('web-acl')
-        target_acl_id = waf_name_id_map.get(target_acl, target_acl)
+        target_acl_ids = [v for k, v in waf_name_id_map.items() if
+                          re.match(target_acl, k)]
 
         results = []
         for r in resources:
             r_web_acl_id = r.get('WebACLId')
             if state:
-                if target_acl_id is None and r_web_acl_id \
-                        and r_web_acl_id in waf_name_id_map.values():
+                if not target_acl and r_web_acl_id:
                     results.append(r)
-                elif target_acl_id and r_web_acl_id == target_acl_id:
+                elif target_acl and r_web_acl_id in target_acl_ids:
                     results.append(r)
             else:
-                if target_acl_id is None and (not r_web_acl_id or r_web_acl_id and
-                                              r_web_acl_id not in waf_name_id_map.values()):
+                if not target_acl and not r_web_acl_id:
                     results.append(r)
-                elif target_acl_id and r_web_acl_id != target_acl_id:
+                elif target_acl and r_web_acl_id not in target_acl_ids:
                     results.append(r)
         return results
 
@@ -510,10 +517,21 @@ class SetWafv2(BaseAction):
                     force: true
                     web-acl: test
 
+            policies:
+              - name: set-wafv2-for-cloudfront-regex
+                resource: distribution
+                filters:
+                  - type: wafv2-enabled
+                    state: false
+                    web-acl: .*FMManagedWebACLV2-?FMS-.*
+                actions:
+                  - type: set-wafv2
+                    state: true
+                    web-acl: FMManagedWebACLV2-?FMS-TestWebACL
     """
     permissions = ('cloudfront:UpdateDistribution', 'wafv2:ListWebACLs')
     schema = type_schema(
-        'set-wafv2', required=['web-acl'], **{
+        'set-wafv2', **{
             'web-acl': {'type': 'string'},
             'force': {'type': 'boolean'},
             'state': {'type': 'boolean'}})
@@ -524,10 +542,17 @@ class SetWafv2(BaseAction):
         query = {'Scope': 'CLOUDFRONT'}
         wafs = self.manager.get_resource_manager('wafv2').resources(query, augment=False)
         waf_name_id_map = {w['Name']: w['ARN'] for w in wafs}
-        target_acl = self.data.get('web-acl')
-        target_acl_id = waf_name_id_map.get(target_acl, target_acl)
-        if target_acl_id not in waf_name_id_map.values():
-            raise ValueError("invalid web acl: %s" % (target_acl_id))
+        state = self.data.get('state', True)
+
+        target_acl_id = ''
+        if state:
+            target_acl = self.data.get('web-acl', '')
+            target_acl_ids = [v for k, v in waf_name_id_map.items() if
+                              re.match(target_acl, k)]
+            if len(target_acl_ids) != 1:
+                raise ValueError(f'{target_acl} matching to none or '
+                                 f'multiple webacls')
+            target_acl_id = target_acl_ids[0]
 
         client = local_session(self.manager.session_factory).client('cloudfront')
         force = self.data.get('force', False)
@@ -727,8 +752,8 @@ class DistributionSSLAction(BaseAction):
 
 class BaseUpdateAction(BaseAction):
     schema = type_schema('set-attributes',
-                        attributes={"type": "object"},
-                        required=('attributes',))
+                         attributes={"type": "object"},
+                         required=('attributes',))
     schema_alias = False
 
     def validate(self, config_name, shape):

--- a/tests/data/cwe/event-cloud-trail-update-distribution.json
+++ b/tests/data/cwe/event-cloud-trail-update-distribution.json
@@ -1,0 +1,264 @@
+{
+    "version": "0",
+    "id": "93a7a030-e28a-6aa0-a35c-7bdbca54b7f6",
+    "detail-type": "AWS API Call via CloudTrail",
+    "source": "aws.cloudfront",
+    "account": "012345678912",
+    "time": "2022-07-13T18:09:19Z",
+    "region": "us-east-1",
+    "resources": [],
+    "detail": {
+        "eventVersion": "1.08",
+        "userIdentity": {
+            "type": "AssumedRole",
+            "principalId": "AROAVD4IK2M7GWZXER5DZ:HarishAchappa",
+            "arn": "arn:aws:sts::012345678912:assumed-role/c7nbot/HarishAchappa",
+            "accountId": "012345678912",
+            "accessKeyId": "ASIAVD4IK2M7C6RULHH3",
+            "sessionContext": {
+                "sessionIssuer": {
+                    "type": "Role",
+                    "principalId": "AROAVD4IK2M7GWZXER5DZ",
+                    "arn": "arn:aws:iam::012345678912:role/c7nbot",
+                    "accountId": "012345678912",
+                    "userName": "c7nbot"
+                },
+                "webIdFederationData": {},
+                "attributes": {
+                    "creationDate": "2022-07-13T17:55:21Z",
+                    "mfaAuthenticated": "false"
+                }
+            }
+        },
+        "eventTime": "2022-07-13T18:09:19Z",
+        "eventSource": "cloudfront.amazonaws.com",
+        "eventName": "UpdateDistribution",
+        "awsRegion": "us-east-1",
+        "sourceIPAddress": "AWS Internal",
+        "userAgent": "AWS Internal",
+        "requestParameters": {
+            "id": "E53370FUHBNLK",
+            "distributionConfig": {
+                "origins": {
+                    "quantity": 1,
+                    "items": [
+                        {
+                            "connectionAttempts": 3,
+                            "customHeaders": {
+                                "items": [],
+                                "quantity": 0
+                            },
+                            "domainName": "c7n-activeresponse-test-to-be-deleted.s3.us-east-1.amazonaws.com",
+                            "connectionTimeout": 10,
+                            "s3OriginConfig": {
+                                "originAccessIdentity": ""
+                            },
+                            "originShield": {
+                                "enabled": false
+                            },
+                            "originPath": "",
+                            "id": "c7n-activeresponse-test-to-be-deleted.s3.us-east-1.amazonaws.com"
+                        }
+                    ]
+                },
+                "aliases": {
+                    "items": [],
+                    "quantity": 0
+                },
+                "defaultCacheBehavior": {
+                    "functionAssociations": {
+                        "quantity": 0,
+                        "items": []
+                    },
+                    "lambdaFunctionAssociations": {
+                        "items": [],
+                        "quantity": 0
+                    },
+                    "fieldLevelEncryptionId": "",
+                    "trustedSigners": {
+                        "items": [],
+                        "enabled": false,
+                        "quantity": 0
+                    },
+                    "trustedKeyGroups": {
+                        "enabled": false,
+                        "quantity": 0,
+                        "items": []
+                    },
+                    "cachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                    "allowedMethods": {
+                        "items": [
+                            "GET",
+                            "HEAD"
+                        ],
+                        "quantity": 2,
+                        "cachedMethods": {
+                            "items": [
+                                "GET",
+                                "HEAD"
+                            ],
+                            "quantity": 2
+                        }
+                    },
+                    "smoothStreaming": false,
+                    "targetOriginId": "c7n-activeresponse-test-to-be-deleted.s3.us-east-1.amazonaws.com",
+                    "viewerProtocolPolicy": "allow-all",
+                    "compress": true
+                },
+                "callerReference": "9c8970c1-b26e-4131-b3cf-985880574e96",
+                "webACLId": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+                "defaultRootObject": "",
+                "enabled": true,
+                "httpVersion": "http2",
+                "comment": "HIDDEN_DUE_TO_SECURITY_REASONS",
+                "logging": {
+                    "includeCookies": false,
+                    "prefix": "",
+                    "bucket": "",
+                    "enabled": false
+                },
+                "isIPV6Enabled": true,
+                "viewerCertificate": {
+                    "cloudFrontDefaultCertificate": true,
+                    "minimumProtocolVersion": "TLSv1"
+                },
+                "priceClass": "PriceClass_All",
+                "originGroups": {
+                    "quantity": 0,
+                    "items": []
+                }
+            }
+        },
+        "responseElements": {
+            "location": "https://cloudfront.amazonaws.com/2020-05-31/distribution/E53370FUHBNLK",
+            "eTag": "E3DFGD1PHNLYY3",
+            "distribution": {
+                "aRN": "arn:aws:cloudfront::012345678912:distribution/E53370FUHBNLK",
+                "id": "E53370FUHBNLK",
+                "lastModifiedTime": "Jul 13, 2022 6:09:18 PM",
+                "activeTrustedSigners": {
+                    "quantity": 0,
+                    "enabled": false
+                },
+                "domainName": "d1bftvz1j2jyjs.cloudfront.net",
+                "activeTrustedKeyGroups": {
+                    "quantity": 0,
+                    "enabled": false
+                },
+                "inProgressInvalidationBatches": 0,
+                "status": "InProgress",
+                "distributionConfig": {
+                    "origins": {
+                        "quantity": 1,
+                        "items": [
+                            {
+                                "connectionAttempts": 3,
+                                "customHeaders": {
+                                    "quantity": 0
+                                },
+                                "oacSigningBehavior": "never",
+                                "domainName": "c7n-activeresponse-test-to-be-deleted.s3.us-east-1.amazonaws.com",
+                                "connectionTimeout": 10,
+                                "s3OriginConfig": {
+                                    "originAccessIdentity": ""
+                                },
+                                "originShield": {
+                                    "enabled": false
+                                },
+                                "originAccessControlId": "",
+                                "originPath": "",
+                                "id": "c7n-activeresponse-test-to-be-deleted.s3.us-east-1.amazonaws.com"
+                            }
+                        ]
+                    },
+                    "aliases": {
+                        "quantity": 0
+                    },
+                    "defaultCacheBehavior": {
+                        "functionAssociations": {
+                            "quantity": 0
+                        },
+                        "lambdaFunctionAssociations": {
+                            "quantity": 0
+                        },
+                        "fieldLevelEncryptionId": "",
+                        "trustedSigners": {
+                            "enabled": false,
+                            "quantity": 0
+                        },
+                        "trustedKeyGroups": {
+                            "enabled": false,
+                            "quantity": 0
+                        },
+                        "cachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+                        "allowedMethods": {
+                            "items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "quantity": 2,
+                            "cachedMethods": {
+                                "items": [
+                                    "HEAD",
+                                    "GET"
+                                ],
+                                "quantity": 2
+                            }
+                        },
+                        "smoothStreaming": false,
+                        "targetOriginId": "c7n-activeresponse-test-to-be-deleted.s3.us-east-1.amazonaws.com",
+                        "viewerProtocolPolicy": "allow-all",
+                        "compress": true
+                    },
+                    "callerReference": "9c8970c1-b26e-4131-b3cf-985880574e96",
+                    "staging": false,
+                    "webACLId": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+                    "defaultRootObject": "",
+                    "customErrorResponses": {
+                        "quantity": 0
+                    },
+                    "enabled": true,
+                    "cacheBehaviors": {
+                        "quantity": 0
+                    },
+                    "continuousDeploymentPolicyId": "",
+                    "httpVersion": "http2",
+                    "comment": "HIDDEN_DUE_TO_SECURITY_REASONS",
+                    "restrictions": {
+                        "geoRestriction": {
+                            "restrictionType": "none",
+                            "quantity": 0
+                        }
+                    },
+                    "logging": {
+                        "includeCookies": false,
+                        "prefix": "",
+                        "bucket": "",
+                        "enabled": false
+                    },
+                    "isIPV6Enabled": true,
+                    "viewerCertificate": {
+                        "cloudFrontDefaultCertificate": true,
+                        "certificateSource": "cloudfront",
+                        "sSLSupportMethod": "vip",
+                        "minimumProtocolVersion": "TLSv1"
+                    },
+                    "priceClass": "PriceClass_All",
+                    "originGroups": {
+                        "quantity": 0
+                    }
+                }
+            }
+        },
+        "requestID": "5e3a89ec-4fb3-4407-a7a1-26e52122ca46",
+        "eventID": "a1474634-7457-45e1-bc0f-d47e7ad72f79",
+        "readOnly": false,
+        "eventType": "AwsApiCall",
+        "apiVersion": "2020_05_31",
+        "managementEvent": true,
+        "recipientAccountId": "012345678912",
+        "eventCategory": "Management",
+        "sessionCredentialFromConsole": "true"
+    },
+    "debug": true
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex/elasticloadbalancing.DescribeLoadBalancers_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex/elasticloadbalancing.DescribeLoadBalancers_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "LoadBalancers": [
+            {
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/test/433ae0ba96204181",
+                "DNSName": "test-1231241576.us-east-1.elb.amazonaws.com",
+                "CanonicalHostedZoneId": "Z35SXDOTRQ7X7K",
+                "CreatedTime": "2020-04-15T02:00:16.010000+00:00",
+                "LoadBalancerName": "test",
+                "Scheme": "internet-facing",
+                "VpcId": "vpc-d2d616b5",
+                "State": {
+                    "Code": "active"
+                },
+                "Type": "application",
+                "AvailabilityZones": [
+                    {
+                        "ZoneName": "us-east-1a",
+                        "SubnetId": "subnet-914763e7",
+                        "LoadBalancerAddresses": []
+                    },
+                    {
+                        "ZoneName": "us-east-1b",
+                        "SubnetId": "subnet-efbcccb7",
+                        "LoadBalancerAddresses": []
+                    }
+                ],
+                "SecurityGroups": [
+                    "sg-6c7fa917"
+                ],
+                "IpAddressType": "ipv4"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex/elasticloadbalancing.DescribeTags_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex/elasticloadbalancing.DescribeTags_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagDescriptions": [
+            {
+                "ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/test/433ae0ba96204181",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex/elasticloadbalancing.DescribeTags_2.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex/elasticloadbalancing.DescribeTags_2.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagDescriptions": [
+            {
+                "ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/test/433ae0ba96204181",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex/wafv2.AssociateWebACL_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex/wafv2.AssociateWebACL_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex/wafv2.DisassociateWebACL_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex/wafv2.DisassociateWebACL_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex/wafv2.ListResourcesForWebACL_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex/wafv2.ListResourcesForWebACL_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceArns": [
+            "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/test/433ae0ba96204181"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex/wafv2.ListWebACLs_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "NextMarker": "791f9fc9-16bb-4d32-8f6a-b55e9b6f11c8",
+        "WebACLs": [
+            {
+                "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+                "ARN": "arn:aws:wafv2:us-east-1:671470938745:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/elasticloadbalancing.DescribeLoadBalancers_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/elasticloadbalancing.DescribeLoadBalancers_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "LoadBalancers": [
+            {
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/test/433ae0ba96204181",
+                "DNSName": "test-1231241576.us-east-1.elb.amazonaws.com",
+                "CanonicalHostedZoneId": "Z35SXDOTRQ7X7K",
+                "CreatedTime": "2020-04-15T02:00:16.010000+00:00",
+                "LoadBalancerName": "test",
+                "Scheme": "internet-facing",
+                "VpcId": "vpc-d2d616b5",
+                "State": {
+                    "Code": "active"
+                },
+                "Type": "application",
+                "AvailabilityZones": [
+                    {
+                        "ZoneName": "us-east-1a",
+                        "SubnetId": "subnet-914763e7",
+                        "LoadBalancerAddresses": []
+                    },
+                    {
+                        "ZoneName": "us-east-1b",
+                        "SubnetId": "subnet-efbcccb7",
+                        "LoadBalancerAddresses": []
+                    }
+                ],
+                "SecurityGroups": [
+                    "sg-6c7fa917"
+                ],
+                "IpAddressType": "ipv4"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/elasticloadbalancing.DescribeTags_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/elasticloadbalancing.DescribeTags_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagDescriptions": [
+            {
+                "ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/test/433ae0ba96204181",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/elasticloadbalancing.DescribeTags_2.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/elasticloadbalancing.DescribeTags_2.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagDescriptions": [
+            {
+                "ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/test/433ae0ba96204181",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/wafv2.AssociateWebACL_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/wafv2.AssociateWebACL_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/wafv2.ListResourcesForWebACL_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/wafv2.ListResourcesForWebACL_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceArns": [
+            "arn:aws:elasticloadbalancing:us-east-1:123456789123:loadbalancer/app/test/433ae0ba96204181"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_appelb_wafv2_regex_multiple_webacl_match/wafv2.ListWebACLs_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "NextMarker": "791f9fc9-16bb-4d32-8f6a-b55e9b6f11c8",
+        "WebACLs": [
+            {
+                "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+                "ARN": "arn:aws:wafv2:us-east-1:123456789123:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            },
+            {
+                "Id": "3c5f3db9-04c1-47f4-a6ab-23b70a3a8509",
+                "Name": "FMManagedWebACLV2-FMS-TEST2-1656966576062",
+                "ARN": "arn:aws:wafv2:us-east-1:123456789123:regional/webacl/FMManagedWebACLV2-FMS-TEST2-1656966576062/3c5f3db9-04c1-47f4-a6ab-23b70a3a8509"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex/cloudfront.GetDistributionConfig_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex/cloudfront.GetDistributionConfig_1.json
@@ -1,0 +1,113 @@
+{
+    "status_code": 200,
+    "data": {
+        "ETag": "EIZMGDN1LXJRI",
+        "DistributionConfig": {
+            "Comment": "",
+            "CacheBehaviors": {
+                "Quantity": 0
+            },
+            "IsIPV6Enabled": true,
+            "Logging": {
+                "Bucket": "",
+                "Prefix": "",
+                "Enabled": false,
+                "IncludeCookies": false
+            },
+            "WebACLId": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+            "Origins": {
+                "Items": [
+                    {
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "Id": "S3-sns-notify-test",
+                        "DomainName": "sns-notify-test.s3.amazonaws.com"
+                    }
+                ],
+                "Quantity": 1
+            },
+            "DefaultRootObject": "",
+            "PriceClass": "PriceClass_All",
+            "Enabled": true,
+            "DefaultCacheBehavior": {
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "TargetOriginId": "S3-sns-notify-test",
+                "ViewerProtocolPolicy": "allow-all",
+                "ForwardedValues": {
+                    "Headers": {
+                        "Quantity": 0
+                    },
+                    "Cookies": {
+                        "Forward": "none"
+                    },
+                    "QueryStringCacheKeys": {
+                        "Quantity": 0
+                    },
+                    "QueryString": false
+                },
+                "MaxTTL": 31536000,
+                "SmoothStreaming": false,
+                "DefaultTTL": 86400,
+                "AllowedMethods": {
+                    "Items": [
+                        "HEAD",
+                        "GET"
+                    ],
+                    "CachedMethods": {
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ],
+                        "Quantity": 2
+                    },
+                    "Quantity": 2
+                },
+                "MinTTL": 0,
+                "Compress": false
+            },
+            "CallerReference": "1499952607732",
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": true,
+                "MinimumProtocolVersion": "TLSv1",
+                "CertificateSource": "cloudfront"
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
+            "HttpVersion": "http2",
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "none",
+                    "Quantity": 0
+                }
+            },
+            "Aliases": {
+                "Quantity": 0
+            }
+        },
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "0755e5c5-a9c9-11e7-82fd-ed12cccaa8d8",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0755e5c5-a9c9-11e7-82fd-ed12cccaa8d8",
+                "content-length": "2180",
+                "vary": "Accept-Encoding",
+                "etag": "EIZMGDN1LXJRI",
+                "date": "Thu, 05 Oct 2017 12:30:53 GMT",
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex/cloudfront.ListDistributions_1.json
@@ -1,0 +1,281 @@
+{
+    "status_code": 200,
+    "data": {
+        "DistributionList": {
+            "Marker": "",
+            "Items": [
+                {
+                    "Status": "Deployed",
+                    "CacheBehaviors": {
+                        "Quantity": 0
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "Origins": {
+                        "Items": [
+                            {
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": ""
+                                },
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "Id": "S3-sns-notify-test",
+                                "DomainName": "sns-notify-test.s3.amazonaws.com"
+                            }
+                        ],
+                        "Quantity": 1
+                    },
+                    "DomainName": "d3naej5h8q7gej.cloudfront.net",
+                    "WebACLId": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": true,
+                    "DefaultCacheBehavior": {
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "TargetOriginId": "S3-sns-notify-test",
+                        "ViewerProtocolPolicy": "allow-all",
+                        "ForwardedValues": {
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            },
+                            "QueryString": false
+                        },
+                        "MaxTTL": 31536000,
+                        "SmoothStreaming": false,
+                        "DefaultTTL": 86400,
+                        "AllowedMethods": {
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ],
+                                "Quantity": 2
+                            },
+                            "Quantity": 2
+                        },
+                        "MinTTL": 0,
+                        "Compress": false
+                    },
+                    "IsIPV6Enabled": true,
+                    "Comment": "",
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "LastModifiedTime": {
+                        "hour": 13,
+                        "__class__": "datetime",
+                        "month": 7,
+                        "second": 8,
+                        "microsecond": 399000,
+                        "year": 2017,
+                        "day": 13,
+                        "minute": 30
+                    },
+                    "HttpVersion": "HTTP2",
+                    "Id": "E53370FUHBNLK",
+                    "ARN": "arn:aws:cloudfront::012345678912:distribution/E53370FUHBNLK",
+                    "Aliases": {
+                        "Quantity": 0
+                    }
+                },
+                {
+                    "Status": "Deployed",
+                    "CacheBehaviors": {
+                        "Items": [
+                            {
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "TargetOriginId": "Custom-google.com",
+                                "ViewerProtocolPolicy": "allow-all",
+                                "ForwardedValues": {
+                                    "Headers": {
+                                        "Quantity": 0
+                                    },
+                                    "Cookies": {
+                                        "Forward": "none"
+                                    },
+                                    "QueryStringCacheKeys": {
+                                        "Quantity": 0
+                                    },
+                                    "QueryString": false
+                                },
+                                "MaxTTL": 31536000,
+                                "PathPattern": "sadf",
+                                "SmoothStreaming": false,
+                                "DefaultTTL": 86400,
+                                "AllowedMethods": {
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ],
+                                    "CachedMethods": {
+                                        "Items": [
+                                            "HEAD",
+                                            "GET"
+                                        ],
+                                        "Quantity": 2
+                                    },
+                                    "Quantity": 2
+                                },
+                                "MinTTL": 0,
+                                "Compress": false
+                            }
+                        ],
+                        "Quantity": 1
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "Origins": {
+                        "Items": [
+                            {
+                                "OriginPath": "",
+                                "CustomOriginConfig": {
+                                    "OriginSslProtocols": {
+                                        "Items": [
+                                            "TLSv1.1",
+                                            "TLSv1.2"
+                                        ],
+                                        "Quantity": 2
+                                    },
+                                    "OriginProtocolPolicy": "http-only",
+                                    "OriginReadTimeout": 30,
+                                    "HTTPPort": 80,
+                                    "HTTPSPort": 443,
+                                    "OriginKeepaliveTimeout": 5
+                                },
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "Id": "Custom-google.com",
+                                "DomainName": "google.com"
+                            }
+                        ],
+                        "Quantity": 1
+                    },
+                    "DomainName": "d34vi31c0msjue.cloudfront.net",
+                    "WebACLId": "",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": true,
+                    "DefaultCacheBehavior": {
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "TargetOriginId": "Custom-google.com",
+                        "ViewerProtocolPolicy": "https-only",
+                        "ForwardedValues": {
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            },
+                            "QueryString": false
+                        },
+                        "MaxTTL": 31536000,
+                        "SmoothStreaming": false,
+                        "DefaultTTL": 86400,
+                        "AllowedMethods": {
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ],
+                                "Quantity": 2
+                            },
+                            "Quantity": 2
+                        },
+                        "MinTTL": 0,
+                        "Compress": false
+                    },
+                    "IsIPV6Enabled": true,
+                    "Comment": "",
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "LastModifiedTime": {
+                        "hour": 18,
+                        "__class__": "datetime",
+                        "month": 9,
+                        "second": 38,
+                        "microsecond": 66000,
+                        "year": 2017,
+                        "day": 21,
+                        "minute": 13
+                    },
+                    "HttpVersion": "HTTP2",
+                    "Id": "EX42KVJ3ATGH",
+                    "ARN": "arn:aws:cloudfront::012345678912:distribution/EX42KVJ3ATGH",
+                    "Aliases": {
+                        "Quantity": 0
+                    }
+                }
+            ],
+            "IsTruncated": false,
+            "MaxItems": 100,
+            "Quantity": 2
+        },
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "05a7e864-a9c9-11e7-b379-c16d51d99c4d",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "05a7e864-a9c9-11e7-b379-c16d51d99c4d",
+                "vary": "Accept-Encoding",
+                "content-length": "5686",
+                "content-type": "text/xml",
+                "date": "Thu, 05 Oct 2017 12:30:50 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex/cloudfront.UpdateDistribution_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex/cloudfront.UpdateDistribution_1.json
@@ -1,0 +1,134 @@
+{
+    "status_code": 200,
+    "data": {
+        "Distribution": {
+            "Status": "InProgress",
+            "DomainName": "d3naej5h8q7gej.cloudfront.net",
+            "InProgressInvalidationBatches": 0,
+            "DistributionConfig": {
+                "Comment": "",
+                "CacheBehaviors": {
+                    "Quantity": 0
+                },
+                "IsIPV6Enabled": true,
+                "Logging": {
+                    "Bucket": "",
+                    "Prefix": "",
+                    "Enabled": false,
+                    "IncludeCookies": false
+                },
+                "WebACLId": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Origins": {
+                    "Items": [
+                        {
+                            "S3OriginConfig": {
+                                "OriginAccessIdentity": ""
+                            },
+                            "OriginPath": "",
+                            "CustomHeaders": {
+                                "Quantity": 0
+                            },
+                            "Id": "S3-sns-notify-test",
+                            "DomainName": "sns-notify-test.s3.amazonaws.com"
+                        }
+                    ],
+                    "Quantity": 1
+                },
+                "DefaultRootObject": "",
+                "PriceClass": "PriceClass_All",
+                "Enabled": true,
+                "DefaultCacheBehavior": {
+                    "TrustedSigners": {
+                        "Enabled": false,
+                        "Quantity": 0
+                    },
+                    "LambdaFunctionAssociations": {
+                        "Quantity": 0
+                    },
+                    "TargetOriginId": "S3-sns-notify-test",
+                    "ViewerProtocolPolicy": "allow-all",
+                    "ForwardedValues": {
+                        "Headers": {
+                            "Quantity": 0
+                        },
+                        "Cookies": {
+                            "Forward": "none"
+                        },
+                        "QueryStringCacheKeys": {
+                            "Quantity": 0
+                        },
+                        "QueryString": false
+                    },
+                    "MaxTTL": 31536000,
+                    "SmoothStreaming": false,
+                    "DefaultTTL": 86400,
+                    "AllowedMethods": {
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ],
+                        "CachedMethods": {
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "Quantity": 2
+                        },
+                        "Quantity": 2
+                    },
+                    "MinTTL": 0,
+                    "Compress": false
+                },
+                "CallerReference": "1499952607732",
+                "ViewerCertificate": {
+                    "CloudFrontDefaultCertificate": true,
+                    "MinimumProtocolVersion": "TLSv1",
+                    "CertificateSource": "cloudfront"
+                },
+                "CustomErrorResponses": {
+                    "Quantity": 0
+                },
+                "HttpVersion": "http2",
+                "Restrictions": {
+                    "GeoRestriction": {
+                        "RestrictionType": "none",
+                        "Quantity": 0
+                    }
+                },
+                "Aliases": {
+                    "Quantity": 0
+                }
+            },
+            "ActiveTrustedSigners": {
+                "Enabled": false,
+                "Quantity": 0
+            },
+            "LastModifiedTime": {
+                "hour": 12,
+                "__class__": "datetime",
+                "month": 10,
+                "second": 53,
+                "microsecond": 843000,
+                "year": 2017,
+                "day": 5,
+                "minute": 30
+            },
+            "Id": "E53370FUHBNLK",
+            "ARN": "arn:aws:cloudfront::012345678912:distribution/E53370FUHBNLK"
+        },
+        "ETag": "E12XBCJWKPGMKF",
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "0772e3a8-a9c9-11e7-82fd-ed12cccaa8d8",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0772e3a8-a9c9-11e7-82fd-ed12cccaa8d8",
+                "content-length": "2634",
+                "vary": "Accept-Encoding",
+                "etag": "E12XBCJWKPGMKF",
+                "date": "Thu, 05 Oct 2017 12:30:53 GMT",
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PaginationToken": "", 
+        "ResourceTagMappingList": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "05d75c18-a9c9-11e7-a028-2f7bd19c01f1", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "05d75c18-a9c9-11e7-a028-2f7bd19c01f1", 
+                "date": "Thu, 05 Oct 2017 12:30:50 GMT", 
+                "content-length": "50", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex/tagging.GetResources_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PaginationToken": "", 
+        "ResourceTagMappingList": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "08a6d06e-a9c9-11e7-bbe7-91ba2b470183", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "08a6d06e-a9c9-11e7-bbe7-91ba2b470183", 
+                "date": "Thu, 05 Oct 2017 12:30:55 GMT", 
+                "content-length": "50", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex/wafv2.GetWebACL_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex/wafv2.GetWebACL_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "WebACL": {
+            "DefaultAction": {
+                "Type": "BLOCK"
+            },
+            "Rules": [],
+            "MetricName": "test2",
+            "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+            "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+            "ARN": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+            "Description": "FMManagedWebACLV2-FMS-TEST-1656966584517"
+        },
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "0631b12c-a9c9-11e7-b1a6-170ff8aa22cc",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0631b12c-a9c9-11e7-b1a6-170ff8aa22cc",
+                "date": "Thu, 05 Oct 2017 12:30:51 GMT",
+                "content-length": "141",
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex/wafv2.ListWebACLs_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200,
+    "data": {
+        "NextMarker": "1ebe0b46-0fd2-4e07-a74c-27bf25adc0bf",
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "05ff3012-a9c9-11e7-8af9-c510054683ae",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "05ff3012-a9c9-11e7-8af9-c510054683ae",
+                "date": "Thu, 05 Oct 2017 12:30:50 GMT",
+                "content-length": "131",
+                "content-type": "application/x-amz-json-1.1"
+            }
+        },
+        "WebACLs": [
+            {
+                "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+                "ARN": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/cloudfront.GetDistributionConfig_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/cloudfront.GetDistributionConfig_1.json
@@ -1,0 +1,113 @@
+{
+    "status_code": 200,
+    "data": {
+        "ETag": "EIZMGDN1LXJRI",
+        "DistributionConfig": {
+            "Comment": "",
+            "CacheBehaviors": {
+                "Quantity": 0
+            },
+            "IsIPV6Enabled": true,
+            "Logging": {
+                "Bucket": "",
+                "Prefix": "",
+                "Enabled": false,
+                "IncludeCookies": false
+            },
+            "WebACLId": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+            "Origins": {
+                "Items": [
+                    {
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "Id": "S3-sns-notify-test",
+                        "DomainName": "sns-notify-test.s3.amazonaws.com"
+                    }
+                ],
+                "Quantity": 1
+            },
+            "DefaultRootObject": "",
+            "PriceClass": "PriceClass_All",
+            "Enabled": true,
+            "DefaultCacheBehavior": {
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "TargetOriginId": "S3-sns-notify-test",
+                "ViewerProtocolPolicy": "allow-all",
+                "ForwardedValues": {
+                    "Headers": {
+                        "Quantity": 0
+                    },
+                    "Cookies": {
+                        "Forward": "none"
+                    },
+                    "QueryStringCacheKeys": {
+                        "Quantity": 0
+                    },
+                    "QueryString": false
+                },
+                "MaxTTL": 31536000,
+                "SmoothStreaming": false,
+                "DefaultTTL": 86400,
+                "AllowedMethods": {
+                    "Items": [
+                        "HEAD",
+                        "GET"
+                    ],
+                    "CachedMethods": {
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ],
+                        "Quantity": 2
+                    },
+                    "Quantity": 2
+                },
+                "MinTTL": 0,
+                "Compress": false
+            },
+            "CallerReference": "1499952607732",
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": true,
+                "MinimumProtocolVersion": "TLSv1",
+                "CertificateSource": "cloudfront"
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
+            "HttpVersion": "http2",
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "none",
+                    "Quantity": 0
+                }
+            },
+            "Aliases": {
+                "Quantity": 0
+            }
+        },
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "0755e5c5-a9c9-11e7-82fd-ed12cccaa8d8",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0755e5c5-a9c9-11e7-82fd-ed12cccaa8d8",
+                "content-length": "2180",
+                "vary": "Accept-Encoding",
+                "etag": "EIZMGDN1LXJRI",
+                "date": "Thu, 05 Oct 2017 12:30:53 GMT",
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/cloudfront.ListDistributions_1.json
@@ -1,0 +1,281 @@
+{
+    "status_code": 200,
+    "data": {
+        "DistributionList": {
+            "Marker": "",
+            "Items": [
+                {
+                    "Status": "Deployed",
+                    "CacheBehaviors": {
+                        "Quantity": 0
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "Origins": {
+                        "Items": [
+                            {
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": ""
+                                },
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "Id": "S3-sns-notify-test",
+                                "DomainName": "sns-notify-test.s3.amazonaws.com"
+                            }
+                        ],
+                        "Quantity": 1
+                    },
+                    "DomainName": "d3naej5h8q7gej.cloudfront.net",
+                    "WebACLId": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": true,
+                    "DefaultCacheBehavior": {
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "TargetOriginId": "S3-sns-notify-test",
+                        "ViewerProtocolPolicy": "allow-all",
+                        "ForwardedValues": {
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            },
+                            "QueryString": false
+                        },
+                        "MaxTTL": 31536000,
+                        "SmoothStreaming": false,
+                        "DefaultTTL": 86400,
+                        "AllowedMethods": {
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ],
+                                "Quantity": 2
+                            },
+                            "Quantity": 2
+                        },
+                        "MinTTL": 0,
+                        "Compress": false
+                    },
+                    "IsIPV6Enabled": true,
+                    "Comment": "",
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "LastModifiedTime": {
+                        "hour": 13,
+                        "__class__": "datetime",
+                        "month": 7,
+                        "second": 8,
+                        "microsecond": 399000,
+                        "year": 2017,
+                        "day": 13,
+                        "minute": 30
+                    },
+                    "HttpVersion": "HTTP2",
+                    "Id": "E53370FUHBNLK",
+                    "ARN": "arn:aws:cloudfront::012345678912:distribution/E53370FUHBNLK",
+                    "Aliases": {
+                        "Quantity": 0
+                    }
+                },
+                {
+                    "Status": "Deployed",
+                    "CacheBehaviors": {
+                        "Items": [
+                            {
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "TargetOriginId": "Custom-google.com",
+                                "ViewerProtocolPolicy": "allow-all",
+                                "ForwardedValues": {
+                                    "Headers": {
+                                        "Quantity": 0
+                                    },
+                                    "Cookies": {
+                                        "Forward": "none"
+                                    },
+                                    "QueryStringCacheKeys": {
+                                        "Quantity": 0
+                                    },
+                                    "QueryString": false
+                                },
+                                "MaxTTL": 31536000,
+                                "PathPattern": "sadf",
+                                "SmoothStreaming": false,
+                                "DefaultTTL": 86400,
+                                "AllowedMethods": {
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ],
+                                    "CachedMethods": {
+                                        "Items": [
+                                            "HEAD",
+                                            "GET"
+                                        ],
+                                        "Quantity": 2
+                                    },
+                                    "Quantity": 2
+                                },
+                                "MinTTL": 0,
+                                "Compress": false
+                            }
+                        ],
+                        "Quantity": 1
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "Origins": {
+                        "Items": [
+                            {
+                                "OriginPath": "",
+                                "CustomOriginConfig": {
+                                    "OriginSslProtocols": {
+                                        "Items": [
+                                            "TLSv1.1",
+                                            "TLSv1.2"
+                                        ],
+                                        "Quantity": 2
+                                    },
+                                    "OriginProtocolPolicy": "http-only",
+                                    "OriginReadTimeout": 30,
+                                    "HTTPPort": 80,
+                                    "HTTPSPort": 443,
+                                    "OriginKeepaliveTimeout": 5
+                                },
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "Id": "Custom-google.com",
+                                "DomainName": "google.com"
+                            }
+                        ],
+                        "Quantity": 1
+                    },
+                    "DomainName": "d34vi31c0msjue.cloudfront.net",
+                    "WebACLId": "",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": true,
+                    "DefaultCacheBehavior": {
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "TargetOriginId": "Custom-google.com",
+                        "ViewerProtocolPolicy": "https-only",
+                        "ForwardedValues": {
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            },
+                            "QueryString": false
+                        },
+                        "MaxTTL": 31536000,
+                        "SmoothStreaming": false,
+                        "DefaultTTL": 86400,
+                        "AllowedMethods": {
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ],
+                                "Quantity": 2
+                            },
+                            "Quantity": 2
+                        },
+                        "MinTTL": 0,
+                        "Compress": false
+                    },
+                    "IsIPV6Enabled": true,
+                    "Comment": "",
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "LastModifiedTime": {
+                        "hour": 18,
+                        "__class__": "datetime",
+                        "month": 9,
+                        "second": 38,
+                        "microsecond": 66000,
+                        "year": 2017,
+                        "day": 21,
+                        "minute": 13
+                    },
+                    "HttpVersion": "HTTP2",
+                    "Id": "EX42KVJ3ATGH",
+                    "ARN": "arn:aws:cloudfront::012345678912:distribution/EX42KVJ3ATGH",
+                    "Aliases": {
+                        "Quantity": 0
+                    }
+                }
+            ],
+            "IsTruncated": false,
+            "MaxItems": 100,
+            "Quantity": 2
+        },
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "05a7e864-a9c9-11e7-b379-c16d51d99c4d",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "05a7e864-a9c9-11e7-b379-c16d51d99c4d",
+                "vary": "Accept-Encoding",
+                "content-length": "5686",
+                "content-type": "text/xml",
+                "date": "Thu, 05 Oct 2017 12:30:50 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/cloudfront.UpdateDistribution_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/cloudfront.UpdateDistribution_1.json
@@ -1,0 +1,134 @@
+{
+    "status_code": 200,
+    "data": {
+        "Distribution": {
+            "Status": "InProgress",
+            "DomainName": "d3naej5h8q7gej.cloudfront.net",
+            "InProgressInvalidationBatches": 0,
+            "DistributionConfig": {
+                "Comment": "",
+                "CacheBehaviors": {
+                    "Quantity": 0
+                },
+                "IsIPV6Enabled": true,
+                "Logging": {
+                    "Bucket": "",
+                    "Prefix": "",
+                    "Enabled": false,
+                    "IncludeCookies": false
+                },
+                "WebACLId": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Origins": {
+                    "Items": [
+                        {
+                            "S3OriginConfig": {
+                                "OriginAccessIdentity": ""
+                            },
+                            "OriginPath": "",
+                            "CustomHeaders": {
+                                "Quantity": 0
+                            },
+                            "Id": "S3-sns-notify-test",
+                            "DomainName": "sns-notify-test.s3.amazonaws.com"
+                        }
+                    ],
+                    "Quantity": 1
+                },
+                "DefaultRootObject": "",
+                "PriceClass": "PriceClass_All",
+                "Enabled": true,
+                "DefaultCacheBehavior": {
+                    "TrustedSigners": {
+                        "Enabled": false,
+                        "Quantity": 0
+                    },
+                    "LambdaFunctionAssociations": {
+                        "Quantity": 0
+                    },
+                    "TargetOriginId": "S3-sns-notify-test",
+                    "ViewerProtocolPolicy": "allow-all",
+                    "ForwardedValues": {
+                        "Headers": {
+                            "Quantity": 0
+                        },
+                        "Cookies": {
+                            "Forward": "none"
+                        },
+                        "QueryStringCacheKeys": {
+                            "Quantity": 0
+                        },
+                        "QueryString": false
+                    },
+                    "MaxTTL": 31536000,
+                    "SmoothStreaming": false,
+                    "DefaultTTL": 86400,
+                    "AllowedMethods": {
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ],
+                        "CachedMethods": {
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "Quantity": 2
+                        },
+                        "Quantity": 2
+                    },
+                    "MinTTL": 0,
+                    "Compress": false
+                },
+                "CallerReference": "1499952607732",
+                "ViewerCertificate": {
+                    "CloudFrontDefaultCertificate": true,
+                    "MinimumProtocolVersion": "TLSv1",
+                    "CertificateSource": "cloudfront"
+                },
+                "CustomErrorResponses": {
+                    "Quantity": 0
+                },
+                "HttpVersion": "http2",
+                "Restrictions": {
+                    "GeoRestriction": {
+                        "RestrictionType": "none",
+                        "Quantity": 0
+                    }
+                },
+                "Aliases": {
+                    "Quantity": 0
+                }
+            },
+            "ActiveTrustedSigners": {
+                "Enabled": false,
+                "Quantity": 0
+            },
+            "LastModifiedTime": {
+                "hour": 12,
+                "__class__": "datetime",
+                "month": 10,
+                "second": 53,
+                "microsecond": 843000,
+                "year": 2017,
+                "day": 5,
+                "minute": 30
+            },
+            "Id": "E53370FUHBNLK",
+            "ARN": "arn:aws:cloudfront::012345678912:distribution/E53370FUHBNLK"
+        },
+        "ETag": "E12XBCJWKPGMKF",
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "0772e3a8-a9c9-11e7-82fd-ed12cccaa8d8",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0772e3a8-a9c9-11e7-82fd-ed12cccaa8d8",
+                "content-length": "2634",
+                "vary": "Accept-Encoding",
+                "etag": "E12XBCJWKPGMKF",
+                "date": "Thu, 05 Oct 2017 12:30:53 GMT",
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PaginationToken": "", 
+        "ResourceTagMappingList": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "05d75c18-a9c9-11e7-a028-2f7bd19c01f1", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "05d75c18-a9c9-11e7-a028-2f7bd19c01f1", 
+                "date": "Thu, 05 Oct 2017 12:30:50 GMT", 
+                "content-length": "50", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/tagging.GetResources_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PaginationToken": "", 
+        "ResourceTagMappingList": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "08a6d06e-a9c9-11e7-bbe7-91ba2b470183", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "08a6d06e-a9c9-11e7-bbe7-91ba2b470183", 
+                "date": "Thu, 05 Oct 2017 12:30:55 GMT", 
+                "content-length": "50", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/wafv2.GetWebACL_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/wafv2.GetWebACL_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "WebACL": {
+            "DefaultAction": {
+                "Type": "BLOCK"
+            },
+            "Rules": [],
+            "MetricName": "test2",
+            "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+            "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+            "ARN": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406",
+            "Description": "FMManagedWebACLV2-FMS-TEST-1656966584517"
+        },
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "0631b12c-a9c9-11e7-b1a6-170ff8aa22cc",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0631b12c-a9c9-11e7-b1a6-170ff8aa22cc",
+                "date": "Thu, 05 Oct 2017 12:30:51 GMT",
+                "content-length": "141",
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_regex_multiple_webacl_match/wafv2.ListWebACLs_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "NextMarker": "1ebe0b46-0fd2-4e07-a74c-27bf25adc0bf",
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "05ff3012-a9c9-11e7-8af9-c510054683ae",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "05ff3012-a9c9-11e7-8af9-c510054683ae",
+                "date": "Thu, 05 Oct 2017 12:30:50 GMT",
+                "content-length": "131",
+                "content-type": "application/x-amz-json-1.1"
+            }
+        },
+        "WebACLs": [
+            {
+                "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+                "ARN": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            },
+            {
+                "Id": "3c5f3db9-04c1-47f4-a6ab-23b70a3a8509",
+                "Name": "FMManagedWebACLV2-FMS-TEST2-1656966576062",
+                "ARN": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST2-1656966576062/3c5f3db9-04c1-47f4-a6ab-23b70a3a8509"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This PR is to support Firewall Manager deployed WebACLs.

```
- FMManagedWebACL name/arn vary by account, region → can overcome using regex
- Still using "web-acl" but now can use regex expression. 
- When detaching WAF, "web-acl" is not required
- Used self.retry to overcome Throttling, etc
```