### PR TITLE
improve docker layer cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,5 @@ results.xml
 pip-selfcheck.json
 .coverage
 *~
+**/tests/
+**/tests_azure/

--- a/docker/c7n
+++ b/docker/c7n
@@ -3,6 +3,7 @@
 FROM ubuntu:22.04 as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -15,29 +16,70 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    poetry install && cd ../../; done
+ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+
+
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+# Now install the root of each provider
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 

--- a/docker/c7n
+++ b/docker/c7n
@@ -88,10 +88,6 @@ FROM ubuntu:22.04
 LABEL name="cli" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
 
-COPY --from=build-env /src /src
-COPY --from=build-env /usr/local /usr/local
-COPY --from=build-env /output /output
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
@@ -99,6 +95,13 @@ RUN apt-get --yes update \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*
+
+# These should remain below any other commands because they will invalidate
+# the layer cache
+COPY --from=build-env /src /src
+COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /output /output
+
 
 RUN adduser --disabled-login --gecos "" custodian
 USER custodian

--- a/docker/c7n
+++ b/docker/c7n
@@ -59,19 +59,19 @@ ADD tools/c7n_gcp /src/tools/c7n_gcp
 RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
 RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_kube /src/tools/c7n_kube
 RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_openstack /src/tools/c7n_openstack
 RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 

--- a/docker/c7n
+++ b/docker/c7n
@@ -30,23 +30,23 @@ ARG providers="gcp azure kube openstack tencentcloud"
 # cache of dependency installs.
 
 ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
 
 
 # Now install the root package
@@ -56,23 +56,23 @@ RUN . /usr/local/bin/activate && poetry install --only-root
 # Now install the root of each provider
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_azure /src/tools/c7n_azure
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_kube /src/tools/c7n_kube
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/docker/c7n
+++ b/docker/c7n
@@ -75,12 +75,6 @@ ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-
 RUN mkdir /output
 
 FROM ubuntu:22.04

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -3,6 +3,7 @@
 FROM debian:10-slim as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -15,29 +16,70 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    poetry install && cd ../../; done
+ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+
+
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+# Now install the root of each provider
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -75,12 +75,6 @@ ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-
 RUN mkdir /output
 
 FROM gcr.io/distroless/python3-debian10

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -59,19 +59,19 @@ ADD tools/c7n_gcp /src/tools/c7n_gcp
 RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
 RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_kube /src/tools/c7n_kube
 RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_openstack /src/tools/c7n_openstack
 RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -30,23 +30,23 @@ ARG providers="gcp azure kube openstack tencentcloud"
 # cache of dependency installs.
 
 ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
 
 
 # Now install the root package
@@ -56,23 +56,23 @@ RUN . /usr/local/bin/activate && poetry install --only-root
 # Now install the root of each provider
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_azure /src/tools/c7n_azure
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_kube /src/tools/c7n_kube
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -3,6 +3,7 @@
 FROM ubuntu:22.04 as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -15,29 +16,70 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    poetry install && cd ../../; done
+ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+
+
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+# Now install the root of each provider
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -59,19 +59,19 @@ ADD tools/c7n_gcp /src/tools/c7n_gcp
 RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
 RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_kube /src/tools/c7n_kube
 RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_openstack /src/tools/c7n_openstack
 RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -75,12 +75,6 @@ ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-
 RUN mkdir /output
 
 # Install c7n-org

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -30,23 +30,23 @@ ARG providers="gcp azure kube openstack tencentcloud"
 # cache of dependency installs.
 
 ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
 
 
 # Now install the root package
@@ -56,23 +56,23 @@ RUN . /usr/local/bin/activate && poetry install --only-root
 # Now install the root of each provider
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_azure /src/tools/c7n_azure
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_kube /src/tools/c7n_kube
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -92,10 +92,6 @@ FROM ubuntu:22.04
 LABEL name="org" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
 
-COPY --from=build-env /src /src
-COPY --from=build-env /usr/local /usr/local
-COPY --from=build-env /output /output
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
@@ -103,6 +99,13 @@ RUN apt-get --yes update \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*
+
+# These should remain below any other commands because they will invalidate
+# the layer cache
+COPY --from=build-env /src /src
+COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /output /output
+
 
 RUN adduser --disabled-login --gecos "" custodian
 USER custodian

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -3,6 +3,7 @@
 FROM debian:10-slim as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -15,29 +16,70 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    poetry install && cd ../../; done
+ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+
+
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+# Now install the root of each provider
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -59,19 +59,19 @@ ADD tools/c7n_gcp /src/tools/c7n_gcp
 RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
 RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_kube /src/tools/c7n_kube
 RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_openstack /src/tools/c7n_openstack
 RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -75,12 +75,6 @@ ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-
 RUN mkdir /output
 
 # Install c7n-org

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -30,23 +30,23 @@ ARG providers="gcp azure kube openstack tencentcloud"
 # cache of dependency installs.
 
 ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
 
 
 # Now install the root package
@@ -56,23 +56,23 @@ RUN . /usr/local/bin/activate && poetry install --only-root
 # Now install the root of each provider
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_azure /src/tools/c7n_azure
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_kube /src/tools/c7n_kube
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/docker/mailer
+++ b/docker/mailer
@@ -3,6 +3,7 @@
 FROM ubuntu:22.04 as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -15,29 +16,70 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    poetry install && cd ../../; done
+ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+
+
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+# Now install the root of each provider
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 

--- a/docker/mailer
+++ b/docker/mailer
@@ -93,10 +93,6 @@ FROM ubuntu:22.04
 LABEL name="mailer" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
 
-COPY --from=build-env /src /src
-COPY --from=build-env /usr/local /usr/local
-COPY --from=build-env /output /output
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
@@ -104,6 +100,13 @@ RUN apt-get --yes update \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*
+
+# These should remain below any other commands because they will invalidate
+# the layer cache
+COPY --from=build-env /src /src
+COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /output /output
+
 
 RUN adduser --disabled-login --gecos "" custodian
 USER custodian

--- a/docker/mailer
+++ b/docker/mailer
@@ -75,12 +75,6 @@ ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-
 RUN mkdir /output
 
 # Install c7n-mailer

--- a/docker/mailer
+++ b/docker/mailer
@@ -59,19 +59,19 @@ ADD tools/c7n_gcp /src/tools/c7n_gcp
 RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
 RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_kube /src/tools/c7n_kube
 RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_openstack /src/tools/c7n_openstack
 RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 

--- a/docker/mailer
+++ b/docker/mailer
@@ -30,23 +30,23 @@ ARG providers="gcp azure kube openstack tencentcloud"
 # cache of dependency installs.
 
 ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
 
 
 # Now install the root package
@@ -56,23 +56,23 @@ RUN . /usr/local/bin/activate && poetry install --only-root
 # Now install the root of each provider
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_azure /src/tools/c7n_azure
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_kube /src/tools/c7n_kube
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -75,12 +75,6 @@ ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-
 RUN mkdir /output
 
 # Install c7n-mailer

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -3,6 +3,7 @@
 FROM debian:10-slim as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -15,29 +16,70 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    poetry install && cd ../../; done
+ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+
+
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+# Now install the root of each provider
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -59,19 +59,19 @@ ADD tools/c7n_gcp /src/tools/c7n_gcp
 RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
 RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_kube /src/tools/c7n_kube
 RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_openstack /src/tools/c7n_openstack
 RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -30,23 +30,23 @@ ARG providers="gcp azure kube openstack tencentcloud"
 # cache of dependency installs.
 
 ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
 
 
 # Now install the root package
@@ -56,23 +56,23 @@ RUN . /usr/local/bin/activate && poetry install --only-root
 # Now install the root of each provider
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_azure /src/tools/c7n_azure
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_kube /src/tools/c7n_kube
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/docker/policystream
+++ b/docker/policystream
@@ -3,6 +3,7 @@
 FROM ubuntu:22.04 as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -15,29 +16,70 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    poetry install && cd ../../; done
+ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+
+
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+# Now install the root of each provider
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 

--- a/docker/policystream
+++ b/docker/policystream
@@ -92,10 +92,6 @@ FROM ubuntu:22.04
 LABEL name="policystream" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
 
-COPY --from=build-env /src /src
-COPY --from=build-env /usr/local /usr/local
-COPY --from=build-env /output /output
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
@@ -103,6 +99,13 @@ RUN apt-get --yes update \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*
+
+# These should remain below any other commands because they will invalidate
+# the layer cache
+COPY --from=build-env /src /src
+COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /output /output
+
 
 RUN adduser --disabled-login --gecos "" custodian
 USER custodian

