### PR TITLE
aws - sqs - fix queue URL format

### DIFF
--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -32,6 +32,11 @@ class DescribeQueue(DescribeSource):
                     QueueUrl=r,
                     AttributeNames=['All'])['Attributes']
                 queue['QueueUrl'] = r
+                region = str(self.manager.config.region)
+                if 'queue' in r:
+                    queueUrl = r.replace("{0}.queue.amazonaws.com".format(region),
+                    "sqs.{0}.amazonaws.com".format(region))
+                    queue['QueueUrl'] = queueUrl
             except ClientError as e:
                 if e.response['Error']['Code'] == 'AWS.SimpleQueueService.NonExistentQueue':
                     return


### PR DESCRIPTION
The format of SQS queue URLs can follow two variants, **service** and **legacy** endpoints (see article below on differences).

https://docs.aws.amazon.com/general/latest/gr/sqs-service.html

Using **legacy** endpoints, resource IDs do not get correctly mapped within AWS Config:

<img width="836" alt="Screen Shot 2022-09-15 at 1 34 58 PM" src="https://user-images.githubusercontent.com/22411908/190503707-b1e8c7f9-c782-41b4-9d5c-9fb2af7a324b.png">

This change modifies the format of SQS queue URLs to match latest **service** endpoints and fixes AWS Config resource associations.