### PR TITLE
aws - opensearch - Add new action to elasticsearch resource to update endpoint TLS config

### DIFF
--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -588,3 +588,41 @@ class ReservedInstances(QueryResourceManager):
         filter_type = 'list'
         arn_type = "reserved-instances"
         permissions_enum = ('es:DescribeReservedElasticsearchInstances',)
+
+
+@ElasticSearchDomain.action_registry.register('update-tls-config')
+class UpdateTlsConfig(Action):
+
+    """Action to update tls-config on a domain endpoint
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: update-tls-config
+                resource: elasticsearch
+                filters:
+                  - type: value
+                    key: 'DomainEndpointOptions.TLSSecurityPolicy'
+                    op: eq
+                    value: "Policy-Min-TLS-1-0-2019-07"
+                actions:
+                  - type: update-tls-config
+                    value: "Policy-Min-TLS-1-2-2019-07"
+    """
+
+    schema = type_schema('update-tls-config', value={'type': 'string',
+        'enum': ['Policy-Min-TLS-1-0-2019-07', 'Policy-Min-TLS-1-2-2019-07']}, required=['value'])
+    permissions = ('es:UpdateElasticsearchDomainConfig', 'es:DescribeElasticsearchDomainConfig',
+        'es:DescribeElasticsearchDomains', 'es:ListDomainNames')
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('es')
+        tls_value = self.data.get('value')
+        for r in resources:
+            if not r['DomainEndpointOptions']['EnforceHTTPS']:
+                client.update_elasticsearch_domain_config(DomainName=r['DomainName'],
+                    DomainEndpointOptions={'EnforceHTTPS': True})
+            client.update_elasticsearch_domain_config(DomainName=r['DomainName'],
+                DomainEndpointOptions={'TLSSecurityPolicy': tls_value})

