### PR TITLE
offhour - support GCP resources with escaped label

### DIFF
--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -204,6 +204,7 @@ used in opt-in mode, not opt-out.
 
 Another option is to escape the tag value with the following mapping, generated
 with the char's unicode number `"u" + hex(ord(the_char))[2:]`.
+This works for GCP resources as well.
 
 - ( and ) as u28 and u29
 - [ and ] as u5b and u5d

--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -209,11 +209,13 @@ with the char's unicode number `"u" + hex(ord(the_char))[2:]`.
 - [ and ] as u5b and u5d
 - , as u2c
 - ; as u3b
+- = as u3d
+- / as u2f
 
 **Examples**::
 
     # off=(M-F,18);tz=Australia/Sydney
-    off=u28M-Fu2c18u29u3btz=Australia/Sydney
+    offu3du28M-Fu2c18u29u3btzu3dAustraliau2fSydney
     # off=[(M-F,18),(S,13)]
     off=u5bu28M-Fu2c18u29u2cu28Su2c13u29u5d
 
@@ -323,8 +325,8 @@ class Time(Filter):
         'nzst': 'Pacific/Auckland',
         'utc': 'Etc/UTC',
     }
-    TAG_RESTRICTIONS = ["(", ")", "[", "]", ",", ";"]
-    # mapping to ['u28', 'u29', 'u5b', 'u5d', 'u2c', 'u3b']
+    TAG_RESTRICTIONS = ["(", ")", "[", "]", ",", ";", "=", "/"]
+    # mapping to ['u28', 'u29', 'u5b', 'u5d', 'u2c', 'u3b', 'u3d', 'u2f']
     TAG_RESTRICTIONS_ESCAPE = ["u" + hex(ord(c))[2:] for c in TAG_RESTRICTIONS]
 
     z_names = list(zoneinfo.get_zonefile_instance().zones)
@@ -470,6 +472,9 @@ class Time(Filter):
             if t['Key'].lower() == self.tag_key:
                 found = t['Value']
                 break
+        # NOTE for GCP resources, eg sql-instance
+        if found == self.fallback_schedule and 'labels' in i:
+            found = i.get('labels', {}).get(self.tag_key) or found
         if found in (False, None):
             return False
         # enforce utf8, or do translate tables via unicode ord mapping

--- a/tools/c7n_gcp/c7n_gcp/resources/compute.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/compute.py
@@ -53,18 +53,8 @@ class Instance(QueryResourceManager):
                     }}
 
 
-@Instance.filter_registry.register('offhour')
-class InstanceOffHour(OffHour):
-
-    def get_tag_value(self, instance):
-        return instance.get('labels', {}).get(self.tag_key, False)
-
-
-@Instance.filter_registry.register('onhour')
-class InstanceOnHour(OnHour):
-
-    def get_tag_value(self, instance):
-        return instance.get('labels', {}).get(self.tag_key, False)
+Instance.filter_registry.register('offhour', OffHour)
+Instance.filter_registry.register('onhour', OnHour)
 
 
 @Instance.filter_registry.register('effective-firewall')

--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -5,6 +5,7 @@ import jmespath
 import re
 
 from c7n.utils import type_schema
