### PR TITLE
aws - sqs - set-encryption key usage consistency

### DIFF
--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -33,6 +33,7 @@ class DescribeQueue(DescribeSource):
                     QueueUrl=r,
                     AttributeNames=['All'])['Attributes']
                 queue['QueueUrl'] = r
+                queue['QueueName'] = queue['QueueArn'].rsplit(':', 1)[-1]
             except ClientError as e:
                 if e.response['Error']['Code'] == 'AWS.SimpleQueueService.NonExistentQueue':
                     return
@@ -332,6 +333,9 @@ class DeleteSqsQueue(BaseAction):
 class SetEncryption(BaseAction):
     """Action to set encryption key on SQS queue
 
+    you can also optionally set data key 'reuse-period', or use with
+    the service managed encryption by not specifying a key.
+
     :example:
 
     .. code-block:: yaml
@@ -348,37 +352,52 @@ class SetEncryption(BaseAction):
     schema = type_schema(
         'set-encryption',
         **{
-            "required": ('key',),
-            "reuse-period": {'type': 'integer'},
-            "key": {'type': 'string'}})
+            "enabled": {'type': 'boolean'},
+            "reuse-period": {'type': 'integer', 'minimum': 60, 'maximum': 86400},
+            "key": {'type': 'string'}}
+    )
 
     permissions = ('sqs:SetQueueAttributes',)
     uuid_regex = re.compile('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
 
     def process(self, queues):
-        # get KeyId
-        key = self.data.get('key', 'alias/aws/sqs')
-        if (not key.startswith('alias')
+        # compatibility, if key is given and not arn/key id/ or prefixed with
+        # alias, add alias to it.
+        key = self.data.get('key', None)
+        if (key
+            and not key.startswith('alias')
             and not key.startswith('arn:')
                 and not self.uuid_regex.search(key)):
             key = "alias/" + key
-        session = local_session(self.manager.session_factory)
-        key_id = session.client(
-            'kms').describe_key(KeyId=key)['KeyMetadata']['KeyId']
+
         client = self.manager.get_client()
 
-        for q in queues:
-            self.process_queue(client, q, key_id)
+        reuse_period = self.data.get('reuse-period', 300)
+        params = {}
+        if not self.data.get('enabled', True):
+            params['SqsManagedSseEnabled'] = 'false'
+            params['KmsMasterKeyId'] = ''
+        elif self.data.get('enable', True) and not key:
+            params['SqsManagedSseEnabled'] = 'true'
+            params['KmsMasterKeyId'] = ''
+        elif self.data.get('enable', True) and key:
+            params['SqsManagedSseEnabled'] = 'false'
+            params['KmsMasterKeyId'] = key
+            params['KmsDataKeyReusePeriodSeconds'] = str(reuse_period)
 
-    def process_queue(self, client, queue, key_id):
+        for q in queues:
+            self.process_queue(client, q, params)
+
+    def process_queue(self, client, queue, params):
         try:
             client.set_queue_attributes(
                 QueueUrl=queue['QueueUrl'],
-                Attributes={'KmsMasterKeyId': key_id}
+                Attributes=params
             )
         except (client.exceptions.QueueDoesNotExist,) as e:
             self.log.exception(
                 "Exception modifying queue:\n %s" % e)
+            raise
 
 
 @SQS.action_registry.register('set-retention-period')

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -397,7 +397,6 @@ class SetEncryption(BaseAction):
         except (client.exceptions.QueueDoesNotExist,) as e:
             self.log.exception(
                 "Exception modifying queue:\n %s" % e)
-            raise
 
 
 @SQS.action_registry.register('set-retention-period')

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -358,7 +358,9 @@ class SetEncryption(BaseAction):
     def process(self, queues):
         # get KeyId
         key = self.data.get('key', 'alias/aws/sqs')
-        if not key.startswith('alias') and not key.startswith('arn:') and not self.uuid_regex.search(key):
+        if (not key.startswith('alias')
+            and not key.startswith('arn:')
+                and not self.uuid_regex.search(key)):
             key = "alias/" + key
         session = local_session(self.manager.session_factory)
         key_id = session.client(


### PR DESCRIPTION
closes #7762

we no longer dereference the key passed in which results in better ux, since the alias will be preserved by the service api, we also supports setting data key reuse period, using service sse, and disabling encryption.

