### PR TITLE
Add env parameter for threading multiplier

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -45,7 +45,8 @@ if sys.platform == 'darwin' and (
 
 
 WORKER_COUNT = int(
-    os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count() * 4))
+    cpu_multiplier = os.environ.get('C7N_ORG_PARALLEL_MULTIPLIER', 4)
+    os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count() * cpu_multiplier))
 
 
 CONFIG_SCHEMA = {

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -45,8 +45,9 @@ if sys.platform == 'darwin' and (
 
 
 WORKER_COUNT = int(
-    cpu_multiplier = os.environ.get('C7N_ORG_PARALLEL_MULTIPLIER', 4)
-    os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count() * cpu_multiplier))
+    os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count() \
+        * os.environ.get('C7N_ORG_PARALLEL_MULTIPLIER', 4))
+    )
 
 
 CONFIG_SCHEMA = {


### PR DESCRIPTION
Added an environmental parameter to allow user to adjust the worker count allocated based on the total number of CPU cores.

This will allow the option for more fine-grained resource tuning.