### PR TITLE
c7n_tencentcloud - Add environment fixture, and add 'qcs' to resources.

### DIFF
--- a/tools/c7n_tencentcloud/c7n_tencentcloud/actions/tags.py
+++ b/tools/c7n_tencentcloud/c7n_tencentcloud/actions/tags.py
@@ -51,7 +51,7 @@ class TagAction(TencentCloudBaseAction):
         The tag request parameter, the default is to add the tag parameter,
         if the action is UnTagResources, it means to delete the tag
         """
-        qcs_list = self.manager.source.get_resource_qcs(resources)
+        qcs_list = [r['qcs'] for r in resources]
 
         if self.t_api_method_name == "UnTagResources":
             return {"ResourceList": qcs_list, "TagKeys": tags}
@@ -127,7 +127,7 @@ class RenameTagAction(TagAction):
         """
         param = {}
         old_tag = self._get_tag_params(resource)
-        qcs_list = self.manager.source.get_resource_qcs([resource])
+        qcs_list = [resource['qcs']]
         param.update({"Resource": qcs_list[0]})
         if old_tag is not None:
             replaceTags = {"ReplaceTags": [{

--- a/tools/c7n_tencentcloud/c7n_tencentcloud/query.py
+++ b/tools/c7n_tencentcloud/c7n_tencentcloud/query.py
@@ -156,14 +156,19 @@ class DescribeSource:
         return []
 
     def augment(self, resources):
+        self.set_qcs_on_resources(resources)
         return self.get_resource_tag(resources)
+
+    def set_qcs_on_resources(self, resources):
+        for qcs, resource in zip(self.get_resource_qcs(resources), resources):
+            resource['qcs'] = qcs
 
     def get_resource_tag(self, resources):
         """
         Get resource tag
         All resource tags need to be obtained separately
         """
-        resource_map = dict(zip(self.get_resource_qcs(resources), resources))
+        resource_map = {r['qcs']:r for r in resources}
 
         for batch in chunks(resource_map, self.tag_batch_size):
             # construct a separate id to qcs code map,since we're using unqualified qcs
@@ -182,7 +187,7 @@ class DescribeSource:
         get_resource_qcs
         resource description https://cloud.tencent.com/document/product/598/10606
         """
-        # qcs::${ServiceType}:${Region}:${Account}:${ResourcePreifx}/${ResourceId}
+        # qcs::${ServiceType}:${Region}:${Account}:${ResourcePrefix}/${ResourceId}
         # qcs::cvm:ap-singapore::instance/ins-ibu7wp2a
         qcs_list = []
         for r in resources:
@@ -280,7 +285,7 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
         params = self.get_resource_query_params()
         resources = self.source.resources(params)
 
-        # filter resoures
+        # filter resources
         resources = self.filter_resources(resources)
 
         self.check_resource_limit(resources)

--- a/tools/c7n_tencentcloud/c7n_tencentcloud/query.py
+++ b/tools/c7n_tencentcloud/c7n_tencentcloud/query.py
@@ -168,7 +168,7 @@ class DescribeSource:
         Get resource tag
         All resource tags need to be obtained separately
         """
-        resource_map = {r['qcs']:r for r in resources}
+        resource_map = {r['qcs']: r for r in resources}
 
         for batch in chunks(resource_map, self.tag_batch_size):
             # construct a separate id to qcs code map,since we're using unqualified qcs

--- a/tools/c7n_tencentcloud/c7n_tencentcloud/resources/cvm.py
+++ b/tools/c7n_tencentcloud/c7n_tencentcloud/resources/cvm.py
@@ -16,6 +16,7 @@ from c7n_tencentcloud.utils import PageMethod
 class CVMDescribe(DescribeSource):
 
     def augment(self, resources):
+        self.set_qcs_on_resources(resources)
         return resources
 
 

--- a/tools/c7n_tencentcloud/tests/conftest.py
+++ b/tools/c7n_tencentcloud/tests/conftest.py
@@ -7,6 +7,13 @@ from c7n.ctx import ExecutionContext
 from c7n_tencentcloud.client import Session
 
 
+@pytest.fixture(autouse=True)
+def credential_env_vars(monkeypatch):
+    monkeypatch.setenv("TENCENTCLOUD_SECRET_ID", "xyz")
+    monkeypatch.setenv("TENCENTCLOUD_SECRET_KEY", "abc123")
+    monkeypatch.setenv("TENCENTCLOUD_REGION", "na-ashburn")
+
+
 @pytest.fixture(scope="package")
 def vcr_config():
     return {

--- a/tools/c7n_tencentcloud/tests/test_tc_provider.py
+++ b/tools/c7n_tencentcloud/tests/test_tc_provider.py
@@ -31,7 +31,8 @@ def test_get_session_factory(tc_provider):
 
 
 test_cases = [
-    ([], os.environ.get('TENCENTCLOUD_REGION', DEFAULT_REGION)),
+    # Default region matches the TENCENTCLOUD_REGION configured in conftest.py
+    ([], "na-ashburn"),
     (["ap-shanghai"], "ap-shanghai"),
     (["ap-shanghai", "others"], "ap-shanghai")
 ]

--- a/tools/c7n_tencentcloud/tests/test_tc_provider.py
+++ b/tools/c7n_tencentcloud/tests/test_tc_provider.py
@@ -1,12 +1,11 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 
 import pytest
 from c7n.config import Config
 from c7n_tencentcloud.client import Session
-from c7n_tencentcloud.provider import TencentCloud, DEFAULT_REGION
+from c7n_tencentcloud.provider import TencentCloud
 from tencentcloud.common.exception.tencent_cloud_sdk_exception import TencentCloudSDKException
 
 


### PR DESCRIPTION
Environment fixture means that the tests can run on a clean checkout.
Adds 'qcs' as a resource key as part of the resource description.