--- a/docker/policystream
+++ b/docker/policystream
@@ -59,19 +59,19 @@ ADD tools/c7n_gcp /src/tools/c7n_gcp
 RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
 RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_kube /src/tools/c7n_kube
 RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_openstack /src/tools/c7n_openstack
 RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 

--- a/docker/policystream
+++ b/docker/policystream
@@ -30,23 +30,23 @@ ARG providers="gcp azure kube openstack tencentcloud"
 # cache of dependency installs.
 
 ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
 
 
 # Now install the root package
@@ -56,23 +56,23 @@ RUN . /usr/local/bin/activate && poetry install --only-root
 # Now install the root of each provider
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_azure /src/tools/c7n_azure
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_kube /src/tools/c7n_kube
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/docker/policystream
+++ b/docker/policystream
@@ -75,12 +75,6 @@ ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-
 RUN mkdir /output
 
 # Install c7n-policystream

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -3,6 +3,7 @@
 FROM debian:10-slim as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -15,29 +16,70 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \
-    for pkg in $providers; do cd tools/c7n_$pkg && \
-    poetry install && cd ../../; done
+ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+
+
+ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+
+
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+# Now install the root of each provider
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -59,19 +59,19 @@ ADD tools/c7n_gcp /src/tools/c7n_gcp
 RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
 RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_kube /src/tools/c7n_kube
 RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_openstack /src/tools/c7n_openstack
 RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -30,23 +30,23 @@ ARG providers="gcp azure kube openstack tencentcloud"
 # cache of dependency installs.
 
 ADD tools/c7n_gcp/pyproject.toml tools/c7n_gcp/poetry.lock /src/tools/c7n_gcp/
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_azure/pyproject.toml tools/c7n_azure/poetry.lock /src/tools/c7n_azure/
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_kube/pyproject.toml tools/c7n_kube/poetry.lock /src/tools/c7n_kube/
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_openstack/pyproject.toml tools/c7n_openstack/poetry.lock /src/tools/c7n_openstack/
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --without dev --no-root; fi
 
 
 ADD tools/c7n_tencentcloud/pyproject.toml tools/c7n_tencentcloud/poetry.lock /src/tools/c7n_tencentcloud/
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --without dev --no-root; fi
 
 
 # Now install the root package
