### PR TITLE
aws - log-group - fix action retention days value exception

### DIFF
--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -582,6 +582,10 @@ class Retention(BaseAction):
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('logs')
         days = self.data['days']
+        try:
+            days = int(str(days).strip())
+        except ValueError:
+            raise PolicyValidationError("Invalid days for value on %s" % (self.data['days']))
         for r in resources:
             self.manager.retry(
                 client.put_retention_policy,

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -255,6 +255,7 @@ class LogGroupTest(BaseTest):
                 "actions": [{"type": "retention", "days": "14days"}],
             },
             session_factory=factory,
+            validate=False,
         )
         self.assertRaises(PolicyValidationError, p.run)
 


### PR DESCRIPTION
- change log-group action retention days value as integer if it is another type.
- related to : https://github.com/cloud-custodian/cloud-custodian/issues/7879