### PR TITLE
docs - c7n-kates helm deployment docs

### DIFF
--- a/docs/Makefile.sphinx
+++ b/docs/Makefile.sphinx
@@ -63,6 +63,7 @@ clean:
 	rm -f $(SRCDIR)/gcp/resources/*
 	rm -f $(SRCDIR)/azure/resources/*
 	rm -f $(SRCDIR)/awscc/resources/*
+	rm -f $(SRCDIR)/tools/*.md
 
 html:
 #	$(SPHINXBINS)/sphinx-apidoc -H "AWS" -o $(SRCDIR)/generated/aws $(SRCDIR)/../../c7n $(SRCDIR)/../../tests $(SRCDIR)/../../c7n/ipaddress.py
@@ -84,6 +85,7 @@ html:
 	cp -p tools/c7n_salactus/README.md $(SRCDIR)/tools/c7n-salactus.md
 	cp -p tools/c7n_logexporter/README.md $(SRCDIR)/tools/c7n-logexporter.md
 	cp -p tools/c7n_left/README.md $(SRCDIR)/tools/c7n-left.md
+	cp -p tools/c7n_kube/readme.md $(SRCDIR)/tools/c7n-kube.md
 	mkdir -p $(SRCDIR)/aws/resources
 	c7n-sphinxext --provider aws --output-dir $(SRCDIR)/aws/resources --group-by=resource_type.service
 	mkdir -p $(SRCDIR)/awscc/resources
@@ -94,23 +96,6 @@ html:
 	c7n-sphinxext --provider azure --output-dir $(SRCDIR)/azure/resources --group-by=resource_type.doc_groups
 
 	$(SPHINXBUILD) -j auto -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-
-#
-# Remove the copies so folks dont accidentally edit the copy
-#	rm $(SRCDIR)/tools/c7n-org.md
-#	rm $(SRCDIR)/tools/c7n-policystream.md
-#	rm $(SRCDIR)/tools/c7n-mailer.md
-#	rm $(SRCDIR)/tools/c7n-trailcreator.md
-#	rm $(SRCDIR)/tools/omnissm.md
-#	rm $(SRCDIR)/tools/c7n-salactus.md
-#	rm $(SRCDIR)/tools/c7n-logexporter.md
-#	rm $(SRCDIR)/tools/c7n-guardian.md
-#	rm $(SRCDIR)/tools/cask.md
-#	rm -R $(SRCDIR)/tools/assets
-#	rm $(SRCDIR)/aws/resources/*rst
-#	rm $(SRCDIR)/azure/resources/*rst
-#	rm $(SRCDIR)/gcp/resources/*rst
-
 
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/source/kubernetes/controllermode.rst
+++ b/docs/source/kubernetes/controllermode.rst
@@ -19,6 +19,9 @@ Install the Server
 Dynamic Admission Controllers can only operate against HTTPS webhooks. To get started, you can either
 create a service inside of your Kubernetes Cluster or use a cloud provider to run a web server.
 
+Option 1: Manual installation
+=============================
+
 To get started, create a new directory of policies:
 
 .. code-block:: bash
@@ -59,7 +62,50 @@ Next, on your server, start c7n-kates:
 
    c7n-kates --policy-dir policies
 
-Next, we can apply a pod manifest to see the warning, create a new file ``pod.yaml`` and add the following:
+Option 2: Helm chart
+====================
+
+First configure the chart. The following  will configure a sample policy, use
+cert-manager to sign your webhook, and operate against all pods when they are
+created or updated. Adjust values.yaml as needed.
+
+.. code-block:: bash
+
+    cat << EOF > values.yaml
+    certManager:
+      enabled: true
+
+    policies:
+      source: configMap
+      configMap:
+        policies:
+          # insert your policies here
+
+          - name: 'example-warn-policy'
+            resource: 'k8s.pod'
+            description: 'This is a sample policy'
+            mode:
+              type: k8s-admission
+              on-match: warn
+              operations:
+                - CREATE
+
+    # These will need to be modified to match your policies.
+    rules:
+      - apiGroups: [""]
+        apiVersions: [v1]
+        operations: [CREATE, UPDATE]
+        resources: [pods]
+        scope: Namespaced
+    EOF
+
+    helm repo add c7n https://cloud-custodian.github.io/helm-charts/`
+    helm install c7n-kube c7n/c7n-kube --values values.yaml
+
+Testing
+-------
+
+We can apply a pod manifest to see the warning, create a new file ``pod.yaml`` and add the following:
 
 .. code-block:: yaml
 
@@ -87,7 +133,7 @@ Which should result in the following message:
    Warning: example-warn-policy:This is a sample policy
    pod/nginx created
 
-  
+
 On the server, you should see:
 
 .. code-block:: bash
@@ -202,18 +248,18 @@ A sample event looks like:
                        "f:metadata":{
                           "f:annotations":{
                              ".":{
-                                
+
                              },
                              "f:kubectl.kubernetes.io/last-applied-configuration":{
-                                
+
                              }
                           },
                           "f:labels":{
                              ".":{
-                                
+
                              },
                              "f:role":{
-                                
+
                              }
                           }
                        },
@@ -221,64 +267,64 @@ A sample event looks like:
                           "f:containers":{
                              "k:{\"name\":\"web\"}":{
                                 ".":{
-                                   
+
                                 },
                                 "f:image":{
-                                   
+
                                 },
                                 "f:imagePullPolicy":{
-                                   
+
                                 },
                                 "f:name":{
-                                   
+
                                 },
                                 "f:ports":{
                                    ".":{
-                                      
+
                                    },
                                    "k:{\"containerPort\":80,\"protocol\":\"TCP\"}":{
                                       ".":{
-                                         
+
                                       },
                                       "f:containerPort":{
-                                         
+
                                       },
                                       "f:name":{
-                                         
+
                                       },
                                       "f:protocol":{
-                                         
+
                                       }
                                    }
                                 },
                                 "f:resources":{
-                                   
+
                                 },
                                 "f:terminationMessagePath":{
-                                   
+
                                 },
                                 "f:terminationMessagePolicy":{
-                                   
+
                                 }
                              }
                           },
                           "f:dnsPolicy":{
-                             
+
                           },
                           "f:enableServiceLinks":{
-                             
+
                           },
                           "f:restartPolicy":{
-                             
+
                           },
                           "f:schedulerName":{
-                             
+
                           },
                           "f:securityContext":{
-                             
+
                           },
                           "f:terminationGracePeriodSeconds":{
-                             
+
                           }
                        }
                     }
@@ -338,7 +384,7 @@ A sample event looks like:
                        }
                     ],
                     "resources":{
-                       
+
                     },
                     "volumeMounts":[
                        {
@@ -358,7 +404,7 @@ A sample event looks like:
               "serviceAccountName":"default",
               "serviceAccount":"default",
               "securityContext":{
-                 
+
               },
               "schedulerName":"default-scheduler",
               "tolerations":[

--- a/tools/c7n_kube/c7n_kube/cli.py
+++ b/tools/c7n_kube/c7n_kube/cli.py
@@ -19,9 +19,6 @@ logging.basicConfig(
     format="%(asctime)s: %(name)s:%(levelname)s %(message)s")
 
 
-PORT = '8800'
-HOST = '0.0.0.0'
-
 TEMPLATE = {
     "apiVersion": "admissionregistration.k8s.io/v1",
     "kind": "MutatingWebhookConfiguration",
@@ -64,7 +61,8 @@ TEMPLATE = {
 
 def _parser():
     parser = argparse.ArgumentParser(description='Cloud Custodian Admission Controller')
-    parser.add_argument('--port', type=int, help='Server port', nargs='?', default=PORT)
+    parser.add_argument('--host', type=str, help='Listen host', default='127.0.0.1')
+    parser.add_argument('--port', type=int, help='Listen port', nargs='?', default='8800')
     parser.add_argument('--policy-dir', type=str, required=True, help='policy directory')
     parser.add_argument(
         '--on-exception', type=str.lower, required=False, default='warn',
@@ -126,7 +124,7 @@ def cli():
         print(yaml.dump(TEMPLATE))
     else:
         init(
-            args.port, args.policy_dir, args.on_exception,
+            args.host, args.port, args.policy_dir, args.on_exception,
             cert_path=args.cert,
             cert_key_path=args.cert_key,
             ca_cert_path=args.ca_cert,

--- a/tools/c7n_kube/c7n_kube/server.py
+++ b/tools/c7n_kube/c7n_kube/server.py
@@ -16,9 +16,6 @@ log = logging.getLogger("c7n_kube.server")
 log.setLevel(logging.DEBUG)
 
 
-HOST = "0.0.0.0"
-
-
 class AdmissionControllerServer(http.server.HTTPServer):
     """
     Admission Controller Server
@@ -151,7 +148,7 @@ class AdmissionControllerHandler(http.server.BaseHTTPRequestHandler):
 
 
 def init(
-    port, policy_dir, on_exception='warn', serve_forever=True,
+    host, port, policy_dir, on_exception='warn', serve_forever=True,
     *, cert_path=None, cert_key_path=None, ca_cert_path=None,
 ):
     use_tls = any((cert_path, cert_key_path))
@@ -161,7 +158,7 @@ def init(
         )
 
     server = AdmissionControllerServer(
-        server_address=(HOST, port),
+        server_address=(host, port),
         RequestHandlerClass=AdmissionControllerHandler,
         policy_dir=policy_dir,
         on_exception=on_exception,
@@ -177,7 +174,7 @@ def init(
             ca_certs=ca_cert_path,
         )
 
-    log.info(f"Serving at http{'s' if use_tls else ''}://{HOST}:{port}")
+    log.info(f"Serving at http{'s' if use_tls else ''}://{host}:{port}")
     while True:
         server.serve_forever()
         # for testing purposes

--- a/tools/c7n_kube/readme.md
+++ b/tools/c7n_kube/readme.md
@@ -1,6 +1,6 @@
 # Custodian Kubernetes Support
 
-Cloud custodian can run policies directly inside your cluster, reporting on 
+Cloud Custodian can run policies directly inside your cluster, reporting on 
 resources that violate those policies, or blocking them altogether.
 
 # Running the server 

--- a/tools/c7n_kube/readme.md
+++ b/tools/c7n_kube/readme.md
@@ -5,7 +5,7 @@ resources that violate those policies, or blocking them altogether.
 
 # Running the server 
 
-c7n-kube can be run and installed via poetry. `poetry install && poetry run c7n-kates`.  
+c7n-kates can be run and installed via poetry. `poetry install && poetry run c7n-kates`.  
 
 | name           | default   | description                                                  |
 |----------------|-----------|--------------------------------------------------------------|

--- a/tools/c7n_kube/readme.md
+++ b/tools/c7n_kube/readme.md
@@ -1,5 +1,36 @@
 # Custodian Kubernetes Support
 
+Cloud custodian can run policies directly inside your cluster, reporting on 
+resources that violate those policies, or blocking them altogether.
 
-Work in Progress - Not Ready For Use.
+# Running the server 
 
+c7n-kube can be run and installed via poetry. `poetry install && poetry run c7n-kates`.  
+
+| name           | default   | description                                                  |
+|----------------|-----------|--------------------------------------------------------------|
+| --host         | 127.0.0.1 | (optional) The host that the server should listen on.        |
+| --port         | 8800      | (optional) The port the server will listen on.               |
+| --policy-dir   |           | Path to the policy directory.                                |
+| --on-exception | warn      | Action to take on an internal exception. One of: warn, deny. |
+| --cert         |           | Path to the certificate.                                     | 
+| --ca-cert      |           | Path to the CA's certificate.                                |
+| --cert-key     |           | Path to the certificate's key.                               |
+
+# Generate a MutatingWebhookConfiguration
+
+After the server is running, you'll need to configure and install the 
+MutatingWebhookConfiguration manually. To generate a webhook configuration, you
+can run `poetry run c7n-kates --generate --endpoint $ENDPOINT_URL --policy-dir $DIR`, and 
+it will generate an appropriate configuration for you, based on your policies.
+
+Note: some modification of the webhook configuration may be required. See the 
+[documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) 
+on webhooks for more configuration.
+
+# Development
+
+You can use [skaffold](https://github.com/GoogleContainerTools/skaffold/) to 
+assist with testing and debugging this controller. Run `skaffold dev` in this
+folder to deploy the local container into a local kubernetes cluster. It will 
+automatically redeploy it as files change.

--- a/tools/c7n_kube/tests/test_cli.py
+++ b/tools/c7n_kube/tests/test_cli.py
@@ -116,9 +116,10 @@ class TestK8sCli(KubeTest):
         patched_args.cert = None
         patched_args.cert_key = None
         patched_args.ca_cert = None
+        patched_args.host = 'localhost'
         patched_parser.return_value.parse_args.return_value = patched_args
         cli()
         patched_init.assert_called_once_with(
-            9000, 'policies', 'warn',
+            'localhost', 9000, 'policies', 'warn',
             cert_path=None, cert_key_path=None, ca_cert_path=None,
         )

--- a/tools/c7n_kube/tests/test_k8s_server.py
+++ b/tools/c7n_kube/tests/test_k8s_server.py
@@ -318,7 +318,7 @@ class TestServer(KubeTest):
     def test_server_init(self):
         with patch('c7n_kube.server.AdmissionControllerServer') as patched:
             port = self.find_port()
-            init(port, 'policies', serve_forever=False)
+            init('0.0.0.0', port, 'policies', serve_forever=False)
             patched.assert_called_once()
             patched.assert_called_with(
                 server_address=('0.0.0.0', port),


### PR DESCRIPTION
I also added `--host` to the list of options taken by c7n-kube, which defaults to listening to localhost, for standard practice security purposes.