### PR TITLE
c7n-left - update tfparse, json output includes resource, also jmespath query for json output

### DIFF
--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -13,6 +13,9 @@ from .core import CollectionRunner
 from .utils import load_policies
 
 
+log = logging.getLogger("c7n.iac")
+
+
 @click.group()
 def cli():
     """Shift Left Policy"""
@@ -26,7 +29,8 @@ def cli():
 @click.option("-d", "--directory", type=click.Path())
 @click.option("-o", "--output", default="cli", type=click.Choice(report_outputs.keys()))
 @click.option("--output-file", type=click.File("w"), default="-")
-def run(format, policy_dir, directory, output, output_file):
+@click.option("--output-query", default=None)
+def run(format, policy_dir, directory, output, output_file, output_query):
     """evaluate policies against IaC sources.
 
     WARNING - CLI interface subject to change.
@@ -36,8 +40,12 @@ def run(format, policy_dir, directory, output, output_file):
         policy_dir=Path(policy_dir),
         output=output,
         output_file=output_file,
+        output_query=output_query,
     )
     policies = load_policies(policy_dir, config)
+    if not policies:
+        log.warning("no policies found")
+        return
     reporter = get_reporter(config)
     runner = CollectionRunner(policies, config, reporter)
     runner.run()

--- a/tools/c7n_left/c7n_left/providers/terraform/graph.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/graph.py
@@ -30,7 +30,8 @@ class TerraformGraph(ResourceGraph):
                 yield type_name, self.as_resource(type_name, data)
             else:
                 resources = []
-                for name, data in type_items.items():
+                for data in type_items:
+                    name = data["__tfmeta"]["path"]
                     resources.append(self.as_resource(name, data))
                 yield type_name, resources
 

--- a/tools/c7n_left/c7n_left/utils.py
+++ b/tools/c7n_left/c7n_left/utils.py
@@ -10,6 +10,9 @@ def load_policies(policy_dir, options):
 
     loader = DirectoryLoader(config=options)
     policies = loader.load_directory(policy_dir)
+    if not policies:
+        return ()
+
     providers = {p.provider_name for p in policies}
     assert len(providers), "only a single provider per policy dir"
     provider_name = providers.pop()

--- a/tools/c7n_left/poetry.lock
+++ b/tools/c7n_left/poetry.lock
@@ -60,7 +60,7 @@ crt = ["awscrt (==0.14.0)"]
 
 [[package]]
 name = "c7n"
-version = "0.9.19"
+version = "0.9.20"
 description = "Cloud Custodian - Policy Rules Engine"
 category = "dev"
 optional = false
@@ -400,7 +400,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "rich"
-version = "12.5.1"
+version = "12.6.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "main"
 optional = false
@@ -449,7 +449,7 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "tfparse"
-version = "0.1.3"
+version = "0.3.0"
 description = "Python HCL/Terraform parser via extension for AquaSecurity defsec"
 category = "main"
 optional = false
@@ -502,7 +502,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4ce0a33620924a59e61b371fe326efab08e25354018188202bf21b6337370194"
+content-hash = "e6587e997710cd520b1bfe68942a857d548fa0e5059f6452ae14714b48254b91"
 
 [metadata.files]
 argcomplete = [
@@ -762,8 +762,8 @@ PyYAML = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 rich = [
-    {file = "rich-12.5.1-py3-none-any.whl", hash = "sha256:2eb4e6894cde1e017976d2975ac210ef515d7548bc595ba20e195fb9628acdeb"},
-    {file = "rich-12.5.1.tar.gz", hash = "sha256:63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"},
+    {file = "rich-12.6.0-py3-none-any.whl", hash = "sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e"},
+    {file = "rich-12.6.0.tar.gz", hash = "sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0"},
 ]
 s3transfer = [
     {file = "s3transfer-0.6.0-py3-none-any.whl", hash = "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd"},
@@ -778,10 +778,10 @@ tabulate = [
     {file = "tabulate-0.8.10.tar.gz", hash = "sha256:6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"},
 ]
 tfparse = [
-    {file = "tfparse-0.1.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6bd58cac7de1e07f02a9c0eb824b5e7d0963814d966c969fafdc1d1bd7c63d5"},
-    {file = "tfparse-0.1.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:90dd576bd1b5ac093b78b4041fa54352318b22c425f3ff7c565da8088de0dcbf"},
-    {file = "tfparse-0.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6e5d9b01b807c96c70ed8b342a46686c0e477266e2479c4cf9b15fe0e58e1ea"},
-    {file = "tfparse-0.1.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29d466c3dace725b2b5c7905e8a4f472b51c63abed5426b27b3e3a584fac7819"},
+    {file = "tfparse-0.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3f9041b8fde62e4fc078f8b55e2db56337867f3c82109501048b7ed28c8d05de"},
+    {file = "tfparse-0.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f1dda1d9cbf817d560f67ebd78c61284315ac1f53ef985dd8c1e09ec45e35422"},
+    {file = "tfparse-0.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa3e22c53f6e7f89ba611f7f38bd1705517ed8e6ef818fab91f724f50f43fc7"},
+    {file = "tfparse-0.3.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:563570692f8a81b58d7046bef629c6eea01d4aec5e350b895db04ac9e6bc7b7c"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -20,7 +20,7 @@ c7n-left = 'c7n_left.cli:cli'
 python = "^3.7"
 click = ">=8.0"
 rich = "^12.5"
-tfparse = "^0.1"
+tfparse = "^0.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -166,6 +166,35 @@ def test_cli_output_github(tmp_path):
     )
 
 
+def test_cli_output_json_query(tmp_path):
+    write_output_test_policy(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "run",
+            "-p",
+            str(tmp_path),
+            "-d",
+            str(terraform_dir / "aws_s3_encryption_audit"),
+            "-o",
+            "json",
+            "--output-file",
+            str(tmp_path / "output.json"),
+            "--output-query",
+            "[].file_path",
+        ],
+    )
+
+    results = json.loads((tmp_path / "output.json").read_text())
+    assert results == {
+        "results": [
+            "tests/terraform/aws_s3_encryption_audit/main.tf",
+        ]
+    }
+
+
 def test_cli_output_json(tmp_path):
     write_output_test_policy(tmp_path)
 

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -110,6 +110,21 @@ def write_output_test_policy(tmp_path):
     )
 
 
+def test_cli_no_policies(tmp_path, caplog):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "run",
+            "-p",
+            str(tmp_path),
+            "-d",
+            str(terraform_dir / "aws_s3_encryption_audit"),
+        ],
+    )
+    assert caplog.record_tuples == [("c7n.iac", 30, "no policies found")]
+
+
 def test_cli_output_rich(tmp_path):
     write_output_test_policy(tmp_path)
     runner = CliRunner()

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -112,7 +112,7 @@ def write_output_test_policy(tmp_path):
 
 def test_cli_no_policies(tmp_path, caplog):
     runner = CliRunner()
-    result = runner.invoke(
+    runner.invoke(
         cli.cli,
         [
             "run",

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -3,6 +3,8 @@
 #
 import json
 import os
+from unittest.mock import ANY
+
 import pytest
 from pathlib import Path
 
@@ -49,6 +51,9 @@ def test_provider_parse():
     rtype, resources = resource_types.pop()
     assert rtype == "aws_subnet"
     assert resources[0]["__tfmeta"] == {
+        "type": "resource",
+        "label": "aws_subnet",
+        "path": "aws_subnet.example",
         "filename": "network.tf",
         "line_start": 5,
         "line_end": 8,
@@ -184,6 +189,21 @@ def test_cli_output_json(tmp_path):
                 "mode": {"type": "terraform-source"},
                 "name": "check-bucket",
                 "resource": "terraform.aws_s3_bucket",
+            },
+            "resource": {
+                "__tfmeta": {
+                    "filename": "main.tf",
+                    "label": "aws_s3_bucket",
+                    "line_end": 28,
+                    "line_start": 25,
+                    "path": "aws_s3_bucket.example_c",
+                    "src_dir": "tests/terraform/aws_s3_encryption_audit",
+                    "type": "resource",
+                },
+                "acl": "private",
+                "bucket": "c7n-aws-s3-encryption-audit-test-c",
+                "c7n:MatchedFilters": ["server_side_encryption_configuration"],
+                "id": ANY,
             },
         }
     ]

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -170,7 +170,7 @@ def test_cli_output_json_query(tmp_path):
     write_output_test_policy(tmp_path)
 
     runner = CliRunner()
-    result = runner.invoke(
+    runner.invoke(
         cli.cli,
         [
             "run",


### PR DESCRIPTION
- support tfparse changes per https://github.com/cloud-custodian/tfparse/pull/47 
- add resources to json output 
- support querying json resource output with jmespath cli flag
- handle no policies found gracefully.