### PR TITLE
feat: add 'copy-aws-service-tags' action to CW logs

### DIFF
--- a/tests/data/placebo/test_copy_aws_service_tags_to_log_group_without_related_resource/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_copy_aws_service_tags_to_log_group_without_related_resource/lambda.GetFunction_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Function not found: arn:aws:lambda:us-east-1:644160558196:function:no_related_lambda_function",
+            "Code": "ResourceNotFoundException"
+        },
+        "ResponseMetadata": {},
+        "Type": "User",
+        "Message": "Function not found: arn:aws:lambda:us-east-1:644160558196:function:no_related_lambda_function"
+    }
+}

--- a/tests/data/placebo/test_copy_aws_service_tags_to_log_group_without_related_resource/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_copy_aws_service_tags_to_log_group_without_related_resource/logs.DescribeLogGroups_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv",
+                "creationTime": 1664195860068,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/no_related_lambda_function",
+                "creationTime": 1664205324080,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/no_related_lambda_function:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_aws_service_tags_to_log_group_without_related_resource/logs.ListTagsLogGroup_1.json
+++ b/tests/data/placebo/test_copy_aws_service_tags_to_log_group_without_related_resource/logs.ListTagsLogGroup_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {},
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_aws_service_tags_to_log_group_without_related_resource/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_copy_aws_service_tags_to_log_group_without_related_resource/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_codebuild_tags_to_log_group/codebuild.BatchGetProjects_1.json
+++ b/tests/data/placebo/test_copy_codebuild_tags_to_log_group/codebuild.BatchGetProjects_1.json
@@ -1,0 +1,85 @@
+{
+    "status_code": 200,
+    "data": {
+        "projects": [
+            {
+                "name": "custodian_test_codebuild_project_name",
+                "arn": "arn:aws:codebuild:us-east-1:644160558196:project/custodian_test_codebuild_project_name",
+                "source": {
+                    "type": "NO_SOURCE",
+                    "gitCloneDepth": 0,
+                    "buildspec": "version: 0.2\n\nphases:\n  build:\n    commands:\n       - echo \"testing\"\n",
+                    "insecureSsl": false
+                },
+                "artifacts": {
+                    "type": "NO_ARTIFACTS",
+                    "overrideArtifactName": false
+                },
+                "cache": {
+                    "type": "NO_CACHE"
+                },
+                "environment": {
+                    "type": "LINUX_CONTAINER",
+                    "image": "aws/codebuild/standard:1.0",
+                    "computeType": "BUILD_GENERAL1_SMALL",
+                    "environmentVariables": [],
+                    "privilegedMode": false,
+                    "imagePullCredentialsType": "CODEBUILD"
+                },
+                "serviceRole": "arn:aws:iam::644160558196:role/iam_for_custodian_test_codebuild_project_name",
+                "timeoutInMinutes": 60,
+                "queuedTimeoutInMinutes": 480,
+                "encryptionKey": "arn:aws:kms:us-east-1:644160558196:alias/aws/s3",
+                "tags": [
+                    {
+                        "key": "copy_tag2",
+                        "value": "value2"
+                    },
+                    {
+                        "key": "not_copy_tag1",
+                        "value": "value3"
+                    },
+                    {
+                        "key": "copy_tag1",
+                        "value": "value1"
+                    }
+                ],
+                "created": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 9,
+                    "day": 26,
+                    "hour": 16,
+                    "minute": 38,
+                    "second": 5,
+                    "microsecond": 683000
+                },
+                "lastModified": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 9,
+                    "day": 26,
+                    "hour": 16,
+                    "minute": 38,
+                    "second": 5,
+                    "microsecond": 683000
+                },
+                "badge": {
+                    "badgeEnabled": false
+                },
+                "logsConfig": {
+                    "cloudWatchLogs": {
+                        "status": "ENABLED"
+                    },
+                    "s3Logs": {
+                        "status": "DISABLED",
+                        "encryptionDisabled": false
+                    }
+                },
+                "projectVisibility": "PRIVATE"
+            }
+        ],
+        "projectsNotFound": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_codebuild_tags_to_log_group/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_copy_codebuild_tags_to_log_group/logs.DescribeLogGroups_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/codebuild/custodian_test_codebuild_project_name",
+                "creationTime": 1664203073872,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/codebuild/custodian_test_codebuild_project_name:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/codebuild/testing-testing",
+                "creationTime": 1664196945924,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/codebuild/testing-testing:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv",
+                "creationTime": 1664195860068,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_codebuild_tags_to_log_group/logs.ListTagsLogGroup_1.json
+++ b/tests/data/placebo/test_copy_codebuild_tags_to_log_group/logs.ListTagsLogGroup_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {
+            "copy_tag1": "value1",
+            "copy_tag2": "value2"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_codebuild_tags_to_log_group/logs.TagLogGroup_1.json
+++ b/tests/data/placebo/test_copy_codebuild_tags_to_log_group/logs.TagLogGroup_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_codebuild_tags_to_log_group/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_copy_codebuild_tags_to_log_group/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/codebuild/testing-testing",
+                "Tags": [
+                    {
+                        "Key": "tag1",
+                        "Value": "value1"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_codebuild_tags_to_log_group_without_related_resource/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_copy_codebuild_tags_to_log_group_without_related_resource/logs.DescribeLogGroups_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv",
+                "creationTime": 1664195860068,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/no_related_lambda_function",
+                "creationTime": 1664205612558,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/no_related_lambda_function:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_codebuild_tags_to_log_group_without_related_resource/logs.ListTagsLogGroup_1.json
+++ b/tests/data/placebo/test_copy_codebuild_tags_to_log_group_without_related_resource/logs.ListTagsLogGroup_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {},
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_codebuild_tags_to_log_group_without_related_resource/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_copy_codebuild_tags_to_log_group_without_related_resource/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group/lambda.GetFunction_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Configuration": {
+            "FunctionName": "custodian_test_lambda_name",
+            "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name",
+            "Runtime": "python3.8",
+            "Role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+            "Handler": "handler.lambda_handler",
+            "CodeSize": 206,
+            "Description": "",
+            "Timeout": 3,
+            "MemorySize": 128,
+            "LastModified": "2022-09-26T11:16:33.813+0000",
+            "CodeSha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+            "Version": "$LATEST",
+            "TracingConfig": {
+                "Mode": "PassThrough"
+            },
+            "RevisionId": "f6cdbe23-5435-48a9-9b1f-7c7756d3f6b2",
+            "State": "Active",
+            "LastUpdateStatus": "Successful",
+            "PackageType": "Zip",
+            "Architectures": [
+                "x86_64"
+            ],
+            "EphemeralStorage": {
+                "Size": 512
+            }
+        },
+        "Code": {
+            "RepositoryType": "S3",
+            "Location": "https://prod-04-2014-tasks.s3.us-east-1.amazonaws.com/snapshots/644160558196/custodian_test_lambda_name-909d4045-e798-4619-877c-5288002e4b4e?versionId=rHwpp26QqPWRX96IS04nT0ybfPzkYIj7&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEEMaCXVzLWVhc3QtMSJHMEUCIQCtkiNP2hZm7yA7HORWP19zcI0bczwl%2BME8mAkq2prLaAIgG%2F2YG2S2UT14GBq2eX3hE%2FEqFhLNTPho6GOsNXH0oQQq1QQI6%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw3NDk2Nzg5MDI4MzkiDFfkbEKMCqRD78Ef1iqpBN7dzjZA31rssr3xSb7rZSAjcXl%2FGOxDlO%2BBr8IB8JpKk3YOt21LazK34g2Z4XIoUgEfcpqJ9rB0U1XaMe2i%2BJu6h2cdn6QSUEy7CoWkJHghlL4LC9BJX1Immiu8fscTA8wvLzVXdw9YEOxCo9tvfhUspA3NQ3UwEv3NJ%2BA%2F5hn7D%2FuKXsaoE2S1b4JPh3Vj9%2BdfCRzxt3YWzhrG5kx6qgyrrTAulBE45Shbas20rCxDqaSM7wCF4vBnmt9QEfhwYBXgtc%2FdXmv%2BzY5UNNPKaQrG9Gw1c2Lx2ZjWEZDoO%2BF%2FADqxiKhETvOW1hcSfBSqObCXC%2FFr3K4SJvNy6DP%2FPUoXZH57gI%2B4GUwH9k8wbn6F5kbYX4n%2B0UKxvt1OfCkr2%2FqgnhkiqNV5NfinqW8PEdSWun3KgYSi0gbZSD%2FscjKZFgL2TuK%2BhfwxhVxXUCntaXsWpcLQvCC74hY8c7rQr%2BQq%2B9kYTx0wwlmerkqycjwaFeN5QJrKgiLqxeYOwTtVOFnEHemQAQ1g44X3KtNYAFQDAeUtwD30HMqhOFX8fJJ1Gr2Z1JFdSo%2BXnCgdqOlnXXmmzH6PxzcZv%2Fx1p4Y7Jy6NPLgT05m3DEz%2FibW6b2mBZmIjfRq%2F1s%2BdeLBD8Jp6ACVw0gvHLmLwDetDf0WufwlIWTeLgib75Hf0dyih5rAS4jBA9KbuwyfaQ6YN58Ho9oBx7%2B9WCxZovg3DDCOeya%2Fqg7p6H2cWbIEw6fXFmQY6qQE%2FDN3Hd7bN%2F5xYNnLp329WIzTWxCDsfNLcfUMm%2F20fcC9F%2BmuATdoNSY4oh7w6dFhHQaSSVH9p10tR%2BKcrgiTd2MteOnlageD%2BqiLjHh%2BBwsmCLyh9HiDxyN9019Jriq3XJUXAmRj4E2Si5Ep7DeFl2rcole2%2FhWJmrvL1PrdJjIPShjm%2BiV%2BaPlymSM6s3fglp131GcW4Y0iMK08EaVoiz5bZkTTDPYmK&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220926T111641Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Credential=ASIA25DCYHY3SYHSE53Y%2F20220926%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=2cbbd780f2cb61652f4b012e0ca18c172f02a6fe04b1af688dbfd28b9791906a"
+        },
+        "Tags": {
+            "not_copy_tag1": "value3",
+            "copy_tag2": "value2",
+            "copy_tag1": "value1"
+        }
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group/logs.DescribeLogGroups_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/cfst-1449-1421af439633bad492a3dd3c366-InitFunction-LSoEFXQN79NH",
+                "creationTime": 1664181272043,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/cfst-1449-1421af439633bad492a3dd3c366-InitFunction-LSoEFXQN79NH:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/custodian_test_lambda_name",
+                "creationTime": 1664190983791,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group/logs.ListTagsLogGroup_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group/logs.ListTagsLogGroup_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {
+            "copy_tag1": "value1",
+            "copy_tag2": "value2"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group/logs.TagLogGroup_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group/logs.TagLogGroup_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/lambda.GetFunction_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Configuration": {
+            "FunctionName": "custodian_test_lambda_name",
+            "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name",
+            "Runtime": "python3.8",
+            "Role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+            "Handler": "handler.lambda_handler",
+            "CodeSize": 206,
+            "Description": "",
+            "Timeout": 3,
+            "MemorySize": 128,
+            "LastModified": "2022-09-26T11:13:12.047+0000",
+            "CodeSha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+            "Version": "$LATEST",
+            "TracingConfig": {
+                "Mode": "PassThrough"
+            },
+            "RevisionId": "5be8a99f-cb19-4b63-ad8a-42dd95e37e9a",
+            "State": "Active",
+            "LastUpdateStatus": "Successful",
+            "PackageType": "Zip",
+            "Architectures": [
+                "x86_64"
+            ],
+            "EphemeralStorage": {
+                "Size": 512
+            }
+        },
+        "Code": {
+            "RepositoryType": "S3",
+            "Location": "https://prod-04-2014-tasks.s3.us-east-1.amazonaws.com/snapshots/644160558196/custodian_test_lambda_name-ab112614-35ad-4c74-aaee-9680c4a23709?versionId=rQ4PdSkinZ6y.JdBcEykGntivSczgcGl&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEEIaCXVzLWVhc3QtMSJHMEUCIQDJQKX%2BslXlUyrdQOclmoyokCP4%2Bjd6tweHtyIXyJ8NigIgZCEeSTG6HNpuXnK5nBkvSgxxmK1obRcCZb%2BqTvhZxQMq1gQI6%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw3NDk2Nzg5MDI4MzkiDB2KQPgOVvQFTit10iqqBHE7AIQcIwZbqrXcQ%2BG%2FiIY4bOPGsuV%2B1gnfnFSGB7g6%2B3gpTKZ04Pq3tk3rk1HucRfeYupPxX4830zBeyMjjRfZwDIf5Drfio6Bsw2pM1cvG041p23te5ArNTHY7P9HAxMTgwz8XQx%2BZCerI42%2FhP6BvJ4PIWv8nQXgG5ZWSORh918DBx5s6HiAna2bCZnMZZemeKZKUmQccPweyqFGpLOHTb6iTWJ36EsV4BuHpBShWEGo42I6J07wbOP4zFao9IIE1DkwsjzLwVpG%2B2s9OaBdpgq9PV5HnXXCREH9dMt0JDA3RRbMkje355j%2Buys1sJ5jXg2Fw2K9oxmQmbsgUGoEbL9Dz4OMvdGVULkovs9BuCQUMI2xnofX6ulg%2Be4NAf%2FwSs32MDukrtv4QdpEYGMNXetdHsBRHQeGhqMDlJwG5fGQOv20inXIOkn61IEaVyAaSP8qj9kpyPYihZcJQClJbsWBXRbVobipUoSK6YbdZDsg9EqsuyqYo0zPExNNihQ6Dmrd7jNpHpjxkbuE0zmVx9aCidisGdjzv%2FAEd5oLDYptYEWUukr0KreJ32FTzokbT85UTuf9f%2B4N2v1AZFIrYBWSAJLQaXsgjMNx81XnpdrZSm1iVdRBkReWPard0CCiE3u67M9PmlTED030Xroi%2BOZAxffDHPYbbYb15R2AJoO%2F2N%2BihX0tDQkFcaICiLdJMm6rMyuU3h1OF4Y5dajokRca%2BR7F0E1rMMrnxZkGOqkB1jOJcR7X6cHFmo5STSPocYhBLR2pCARNjU9eaC6273G%2FcfVLuy3pGPPoNBd%2Bw69DcHb%2Fdgb%2BQeoJOBawB3P5Zb2dY5u3G6Huchyr4vB0eDhvNxdTQC7cv6IcY1Ocn2n5G0X1JuL9%2BkOcEIghlQw4XLqLFp%2FIC5Lf0V0kjuRruMgSV7FhO5L25xiw1LQOC4mFYLx3OCiXcROg0POD4kzzd%2FuuoVyOidvZhA%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220926T111319Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Credential=ASIA25DCYHY326I3GNPF%2F20220926%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=f0d028b63f256b3bafd348842d234f2f68b3f7004e5d2dff4380aa5eec1294ff"
+        },
+        "Tags": {
+            "not_copy_tag1": "value3",
+            "existing_tag": "lambda_existing_tag",
+            "copy_tag1": "value1"
+        }
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/logs.DescribeLogGroups_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/cfst-1449-1421af439633bad492a3dd3c366-InitFunction-LSoEFXQN79NH",
+                "creationTime": 1664181272043,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/cfst-1449-1421af439633bad492a3dd3c366-InitFunction-LSoEFXQN79NH:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/custodian_test_lambda_name",
+                "creationTime": 1664190781929,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/logs.ListTagsLogGroup_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/logs.ListTagsLogGroup_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {
+            "copy_tag1": "value1",
+            "existing_tag": "lambda_existing_tag"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/logs.TagLogGroup_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/logs.TagLogGroup_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_do_not_skip_existing_tags/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name",
+                "Tags": [
+                    {
+                        "Key": "existing_tag",
+                        "Value": "log_group_existing_tag"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/lambda.GetFunction_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Configuration": {
+            "FunctionName": "custodian_test_lambda_name",
+            "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name",
+            "Runtime": "python3.8",
+            "Role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+            "Handler": "handler.lambda_handler",
+            "CodeSize": 206,
+            "Description": "",
+            "Timeout": 3,
+            "MemorySize": 128,
+            "LastModified": "2022-09-26T11:08:27.977+0000",
+            "CodeSha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+            "Version": "$LATEST",
+            "TracingConfig": {
+                "Mode": "PassThrough"
+            },
+            "RevisionId": "d3653169-62f1-48cf-9624-45abf9700b9c",
+            "State": "Active",
+            "LastUpdateStatus": "Successful",
+            "PackageType": "Zip",
+            "Architectures": [
+                "x86_64"
+            ],
+            "EphemeralStorage": {
+                "Size": 512
+            }
+        },
+        "Code": {
+            "RepositoryType": "S3",
+            "Location": "https://prod-04-2014-tasks.s3.us-east-1.amazonaws.com/snapshots/644160558196/custodian_test_lambda_name-8e8e48c4-7d87-4bf5-acc9-c577711499f9?versionId=bA6_PmAtpVZOD45n91huhmtGRI9_Hsil&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEEIaCXVzLWVhc3QtMSJHMEUCIDTghSi7Ko3ObUQmTwJVKfqmR66seDQBrQt1bJPpiJgGAiEAgHiljG3EvywnHtiKDXcsVhNLmSufX7z%2BoyRhEWKTQYsq1QQI6v%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw3NDk2Nzg5MDI4MzkiDLCdEP%2BM0buOvd4hgyqpBGQAMssgqcv3HNGD5XyVNsXef9dJklydON2bNnWt3m59UZJEg9kQGppqCvHxWWxicCcf3D3G2aHhkAkNlsLv9GXRf10ixmqrvUD0OLkssBi4NylhFknYfC9Bvb5IV%2FTjdq00QCrIJFH5a2hBW9II2%2B09u74l7zeb0Mee5HlixUn3FyMTHHMO6%2Bs%2Bu4tNTGF%2BK1sFTwsmLVRJinRglfYwjwuVMfERqmz07CB4q7SdcuKgCBfV%2F1Zgccp%2FEmgzO3bTl7jWq8sz9qbMHpsZKdU9yGeyki2iayDK4eFt9gG9eWcHkunVp20qnU9tKeCizRWqw0obOYD1Afpo8%2B7iu6xdVMdCycPwDy4DjMA99UcnCd4JYMPNd399rUzeFNRjni%2FhjYRXiMs1F6zbkJu%2FCDPaAeAVAdrFSaOQs9i23XF7KyDGR3Wa10zL3it2icMqMartxLFe2rRVqgogtbIEaVvT4CEDUBghsP1Y5NnMYHRD5YpkB3PfBmctx4HbeHLqghQP5EgC5d1aMzYdYVwC4I0jsAFerm0mlRG9NGAgrMpMj6n7K5rYhP9t%2FNTECkR9RHonXrVHoq%2F0s2XdFrq7Zlv%2BYxwRfNAMpXXIIjh1UIT6Xvx73GEgmCcZ0XnAToz95gUib3KRnsfbG2ahyjs3PBwUWNLWOtZsPqMvkV8E3uXxfnccbg%2FvVfIWwQTWCYOQeZvQP30h2G%2BtYirG3clWSOqZy2bW3KcROotKHmow8%2BDFmQY6qQFb%2BFilOO%2F7szm5llIGHNOmQNpAh4aiQ5MybBjYZcZmveg416koJCbmRuvt8LwyC4enRC4Gj3Nh%2BdxpQZD6VXPvCtxsZ51EjQE%2FfjS0VS7t9ofCGek0gbE6%2Bnbvna5POPrN49Qf1kbt%2BENxyZCezfE%2FEKis3e8yU%2FuEJrBLarYeQSrn72CiY7ZILtTloj40Jyz1p7uQe5xnrn7p4DXPOW4UkltBp6lr4lCj&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220926T110835Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Credential=ASIA25DCYHY35XQYFHU4%2F20220926%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=641aa67fe3a5178dd85e76c14598ccff3d77ddf6551ce825322c595aaedc8271"
+        },
+        "Tags": {
+            "not_copy_tag1": "value3",
+            "existing_tag": "lambda_existing_tag",
+            "copy_tag1": "value1"
+        }
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/logs.DescribeLogGroups_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/cfst-1449-1421af439633bad492a3dd3c366-InitFunction-LSoEFXQN79NH",
+                "creationTime": 1664181272043,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/cfst-1449-1421af439633bad492a3dd3c366-InitFunction-LSoEFXQN79NH:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/custodian_test_lambda_name",
+                "creationTime": 1664190498026,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/logs.ListTagsLogGroup_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/logs.ListTagsLogGroup_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {
+            "copy_tag1": "value1",
+            "existing_tag": "log_group_existing_tag"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/logs.TagLogGroup_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/logs.TagLogGroup_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_skip_existing_tags/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name",
+                "Tags": [
+                    {
+                        "Key": "existing_tag",
+                        "Value": "log_group_existing_tag"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_without_related_resource/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_without_related_resource/lambda.GetFunction_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Function not found: arn:aws:lambda:us-east-1:644160558196:function:no_related_lambda_function",
+            "Code": "ResourceNotFoundException"
+        },
+        "ResponseMetadata": {},
+        "Type": "User",
+        "Message": "Function not found: arn:aws:lambda:us-east-1:644160558196:function:no_related_lambda_function"
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_without_related_resource/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_without_related_resource/logs.DescribeLogGroups_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv",
+                "creationTime": 1664195860068,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/no_related_lambda_function",
+                "creationTime": 1664205414155,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/no_related_lambda_function:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_without_related_resource/logs.ListTagsLogGroup_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_without_related_resource/logs.ListTagsLogGroup_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {},
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_lambda_tags_to_log_group_without_related_resource/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_copy_lambda_tags_to_log_group_without_related_resource/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/codebuild.BatchGetProjects_1.json
+++ b/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/codebuild.BatchGetProjects_1.json
@@ -1,0 +1,85 @@
+{
+    "status_code": 200,
+    "data": {
+        "projects": [
+            {
+                "name": "custodian_test_codebuild_project_name",
+                "arn": "arn:aws:codebuild:us-east-1:644160558196:project/custodian_test_codebuild_project_name",
+                "source": {
+                    "type": "NO_SOURCE",
+                    "gitCloneDepth": 0,
+                    "buildspec": "version: 0.2\n\nphases:\n  build:\n    commands:\n       - echo \"testing\"\n",
+                    "insecureSsl": false
+                },
+                "artifacts": {
+                    "type": "NO_ARTIFACTS",
+                    "overrideArtifactName": false
+                },
+                "cache": {
+                    "type": "NO_CACHE"
+                },
+                "environment": {
+                    "type": "LINUX_CONTAINER",
+                    "image": "aws/codebuild/standard:1.0",
+                    "computeType": "BUILD_GENERAL1_SMALL",
+                    "environmentVariables": [],
+                    "privilegedMode": false,
+                    "imagePullCredentialsType": "CODEBUILD"
+                },
+                "serviceRole": "arn:aws:iam::644160558196:role/iam_for_custodian_test_codebuild_project_name",
+                "timeoutInMinutes": 60,
+                "queuedTimeoutInMinutes": 480,
+                "encryptionKey": "arn:aws:kms:us-east-1:644160558196:alias/aws/s3",
+                "tags": [
+                    {
+                        "key": "copy_tag2",
+                        "value": "value2"
+                    },
+                    {
+                        "key": "not_copy_tag1",
+                        "value": "value3"
+                    },
+                    {
+                        "key": "copy_tag1",
+                        "value": "value1"
+                    }
+                ],
+                "created": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 9,
+                    "day": 26,
+                    "hour": 16,
+                    "minute": 51,
+                    "second": 33,
+                    "microsecond": 407000
+                },
+                "lastModified": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 9,
+                    "day": 26,
+                    "hour": 16,
+                    "minute": 51,
+                    "second": 33,
+                    "microsecond": 407000
+                },
+                "badge": {
+                    "badgeEnabled": false
+                },
+                "logsConfig": {
+                    "cloudWatchLogs": {
+                        "status": "ENABLED"
+                    },
+                    "s3Logs": {
+                        "status": "DISABLED",
+                        "encryptionDisabled": false
+                    }
+                },
+                "projectVisibility": "PRIVATE"
+            }
+        ],
+        "projectsNotFound": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/lambda.GetFunction_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Configuration": {
+            "FunctionName": "custodian_test_lambda_name",
+            "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name",
+            "Runtime": "python3.8",
+            "Role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+            "Handler": "handler.lambda_handler",
+            "CodeSize": 206,
+            "Description": "",
+            "Timeout": 3,
+            "MemorySize": 128,
+            "LastModified": "2022-09-26T14:51:31.651+0000",
+            "CodeSha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+            "Version": "$LATEST",
+            "TracingConfig": {
+                "Mode": "PassThrough"
+            },
+            "RevisionId": "81d9e41d-ff88-4be4-a3ed-646164fd0667",
+            "State": "Active",
+            "LastUpdateStatus": "Successful",
+            "PackageType": "Zip",
+            "Architectures": [
+                "x86_64"
+            ],
+            "EphemeralStorage": {
+                "Size": 512
+            }
+        },
+        "Code": {
+            "RepositoryType": "S3",
+            "Location": "https://prod-04-2014-tasks.s3.us-east-1.amazonaws.com/snapshots/644160558196/custodian_test_lambda_name-644a3c33-d61f-4962-98fa-be38bc9846d5?versionId=fFpBDdSdnvwXVOFYX5rydiKXSUb2fN3t&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEEYaCXVzLWVhc3QtMSJIMEYCIQD6AGvLAMtkJQFbU%2BNo5B6c5W1cdgdEf3GmSNf1SJ7TOQIhAMNrljhAzbJODVLc0ar6%2FyQdEI84fofy0%2BxIWi5jzXPcKtYECO%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQABoMNzQ5Njc4OTAyODM5Igx%2B7IjTJ1%2FSQBMVMYoqqgRRVmdhxpp5d2kquXkVL516u1AUmuga4ubaDHTBoEvA3aqq4szSz4UWRE9T0qaI2oFnKBBqGaBh5rOUk0mCZg6eEsaH%2Bh5JC8c36ncm43pAGppvecYuxWnNCbj%2FAzOXFE4zzGdogCmhAViXZETPWkFWFFc%2B4HVQJNoCq6n8SHeFYBm8%2BO16%2FUXdVpheJ682vqSL6M0f0Y2pWAc25PFyMBpaHuW55cwpvjQj2rz2bqDrTMbZWUph3VGSCUDhVf8LPgDcbKTimhTG8JLADEv0OSFBaeq0Lc560UtMTQus3yHvxOOpcuXwQiH84SZkYPL5qhu3vN4gF08tp8YSKDP8T3T5Q9YGQRQUw3Z2EfcnDVA6z3a25WbnGHDcphh5fhmgPtsKlxibzwDVcV4mgPuUHTeu1%2FELL92uPqqSO3UoFDgg4hWeGVWA2%2BxLzAB3yhPTsO1KlZV0%2FNer5cG4D9bp%2FVLTTSleOuJ5fVaN8LBirL1jsZckAK1GLiOAND%2FzOk2i%2FFs%2Bax0QtoU%2BYac4xvN9FN6UR0XE%2BLeYRSLEp8YH12xfAeWmPk4wLPM5HdFYFJ%2FH1TxXufnT7sVTBpDm6SKZ9Y04lCjjhj81PMcbiTP8r1wk79HoC%2F5K3C1ADIGf7zuF5ZF8X385D8yL%2FPPHXxDiTAxRcsNOFUEgOOcKhS7ZeM%2FM6s9yYmIl9em22Vgl7n7Y1lE0AJwnEew%2BOTalzpg7CyYmiBJgxaAUkAiL8jCW4caZBjqoAZiUQG%2FgnWyIROdSO7xpdVcITAe5rPSl0veVmuHC%2Ftrncqp4DBJMTvGRRFsZW9%2FXLMj1Z5ZgBZHQiHLsLf36r7%2Fdlya27tjagCz4A64DXfK10%2BIZW%2BZhFvrvZIXsdY7b24hBYem5PdLC4Kdqo46OQuzBVh8m0Vge1hP6C4F9LxFl%2BkzW2ep8%2BB9Vu%2BAsRi%2ByxRmIj9nMt8sdCXgLmdvcQf8rhcgYWRsPJw%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220926T145140Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Credential=ASIA25DCYHY35U6WW24J%2F20220926%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=ffa810dcf6e18f2e6a487b65b64e987823b0bc9d337b5628b6b72ab177184625"
+        },
+        "Tags": {
+            "not_copy_tag1": "value3",
+            "copy_tag2": "value2",
+            "copy_tag1": "value1"
+        }
+    }
+}

--- a/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.DescribeLogGroups_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/codebuild/custodian_test_codebuild_project_name",
+                "creationTime": 1664203881558,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/codebuild/custodian_test_codebuild_project_name:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/codebuild/testing-testing",
+                "creationTime": 1664196945924,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/codebuild/testing-testing:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv",
+                "creationTime": 1664195860068,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/cfst-1449-cf2af7b50e9b9c80543d2cf6248-InitFunction-ua21B80ekQNv:*",
+                "storedBytes": 0
+            },
+            {
+                "logGroupName": "/aws/lambda/custodian_test_lambda_name",
+                "creationTime": 1664203881559,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.ListTagsLogGroup_1.json
+++ b/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.ListTagsLogGroup_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {
+            "copy_tag1": "value1",
+            "copy_tag2": "value2"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.ListTagsLogGroup_2.json
+++ b/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.ListTagsLogGroup_2.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "tags": {
+            "copy_tag1": "value1",
+            "copy_tag2": "value2"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.TagLogGroup_1.json
+++ b/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.TagLogGroup_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.TagLogGroup_2.json
+++ b/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/logs.TagLogGroup_2.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_copy_multiple_service_tags_to_log_group/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/codebuild/testing-testing",
+                "Tags": [
+                    {
+                        "Key": "tag1",
+                        "Value": "value1"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/copy_codebuild_tags_to_log_group/locals.tf
+++ b/tests/terraform/copy_codebuild_tags_to_log_group/locals.tf
@@ -1,0 +1,3 @@
+locals {
+    codebuild_project_name = "custodian_test_codebuild_project_name"
+}

--- a/tests/terraform/copy_codebuild_tags_to_log_group/main.tf
+++ b/tests/terraform/copy_codebuild_tags_to_log_group/main.tf
@@ -1,0 +1,57 @@
+resource "aws_iam_role" "this" {
+  name = "iam_for_${local.codebuild_project_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name = "/aws/codebuild/${local.codebuild_project_name}"
+
+  tags = {}
+}
+
+resource "aws_codebuild_project" "this" {
+  name           = local.codebuild_project_name
+  service_role = aws_iam_role.this.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:1.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+  }
+
+  source {
+    type            = "NO_SOURCE"
+    buildspec       = "version: 0.2\n\nphases:\n  build:\n    commands:\n       - echo \"testing\"\n"
+  }
+
+  tags = {
+    copy_tag1     = "value1",
+    copy_tag2     = "value2",
+    not_copy_tag1 = "value3",
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+    aws_iam_role.this,
+  ]
+}

--- a/tests/terraform/copy_codebuild_tags_to_log_group/providers.tf
+++ b/tests/terraform/copy_codebuild_tags_to_log_group/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/tests/terraform/copy_codebuild_tags_to_log_group/tf_resources.json
+++ b/tests/terraform/copy_codebuild_tags_to_log_group/tf_resources.json
@@ -1,0 +1,138 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_cloudwatch_log_group": {
+            "this": {
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/codebuild/custodian_test_codebuild_project_name",
+                "id": "/aws/codebuild/custodian_test_codebuild_project_name",
+                "kms_key_id": "",
+                "name": "/aws/codebuild/custodian_test_codebuild_project_name",
+                "name_prefix": null,
+                "retention_in_days": 0,
+                "tags": null,
+                "tags_all": {}
+            }
+        },
+        "aws_codebuild_project": {
+            "this": {
+                "arn": "arn:aws:codebuild:us-east-1:644160558196:project/custodian_test_codebuild_project_name",
+                "artifacts": [
+                    {
+                        "artifact_identifier": "",
+                        "bucket_owner_access": "",
+                        "encryption_disabled": false,
+                        "location": "",
+                        "name": "",
+                        "namespace_type": "",
+                        "override_artifact_name": false,
+                        "packaging": "",
+                        "path": "",
+                        "type": "NO_ARTIFACTS"
+                    }
+                ],
+                "badge_enabled": false,
+                "badge_url": "",
+                "build_batch_config": [],
+                "build_timeout": 60,
+                "cache": [
+                    {
+                        "location": "",
+                        "modes": [],
+                        "type": "NO_CACHE"
+                    }
+                ],
+                "concurrent_build_limit": 0,
+                "description": "",
+                "encryption_key": "arn:aws:kms:us-east-1:644160558196:alias/aws/s3",
+                "environment": [
+                    {
+                        "certificate": "",
+                        "compute_type": "BUILD_GENERAL1_SMALL",
+                        "environment_variable": [],
+                        "image": "aws/codebuild/standard:1.0",
+                        "image_pull_credentials_type": "CODEBUILD",
+                        "privileged_mode": false,
+                        "registry_credential": [],
+                        "type": "LINUX_CONTAINER"
+                    }
+                ],
+                "file_system_locations": [],
+                "id": "arn:aws:codebuild:us-east-1:644160558196:project/custodian_test_codebuild_project_name",
+                "logs_config": [
+                    {
+                        "cloudwatch_logs": [
+                            {
+                                "group_name": "",
+                                "status": "ENABLED",
+                                "stream_name": ""
+                            }
+                        ],
+                        "s3_logs": [
+                            {
+                                "bucket_owner_access": "",
+                                "encryption_disabled": false,
+                                "location": "",
+                                "status": "DISABLED"
+                            }
+                        ]
+                    }
+                ],
+                "name": "custodian_test_codebuild_project_name",
+                "project_visibility": "PRIVATE",
+                "public_project_alias": "",
+                "queued_timeout": 480,
+                "resource_access_role": "",
+                "secondary_artifacts": [],
+                "secondary_source_version": [],
+                "secondary_sources": [],
+                "service_role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_codebuild_project_name",
+                "source": [
+                    {
+                        "auth": [],
+                        "build_status_config": [],
+                        "buildspec": "version: 0.2\n\nphases:\n  build:\n    commands:\n       - echo \"testing\"\n",
+                        "git_clone_depth": 0,
+                        "git_submodules_config": [],
+                        "insecure_ssl": false,
+                        "location": "",
+                        "report_build_status": false,
+                        "type": "NO_SOURCE"
+                    }
+                ],
+                "source_version": "",
+                "tags": {
+                    "copy_tag1": "value1",
+                    "copy_tag2": "value2",
+                    "not_copy_tag1": "value3"
+                },
+                "tags_all": {
+                    "copy_tag1": "value1",
+                    "copy_tag2": "value2",
+                    "not_copy_tag1": "value3"
+                },
+                "vpc_config": []
+            }
+        },
+        "aws_iam_role": {
+            "this": {
+                "arn": "arn:aws:iam::644160558196:role/iam_for_custodian_test_codebuild_project_name",
+                "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"codebuild.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+                "create_date": "2022-09-26T14:37:53Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "iam_for_custodian_test_codebuild_project_name",
+                "inline_policy": [],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "iam_for_custodian_test_codebuild_project_name",
+                "name_prefix": "",
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "tags_all": {},
+                "unique_id": "AROAUY7BEYQVJ373OJSEW"
+            }
+        }
+    }
+}

--- a/tests/terraform/copy_codebuild_tags_to_log_group_without_related_resource/main.tf
+++ b/tests/terraform/copy_codebuild_tags_to_log_group_without_related_resource/main.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name = "/aws/lambda/no_related_lambda_function"
+
+  tags = {}
+}

--- a/tests/terraform/copy_codebuild_tags_to_log_group_without_related_resource/providers.tf
+++ b/tests/terraform/copy_codebuild_tags_to_log_group_without_related_resource/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/tests/terraform/copy_codebuild_tags_to_log_group_without_related_resource/tf_resources.json
+++ b/tests/terraform/copy_codebuild_tags_to_log_group_without_related_resource/tf_resources.json
@@ -1,0 +1,18 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_cloudwatch_log_group": {
+            "this": {
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/no_related_lambda_function",
+                "id": "/aws/lambda/no_related_lambda_function",
+                "kms_key_id": "",
+                "name": "/aws/lambda/no_related_lambda_function",
+                "name_prefix": null,
+                "retention_in_days": 0,
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group/datasources.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group/datasources.tf
@@ -1,0 +1,12 @@
+data "archive_file" "lambda_package" {
+  type        = "zip"
+  output_path = "${path.module}/lambda_package.zip"
+
+  source {
+    content  = <<EOF
+def lambda_handler(event, context):
+  print('Hello from Lambda')
+EOF
+    filename = "${path.module}/handler.py"
+  }
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group/locals.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group/locals.tf
@@ -1,0 +1,3 @@
+locals {
+    lambda_function_name = "custodian_test_lambda_name"
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group/main.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group/main.tf
@@ -1,0 +1,44 @@
+resource "aws_iam_role" "this" {
+  name = "iam_for_${local.lambda_function_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name = "/aws/lambda/${local.lambda_function_name}"
+
+  tags = {}
+}
+
+resource "aws_lambda_function" "this" {
+  function_name = local.lambda_function_name
+  role          = aws_iam_role.this.arn
+  runtime       = "python3.8"
+  filename      = data.archive_file.lambda_package.output_path
+  handler       = "handler.lambda_handler"
+
+  tags = {
+    copy_tag1     = "value1",
+    copy_tag2     = "value2",
+    not_copy_tag1 = "value3",
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+    aws_iam_role.this,
+  ]
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group/providers.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group/tf_resources.json
+++ b/tests/terraform/copy_lambda_tags_to_log_group/tf_resources.json
@@ -1,0 +1,123 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "archive_file": {
+            "lambda_package": {
+                "excludes": null,
+                "id": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_base64sha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "output_file_mode": null,
+                "output_md5": "dbda80a51ce93cd8b7917d718b98351f",
+                "output_path": "./lambda_package.zip",
+                "output_sha": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_size": 206,
+                "source": [
+                    {
+                        "content": "def lambda_handler(event, context):\n  print('Hello from Lambda')\n",
+                        "filename": "./handler.py"
+                    }
+                ],
+                "source_content": null,
+                "source_content_filename": null,
+                "source_dir": null,
+                "source_file": null,
+                "type": "zip"
+            }
+        },
+        "aws_cloudwatch_log_group": {
+            "this": {
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name",
+                "id": "/aws/lambda/custodian_test_lambda_name",
+                "kms_key_id": "",
+                "name": "/aws/lambda/custodian_test_lambda_name",
+                "name_prefix": null,
+                "retention_in_days": 0,
+                "tags": null,
+                "tags_all": {}
+            }
+        },
+        "aws_iam_role": {
+            "this": {
+                "arn": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+                "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+                "create_date": "2022-09-26T11:16:23Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "iam_for_custodian_test_lambda_name",
+                "inline_policy": [],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "iam_for_custodian_test_lambda_name",
+                "name_prefix": "",
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "tags_all": {},
+                "unique_id": "AROAYTUGZTJLWIQRH27WM"
+            }
+        },
+        "aws_lambda_function": {
+            "this": {
+                "architectures": [
+                    "x86_64"
+                ],
+                "arn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name",
+                "code_signing_config_arn": "",
+                "dead_letter_config": [],
+                "description": "",
+                "environment": [],
+                "ephemeral_storage": [
+                    {
+                        "size": 512
+                    }
+                ],
+                "file_system_config": [],
+                "filename": "./lambda_package.zip",
+                "function_name": "custodian_test_lambda_name",
+                "handler": "handler.lambda_handler",
+                "id": "custodian_test_lambda_name",
+                "image_config": [],
+                "image_uri": "",
+                "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name/invocations",
+                "kms_key_arn": "",
+                "last_modified": "2022-09-26T11:16:33.813+0000",
+                "layers": null,
+                "memory_size": 128,
+                "package_type": "Zip",
+                "publish": false,
+                "qualified_arn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name:$LATEST",
+                "qualified_invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name:$LATEST/invocations",
+                "reserved_concurrent_executions": -1,
+                "role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+                "runtime": "python3.8",
+                "s3_bucket": null,
+                "s3_key": null,
+                "s3_object_version": null,
+                "signing_job_arn": "",
+                "signing_profile_version_arn": "",
+                "source_code_hash": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "source_code_size": 206,
+                "tags": {
+                    "copy_tag1": "value1",
+                    "copy_tag2": "value2",
+                    "not_copy_tag1": "value3"
+                },
+                "tags_all": {
+                    "copy_tag1": "value1",
+                    "copy_tag2": "value2",
+                    "not_copy_tag1": "value3"
+                },
+                "timeout": 3,
+                "timeouts": null,
+                "tracing_config": [
+                    {
+                        "mode": "PassThrough"
+                    }
+                ],
+                "version": "$LATEST",
+                "vpc_config": []
+            }
+        }
+    }
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/datasources.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/datasources.tf
@@ -1,0 +1,12 @@
+data "archive_file" "lambda_package" {
+  type        = "zip"
+  output_path = "${path.module}/lambda_package.zip"
+
+  source {
+    content  = <<EOF
+def lambda_handler(event, context):
+  print('Hello from Lambda')
+EOF
+    filename = "${path.module}/handler.py"
+  }
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/locals.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/locals.tf
@@ -1,0 +1,3 @@
+locals {
+    lambda_function_name = "custodian_test_lambda_name"
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/main.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/main.tf
@@ -1,0 +1,46 @@
+resource "aws_iam_role" "this" {
+  name = "iam_for_${local.lambda_function_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name = "/aws/lambda/${local.lambda_function_name}"
+
+  tags = {
+    existing_tag = "log_group_existing_tag",
+  }
+}
+
+resource "aws_lambda_function" "this" {
+  function_name = local.lambda_function_name
+  role          = aws_iam_role.this.arn
+  runtime       = "python3.8"
+  filename      = data.archive_file.lambda_package.output_path
+  handler       = "handler.lambda_handler"
+
+  tags = {
+    copy_tag1     = "value1",
+    existing_tag  = "lambda_existing_tag",
+    not_copy_tag1 = "value3",
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+    aws_iam_role.this,
+  ]
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/providers.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/tf_resources.json
+++ b/tests/terraform/copy_lambda_tags_to_log_group_do_not_skip_existing_tags/tf_resources.json
@@ -1,0 +1,127 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "archive_file": {
+            "lambda_package": {
+                "excludes": null,
+                "id": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_base64sha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "output_file_mode": null,
+                "output_md5": "dbda80a51ce93cd8b7917d718b98351f",
+                "output_path": "./lambda_package.zip",
+                "output_sha": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_size": 206,
+                "source": [
+                    {
+                        "content": "def lambda_handler(event, context):\n  print('Hello from Lambda')\n",
+                        "filename": "./handler.py"
+                    }
+                ],
+                "source_content": null,
+                "source_content_filename": null,
+                "source_dir": null,
+                "source_file": null,
+                "type": "zip"
+            }
+        },
+        "aws_cloudwatch_log_group": {
+            "this": {
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name",
+                "id": "/aws/lambda/custodian_test_lambda_name",
+                "kms_key_id": "",
+                "name": "/aws/lambda/custodian_test_lambda_name",
+                "name_prefix": null,
+                "retention_in_days": 0,
+                "tags": {
+                    "existing_tag": "log_group_existing_tag"
+                },
+                "tags_all": {
+                    "existing_tag": "log_group_existing_tag"
+                }
+            }
+        },
+        "aws_iam_role": {
+            "this": {
+                "arn": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+                "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+                "create_date": "2022-09-26T11:13:02Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "iam_for_custodian_test_lambda_name",
+                "inline_policy": [],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "iam_for_custodian_test_lambda_name",
+                "name_prefix": "",
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "tags_all": {},
+                "unique_id": "AROAYTUGZTJL7C3EPUGFR"
+            }
+        },
+        "aws_lambda_function": {
+            "this": {
+                "architectures": [
+                    "x86_64"
+                ],
+                "arn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name",
+                "code_signing_config_arn": "",
+                "dead_letter_config": [],
+                "description": "",
+                "environment": [],
+                "ephemeral_storage": [
+                    {
+                        "size": 512
+                    }
+                ],
+                "file_system_config": [],
+                "filename": "./lambda_package.zip",
+                "function_name": "custodian_test_lambda_name",
+                "handler": "handler.lambda_handler",
+                "id": "custodian_test_lambda_name",
+                "image_config": [],
+                "image_uri": "",
+                "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name/invocations",
+                "kms_key_arn": "",
+                "last_modified": "2022-09-26T11:13:12.047+0000",
+                "layers": null,
+                "memory_size": 128,
+                "package_type": "Zip",
+                "publish": false,
+                "qualified_arn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name:$LATEST",
+                "qualified_invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name:$LATEST/invocations",
+                "reserved_concurrent_executions": -1,
+                "role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+                "runtime": "python3.8",
+                "s3_bucket": null,
+                "s3_key": null,
+                "s3_object_version": null,
+                "signing_job_arn": "",
+                "signing_profile_version_arn": "",
+                "source_code_hash": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "source_code_size": 206,
+                "tags": {
+                    "copy_tag1": "value1",
+                    "existing_tag": "lambda_existing_tag",
+                    "not_copy_tag1": "value3"
+                },
+                "tags_all": {
+                    "copy_tag1": "value1",
+                    "existing_tag": "lambda_existing_tag",
+                    "not_copy_tag1": "value3"
+                },
+                "timeout": 3,
+                "timeouts": null,
+                "tracing_config": [
+                    {
+                        "mode": "PassThrough"
+                    }
+                ],
+                "version": "$LATEST",
+                "vpc_config": []
+            }
+        }
+    }
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/datasources.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/datasources.tf
@@ -1,0 +1,12 @@
+data "archive_file" "lambda_package" {
+  type        = "zip"
+  output_path = "${path.module}/lambda_package.zip"
+
+  source {
+    content  = <<EOF
+def lambda_handler(event, context):
+  print('Hello from Lambda')
+EOF
+    filename = "${path.module}/handler.py"
+  }
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/locals.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/locals.tf
@@ -1,0 +1,3 @@
+locals {
+    lambda_function_name = "custodian_test_lambda_name"
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/main.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/main.tf
@@ -1,0 +1,46 @@
+resource "aws_iam_role" "this" {
+  name = "iam_for_${local.lambda_function_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name = "/aws/lambda/${local.lambda_function_name}"
+
+  tags = {
+    existing_tag = "log_group_existing_tag",
+  }
+}
+
+resource "aws_lambda_function" "this" {
+  function_name = local.lambda_function_name
+  role          = aws_iam_role.this.arn
+  runtime       = "python3.8"
+  filename      = data.archive_file.lambda_package.output_path
+  handler       = "handler.lambda_handler"
+
+  tags = {
+    copy_tag1     = "value1",
+    existing_tag  = "lambda_existing_tag",
+    not_copy_tag1 = "value3",
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+    aws_iam_role.this,
+  ]
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/providers.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/tf_resources.json
+++ b/tests/terraform/copy_lambda_tags_to_log_group_skip_existing_tags/tf_resources.json
@@ -1,0 +1,127 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "archive_file": {
+            "lambda_package": {
+                "excludes": null,
+                "id": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_base64sha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "output_file_mode": null,
+                "output_md5": "dbda80a51ce93cd8b7917d718b98351f",
+                "output_path": "./lambda_package.zip",
+                "output_sha": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_size": 206,
+                "source": [
+                    {
+                        "content": "def lambda_handler(event, context):\n  print('Hello from Lambda')\n",
+                        "filename": "./handler.py"
+                    }
+                ],
+                "source_content": null,
+                "source_content_filename": null,
+                "source_dir": null,
+                "source_file": null,
+                "type": "zip"
+            }
+        },
+        "aws_cloudwatch_log_group": {
+            "this": {
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name",
+                "id": "/aws/lambda/custodian_test_lambda_name",
+                "kms_key_id": "",
+                "name": "/aws/lambda/custodian_test_lambda_name",
+                "name_prefix": null,
+                "retention_in_days": 0,
+                "tags": {
+                    "existing_tag": "log_group_existing_tag"
+                },
+                "tags_all": {
+                    "existing_tag": "log_group_existing_tag"
+                }
+            }
+        },
+        "aws_iam_role": {
+            "this": {
+                "arn": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+                "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+                "create_date": "2022-09-26T11:08:18Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "iam_for_custodian_test_lambda_name",
+                "inline_policy": [],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "iam_for_custodian_test_lambda_name",
+                "name_prefix": "",
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "tags_all": {},
+                "unique_id": "AROAYTUGZTJLZN3R6KM4V"
+            }
+        },
+        "aws_lambda_function": {
+            "this": {
+                "architectures": [
+                    "x86_64"
+                ],
+                "arn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name",
+                "code_signing_config_arn": "",
+                "dead_letter_config": [],
+                "description": "",
+                "environment": [],
+                "ephemeral_storage": [
+                    {
+                        "size": 512
+                    }
+                ],
+                "file_system_config": [],
+                "filename": "./lambda_package.zip",
+                "function_name": "custodian_test_lambda_name",
+                "handler": "handler.lambda_handler",
+                "id": "custodian_test_lambda_name",
+                "image_config": [],
+                "image_uri": "",
+                "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name/invocations",
+                "kms_key_arn": "",
+                "last_modified": "2022-09-26T11:08:27.977+0000",
+                "layers": null,
+                "memory_size": 128,
+                "package_type": "Zip",
+                "publish": false,
+                "qualified_arn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name:$LATEST",
+                "qualified_invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name:$LATEST/invocations",
+                "reserved_concurrent_executions": -1,
+                "role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+                "runtime": "python3.8",
+                "s3_bucket": null,
+                "s3_key": null,
+                "s3_object_version": null,
+                "signing_job_arn": "",
+                "signing_profile_version_arn": "",
+                "source_code_hash": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "source_code_size": 206,
+                "tags": {
+                    "copy_tag1": "value1",
+                    "existing_tag": "lambda_existing_tag",
+                    "not_copy_tag1": "value3"
+                },
+                "tags_all": {
+                    "copy_tag1": "value1",
+                    "existing_tag": "lambda_existing_tag",
+                    "not_copy_tag1": "value3"
+                },
+                "timeout": 3,
+                "timeouts": null,
+                "tracing_config": [
+                    {
+                        "mode": "PassThrough"
+                    }
+                ],
+                "version": "$LATEST",
+                "vpc_config": []
+            }
+        }
+    }
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_without_related_resource/main.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_without_related_resource/main.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name = "/aws/codebuild/no_related_lambda_function"
+
+  tags = {}
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_without_related_resource/providers.tf
+++ b/tests/terraform/copy_lambda_tags_to_log_group_without_related_resource/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/tests/terraform/copy_lambda_tags_to_log_group_without_related_resource/tf_resources.json
+++ b/tests/terraform/copy_lambda_tags_to_log_group_without_related_resource/tf_resources.json
@@ -1,0 +1,18 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_cloudwatch_log_group": {
+            "this": {
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/no_related_lambda_function",
+                "id": "/aws/lambda/no_related_lambda_function",
+                "kms_key_id": "",
+                "name": "/aws/lambda/no_related_lambda_function",
+                "name_prefix": null,
+                "retention_in_days": 0,
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}

--- a/tests/terraform/copy_multiple_service_tags_to_log_group/datasources.tf
+++ b/tests/terraform/copy_multiple_service_tags_to_log_group/datasources.tf
@@ -1,0 +1,12 @@
+data "archive_file" "lambda_package" {
+  type        = "zip"
+  output_path = "${path.module}/lambda_package.zip"
+
+  source {
+    content  = <<EOF
+def lambda_handler(event, context):
+  print('Hello from Lambda')
+EOF
+    filename = "${path.module}/handler.py"
+  }
+}

--- a/tests/terraform/copy_multiple_service_tags_to_log_group/locals.tf
+++ b/tests/terraform/copy_multiple_service_tags_to_log_group/locals.tf
@@ -1,0 +1,4 @@
+locals {
+    lambda_function_name = "custodian_test_lambda_name"
+    codebuild_project_name = "custodian_test_codebuild_project_name"
+}

--- a/tests/terraform/copy_multiple_service_tags_to_log_group/main.tf
+++ b/tests/terraform/copy_multiple_service_tags_to_log_group/main.tf
@@ -1,0 +1,102 @@
+resource "aws_iam_role" "lambda" {
+  name = "iam_for_${local.lambda_function_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name = "/aws/lambda/${local.lambda_function_name}"
+
+  tags = {}
+}
+
+resource "aws_lambda_function" "this" {
+  function_name = local.lambda_function_name
+  role          = aws_iam_role.lambda.arn
+  runtime       = "python3.8"
+  filename      = data.archive_file.lambda_package.output_path
+  handler       = "handler.lambda_handler"
+
+  tags = {
+    copy_tag1     = "value1",
+    copy_tag2     = "value2",
+    not_copy_tag1 = "value3",
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.lambda,
+    aws_iam_role.lambda,
+  ]
+}
+
+resource "aws_iam_role" "codebuild" {
+  name = "iam_for_${local.codebuild_project_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "codebuild" {
+  name = "/aws/codebuild/${local.codebuild_project_name}"
+
+  tags = {}
+}
+
+resource "aws_codebuild_project" "this" {
+  name           = local.codebuild_project_name
+  service_role = aws_iam_role.codebuild.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:1.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+  }
+
+  source {
+    type            = "NO_SOURCE"
+    buildspec       = "version: 0.2\n\nphases:\n  build:\n    commands:\n       - echo \"testing\"\n"
+  }
+
+  tags = {
+    copy_tag1     = "value1",
+    copy_tag2     = "value2",
+    not_copy_tag1 = "value3",
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.codebuild,
+    aws_iam_role.codebuild,
+  ]
+}

--- a/tests/terraform/copy_multiple_service_tags_to_log_group/providers.tf
+++ b/tests/terraform/copy_multiple_service_tags_to_log_group/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/tests/terraform/copy_multiple_service_tags_to_log_group/tf_resources.json
+++ b/tests/terraform/copy_multiple_service_tags_to_log_group/tf_resources.json
@@ -1,0 +1,251 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "archive_file": {
+            "lambda_package": {
+                "excludes": null,
+                "id": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_base64sha256": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "output_file_mode": null,
+                "output_md5": "dbda80a51ce93cd8b7917d718b98351f",
+                "output_path": "./lambda_package.zip",
+                "output_sha": "68afcc90d1f53fb453427fa5f77739a0fa5abd03",
+                "output_size": 206,
+                "source": [
+                    {
+                        "content": "def lambda_handler(event, context):\n  print('Hello from Lambda')\n",
+                        "filename": "./handler.py"
+                    }
+                ],
+                "source_content": null,
+                "source_content_filename": null,
+                "source_dir": null,
+                "source_file": null,
+                "type": "zip"
+            }
+        },
+        "aws_cloudwatch_log_group": {
+            "codebuild": {
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/codebuild/custodian_test_codebuild_project_name",
+                "id": "/aws/codebuild/custodian_test_codebuild_project_name",
+                "kms_key_id": "",
+                "name": "/aws/codebuild/custodian_test_codebuild_project_name",
+                "name_prefix": null,
+                "retention_in_days": 0,
+                "tags": null,
+                "tags_all": {}
+            },
+            "lambda": {
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/custodian_test_lambda_name",
+                "id": "/aws/lambda/custodian_test_lambda_name",
+                "kms_key_id": "",
+                "name": "/aws/lambda/custodian_test_lambda_name",
+                "name_prefix": null,
+                "retention_in_days": 0,
+                "tags": null,
+                "tags_all": {}
+            }
+        },
+        "aws_codebuild_project": {
+            "this": {
+                "arn": "arn:aws:codebuild:us-east-1:644160558196:project/custodian_test_codebuild_project_name",
+                "artifacts": [
+                    {
+                        "artifact_identifier": "",
+                        "bucket_owner_access": "",
+                        "encryption_disabled": false,
+                        "location": "",
+                        "name": "",
+                        "namespace_type": "",
+                        "override_artifact_name": false,
+                        "packaging": "",
+                        "path": "",
+                        "type": "NO_ARTIFACTS"
+                    }
+                ],
+                "badge_enabled": false,
+                "badge_url": "",
+                "build_batch_config": [],
+                "build_timeout": 60,
+                "cache": [
+                    {
+                        "location": "",
+                        "modes": [],
+                        "type": "NO_CACHE"
+                    }
+                ],
+                "concurrent_build_limit": 0,
+                "description": "",
+                "encryption_key": "arn:aws:kms:us-east-1:644160558196:alias/aws/s3",
+                "environment": [
+                    {
+                        "certificate": "",
+                        "compute_type": "BUILD_GENERAL1_SMALL",
+                        "environment_variable": [],
+                        "image": "aws/codebuild/standard:1.0",
+                        "image_pull_credentials_type": "CODEBUILD",
+                        "privileged_mode": false,
+                        "registry_credential": [],
+                        "type": "LINUX_CONTAINER"
+                    }
+                ],
+                "file_system_locations": [],
+                "id": "arn:aws:codebuild:us-east-1:644160558196:project/custodian_test_codebuild_project_name",
+                "logs_config": [
+                    {
+                        "cloudwatch_logs": [
+                            {
+                                "group_name": "",
+                                "status": "ENABLED",
+                                "stream_name": ""
+                            }
+                        ],
+                        "s3_logs": [
+                            {
+                                "bucket_owner_access": "",
+                                "encryption_disabled": false,
+                                "location": "",
+                                "status": "DISABLED"
+                            }
+                        ]
+                    }
+                ],
+                "name": "custodian_test_codebuild_project_name",
+                "project_visibility": "PRIVATE",
+                "public_project_alias": "",
+                "queued_timeout": 480,
+                "resource_access_role": "",
+                "secondary_artifacts": [],
+                "secondary_source_version": [],
+                "secondary_sources": [],
+                "service_role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_codebuild_project_name",
+                "source": [
+                    {
+                        "auth": [],
+                        "build_status_config": [],
+                        "buildspec": "version: 0.2\n\nphases:\n  build:\n    commands:\n       - echo \"testing\"\n",
+                        "git_clone_depth": 0,
+                        "git_submodules_config": [],
+                        "insecure_ssl": false,
+                        "location": "",
+                        "report_build_status": false,
+                        "type": "NO_SOURCE"
+                    }
+                ],
+                "source_version": "",
+                "tags": {
+                    "copy_tag1": "value1",
+                    "copy_tag2": "value2",
+                    "not_copy_tag1": "value3"
+                },
+                "tags_all": {
+                    "copy_tag1": "value1",
+                    "copy_tag2": "value2",
+                    "not_copy_tag1": "value3"
+                },
+                "vpc_config": []
+            }
+        },
+        "aws_iam_role": {
+            "codebuild": {
+                "arn": "arn:aws:iam::644160558196:role/iam_for_custodian_test_codebuild_project_name",
+                "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"codebuild.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+                "create_date": "2022-09-26T14:51:21Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "iam_for_custodian_test_codebuild_project_name",
+                "inline_policy": [],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "iam_for_custodian_test_codebuild_project_name",
+                "name_prefix": "",
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "tags_all": {},
+                "unique_id": "AROAUY7BEYQVBE7437VJT"
+            },
+            "lambda": {
+                "arn": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+                "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+                "create_date": "2022-09-26T14:51:21Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "iam_for_custodian_test_lambda_name",
+                "inline_policy": [],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "iam_for_custodian_test_lambda_name",
+                "name_prefix": "",
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": null,
+                "tags_all": {},
+                "unique_id": "AROAUY7BEYQVIGGDJZWMU"
+            }
+        },
+        "aws_lambda_function": {
+            "this": {
+                "architectures": [
+                    "x86_64"
+                ],
+                "arn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name",
+                "code_signing_config_arn": "",
+                "dead_letter_config": [],
+                "description": "",
+                "environment": [],
+                "ephemeral_storage": [
+                    {
+                        "size": 512
+                    }
+                ],
+                "file_system_config": [],
+                "filename": "./lambda_package.zip",
+                "function_name": "custodian_test_lambda_name",
+                "handler": "handler.lambda_handler",
+                "id": "custodian_test_lambda_name",
+                "image_config": [],
+                "image_uri": "",
+                "invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name/invocations",
+                "kms_key_arn": "",
+                "last_modified": "2022-09-26T14:51:31.651+0000",
+                "layers": null,
+                "memory_size": 128,
+                "package_type": "Zip",
+                "publish": false,
+                "qualified_arn": "arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name:$LATEST",
+                "qualified_invoke_arn": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:644160558196:function:custodian_test_lambda_name:$LATEST/invocations",
+                "reserved_concurrent_executions": -1,
+                "role": "arn:aws:iam::644160558196:role/iam_for_custodian_test_lambda_name",
+                "runtime": "python3.8",
+                "s3_bucket": null,
+                "s3_key": null,
+                "s3_object_version": null,
+                "signing_job_arn": "",
+                "signing_profile_version_arn": "",
+                "source_code_hash": "lD/UayWBQclNCPtLONanF0NsCwgfVii9QazqWgmwtIE=",
+                "source_code_size": 206,
+                "tags": {
+                    "copy_tag1": "value1",
+                    "copy_tag2": "value2",
+                    "not_copy_tag1": "value3"
+                },
+                "tags_all": {
+                    "copy_tag1": "value1",
+                    "copy_tag2": "value2",
+                    "not_copy_tag1": "value3"
+                },
+                "timeout": 3,
+                "timeouts": null,
+                "tracing_config": [
+                    {
+                        "mode": "PassThrough"
+                    }
+                ],
+                "version": "$LATEST",
+                "vpc_config": []
+            }
+        }
+    }
+}


### PR DESCRIPTION
Copy tags from related AWS resources to CloudWatch log groups. A related resource is found by CloudWatch log group name removing '/aws/<service>' prefix.

This action can be useful to tag CloudWatch log groups created automatically. For example, a Lambda function may create a log group if it doesn't exist (unfortunately, log group would be created without tags even if a lambda function has tags).

At this moment, only *lambda* and *codebuild* services are supported.

A new action is added since there is specific logic of relationship between child and parent resources (based on log group name pattern) so that I decided to implement this separately from `copy-related-tags` action.