### PR TITLE
use the latest published version of the helm chart

### DIFF
--- a/tools/c7n_kube/.skaffold/values.yaml
+++ b/tools/c7n_kube/.skaffold/values.yaml
@@ -32,8 +32,6 @@ policies:
               - metadata.labels."app.kubernetes.io/managed-by": absent
 
 webhook:
-  caBundle: blahblahblah
-
   namespaceSelector:
     matchExpressions:
       - key: c7n-monitor

--- a/tools/c7n_kube/.skaffold/values.yaml
+++ b/tools/c7n_kube/.skaffold/values.yaml
@@ -1,24 +1,48 @@
-caBundle: blahblahblah
-
 certManager:
   enabled: true
 
-namespaceSelector:
-  matchExpressions:
-    - key: c7n-monitor
-      operator: NotIn
-      values: ["false"]
-
 policies:
-  volume:
-    configMap:
-      name: policies
-  volumeMount:
-    readOnly: true
+  source: configMap
+  configMap:
+    policies:
+      - name: missing-recommended-labels
+        mode:
+          type: k8s-admission
+          on-match: deny
+          operations:
+            - CREATE
+            - UPDATE
+        description: |
+          Kubernetes recommmended the following labels from its docs:
+          app.kubernetes.io/name
+          app.kubernetes.io/instance
+          app.kubernetes.io/version
+          app.kubernetes.io/component
+          app.kubernetes.io/part-of
+          app.kubernetes.io/managed-by
+          https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+        resource: k8s.pod
+        filters:
+          - or:
+              - metadata.labels."app.kubernetes.io/name": absent
+              - metadata.labels."app.kubernetes.io/instance": absent
+              - metadata.labels."app.kubernetes.io/version": absent
+              - metadata.labels."app.kubernetes.io/component": absent
+              - metadata.labels."app.kubernetes.io/part-of": absent
+              - metadata.labels."app.kubernetes.io/managed-by": absent
 
-rules:
-  - apiGroups: [""]
-    apiVersions: ["v1"]
-    operations: ["CREATE"]
-    resources: ["pods"]
-    scope: Namespaced
+webhook:
+  caBundle: blahblahblah
+
+  namespaceSelector:
+    matchExpressions:
+      - key: c7n-monitor
+        operator: NotIn
+        values: [ "false" ]
+
+  rules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
+      scope: Namespaced

--- a/tools/c7n_kube/skaffold.yaml
+++ b/tools/c7n_kube/skaffold.yaml
@@ -1,7 +1,3 @@
-
-
----
-
 apiVersion: skaffold/v2beta29
 kind: Config
 metadata:
@@ -10,7 +6,6 @@ deploy:
   kubectl:
     manifests:
       - .skaffold/namespace.yaml
-
 ---
 apiVersion: skaffold/v2beta29
 kind: Config

--- a/tools/c7n_kube/skaffold.yaml
+++ b/tools/c7n_kube/skaffold.yaml
@@ -32,13 +32,16 @@ deploy:
       - .skaffold/templates/*.yaml
 
   helm:
+    flags:
+      global:
+        - "--debug"
     releases:
       - artifactOverrides:
-          image: c7n-kube
-        chartPath: ../../../c7n-helm-charts/c7n_kube/
+          controller.image: c7n-kube
+        name: c7n-kube
+        remoteChart: https://github.com/cloud-custodian/helm-charts/releases/download/c7n-kube-0.1.1/c7n-kube-0.1.1.tgz
         imageStrategy:
           fqn: {}
-        name: c7n-kube
         namespace: c7n-system
         valuesFiles:
           - .skaffold/values.yaml

--- a/tools/c7n_kube/skaffold.yaml
+++ b/tools/c7n_kube/skaffold.yaml
@@ -38,10 +38,11 @@ deploy:
     releases:
       - artifactOverrides:
           controller.image: c7n-kube
-        name: c7n-kube
-        remoteChart: https://github.com/cloud-custodian/helm-charts/releases/download/c7n-kube-0.1.1/c7n-kube-0.1.1.tgz
         imageStrategy:
           fqn: {}
+        name: c7n-kube
         namespace: c7n-system
+        remoteChart: c7n-kube
+        repo: https://cloud-custodian.github.io/helm-charts/
         valuesFiles:
           - .skaffold/values.yaml


### PR DESCRIPTION
Currently this requires that two repositories are checked out locally, and in a specific place. something like:

```
/c7n-helm-charts   = github.com/cloud-custodian/helm-charts
/cloud-custodian   = github.com/cloud-custodian/cloud-custodian
```

Specifically, they need to be checked out next to each other, and the helm charts repo MUST be called `c7n-helm-charts`. This makes the local development process brittle and hard to set up for a first time experience.

If we make the assumption that iterating on the container generally won't mean iterating on the helm chart as well, we can simplify this by using the released version of the chart and a static set of values that are known to work with skaffold. 

#7920 was accidentally closed, and I couldn't reopen it. Reopened here.