### PR TITLE
Add option to invert account filter

### DIFF
--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -257,3 +257,9 @@ class OrgTest(TestUtils):
         self.assertEqual(
             [a['name'] for a in t4['accounts']],
             ['dev'])
+        
+        t5 = copy.deepcopy(d)
+        org.filter_accounts(t5, ['blue'], [], [], True)
+        self.assertEqual(
+            [a['name'] for a in 5['accounts']],
+            ['prod'])

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -257,7 +257,7 @@ class OrgTest(TestUtils):
         self.assertEqual(
             [a['name'] for a in t4['accounts']],
             ['dev'])
-        
+
         t5 = copy.deepcopy(d)
         org.filter_accounts(t5, ['blue'], [], [], True)
         self.assertEqual(

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -261,5 +261,5 @@ class OrgTest(TestUtils):
         t5 = copy.deepcopy(d)
         org.filter_accounts(t5, ['blue'], [], [], True)
         self.assertEqual(
-            [a['name'] for a in 5['accounts']],
+            [a['name'] for a in t5['accounts']],
             ['prod'])

--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -200,13 +200,13 @@ def main():
     files = []
 
     if options.path:
-      for root, dirs, policies in os.walk(options.path):
-        for policy in policies:
-          files.append(os.path.join(root, policy))
+        for root, dirs, policies in os.walk(options.path):
+            for policy in policies:
+                files.append(os.path.join(root, policy))
 
     if options.config_files:
-      files.extend(itertools.chain(*options.config_files))
-      files.extend(options.configs)
+        files.extend(itertools.chain(*options.config_files))
+        files.extend(options.configs)
 
     options.config_files = files
 

--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -148,6 +148,9 @@ def setup_parser():
         '-c', '--config', dest="config_files", nargs="*", action='append',
         help="Policy configuration files(s)", default=[])
     parser.add_argument(
+        "--path",
+        help="Path to policy configuration files(s). Respects subdirectories.")
+    parser.add_argument(
         "--present", action="store_true", default=False,
         help='Target policies present in config files for removal instead of skipping them.')
     parser.add_argument(
@@ -195,8 +198,16 @@ def main():
         options.regions = [os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')]
 
     files = []
-    files.extend(itertools.chain(*options.config_files))
-    files.extend(options.configs)
+
+    if options.path:
+      for root, dirs, policies in os.walk(options.path):
+        for policy in policies:
+          files.append(os.path.join(root, policy))
+
+    if options.config_files:
+      files.extend(itertools.chain(*options.config_files))
+      files.extend(options.configs)
+
     options.config_files = files
 
     if not files:


### PR DESCRIPTION
Hey guys,

we are planning to use the [mugc script](https://github.com/cloud-custodian/cloud-custodian/blob/master/tools/ops/mugc.py) in combination with the [conditional policy execution feature](https://cloudcustodian.io/docs/quickstart/advanced.html#conditional-policy-execution).
This means we would like to delete policies in all accounts that do not match the current tags (of these policies) anymore.
(In addition to delete policies not part of our repository anymore)

To be able to do this we had to add an option to invert the current account filter function.

Our cleanup process has 2 steps:
1. `c7n-org run-script -c accounts.yml "python3 mugc.py --path policies"`
(Delete all policies in all accounts not in path - e.g. not part of our repository anymore)
(Extended the mugc invocation here...added the `--path` option to be able to read policies also from a local path)
2. `for policy in policies:`
`c7n-org run-script -c accounts.yml -t policy.tags -i "python3 mugc.py -c policy.name --present"`
(Delete all policies in all accounts that do not match the current tags anymore)
(-i or --invert-conditional-execution)

Maybe this feature is also helpful for others, this is why I've created this PR.