### PR TITLE
core - allow variables file to be passed on cli

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -74,9 +74,8 @@ def _default_options(p, exclude=[]):
                         action="store_true")
 
     if 'vars' not in exclude:
-        # p.add_argument('--vars', default=None,
-        #               help='Vars file to substitute into policy')
-        p.set_defaults(vars=None)
+        p.add_argument('--vars', default=None, dest="vars_file",
+                       help='Vars file to substitute into policy')
 
     if 'log-group' not in exclude:
         p.add_argument(

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -132,15 +132,13 @@ def policy_command(f):
 
 def _load_vars(options):
     vars = None
-    if options.vars:
+    if options.vars_file:
         try:
             vars = load_file(options.vars)
         except IOError as e:
             log.error('Problem loading vars file "{}": {}'.format(options.vars, e.strerror))
             sys.exit(1)
-
-    # TODO - provide builtin vars here (such as account)
-
+    options.vars = vars
     return vars
 
 

--- a/c7n/config.py
+++ b/c7n/config.py
@@ -43,6 +43,7 @@ class Config(Bag):
             'output_dir': '',
             'cache_period': 0,
             'dryrun': False,
+            'vars_file': None,
             'authorization_file': None})
         d.update(kw)
         return cls(d)


### PR DESCRIPTION


still wip, bring some parity with c7n-org variables to c7n via allowing 
variables to be passed via json/yaml file on cli to policy interpolation.