--- a/tests/data/placebo/test_elasticsearch_update_tls_config/es.DescribeElasticsearchDomain_1.json
+++ b/tests/data/placebo/test_elasticsearch_update_tls_config/es.DescribeElasticsearchDomain_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DomainStatus": {
+            "ElasticsearchClusterConfig": {
+                "DedicatedMasterEnabled": false, 
+                "InstanceCount": 1, 
+                "ZoneAwarenessEnabled": false, 
+                "InstanceType": "m4.large.elasticsearch"
+            }, 
+            "Endpoint": "vpc-test-es-7fwggtvvcqbcegsm5xxtdaob2a.us-east-1.es.amazonaws.com", 
+            "Created": true, 
+            "Deleted": true, 
+            "DomainName": "test-es", 
+            "EBSOptions": {
+                "VolumeSize": 20, 
+                "VolumeType": "gp2", 
+                "EBSEnabled": true
+            }, 
+            "SnapshotOptions": {
+                "AutomatedSnapshotStartHour": 0
+            }, 
+            "DomainId": "644160558196/test-es", 
+            "AccessPolicies": "", 
+            "Processing": true, 
+            "AdvancedOptions": {
+                "rest.action.multi.allow_explicit_index": "true"
+            }, 
+            "ElasticsearchVersion": "5.3", 
+            "ARN": "arn:aws:es:us-east-1:644160558196:domain/test-es",
+            "DomainEndpointOptions": {
+                "EnforceHTTPS": true, 
+                "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07", 
+                "CustomEndpointEnabled": false
+            }
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6d259b75-477b-11e7-8992-3f6840925921", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6d259b75-477b-11e7-8992-3f6840925921", 
+                "date": "Fri, 02 Jun 2017 10:08:28 GMT", 
+                "content-length": "744", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_update_tls_config/es.DescribeElasticsearchDomains_1.json
+++ b/tests/data/placebo/test_elasticsearch_update_tls_config/es.DescribeElasticsearchDomains_1.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DomainStatusList": [
+            {
+                "ElasticsearchClusterConfig": {
+                    "DedicatedMasterEnabled": false, 
+                    "InstanceCount": 1, 
+                    "ZoneAwarenessEnabled": false, 
+                    "InstanceType": "m4.large.elasticsearch"
+                }, 
+                "Endpoint": "vpc-test-es-7fwggtvvcqbcegsm5xxtdaob2a.us-east-1.es.amazonaws.com", 
+                "Created": true, 
+                "Deleted": false, 
+                "DomainName": "test-es", 
+                "EBSOptions": {
+                    "VolumeSize": 20, 
+                    "VolumeType": "gp2", 
+                    "EBSEnabled": true
+                }, 
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 0
+                }, 
+                "DomainId": "644160558196/test-es", 
+                "AccessPolicies": "", 
+                "Processing": false, 
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true"
+                }, 
+                "ElasticsearchVersion": "5.3", 
+                "ARN": "arn:aws:es:us-east-1:644160558196:domain/test-es",
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": false, 
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07" 
+                }
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6c6d967b-477b-11e7-8f47-b5da530f0441", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6c6d967b-477b-11e7-8f47-b5da530f0441", 
+                "date": "Fri, 02 Jun 2017 10:08:27 GMT", 
+                "content-length": "752", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_update_tls_config/es.ListDomainNames_1.json
+++ b/tests/data/placebo/test_elasticsearch_update_tls_config/es.ListDomainNames_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6c54de17-477b-11e7-98d1-0d9721a87f47", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6c54de17-477b-11e7-98d1-0d9721a87f47", 
+                "date": "Fri, 02 Jun 2017 10:08:27 GMT", 
+                "content-length": "43", 
+                "content-type": "application/json"
+            }
+        }, 
+        "DomainNames": [
+            {
+                "DomainName": "test-es"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_update_tls_config/es.ListTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_update_tls_config/es.ListTags_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6c8897ba-477b-11e7-afab-69ceea836cda", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6c8897ba-477b-11e7-afab-69ceea836cda", 
+                "date": "Fri, 02 Jun 2017 10:08:28 GMT", 
+                "content-length": "41", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Dev", 
+                "Key": "Env"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_update_tls_config/es.UpdateElasticsearchDomainConfig_1.json
+++ b/tests/data/placebo/test_elasticsearch_update_tls_config/es.UpdateElasticsearchDomainConfig_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DomainStatus": {
+            "ElasticsearchClusterConfig": {
+                "DedicatedMasterEnabled": false, 
+                "InstanceCount": 1, 
+                "ZoneAwarenessEnabled": false, 
+                "InstanceType": "m4.large.elasticsearch"
+            }, 
+            "Endpoint": "vpc-test-es-7fwggtvvcqbcegsm5xxtdaob2a.us-east-1.es.amazonaws.com", 
+            "Created": true, 
+            "Deleted": true, 
+            "DomainName": "test-es", 
+            "EBSOptions": {
+                "VolumeSize": 20, 
+                "VolumeType": "gp2", 
+                "EBSEnabled": true
+            }, 
+            "SnapshotOptions": {
+                "AutomatedSnapshotStartHour": 0
+            }, 
+            "DomainId": "644160558196/test-es", 
+            "AccessPolicies": "", 
+            "Processing": true, 
+            "AdvancedOptions": {
+                "rest.action.multi.allow_explicit_index": "true"
+            }, 
+            "ElasticsearchVersion": "5.3", 
+            "ARN": "arn:aws:es:us-east-1:644160558196:domain/test-es"
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6cb8cf80-477b-11e7-afab-69ceea836cda", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6cb8cf80-477b-11e7-afab-69ceea836cda", 
+                "date": "Fri, 02 Jun 2017 10:08:29 GMT", 
+                "content-length": "744", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Elasticsearch(Opensearch) resource does not have an action to update the ["DomainEndpointOptions"](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/configuration-api.html#configuration-api-datatypes-domainendpointoptions) settings which enables TLS security policy that needs to be applied to the HTTPS endpoint of Elasticsearch domain. It needs to set to TLSv1.2, if not enabled or set lower as required by [this](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-opensearch-8) Security Hub rule. 

Sample policy

```
- name: elasticsearch-update-tls-config-test
  resource: elasticsearch
  filters:
       - or:
          - type: value
            key: 'DomainEndpointOptions.EnforceHTTPS'
            op: ne
            value: true
          - type: value
            key: 'DomainEndpointOptions.TLSSecurityPolicy'
            op: ne
            value: "Policy-Min-TLS-1-2-2019-07"
  actions:
       - type: update-tls-config
         value: "Policy-Min-TLS-1-2-2019-07"
```
