### PR TITLE
releng - update ci and docker builds to use poetry 1.2.1

### DIFF
--- a/.github/composites/docker-build-push/action.yaml
+++ b/.github/composites/docker-build-push/action.yaml
@@ -14,7 +14,7 @@ inputs:
     default: false
   poetry_version:
     description: "Poetry Version to use"
-    default: "1.1.14"
+    default: "1.2.1"
   trivy_version:
     description: "Trivy version to use"
     default: "0.5.4"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,5 +1,6 @@
 name: "CI"
-
+env:
+  POETRY_VERSION: "1.2.1"
 on:
   push:
     branches:
@@ -55,7 +56,7 @@ jobs:
         shell: bash
         run: |
           curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-            | python - -y --version 1.1.9
+            | python - -y --version $POETRY_VERSION
 
       - name: Set up cache
         uses: actions/cache@v2
@@ -148,7 +149,7 @@ jobs:
         shell: bash
         run: |
           curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-            | python - -y --version 1.1.13
+            | python - -y --version $POETRY_VERSION
 
       - name: Set up cache
         uses: actions/cache@v2

--- a/docker/c7n
+++ b/docker/c7n
@@ -2,7 +2,7 @@
 
 FROM ubuntu:22.04 as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -2,7 +2,7 @@
 
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -2,7 +2,7 @@
 
 FROM ubuntu:22.04 as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -2,7 +2,7 @@
 
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian

--- a/docker/mailer
+++ b/docker/mailer
@@ -2,7 +2,7 @@
 
 FROM ubuntu:22.04 as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -2,7 +2,7 @@
 
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian

--- a/docker/policystream
+++ b/docker/policystream
@@ -2,7 +2,7 @@
 
 FROM ubuntu:22.04 as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -2,7 +2,7 @@
 
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -30,7 +30,7 @@ BUILD_STAGE = """\
 
 FROM {base_build_image} as build-env
 
-ARG POETRY_VERSION="1.1.15"
+ARG POETRY_VERSION="1.2.1"
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian


### PR DESCRIPTION
In response to [this comment](https://github.com/cloud-custodian/cloud-custodian/pull/7782#issuecomment-1254084443), start using Poetry 1.2.x in CI.

(The broader context is that Poetry 1.2 was more effective at downgrading yanked/locked package versions, and we were looking to upgrade at some point anyway. This seemed a good nudge, and using 1.2.x across CI, Docker builds and release prep seems like a useful bit of consistency.)