### PR TITLE
aws - dynamodb - disable consecutive backups filter

### DIFF
--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -671,7 +671,6 @@ class DaxSubnetFilter(SubnetFilter):
         return super(DaxSubnetFilter, self).process(resources)
 
 
-@Table.filter_registry.register('consecutive-backups')
 class TableConsecutiveBackups(Filter):
     """Returns tables where number of consective daily backups is
     equal to/or greater than n days.

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -4,7 +4,10 @@ from .common import BaseTest
 import datetime
 from dateutil import tz as tzutil
 from unittest.mock import MagicMock
+from c7n.testing import mock_datetime_now
+from dateutil import parser
 
+import c7n.resources.dynamodb
 from c7n.resources.dynamodb import DeleteTable
 from c7n.executor import MainThreadExecutor
 
@@ -541,21 +544,21 @@ class DynamoDbAccelerator(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['TotalNodes'], 1)
 
-#   def test_dynamodb_consecutive_backup_count_filter(self):
-#       session_factory = self.replay_flight_data("test_dynamodb_consecutive_backup_count_filter")
-#       p = self.load_policy(
-#           {
-#               "name": "dynamodb_consecutive_backup_count_filter",
-#               "resource": "dynamodb-table",
-#               "filters": [
-#                   {
-#                       "type": "consecutive-backups",
-#                       "days": 2
-#                   }
-#               ]
-#           },
-#           session_factory=session_factory,
-#       )
-#       with mock_datetime_now(parser.parse("2022-08-31T00:00:00+00:00"), c7n.resources.dynamodb):
-#           resources = p.run()
-#       self.assertEqual(len(resources), 1)
+    def x_test_dynamodb_consecutive_backup_count_filter(self):
+        session_factory = self.replay_flight_data("test_dynamodb_consecutive_backup_count_filter")
+        p = self.load_policy(
+            {
+                "name": "dynamodb_consecutive_backup_count_filter",
+                "resource": "dynamodb-table",
+                "filters": [
+                    {
+                        "type": "consecutive-backups",
+                        "days": 2
+                    }
+                ]
+            },
+            session_factory=session_factory,
+        )
+        with mock_datetime_now(parser.parse("2022-08-31T00:00:00+00:00"), c7n.resources.dynamodb):
+            resources = p.run()
+        self.assertEqual(len(resources), 1)

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -4,10 +4,7 @@ from .common import BaseTest
 import datetime
 from dateutil import tz as tzutil
 from unittest.mock import MagicMock
-from c7n.testing import mock_datetime_now
-from dateutil import parser
 
-import c7n.resources.dynamodb
 from c7n.resources.dynamodb import DeleteTable
 from c7n.executor import MainThreadExecutor
 
@@ -544,21 +541,21 @@ class DynamoDbAccelerator(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['TotalNodes'], 1)
 
-    def test_dynamodb_consecutive_backup_count_filter(self):
-        session_factory = self.replay_flight_data("test_dynamodb_consecutive_backup_count_filter")
-        p = self.load_policy(
-            {
-                "name": "dynamodb_consecutive_backup_count_filter",
-                "resource": "dynamodb-table",
-                "filters": [
-                    {
-                        "type": "consecutive-backups",
-                        "days": 2
-                    }
-                ]
-            },
-            session_factory=session_factory,
-        )
-        with mock_datetime_now(parser.parse("2022-08-31T00:00:00+00:00"), c7n.resources.dynamodb):
-            resources = p.run()
-        self.assertEqual(len(resources), 1)
+#   def test_dynamodb_consecutive_backup_count_filter(self):
+#       session_factory = self.replay_flight_data("test_dynamodb_consecutive_backup_count_filter")
+#       p = self.load_policy(
+#           {
+#               "name": "dynamodb_consecutive_backup_count_filter",
+#               "resource": "dynamodb-table",
+#               "filters": [
+#                   {
+#                       "type": "consecutive-backups",
+#                       "days": 2
+#                   }
+#               ]
+#           },
+#           session_factory=session_factory,
+#       )
+#       with mock_datetime_now(parser.parse("2022-08-31T00:00:00+00:00"), c7n.resources.dynamodb):
+#           resources = p.run()
+#       self.assertEqual(len(resources), 1)


### PR DESCRIPTION
Chatted with @kapilt on this, we want to go a different direction with this filter something more generic that allows for other expressions such as richer attribute filtering