### PR TITLE
UnitTests using assertTrue(x, y) instead of assertEqual(x, y)

### DIFF
--- a/tests/test_airflow.py
+++ b/tests/test_airflow.py
@@ -46,7 +46,7 @@ class TestApacheAirflow(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=(jmespath.search(expression, resources[0])))
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/mwaa')
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -96,6 +96,6 @@ class BackupVaultTest(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['EncryptionKeyArn'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/aws/backup')

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -66,7 +66,7 @@ class LogGroupTest(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['kmsKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/cw')
 

--- a/tests/test_eks.py
+++ b/tests/test_eks.py
@@ -181,7 +181,7 @@ class EKS(BaseTest):
             session_factory=factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         kmsKeyId = resources[0]['encryptionConfig'][0]['provider']['keyArn']
         aliases = kms.list_aliases(KeyId=kmsKeyId)
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/eks')

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -294,7 +294,7 @@ class ElasticSearch(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['EncryptionAtRestOptions']['KmsKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/aws/es')
 

--- a/tests/test_fsx.py
+++ b/tests/test_fsx.py
@@ -313,7 +313,7 @@ class TestFSx(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory().client('fsx')
         fs = client.describe_file_systems(
             FileSystemIds=[resources[0]['FileSystemId']])['FileSystems']
@@ -359,7 +359,7 @@ class TestFSx(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory().client('fsx')
         fs = client.describe_file_systems(
             FileSystemIds=[resources[0]['FileSystemId']])['FileSystems']
@@ -399,7 +399,7 @@ class TestFSx(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory().client('fsx')
         fs = client.describe_file_systems(
             FileSystemIds=[resources[0]['FileSystemId']])['FileSystems']
@@ -493,7 +493,7 @@ class TestFSxBackup(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory().client('fsx')
         backups = client.describe_backups(
             Filters=[
@@ -530,7 +530,7 @@ class TestFSxBackup(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
 
         client = session_factory().client('fsx')
         backups = client.describe_backups(
@@ -566,7 +566,7 @@ class TestFSxBackup(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
 
         client = session_factory().client('fsx')
         backups = client.describe_backups(

--- a/tests/test_fsx.py
+++ b/tests/test_fsx.py
@@ -25,7 +25,7 @@ class TestFSx(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources))
+        self.assertTrue(len(resources)) 
 
     def test_fsx_tag_resource(self):
         session_factory = self.replay_flight_data('test_fsx_tag_resource')

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -12,7 +12,7 @@ class HealthResource(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertEqual(len(resources), 0)
+        self.assertEqual(len(resources), 0) #test
 
     def test_health_resource_query(self):
         session_factory = self.replay_flight_data("test_health_resource_query")

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -121,6 +121,6 @@ class KafkaTest(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=(jmespath.search(expression, resources[0])))
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/aws/kafka')

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -268,7 +268,7 @@ class Kinesis(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['KmsKeyId'],
             'arn:aws:kms:us-east-1:123456789012:key/0d543df5-915c-42a1-afa1-c9c5f1f97955')
 

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -324,7 +324,7 @@ class KMSTagging(BaseTest):
         )
 
         resources = policy.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["KeyId"], key_id)
         tags = client.list_resource_tags(KeyId=key_id)["Tags"]
         self.assertEqual(len(tags), 0)

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -672,7 +672,7 @@ class TestModifyVpcSecurityGroupsAction(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['KMSKeyArn'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/skunk/trails')
 

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -64,7 +64,7 @@ class MessageQueue(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['EncryptionOptions']['KmsKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/aws/mq')
 
@@ -105,7 +105,7 @@ class MessageQueue(BaseTest):
             session_factory=factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = factory().client("mq")
         if self.recording:
             time.sleep(1)
@@ -134,7 +134,7 @@ class MessageQueue(BaseTest):
             session_factory=factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = factory().client("mq")
         if self.recording:
             time.sleep(1)

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -912,7 +912,7 @@ class RDSSnapshotTest(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["DBInstanceIdentifier"], "mydbinstance")
 
         self.assertTrue(
@@ -956,7 +956,7 @@ class RDSSnapshotTest(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["DBInstanceIdentifier"], "mydbinstance")
 
         self.assertFalse(

--- a/tests/test_sagemaker.py
+++ b/tests/test_sagemaker.py
@@ -127,7 +127,7 @@ class TestNotebookInstance(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
 
         client = session_factory().client("sagemaker")
         notebook = client.describe_notebook_instance(
@@ -149,7 +149,7 @@ class TestNotebookInstance(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
 
         client = session_factory().client("sagemaker")
         notebook = client.describe_notebook_instance(
@@ -171,7 +171,7 @@ class TestNotebookInstance(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
 
         client = session_factory().client("sagemaker")
         notebook = client.describe_notebook_instance(
@@ -236,7 +236,7 @@ class TestNotebookInstance(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['KmsKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/skunk/trails')
 
@@ -345,7 +345,7 @@ class TestModelInstance(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["ModelArn"])["Tags"]
         self.assertTrue(tags[0], "custodian_cleanup")
@@ -406,7 +406,7 @@ class TestSagemakerJob(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         job = client.describe_training_job(
             TrainingJobName=resources[0]["TrainingJobName"]
         )
@@ -424,7 +424,7 @@ class TestSagemakerJob(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["TrainingJobArn"])["Tags"]
         self.assertEqual([tags[0]["Key"], tags[0]["Value"]], ["JobTag", "JobTagValue"])
@@ -443,7 +443,7 @@ class TestSagemakerJob(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["TrainingJobArn"])["Tags"]
         self.assertEqual(len(tags), 0)
@@ -484,7 +484,7 @@ class TestSagemakerTransformJob(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         job = client.describe_transform_job(
             TransformJobName=resources[0]["TransformJobName"]
         )
@@ -502,7 +502,7 @@ class TestSagemakerTransformJob(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["TransformJobArn"])["Tags"]
         self.assertEqual([tags[0]["Key"], tags[0]["Value"]], ["JobTag", "JobTagValue"])
@@ -521,7 +521,7 @@ class TestSagemakerTransformJob(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["TransformJobArn"])["Tags"]
         self.assertEqual(len(tags), 0)
@@ -571,7 +571,7 @@ class TestSagemakerEndpoint(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["EndpointArn"])["Tags"]
         self.assertTrue(tags[0]["Key"], "required-tag")
@@ -589,7 +589,7 @@ class TestSagemakerEndpoint(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["EndpointArn"])["Tags"]
         self.assertEqual(len(tags), 0)
@@ -613,7 +613,7 @@ class TestSagemakerEndpoint(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["EndpointArn"])["Tags"]
         self.assertTrue(tags[0], "custodian_cleanup")
@@ -692,7 +692,7 @@ class TestSagemakerEndpointConfig(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["EndpointConfigArn"])["Tags"]
         self.assertEqual(
@@ -713,7 +713,7 @@ class TestSagemakerEndpointConfig(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["EndpointConfigArn"])["Tags"]
         self.assertEqual(len(tags), 0)
@@ -746,7 +746,7 @@ class TestSagemakerEndpointConfig(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = session_factory(region="us-east-1").client("sagemaker")
         tags = client.list_tags(ResourceArn=resources[0]["EndpointConfigArn"])["Tags"]
         self.assertTrue(tags[0], "custodian_cleanup")
@@ -794,6 +794,6 @@ class TestSagemakerEndpointConfig(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['KmsKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/skunk/trails')

--- a/tests/test_secretsmanager.py
+++ b/tests/test_secretsmanager.py
@@ -41,7 +41,7 @@ class TestSecretsManager(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['KmsKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/skunk/trails')
 

--- a/tests/test_servicecatalog.py
+++ b/tests/test_servicecatalog.py
@@ -100,5 +100,5 @@ class TestServiceCatalog(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertTrue(resources[0]['Name'], 'testProduct')

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -69,7 +69,7 @@ class TestStepFunction(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertTrue(resources[0]['name'], 'test')
 
     def test_sfn_tag_resource(self):

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -486,7 +486,7 @@ class TestSNS(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['KmsMasterKeyId'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/skunk/trails')
 

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -83,7 +83,7 @@ class WorkspacesTest(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         aliases = kms.list_aliases(KeyId=resources[0]['VolumeEncryptionKey'])
         self.assertEqual(aliases['Aliases'][0]['AliasName'], 'alias/aws/workspaces')
 

--- a/tools/c7n_kube/tests/test_actions.py
+++ b/tools/c7n_kube/tests/test_actions.py
@@ -75,7 +75,7 @@ class TestPatchAction(KubeTest):
             session_factory=factory
         )
         resources = p.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         client = factory().client('Apps', 'V1')
         deployments = client.list_deployment_for_all_namespaces().to_dict()['items']
         hello_node_deployment = [d for d in deployments if d['metadata']['name'] == 'hello-node'][0]

--- a/tools/c7n_kube/tests/test_custom_resource.py
+++ b/tools/c7n_kube/tests/test_custom_resource.py
@@ -26,7 +26,7 @@ class TestCustomResource(KubeTest):
         )
 
         resources = policy.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['apiVersion'], 'stable.example.com/v1')
         self.assertEqual(resources[0]['kind'], 'CronTabCluster')
 
@@ -48,7 +48,7 @@ class TestCustomResource(KubeTest):
         )
 
         resources = policy.run()
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['apiVersion'], 'stable.example.com/v1')
         self.assertEqual(resources[0]['kind'], 'CronTab')
 


### PR DESCRIPTION
Related to https://github.com/cloud-custodian/cloud-custodian/issues/7634 . Using assertEqual instead