@@ -56,23 +56,23 @@ RUN . /usr/local/bin/activate && poetry install --only-root
 # Now install the root of each provider
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN if [[ " ${providers[*]} " =~ " gcp " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "gcp" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_gcp &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_azure /src/tools/c7n_azure
-RUN if [[ " ${providers[*]} " =~ " azure " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "azure" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_azure &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_kube /src/tools/c7n_kube
-RUN if [[ " ${providers[*]} " =~ " kube " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "kube" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_kube &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN if [[ " ${providers[*]} " =~ " openstack " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "openstack" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_openstack &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN if [[ " ${providers[*]} " =~ " tencentcloud " ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
+RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
 ADD tools/c7n_gcp /src/tools/c7n_gcp

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -75,12 +75,6 @@ ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 RUN if [[ " ${providers[*]} " =~ "tencentcloud" ]]; then     . /usr/local/bin/activate &&     cd tools/c7n_tencentcloud &&     poetry install --only-root; fi
 
 
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-
 RUN mkdir /output
 
 # Install c7n-policystream

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -27,7 +27,7 @@ log = logging.getLogger("dockerpkg")
 
 PHASE_1_INSTALL_TMPL = """
 ADD tools/c7n_{pkg}/pyproject.toml tools/c7n_{pkg}/poetry.lock /src/tools/c7n_{pkg}/
-RUN if [[ " ${{providers[*]}} " =~ " {pkg} " ]]; then \
+RUN if [[ " ${{providers[*]}} " =~ "{pkg}" ]]; then \
     . /usr/local/bin/activate && \
     cd tools/c7n_{pkg} && \
     poetry install --without dev --no-root; \
@@ -36,7 +36,7 @@ fi
 
 PHASE_2_INSTALL_TMPL = """
 ADD tools/c7n_{pkg} /src/tools/c7n_{pkg}
-RUN if [[ " ${{providers[*]}} " =~ " {pkg} " ]]; then \
+RUN if [[ " ${{providers[*]}} " =~ "{pkg}" ]]; then \
     . /usr/local/bin/activate && \
     cd tools/c7n_{pkg} && \
     poetry install --only-root; \

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -113,10 +113,6 @@ FROM {base_target_image}
 LABEL name="{name}" \\
       repository="http://github.com/cloud-custodian/cloud-custodian"
 
-COPY --from=build-env /src /src
-COPY --from=build-env /usr/local /usr/local
-COPY --from=build-env /output /output
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \\
@@ -124,6 +120,13 @@ RUN apt-get --yes update \\
         && rm -Rf /var/cache/apt \\
         && rm -Rf /var/lib/apt/lists/* \\
         && rm -Rf /var/log/*
+
+# These should remain below any other commands because they will invalidate
+# the layer cache
+COPY --from=build-env /src /src
+COPY --from=build-env /usr/local /usr/local
+COPY --from=build-env /output /output
+
 
 RUN adduser --disabled-login --gecos "" custodian
 USER custodian

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -35,7 +35,7 @@ fi
 """
 
 PHASE_2_INSTALL_TMPL = """
-ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_{pkg} /src/tools/c7n_{pkg}
 RUN if [[ " ${{providers[*]}} " =~ " {pkg} " ]]; then \
     . /usr/local/bin/activate && \
     cd tools/c7n_{pkg} && \

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -25,12 +25,48 @@ import click
 
 log = logging.getLogger("dockerpkg")
 
+PHASE_1_INSTALL_TMPL = """
+ADD tools/c7n_{pkg}/pyproject.toml tools/c7n_{pkg}/poetry.lock /src/tools/c7n_{pkg}/
+RUN if [[ " ${{providers[*]}} " =~ " {pkg} " ]]; then \
+    . /usr/local/bin/activate && \
+    cd tools/c7n_{pkg} && \
+    poetry install --without dev --no-root; \
+fi
+"""
+
+PHASE_2_INSTALL_TMPL = """
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+RUN if [[ " ${{providers[*]}} " =~ " {pkg} " ]]; then \
+    . /usr/local/bin/activate && \
+    cd tools/c7n_{pkg} && \
+    poetry install --only-root; \
+fi
+"""
+
+default_providers = ["gcp", "azure", "kube", "openstack", "tencentcloud"]
+
+PHASE_1_PKG_INSTALL = """\
+# We include `pyproject.toml` and `poetry.lock` first to allow
+# cache of dependency installs.
+"""
+PHASE_2_PKG_INSTALL = """\
+# Now install the root of each provider
+"""
+PHASE_1_PKG_INSTALL += "\n".join(
+    [PHASE_1_INSTALL_TMPL.format(pkg=pkg) for pkg in default_providers]
+)
+
+PHASE_2_PKG_INSTALL += "\n".join(
+    [PHASE_2_INSTALL_TMPL.format(pkg=pkg) for pkg in default_providers]
+)
+
 BUILD_STAGE = """\
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 
 FROM {base_build_image} as build-env
 
 ARG POETRY_VERSION="1.2.1"
+SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN adduser --disabled-login --gecos "" custodian
@@ -43,30 +79,30 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && pip install -U pip
-RUN . /usr/local/bin/activate && poetry install --no-dev
+
+# Ignore root first pass so if source changes we don't have to invalidate
+# dependency install
+RUN . /usr/local/bin/activate && poetry install --without dev --no-root
 RUN . /usr/local/bin/activate && pip install -q wheel && \
       pip install -U pip
 RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
+ARG providers="{providers}"
 # Add provider packages
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-RUN rm -R tools/c7n_gcp/tests
-ADD tools/c7n_azure /src/tools/c7n_azure
-RUN rm -R tools/c7n_azure/tests_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-RUN rm -R tools/c7n_kube/tests
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-RUN rm -R tools/c7n_openstack/tests
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
-RUN rm -R tools/c7n_tencentcloud/tests
+{PHASE_1_PKG_INSTALL}
 
-# Install requested providers
-ARG providers="gcp kube openstack tencentcloud azure"
-RUN . /usr/local/bin/activate && \\
-    for pkg in $providers; do cd tools/c7n_$pkg && \\
-    poetry install && cd ../../; done
+# Now install the root package
+ADD c7n /src/c7n/
+RUN . /usr/local/bin/activate && poetry install --only-root
+
+{PHASE_2_PKG_INSTALL}
+
+ADD tools/c7n_gcp /src/tools/c7n_gcp
+ADD tools/c7n_azure /src/tools/c7n_azure
+ADD tools/c7n_kube /src/tools/c7n_kube
+ADD tools/c7n_openstack /src/tools/c7n_openstack
+ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
 
 RUN mkdir /output
 """
@@ -170,7 +206,10 @@ class Image:
     defaults = dict(
         base_build_image="ubuntu:22.04",
         base_target_image="ubuntu:22.04",
-        poetry_version="${POETRY_VERSION}"
+        poetry_version="${POETRY_VERSION}",
+        providers=" ".join(default_providers),
+        PHASE_1_PKG_INSTALL=PHASE_1_PKG_INSTALL,
+        PHASE_2_PKG_INSTALL=PHASE_2_PKG_INSTALL,
     )
 
     def __init__(self, metadata, build, target):

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -45,18 +45,18 @@ fi
 
 default_providers = ["gcp", "azure", "kube", "openstack", "tencentcloud"]
 
-PHASE_1_PKG_INSTALL = """\
+PHASE_1_PKG_INSTALL_DEP = """\
 # We include `pyproject.toml` and `poetry.lock` first to allow
 # cache of dependency installs.
 """
-PHASE_2_PKG_INSTALL = """\
+PHASE_2_PKG_INSTALL_ROOT = """\
 # Now install the root of each provider
 """
-PHASE_1_PKG_INSTALL += "\n".join(
+PHASE_1_PKG_INSTALL_DEP += "\n".join(
     [PHASE_1_INSTALL_TMPL.format(pkg=pkg) for pkg in default_providers]
 )
 
-PHASE_2_PKG_INSTALL += "\n".join(
+PHASE_2_PKG_INSTALL_ROOT += "\n".join(
     [PHASE_2_INSTALL_TMPL.format(pkg=pkg) for pkg in default_providers]
 )
 
@@ -90,19 +90,13 @@ RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="{providers}"
 # Add provider packages
-{PHASE_1_PKG_INSTALL}
+{PHASE_1_PKG_INSTALL_DEP}
 
 # Now install the root package
 ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && poetry install --only-root
 
-{PHASE_2_PKG_INSTALL}
-
-ADD tools/c7n_gcp /src/tools/c7n_gcp
-ADD tools/c7n_azure /src/tools/c7n_azure
-ADD tools/c7n_kube /src/tools/c7n_kube
-ADD tools/c7n_openstack /src/tools/c7n_openstack
-ADD tools/c7n_tencentcloud /src/tools/c7n_tencentcloud
+{PHASE_2_PKG_INSTALL_ROOT}
 
 RUN mkdir /output
 """
@@ -211,8 +205,8 @@ class Image:
         base_target_image="ubuntu:22.04",
         poetry_version="${POETRY_VERSION}",
         providers=" ".join(default_providers),
-        PHASE_1_PKG_INSTALL=PHASE_1_PKG_INSTALL,
-        PHASE_2_PKG_INSTALL=PHASE_2_PKG_INSTALL,
+        PHASE_1_PKG_INSTALL_DEP=PHASE_1_PKG_INSTALL_DEP,
+        PHASE_2_PKG_INSTALL_ROOT=PHASE_2_PKG_INSTALL_ROOT,
     )
 
     def __init__(self, metadata, build, target):


### PR DESCRIPTION
This is an attempt at making the poetry install of every package a two phase run:

1. First, copy pyproject.toml and poetry.lock and install then
2. Copy the source up and install that

This gives us the ability to not re-run the install of the dependencies of the packages when we are modifying the source if they don't need to be reinstalled.   This makes rebuilding the docker images significantly faster when only changing c7n code. 

This also adds `tests/` to the `.dockerignore` so we don't have to remove them during the build process.

It also stops installing dev dependencies for all providers.   For every provider we were using straight `poetry install` which was including all dependencies such as `pytest`.  Now it'll only include the dependencies necessary to run. 

With this change, if you modify the core c7n code after you have a docker cache and rebuild the image it takes:

```
docker build . -f docker/c7n -t c7n  0.33s user 0.34s system 1% cpu 37.089 total
```

On master if you do this same:

```
docker build . -f docker/c7n -t c7n  0.22s user 0.22s system 2% cpu 18.610 total
```

so it effectively cuts the build time in more than half for subsequent builds.