+from c7n.filters.offhours import OffHour, OnHour
 from c7n_gcp.actions import MethodAction
 from c7n_gcp.provider import resources
 from c7n_gcp.query import (
@@ -62,6 +63,10 @@ class SqlInstance(QueryResourceManager):
             if 'userLabels' in r['settings']:
                 r['labels'] = r['settings']['userLabels']
         return resources
+
+
+SqlInstance.filter_registry.register('offhour', OffHour)
+SqlInstance.filter_registry.register('onhour', OnHour)
 
 
 class SqlInstanceAction(MethodAction):

--- a/tools/c7n_gcp/tests/data/flights/sqlinstance-offhour/get-sql-v1beta4-projects-cloud-custodian-instances_1.json
+++ b/tools/c7n_gcp/tests/data/flights/sqlinstance-offhour/get-sql-v1beta4-projects-cloud-custodian-instances_1.json
@@ -1,0 +1,102 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 01 Sep 2022 02:26:55 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "4281",
+    "-content-encoding": "gzip",
+    "content-location": "https://sqladmin.googleapis.com/sql/v1beta4/projects/cloud-custodian/instances?alt=json"
+  },
+  "body": {
+    "items": [
+      {
+        "kind": "sql#instance",
+        "state": "RUNNABLE",
+        "databaseVersion": "MYSQL_8_0",
+        "settings": {
+          "authorizedGaeApplications": [],
+          "tier": "db-f1-micro",
+          "kind": "sql#settings",
+          "userLabels": {
+            "custodian_onhours": "onu3du28m-fu2c11u29u3btzu3daustraliau2fsydney",
+            "custodian_offhours": "offu3du28m-fu2c02u29u3btzu3dutc"
+          },
+          "availabilityType": "ZONAL",
+          "pricingPlan": "PER_USE",
+          "replicationType": "SYNCHRONOUS",
+          "activationPolicy": "ALWAYS",
+          "ipConfiguration": {
+            "privateNetwork": "projects/cloud-custodian/global/networks/kent-testing-vpc",
+            "authorizedNetworks": [],
+            "ipv4Enabled": false
+          },
+          "locationPreference": {
+            "zone": "us-central1-c",
+            "kind": "sql#locationPreference"
+          },
+          "dataDiskType": "PD_SSD",
+          "maintenanceWindow": {
+            "updateTrack": "stable",
+            "kind": "sql#maintenanceWindow",
+            "hour": 0,
+            "day": 0
+          },
+          "backupConfiguration": {
+            "startTime": "06:00",
+            "kind": "sql#backupConfiguration",
+            "location": "us",
+            "backupRetentionSettings": {
+              "retentionUnit": "COUNT",
+              "retainedBackups": 7
+            },
+            "enabled": true,
+            "binaryLogEnabled": true,
+            "transactionLogRetentionDays": 7
+          },
+          "connectorEnforcement": "NOT_REQUIRED",
+          "settingsVersion": "3",
+          "storageAutoResizeLimit": "0",
+          "storageAutoResize": true,
+          "dataDiskSizeGb": "10",
+          "deletionProtectionEnabled": true
+        },
+        "etag": "beaa44e8aaa58edb500fa024aae4ca0207628fc6d3063d634b15eb3df2015652",
+        "ipAddresses": [
+          {
+            "type": "PRIVATE",
+            "ipAddress": "10.210.0.3"
+          }
+        ],
+        "serverCaCert": {
+          "kind": "sql#sslCert",
+          "certSerialNumber": "0",
+          "cert": "-----BEGIN CERTIFICATE-----\nMVmaHw55nXHmH2N1G7P0Ro4RDnP3SXOp+x70rELwErPxlei\nt6F5J004+ZgPkC1/LcUxZS0F5GGmn2MWjh5uWSwG6NwgiP7VzRppBCzNjkor4bgA\niOBTMA9nMBGVmDWfmIUP8XRGNXmpbSHtzZ9KcXh43SlCU7xUL7nQrRksJ/KT9r6t\nkE+N4PBQ7a8pOpEr6eoahRsuKMy72ckZCXckZx9pRHGTkTRV6CNtPh3NhvLLWhlX\nGKPkFZJHeez/nBfXWgMF50FZ7gF75IyXoIPOlZH0BdmNi96QL+VxK1Rb6Pye6Vjq\nZ+6uosotJrg21mVdfH0Z/gSpAgMBAAGjFjAUMBIGA1UdEwEB/wQIMAYBAf8CAQAw\nDQYJKoZIhvcNAQELBQADggEBAJaQXW/mb+rG5+d/2HpeDvpw0/4cZGQWY2Rt3Srr\nLMTJxULJADtINOE0nTdroaxTiSjpIai7QEW9tQsXS8ciw69kT+db6zBXI+BI64Ej\ntChIjsZ1rgWpKG2macXRmF6xbyUO+tqu8+DyEJFSkC1rQxXuiAlXwPnUbiRSEvgK\np+FY/CWq42MI4LjKPv6IFS9gbleY9N3ozVHgevQwuMM3yEn4w+ZO51Fu51x2Rm+W\nHBptVQByXIQI9PRXfXCTZewgJEk0Rf4m9oRmi06DNZl1gNF4JTBebaDe7qAojQ/B\nrfcBZtH0zxOLpM0sSycwqtFpA/GoS4fIOuzQylOaKuyWiLE=\n-----END CERTIFICATE-----",
+          "commonName": "C=US,O=Google\\, Inc,CN=Google Cloud SQL Server CA,dnQualifier=7557339c-fea2-448f-9370-2939f8b23783",
+          "sha1Fingerprint": "e4e35607e581870ee78995370d57777ad3b38e1e",
+          "instance": "kent-testing-sql",
+          "createTime": "2022-09-01T00:55:47.457Z",
+          "expirationTime": "2032-08-29T00:56:47.457Z"
+        },
+        "instanceType": "CLOUD_SQL_INSTANCE",
+        "project": "cloud-custodian",
+        "serviceAccountEmailAddress": "p300975412108-z85u3n@gcp-sa-cloud-sql.iam.gserviceaccount.com",
+        "backendType": "SECOND_GEN",
+        "selfLink": "https://sqladmin.googleapis.com/sql/v1beta4/projects/cloud-custodian/instances/kent-testing-sql",
+        "connectionName": "cloud-custodian:us-central1:kent-testing-sql",
+        "name": "kent-testing-sql",
+        "region": "us-central1",
+        "gceZone": "us-central1-c",
+        "databaseInstalledVersion": "MYSQL_8_0_26",
+        "createTime": "2022-09-01T00:52:41.788Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
1. Simplify the offhour coding for GCP resources
2. Support escaped `=` and `/`
3. Add `onhour` and `offhour` for GCP SQL Instance