### PR TITLE
gcp - build - query fix & resource_map cleanup

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/build.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/build.py
@@ -10,7 +10,7 @@ class CloudBuild(QueryResourceManager):
     class resource_type(TypeInfo):
         service = 'cloudbuild'
         version = 'v1'
-        component = 'projects.builds.list'
+        component = 'projects.builds'
         enum_spec = ('list', 'builds[]', None)
         scope = 'project'
         scope_key = 'projectId'

--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -10,7 +10,6 @@ ResourceMap = {
     "gcp.autoscaler": "c7n_gcp.resources.compute.Autoscaler",
     "gcp.bq-dataset": "c7n_gcp.resources.bigquery.DataSet",
     "gcp.bq-job": "c7n_gcp.resources.bigquery.BigQueryJob",
-    "gcp.bq-project": "c7n_gcp.resources.bigquery.BigQueryProject",
     "gcp.bq-table": "c7n_gcp.resources.bigquery.BigQueryTable",
     "gcp.bucket": "c7n_gcp.resources.storage.Bucket",
     "gcp.build": "c7n_gcp.resources.build.CloudBuild",


### PR DESCRIPTION
- `gcp.bq-project` was removed here https://github.com/cloud-custodian/cloud-custodian/pull/5873, but not removed from the map.
- `gcp.build` can't be queried - `component` is wrong - `list` is a method already specified under `enum_spec`.