### PR TITLE
aws - augment resources with model data

### DIFF
--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -123,6 +123,17 @@ class ResourceManager:
         """
         return self.query.resolve(self.resource_type)
 
+    def model_augment(self, resources):
+        """Add resource-level model metadata to resource records"""
+        model = self.get_model()
+        for r in resources:
+            r["c7n:resource-model"] = {
+                "arn": r[model.arn] if model.arn else self.generate_arn(r[model.id]),
+                "id": r[model.id],
+                "name": r[model.name],
+            }
+        return resources
+
     def iter_filters(self, block_end=False):
         return iter_filters(self.filters, block_end=block_end)
 

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -134,12 +134,12 @@ class ResourceManager:
             return r[model.arn] or self.generate_arn(resource[model.id])
 
         for r in resources:
-
             r["c7n:resource-model"] = {
                 "arn": _get_arn(model, r),
                 "id": r[model.id],
                 "name": r[model.name],
             }
+
         return resources
 
     def iter_filters(self, block_end=False):

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -129,15 +129,21 @@ class ResourceManager:
 
         def _get_arn(model, resource):
             """Get or generate a resource ARN, if applicable"""
-            if not self.has_arn():
-                return None
-            return r[model.arn] or self.generate_arn(resource[model.id])
+            if model.arn:
+                return r.get(model.arn)
+            if self.has_arn() and model.id in resource:
+                return self.generate_arn(resource[model.id])
+            # It's not possible to get or generate an ARN for
+            # this resource. Explicitly return None.
+            return None
 
         for r in resources:
+            if not isinstance(r, dict):
+                continue
             r["c7n:resource-model"] = {
                 "arn": _get_arn(model, r),
-                "id": r[model.id],
-                "name": r[model.name],
+                "id": r.get(model.id),
+                "name": r.get(model.name),
             }
 
         return resources

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -126,9 +126,17 @@ class ResourceManager:
     def model_augment(self, resources):
         """Add resource-level model metadata to resource records"""
         model = self.get_model()
+
+        def _get_arn(model, resource):
+            """Get or generate a resource ARN, if applicable"""
+            if not self.has_arn():
+                return None
+            return r[model.arn] or self.generate_arn(resource[model.id])
+
         for r in resources:
+
             r["c7n:resource-model"] = {
-                "arn": r[model.arn] if model.arn else self.generate_arn(r[model.id]),
+                "arn": _get_arn(model, r),
                 "id": r[model.id],
                 "name": r[model.name],
             }


### PR DESCRIPTION
The custodian resource model defines a standard set of attributes per resource type. It may be helpful to expose that data as an annotation so that:

* Policies can use consistent keys to look up properties like a resource's ID, ARN or Name
* The ARN is consistently available even if it isn't exposed today via existing list/describe/augment logic

The proposal here is to add a `c7n:resource-model` annotation for each resource. In practice it might look like this for an EC2 instance:

```json
{
    "InstanceId": "i-ef700b7bdc405964c",
    "PublicDnsName": "ec2-54-174-90-116.us-west-2.compute.amazonaws.com",
    "PublicIpAddress": "54.174.90.116",
    "and more fields": "but then...",
    "c7n:resource-model": {
        "arn": "arn:aws:ec2:us-west-2:123456789012:instance/i-ef700b7bdc405964c",
        "id": "i-ef700b7bdc405964c",
        "name": "ec2-54-174-90-116.us-west-2.compute.amazonaws.com"
    }
}
``` 

This would need some docs and testing, at the moment this is more of a proposal and sample implementation.

Addresses #7686 