### PR TITLE
Add appsync resource

### DIFF
--- a/c7n/resources/appsync.py
+++ b/c7n/resources/appsync.py
@@ -1,0 +1,169 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+import re
+
+from c7n.actions import BaseAction
+from c7n.filters import Filter
+from c7n.manager import resources
+from c7n.query import QueryResourceManager, TypeInfo
+from c7n.utils import local_session, type_schema, get_retry
+
+
+@resources.register('graphql-api')
+class GraphQLApi(QueryResourceManager):
+    """Resource Manager for AppSync GraphQLApi
+    """
+    class resource_type(TypeInfo):
+        service = 'appsync'
+        enum_spec = ('list_graphql_apis', 'graphqlApis', {'maxResults': 25})
+        id = 'apiId'
+        name = 'name'
+        cfn_type = 'AWS::AppSync::GraphQLApi'
+        arn_type = 'apis'
+        arn = 'arn'
+        universal_taggable = True
+
+
+@GraphQLApi.filter_registry.register('wafv2-enabled')
+class WafV2Enabled(Filter):
+    """Filter AppSync GraphQLApi by wafv2 web-acl
+    :example:
+    .. code-block:: yaml
+            policies:
+              - name: filter-graphql-api-wafv2
+                resource: graphql-api
+                filters:
+                  - type: wafv2-enabled
+                    state: false
+                    web-acl: test-waf-v2
+              - name: filter-graphql-api-wafv2-regex
+                resource: graphql-api
+                filters:
+                  - type: wafv2-enabled
+                    state: false
+                    web-acl: .*FMManagedWebACLV2-?FMS-.*
+    """
+
+    schema = type_schema(
+        'wafv2-enabled', **{
+            'web-acl': {'type': 'string'},
+            'state': {'type': 'boolean'}})
+
+    permissions = ('wafv2:ListWebACLs',)
+
+    def process(self, resources, event=None):
+        wafs = self.manager.get_resource_manager('wafv2').resources(augment=False)
+        waf_name_id_map = {w['Name']: w['ARN'] for w in wafs}
+
+        target_acl = self.data.get('web-acl', '')
+        state = self.data.get('state', False)
+        target_acl_ids = [v for k, v in waf_name_id_map.items() if
+                          re.match(target_acl, k)]
+
+        results = []
+        for r in resources:
+            r_web_acl_id = r.get('wafWebAclArn')
+            if state:
+                if not target_acl and r_web_acl_id:
+                    results.append(r)
+                elif target_acl and r_web_acl_id in target_acl_ids:
+                    results.append(r)
+            else:
+                if not target_acl and not r_web_acl_id:
+                    results.append(r)
+                elif target_acl and r_web_acl_id not in target_acl_ids:
+                    results.append(r)
+        return results
+
+
+@GraphQLApi.action_registry.register('set-wafv2')
+class SetWafv2(BaseAction):
+    """Enable wafv2 protection on AppSync graphqlApi.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: set-wafv2-for-graphql-api
+                resource: graphql-api
+                filters:
+                  - type: wafv2-enabled
+                    state: false
+                    web-acl: test-waf-v2
+                actions:
+                  - type: set-wafv2
+                    state: true
+                    force: true
+                    web-acl: test-waf-v2
+
+              - name: unset-wafv2-for-graphql-api
+                resource: graphql-api
+                filters:
+                  - type: wafv2-enabled
+                    state: true
+                actions:
+                  - type: set-wafv2
+                    state: true
+                    force: true
+                    web-acl: test-waf-v2
+
+            policies:
+              - name: set-wafv2-for-graphql-api-regex
+                resource: graphql-api
+                filters:
+                  - type: wafv2-enabled
+                    state: false
+                    web-acl: .*FMManagedWebACLV2-?FMS-.*
+                actions:
+                  - type: set-wafv2
+                    state: true
+                    web-acl: FMManagedWebACLV2-?FMS-TestWebACL
+    """
+    permissions = ('appsync:UpdateGraphqlApi', 'wafv2:ListWebACLs')
+    schema = type_schema(
+        'set-wafv2', **{
+            'web-acl': {'type': 'string'},
+            'force': {'type': 'boolean'},
+            'state': {'type': 'boolean'}})
+
+    retry = staticmethod(get_retry((
+        'ThrottlingException',
+        'RequestLimitExceeded',
+        'Throttled',
+        'ThrottledException',
+        'Throttling',
+        'Client.RequestLimitExceeded')))
+
+    def process(self, resources):
+        wafs = self.manager.get_resource_manager('wafv2').resources(augment=False)
+        waf_name_id_map = {w['Name']: w['ARN'] for w in wafs}
+        state = self.data.get('state', True)
+
+        target_acl_id = ''
+        if state:
+            target_acl = self.data.get('web-acl', '')
+            target_acl_ids = [v for k, v in waf_name_id_map.items() if
+                              re.match(target_acl, k)]
+            if len(target_acl_ids) != 1:
+                raise ValueError(f'{target_acl} matching to none or '
+                                 f'multiple webacls')
+            target_acl_id = target_acl_ids[0]
+
+        client = local_session(self.manager.session_factory).client('wafv2')
+        force = self.data.get('force', False)
+
+        arn_key = self.manager.resource_type.arn
+
+        for r in resources:
+            if r.get('wafWebAclArn') and not force:
+                continue
+            if r.get('wafWebAclArn') == target_acl_id:
+                continue
+            if state:
+                self.retry(client.associate_web_acl,
+                           WebACLArn=target_acl_id,
+                           ResourceArn=r[arn_key])
+            else:
+                self.retry(client.disassociate_web_acl,
+                           ResourceArn=r[arn_key])

