### PR TITLE
releng - docker - fix the dockerfile symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-docker/cli
+docker/c7n


### PR DESCRIPTION
After we changed the naming convention of the dockerfiles in the docker directory we didnt update the Dockerfile symlink at the root