### PR TITLE
aws - s3 - set-inventory: add the additional optional fields

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -2654,7 +2654,7 @@ class SetInventory(BucketActionBase):
             'Size', 'LastModifiedDate', 'StorageClass', 'ETag',
             'IsMultipartUploaded', 'ReplicationStatus', 'EncryptionStatus',
             'ObjectLockRetainUntilDate', 'ObjectLockMode', 'ObjectLockLegalHoldStatus',
-            'IntelligentTieringAccessTier']}})
+            'IntelligentTieringAccessTier', 'BucketKeyStatus', 'ChecksumAlgorithm']}})
 
     permissions = ('s3:PutInventoryConfiguration', 's3:GetInventoryConfiguration')
 


### PR DESCRIPTION
Support the new optional fields:
- Bucket key status
- Additional checksums function

Example
```yaml
    filters:
      - type: value
        key: Location.LocationConstraint
        value: us-east-2
      - not:
        - type: inventory
          key: Id
          value: s3_inventory
    actions:
      - type: set-inventory
        name: s3_inventory
        versions: All
        destination: my_dst
        prefix: my_prefix/{account_id}
        schedule: Weekly
        format: Parquet
        state: enabled
        encryption: SSES3
        fields:
          - Size
          - LastModifiedDate
          - StorageClass
          - ETag
          - IsMultipartUploaded
          - ReplicationStatus
          - EncryptionStatus
          - ObjectLockRetainUntilDate
          - ObjectLockMode
          - ObjectLockLegalHoldStatus
          - IntelligentTieringAccessTier
          - BucketKeyStatus
          - ChecksumAlgorithm
```