--- a/c7n/resources/appsync.py
+++ b/c7n/resources/appsync.py
@@ -118,6 +118,7 @@ class SetWafv2(BaseAction):
                 actions:
                   - type: set-wafv2
                     state: true
+                    force: true
                     web-acl: FMManagedWebACLV2-?FMS-TestWebACL
     """
     permissions = ('appsync:UpdateGraphqlApi', 'wafv2:ListWebACLs')

--- a/c7n/resources/appsync.py
+++ b/c7n/resources/appsync.py
@@ -121,7 +121,10 @@ class SetWafv2(BaseAction):
                     force: true
                     web-acl: FMManagedWebACLV2-?FMS-TestWebACL
     """
-    permissions = ('appsync:UpdateGraphqlApi', 'wafv2:ListWebACLs')
+    permissions = ('wafv2:AssociateWebACL',
+                   'wafv2:DisassociateWebACL',
+                   'wafv2:ListWebACLs')
+
     schema = type_schema(
         'set-wafv2', **{
             'web-acl': {'type': 'string'},

--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -556,11 +556,15 @@ class SetWafv2(BaseAction):
 
         client = local_session(self.manager.session_factory).client('cloudfront')
         force = self.data.get('force', False)
+        print(f'cahn0: target_acl_id={target_acl_id}')
+        print(f'cahn1: force={force}')
 
         for r in resources:
             if r.get('WebACLId') and not force:
+                print(f'cahn2: WebACL attached and Not forced')
                 continue
             if r.get('WebACLId') == target_acl_id:
+                print(f'cahn3: WebACL == target_acl_id')
                 continue
             result = client.get_distribution_config(Id=r['Id'])
             config = result['DistributionConfig']

--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -556,15 +556,11 @@ class SetWafv2(BaseAction):
 
         client = local_session(self.manager.session_factory).client('cloudfront')
         force = self.data.get('force', False)
-        print(f'cahn0: target_acl_id={target_acl_id}')
-        print(f'cahn1: force={force}')
 
         for r in resources:
             if r.get('WebACLId') and not force:
-                print(f'cahn2: WebACL attached and Not forced')
                 continue
             if r.get('WebACLId') == target_acl_id:
-                print(f'cahn3: WebACL == target_acl_id')
                 continue
             result = client.get_distribution_config(Id=r['Id'])
             config = result['DistributionConfig']

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -10,6 +10,7 @@ ResourceMap = {
     "aws.app-elb": "c7n.resources.appelb.AppELB",
     "aws.app-elb-target-group": "c7n.resources.appelb.AppELBTargetGroup",
     "aws.app-flow": "c7n.resources.appflow.AppFlow",
+    "aws.graphql-api": "c7n.resources.appsync.GraphQLApi",
     "aws.asg": "c7n.resources.asg.ASG",
     "aws.backup-plan": "c7n.resources.backup.BackupPlan",
     "aws.backup-vault": "c7n.resources.backup.BackupVault",

--- a/tests/data/placebo/test_graphql_api_action_wafv2/appsync.ListGraphqlApis_1.json
+++ b/tests/data/placebo/test_graphql_api_action_wafv2/appsync.ListGraphqlApis_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "graphqlApis": [
+            {
+                "name": "My AppSync Api1",
+                "apiId": "lopd6grtrnctrfi7g7ywvfkzta",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678912:apis/lopd6grtrnctrfi7g7ywvfkzta",
+                "uris": {
+                    "REALTIME": "wss://az5joslekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://az5joslekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false,
+                "wafWebAclArn": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            },
+            {
+                "name": "My AppSync Api2",
+                "apiId": "mlpaw0grtrnctrfi7g7ywvfk908",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678912:apis/mlpaw0grtrnctrfi7g7ywvfk908",
+                "uris": {
+                    "REALTIME": "wss://kslwp0lekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://kslwp0lekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false
+            },
+            {
+                "name": "My AppSync Api3",
+                "apiId": "p012w0grtrnctrfi7g7ywvf4y67",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678912:apis/p012w0grtrnctrfi7g7ywvf4y67",
+                "uris": {
+                    "REALTIME": "wss://pqlap0lekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://pqlap0lekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false,
+                "wafWebAclArn": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/WebACL_TESTv2/887bbaec-c70b-4884-b290-ec7c7b5a43kl"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_graphql_api_action_wafv2/wafv2.AssociateWebACL_1.json
+++ b/tests/data/placebo/test_graphql_api_action_wafv2/wafv2.AssociateWebACL_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_graphql_api_action_wafv2/wafv2.DisassociateWebACL_1.json
+++ b/tests/data/placebo/test_graphql_api_action_wafv2/wafv2.DisassociateWebACL_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_graphql_api_action_wafv2/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_graphql_api_action_wafv2/wafv2.ListWebACLs_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200,
+    "data": {
+        "NextMarker": "1ebe0b46-0fd2-4e07-a74c-27bf25adc0bf",
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "05ff3012-a9c9-11e7-8af9-c510054683ae",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "05ff3012-a9c9-11e7-8af9-c510054683ae",
+                "date": "Thu, 05 Oct 2017 12:30:50 GMT",
+                "content-length": "131",
+                "content-type": "application/x-amz-json-1.1"
+            }
+        },
+        "WebACLs": [
+            {
+                "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+                "ARN": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_graphql_api_action_wafv2_regex_multiple_webacl_match/appsync.ListGraphqlApis_1.json
+++ b/tests/data/placebo/test_graphql_api_action_wafv2_regex_multiple_webacl_match/appsync.ListGraphqlApis_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "graphqlApis": [
+            {
+                "name": "My AppSync Api1",
+                "apiId": "lopd6grtrnctrfi7g7ywvfkzta",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678901:apis/lopd6grtrnctrfi7g7ywvfkzta",
+                "uris": {
+                    "REALTIME": "wss://az5joslekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://az5joslekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false,
+                "wafWebAclArn": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            },
+            {
+                "name": "My AppSync Api2",
+                "apiId": "mlpaw0grtrnctrfi7g7ywvfk908",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678901:apis/mlpaw0grtrnctrfi7g7ywvfk908",
+                "uris": {
+                    "REALTIME": "wss://kslwp0lekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://kslwp0lekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false
+            },
+            {
+                "name": "My AppSync Api3",
+                "apiId": "p012w0grtrnctrfi7g7ywvf4y67",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678901:apis/p012w0grtrnctrfi7g7ywvf4y67",
+                "uris": {
+                    "REALTIME": "wss://pqlap0lekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://pqlap0lekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false,
+                "wafWebAclArn": "arn:aws:wafv2:us-east-1:012345678901:regional/webacl/WebACL_TESTv2/887bbaec-c70b-4884-b290-ec7c7b5a43kl"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_graphql_api_action_wafv2_regex_multiple_webacl_match/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_graphql_api_action_wafv2_regex_multiple_webacl_match/wafv2.ListWebACLs_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "NextMarker": "791f9fc9-16bb-4d32-8f6a-b55e9b6f11c8",
+        "WebACLs": [
+            {
+                "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+                "ARN": "arn:aws:wafv2:us-east-1:123456789123:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            },
+            {
+                "Id": "3c5f3db9-04c1-47f4-a6ab-23b70a3a8509",
+                "Name": "FMManagedWebACLV2-FMS-TEST2-1656966576062",
+                "ARN": "arn:aws:wafv2:us-east-1:123456789123:regional/webacl/FMManagedWebACLV2-FMS-TEST2-1656966576062/3c5f3db9-04c1-47f4-a6ab-23b70a3a8509"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_graphql_api_filter_wafv2/appsync.ListGraphqlApis_1.json
+++ b/tests/data/placebo/test_graphql_api_filter_wafv2/appsync.ListGraphqlApis_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "graphqlApis": [
+            {
+                "name": "My AppSync Api1",
+                "apiId": "lopd6grtrnctrfi7g7ywvfkzta",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678901:apis/lopd6grtrnctrfi7g7ywvfkzta",
+                "uris": {
+                    "REALTIME": "wss://az5joslekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://az5joslekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false,
+                "wafWebAclArn": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            },
+            {
+                "name": "My AppSync Api2",
+                "apiId": "mlpaw0grtrnctrfi7g7ywvfk908",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678901:apis/mlpaw0grtrnctrfi7g7ywvfk908",
+                "uris": {
+                    "REALTIME": "wss://kslwp0lekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://kslwp0lekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false
+            },
+            {
+                "name": "My AppSync Api3",
+                "apiId": "p012w0grtrnctrfi7g7ywvf4y67",
+                "authenticationType": "API_KEY",
+                "arn": "arn:aws:appsync:us-east-1:012345678901:apis/p012w0grtrnctrfi7g7ywvf4y67",
+                "uris": {
+                    "REALTIME": "wss://pqlap0lekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                    "GRAPHQL": "https://pqlap0lekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+                },
+                "tags": {
+                    "waf": "test"
+                },
+                "xrayEnabled": false,
+                "wafWebAclArn": "arn:aws:wafv2:us-east-1:012345678901:regional/webacl/WebACL_TESTv2/887bbaec-c70b-4884-b290-ec7c7b5a43kl"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_graphql_api_filter_wafv2/appsync.UpdateGraphqlApi_1.json
+++ b/tests/data/placebo/test_graphql_api_filter_wafv2/appsync.UpdateGraphqlApi_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "graphqlApi": {
+            "name": "My AppSync App1",
+            "apiId": "lopd6grtrnctrfi7g7ywvfkzta",
+            "authenticationType": "API_KEY",
+            "arn": "arn:aws:appsync:us-east-1:012345678901:apis/lopd6grtrnctrfi7g7ywvfkzta",
+            "uris": {
+                "REALTIME": "wss://az5joslekdcedka43ordq3fcvq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+                "GRAPHQL": "https://az5joslekdcedka43ordq3fcvq.appsync-api.us-east-1.amazonaws.com/graphql"
+            },
+            "tags": {
+                "waf": "test"
+            },
+            "xrayEnabled": false,
+            "wafWebAclArn": "arn:aws:wafv2:us-east-1:012345678901:regional/webacl/FMManagedWebACLV2-FMS-TESTv2-1664820598463/eb4ebaec-c70b-4884-b290-ec7c7b5a213c"
+        }
+    }
+}

--- a/tests/data/placebo/test_graphql_api_filter_wafv2/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_graphql_api_filter_wafv2/wafv2.ListWebACLs_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200,
+    "data": {
+        "NextMarker": "1ebe0b46-0fd2-4e07-a74c-27bf25adc0bf",
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "05ff3012-a9c9-11e7-8af9-c510054683ae",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "05ff3012-a9c9-11e7-8af9-c510054683ae",
+                "date": "Thu, 05 Oct 2017 12:30:50 GMT",
+                "content-length": "131",
+                "content-type": "application/x-amz-json-1.1"
+            }
+        },
+        "WebACLs": [
+            {
+                "Id": "96494e83-ee49-4505-9f68-9103c6cd9406",
+                "Name": "FMManagedWebACLV2-FMS-TEST-1656966584517",
+                "ARN": "arn:aws:wafv2:us-east-1:012345678912:regional/webacl/FMManagedWebACLV2-FMS-TEST-1656966584517/96494e83-ee49-4505-9f68-9103c6cd9406"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_security_group_cidr_ingress/ec2.DescribeSecurityGroups_2.json
+++ b/tests/data/placebo/test_security_group_cidr_ingress/ec2.DescribeSecurityGroups_2.json
@@ -1,0 +1,54 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "PrefixListIds": [],
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "UserIdGroupPairs": [],
+                        "Ipv6Ranges": []
+                    }
+                ],
+                "Description": "inbound access",
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [],
+                        "FromPort": 443,
+                        "IpRanges": [
+                            {
+                                "CidrIp": "10.42.1.0/24"
+                            }
+                        ],
+                        "ToPort": 443,
+                        "IpProtocol": "tcp",
+                        "UserIdGroupPairs": [],
+                        "Ipv6Ranges": []
+                    }
+                ],
+                "GroupName": "allow-https-ingress",
+                "VpcId": "vpc-1fcf7766",
+                "OwnerId": "644160558196",
+                "GroupId": "sg-2f8e3b5e"
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "87ed25e0-4c6e-496a-a347-4d63c39d7964",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Tue, 27 Jun 2017 15:46:34 GMT"
+            }
+        }
+    }
+}

--- a/tests/test_appsync.py
+++ b/tests/test_appsync.py
@@ -114,5 +114,5 @@ class AppSyncWafV2(BaseTest):
         )
         with self.assertRaises(ValueError) as ctx:
             p.run()
-            self.assertTrue('matching to none or multiple webacls' in str(
-                ctx.exception))
+        self.assertIn('matching to none or multiple webacls', str(
+            ctx.exception))

--- a/tests/test_appsync.py
+++ b/tests/test_appsync.py
@@ -1,11 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-import jmespath
 
 from .common import BaseTest, event_data
-from c7n.resources.aws import shape_validate
-from c7n.utils import local_session
-from unittest.mock import MagicMock
 
 
 class AppSyncWafV2(BaseTest):

--- a/tests/test_appsync.py
+++ b/tests/test_appsync.py
@@ -1,7 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-from .common import BaseTest, event_data
+from .common import BaseTest
 
 
 class AppSyncWafV2(BaseTest):

--- a/tests/test_appsync.py
+++ b/tests/test_appsync.py
@@ -1,0 +1,122 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+import jmespath
+
+from .common import BaseTest, event_data
+from c7n.resources.aws import shape_validate
+from c7n.utils import local_session
+from unittest.mock import MagicMock
+
+
+class AppSyncWafV2(BaseTest):
+
+    def test_graphql_api_filter_wafv2(self):
+        factory = self.replay_flight_data("test_graphql_api_filter_wafv2")
+        p = self.load_policy(
+            {
+                "name": "filter-graphql-api-wafv2",
+                "resource": "graphql-api",
+                "filters": [{"type": "wafv2-enabled", "state": True}]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
+        p = self.load_policy(
+            {
+                "name": "filter-graphql-api-wafv2",
+                "resource": "graphql-api",
+                "filters": [{"type": "wafv2-enabled", "state": True,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-.*"}]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        p = self.load_policy(
+            {
+                "name": "filter-graphql-api-wafv2",
+                "resource": "graphql-api",
+                "filters": [{"type": "wafv2-enabled", "state": False}]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        p = self.load_policy(
+            {
+                "name": "filter-graphql-api-wafv2",
+                "resource": "graphql-api",
+                "filters": [{"type": "wafv2-enabled", "state": False,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-.*"}]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
+    def test_graphql_api_action_wafv2(self):
+        factory = self.replay_flight_data("test_graphql_api_action_wafv2")
+        p = self.load_policy(
+            {
+                "name": "action-graphql-api-wafv2",
+                "resource": "graphql-api",
+                "filters": [{"type": "wafv2-enabled", "state": False,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-.*"}],
+                "actions": [{"type": "set-wafv2", "state": True,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-.*"}]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
+        p = self.load_policy(
+            {
+                "name": "action-graphql-api-wafv2",
+                "resource": "graphql-api",
+                "filters": [{"type": "wafv2-enabled", "state": True,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-.*"}],
+                "actions": [{"type": "set-wafv2", "state": False,
+                             "force": True}]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        p = self.load_policy(
+            {
+                "name": "action-graphql-api-wafv2",
+                "resource": "graphql-api",
+                "filters": [{"type": "wafv2-enabled", "state": True,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-.*"}],
+                "actions": [{"type": "set-wafv2", "state": True, "force": True,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-TEST.*"}]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_graphql_api_action_wafv2_regex_multiple_webacl_match(self):
+        factory = self.replay_flight_data(
+            "test_graphql_api_action_wafv2_regex_multiple_webacl_match")
+        p = self.load_policy(
+            {
+                "name": "action-graphql-api-wafv2",
+                "resource": "graphql-api",
+                "filters": [{"type": "wafv2-enabled", "state": False,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-.*"}],
+                "actions": [{"type": "set-wafv2", "state": True,
+                             "web-acl": ".*FMManagedWebACLV2-?FMS-.*"}]
+            },
+            session_factory=factory,
+        )
+        with self.assertRaises(ValueError) as ctx:
+            p.run()
+            self.assertTrue('matching to none or multiple webacls' in str(
+                ctx.exception))

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -402,6 +402,7 @@ class PolicyMetaLint(BaseTest):
             'AWS::DMS::Certificate',
             'AWS::Detective::Graph',
             'AWS::EC2::TransitGatewayRouteTable',
+            'AWS::AppSync::GraphQLApi',
         }
 
         resource_map = {}


### PR DESCRIPTION
This PR is to add [AppSync](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/appsync.html) `graphql-api` resource.

Also adding support for local and Firewall Manager deployed WebACLs with regex support. This is subsequent PR to support `graphql-api` from [pr/7706](https://github.com/cloud-custodian/cloud-custodian/pull/7706).

With this PR, we can use regex expression and it still works with local WAF as well.

```
    policies:
      - name: filter-graphql-api-wafv2
        resource: graphql-api
        filters:
          - type: wafv2-enabled
            state: false
            web-acl: test-waf-v2

      - name: filter-graphql-api-wafv2-regex
        resource: graphql-api
        filters:
          - type: wafv2-enabled
            state: false
            web-acl: .*FMManagedWebACLV2-?FMS-.*
```

Similar filter and action were used from [pr/7706](https://github.com/cloud-custodian/cloud-custodian/pull/7706).

Complete example policy:
```
    policies:
      - name: set-wafv2-for-graphql-api-regex
        resource: graphql-api
        filters:
          - type: wafv2-enabled
            state: false
            web-acl: .*FMManagedWebACLV2-?FMS-.*
        actions:
          - type: set-wafv2
            state: true
            force: true
            web-acl: FMManagedWebACLV2-?FMS-TestWebACL
```
