### PR TITLE
utils - handle interpolation of non-string variables

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -524,6 +524,13 @@ class UtilTest(BaseTest):
                 {'k': '{limit}',
                  'b': '{account_id}'}, account_id=21),
             {'k': '{limit}',
+             'b': 21})
+
+        self.assertEqual(
+            utils.format_string_values(
+                {'k': '{limit}',
+                 'b': '{account_id}'}, account_id='21'),
+            {'k': '{limit}',
              'b': '21'})
 
     def test_get_support_region(self):

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -722,3 +722,7 @@ def run(config, use, output_dir, accounts, tags, region,
 
     if not success:
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
This is an experiment / discussion-starter around issue #7553 (and by extension #6734 ). It looks like the root of the issue is this conflict:

* Folks writing policies and c7n-org config files want to define non-string variable values
* Injecting those variables at runtime calls [str.format()](https://docs.python.org/3/library/stdtypes.html#str.format) under the hood, which converts those variables to strings
* Suggested workarounds either cause policies to fail validation, or don't address this conflict

Now I'm not sure this is the _right_ idea, but one thing we _could_ do is focus on a very specific situation like this:

```yaml
    actions:
      - type: mark-for-op
        op: delete
        days: "{deletion_grace_days}"
        tag: Status
```

Note that `"{deletion_grace_days}"` contains exactly one variable replacement field, and it represents the entire string. It's possible that when we detect that specific case, we substitute a variable directly rather than calling `str.format()` on it.

Again, I'm not sure this is the right approach. But rejecting it would probably be a useful discussion.