### PR TITLE
releng - update codecov action

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -219,7 +219,7 @@ jobs:
           fi
 
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         if: contains(matrix.python-version, '3.10') && contains(matrix.os, 'ubuntu')
         with:
           files: ./coverage.xml


### PR DESCRIPTION
codecov seems to be barfing at the moment on uploads, and their status site shows nothing. try updating the codecov 
action to latest and greatest to see if it resolves. for ref the issue we're seeing.


```
[2022-10-20T17:22:43.103Z] ['verbose'] parent
63
[2022-10-20T17:22:43.104Z] ['info'] Pinging Codecov: 
https://codecov.io/upload/v4?package=github-action-2.1.0-uploader-0.3.2&token=*******&branch=add-rds-proxy-resource&build=3291567706&build_url=https%3A%2F%2Fgithub.com%2Fcloud-custodian%2Fcloud-custodian%2Factions%2Fruns%2F3291567706&commit=c743f6c1e45b25df09bffa0ad04dba281ece80fd&job=CI&pr=7859&service=github-actions&slug=cloud-custodian%2Fcloud-custodian&name=codecov&tag=&flags=&parent=
64
[2022-10-20T17:22:43.104Z] ['verbose'] Passed token was 0 characters long
65
[2022-10-20T17:22:43.104Z] ['verbose'] 
https://codecov.io/upload/v4?package=github-action-2.1.0-uploader-0.3.2&branch=add-rds-proxy-resource&build=3291567706&build_url=https%3A%2F%2Fgithub.com%2Fcloud-custodian%2Fcloud-custodian%2Factions%2Fruns%2F3291567706&commit=c743f6c1e45b25df09bffa0ad04dba281ece80fd&job=CI&pr=7859&service=github-actions&slug=cloud-custodian%2Fcloud-custodian&name=codecov&tag=&flags=&parent=
66
        Content-Type: 'text/plain'
67
        Content-Encoding: 'gzip'
68
        X-Reduced-Redundancy: 'false'
69
[2022-10-20T17:22:43.262Z] ['error'] There was an error running the uploader: Error uploading to 
https://codecov.io: Error: There was an error fetching the storage URL during POST: 503 - upstream connect error or 
disconnect/reset before headers. reset reason: connection failure
70
[2022-10-20T17:22:43.262Z] ['verbose'] The error stack is: Error: Error uploading to https://codecov.io: Error: 
There was an error fetching the storage URL during POST: 503 - upstream connect error or disconnect/reset before 
headers. reset reason: connection failure
71
    at main (/snapshot/repo/dist/src/index.js)
72
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
73
[2022-10-20T17:22:43.262Z] ['verbose'] End of uploader: 1066 milliseconds
```
