### PR TITLE
aws - servicecatalog - added new resource of type catalog-product

### DIFF
--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -20,6 +20,7 @@ ResourceMap = {
     "aws.cache-snapshot": "c7n.resources.elasticache.ElastiCacheSnapshot",
     "aws.cache-subnet-group": "c7n.resources.elasticache.ElastiCacheSubnetGroup",
     "aws.catalog-portfolio": "c7n.resources.servicecatalog.CatalogPortfolio",
+    "aws.catalog-product": "c7n.resources.servicecatalog.CatalogProduct",
     "aws.cfn": "c7n.resources.cfn.CloudFormation",
     "aws.cloud-directory": "c7n.resources.directory.CloudDirectory",
     "aws.cloudhsm-cluster": "c7n.resources.hsm.CloudHSMCluster",

--- a/c7n/resources/servicecatalog.py
+++ b/c7n/resources/servicecatalog.py
@@ -169,3 +169,19 @@ class RemoveSharedAccounts(BaseAction):
         client = local_session(self.manager.session_factory).client('servicecatalog')
         for p in portfolios:
             self.delete_shared_accounts(client, p)
+
+
+@resources.register('catalog-product')
+class CatalogProduct(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'servicecatalog'
+        arn_type = 'catalog-product'
+        enum_spec = ('search_products_as_admin', 'ProductViewDetails[].ProductViewSummary', None)
+        detail_spec = ('describe_product_as_admin', 'Id', 'ProductId', None)
+        id = 'ProductId'
+        name = 'Name'
+        arn = 'ProductARN'
+        date = 'CreatedTime'
+        universal_taggable = object()
+        cfn_type = 'AWS::ServiceCatalog::CloudFormationProduct'

--- a/tests/data/placebo/test_catalog_product_resource/servicecatalog.DescribeProductAsAdmin_1.json
+++ b/tests/data/placebo/test_catalog_product_resource/servicecatalog.DescribeProductAsAdmin_1.json
@@ -1,0 +1,63 @@
+{
+    "status_code": 200,
+    "data": {
+        "ProductViewDetail": {
+            "ProductViewSummary": {
+                "Id": "testview-ipzsltwzr26dq",
+                "ProductId": "test-6orqs3iobd7om",
+                "Name": "testProduct",
+                "Owner": "testOwner",
+                "ShortDescription": "test-product",
+                "Type": "CLOUD_FORMATION_TEMPLATE",
+                "Distributor": "xyz",
+                "HasDefaultPath": true,
+                "SupportEmail": "xyz@test.com",
+                "SupportDescription": "",
+                "SupportUrl": ""
+            },
+            "Status": "AVAILABLE",
+            "ProductARN": "arn:aws:catalog:us-east-2:123456789012:product/test-6orqs3iobd7om",
+            "CreatedTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 17,
+                "hour": 6,
+                "minute": 1,
+                "second": 58,
+                "microsecond": 667000
+            }
+        },
+        "ProvisioningArtifactSummaries": [
+            {
+                "Id": "pa-wxfliske47cp2",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 6,
+                    "minute": 1,
+                    "second": 58,
+                    "microsecond": 667000
+                },
+                "ProvisioningArtifactMetadata": {
+                    "SourceProvisioningArtifactId": "pa-wxfliske47cp2"
+                }
+            }
+        ],
+        "Tags": [
+            {
+                "Key": "Name",
+                "Value": "testProduct"
+            }
+        ],
+        "TagOptions": [],
+        "Budgets": [
+            {
+                "BudgetName": "testBudget"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_catalog_product_resource/servicecatalog.SearchProductsAsAdmin_1.json
+++ b/tests/data/placebo/test_catalog_product_resource/servicecatalog.SearchProductsAsAdmin_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "ProductViewDetails": [
+            {
+                "ProductViewSummary": {
+                    "Id": "testview-ipzsltwzr26dq",
+                    "ProductId": "test-6orqs3iobd7om",
+                    "Name": "testProduct",
+                    "Owner": "testOwner",
+                    "ShortDescription": "test-product",
+                    "Type": "CLOUD_FORMATION_TEMPLATE",
+                    "Distributor": "xyz",
+                    "HasDefaultPath": true,
+                    "SupportEmail": "xyz@test.com",
+                    "SupportDescription": "",
+                    "SupportUrl": ""
+                },
+                "Status": "AVAILABLE",
+                "ProductARN": "arn:aws:catalog:us-east-2:123456789012:product/test-6orqs3iobd7om",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 6,
+                    "minute": 1,
+                    "second": 58,
+                    "microsecond": 667000
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_servicecatalog.py
+++ b/tests/test_servicecatalog.py
@@ -82,3 +82,23 @@ class TestServiceCatalog(BaseTest):
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 0)
+
+    def test_catalog_product_resource(self):
+        session_factory = self.replay_flight_data('test_catalog_product_resource')
+        p = self.load_policy(
+            {
+                'name': 'test-catalog-product',
+                'resource': 'catalog-product',
+                'filters': [
+                    {
+                        'type': 'value',
+                        'key': 'ProductId',
+                        'value': 'test-6orqs3iobd7om'
+                    }
+                ]
+            },
+            session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertTrue(len(resources), 1)
+        self.assertTrue(resources[0]['Name'], 'testProduct')


### PR DESCRIPTION
Adding a new resource type for 'catalog-product ' to aid checking TagOption configuration for Service Catalog products so that we can determine which service catalog products do not have a specified tag and are active.
Since there is no existing resource to capture the catalog products. 

Sample policies
```
Service Catalog

- name: service-catalog-product-tag-check-daily
  resource: catalog-product
  filters:
      - type: value
        key: TagOptions[].Key
        op: in
        value: asset_id
        value_type: swap
  actions:
      - type: notify
```