### PR TITLE
aws - rds-snapshot - skip automated snapshots in delete action 

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1426,6 +1426,10 @@ class RDSSnapshotDelete(BaseAction):
     permissions = ('rds:DeleteDBSnapshot',)
 
     def process(self, snapshots):
+        skipped = len([s for s in snapshots if s['SnapshotType'] == 'automated'])
+        snapshots = [s for s in snapshots if s['SnapshotType'] != 'automated']
+        if skipped:
+            self.log.info("Automated snapshots cannot be deleted, skipping %d snapshot(s)", skipped)
         log.info("Deleting %d rds snapshots", len(snapshots))
         with self.executor_factory(max_workers=3) as w:
             futures = []

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1427,6 +1427,8 @@ class RDSSnapshotDelete(BaseAction):
 
     def process(self, snapshots):
         snapshots = self.filter_resources(snapshots, 'SnapshotType', ('manual',))
+        if not snapshots:
+            return []
         log.info("Deleting %d rds snapshots", len(snapshots))
         with self.executor_factory(max_workers=3) as w:
             futures = []

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1426,10 +1426,7 @@ class RDSSnapshotDelete(BaseAction):
     permissions = ('rds:DeleteDBSnapshot',)
 
     def process(self, snapshots):
-        skipped = len([s for s in snapshots if s['SnapshotType'] == 'automated'])
-        snapshots = [s for s in snapshots if s['SnapshotType'] != 'automated']
-        if skipped:
-            self.log.info("Automated snapshots cannot be deleted, skipping %d snapshot(s)", skipped)
+        snapshots = self.filter_resources(snapshots, 'SnapshotType', ('manual',))
         log.info("Deleting %d rds snapshots", len(snapshots))
         with self.executor_factory(max_workers=3) as w:
             futures = []

--- a/tests/data/placebo/test_rds_snapshot_delete_skip_automated/rds.DeleteDBSnapshot_1.json
+++ b/tests/data/placebo/test_rds_snapshot_delete_skip_automated/rds.DeleteDBSnapshot_1.json
@@ -1,0 +1,61 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBSnapshot": {
+            "DBSnapshotIdentifier": "this-one-is-manual",
+            "DBInstanceIdentifier": "c7n-test",
+            "SnapshotCreateTime": {
+                "__class__": "datetime",
+                "year": 2022,
+                "month": 10,
+                "day": 24,
+                "hour": 21,
+                "minute": 6,
+                "second": 14,
+                "microsecond": 883000
+            },
+            "Engine": "postgres",
+            "AllocatedStorage": 30,
+            "Status": "deleted",
+            "Port": 5432,
+            "AvailabilityZone": "us-east-2c",
+            "VpcId": "vpc-06fbfb0683669c546",
+            "InstanceCreateTime": {
+                "__class__": "datetime",
+                "year": 2022,
+                "month": 3,
+                "day": 12,
+                "hour": 16,
+                "minute": 11,
+                "second": 4,
+                "microsecond": 358000
+            },
+            "MasterUsername": "root",
+            "EngineVersion": "13.4",
+            "LicenseModel": "postgresql-license",
+            "SnapshotType": "manual",
+            "OptionGroupName": "default:postgres-13",
+            "PercentProgress": 100,
+            "StorageType": "gp2",
+            "Encrypted": true,
+            "KmsKeyId": "arn:aws:kms:us-east-2:644160558196:key/dd462ea7-52bc-4818-8f97-7d4cbbe95073",
+            "DBSnapshotArn": "arn:aws:rds:us-east-2:644160558196:snapshot:this-one-is-manual",
+            "IAMDatabaseAuthenticationEnabled": true,
+            "ProcessorFeatures": [],
+            "DbiResourceId": "db-GV4PVF2U7EQCCJP43MJHX4DLTY",
+            "TagList": [],
+            "OriginalSnapshotCreateTime": {
+                "__class__": "datetime",
+                "year": 2022,
+                "month": 10,
+                "day": 24,
+                "hour": 21,
+                "minute": 6,
+                "second": 14,
+                "microsecond": 883000
+            },
+            "SnapshotTarget": "region"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_snapshot_delete_skip_automated/rds.DescribeDBSnapshots_1.json
+++ b/tests/data/placebo/test_rds_snapshot_delete_skip_automated/rds.DescribeDBSnapshots_1.json
@@ -1,0 +1,128 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBSnapshots": [
+            {
+                "DBSnapshotIdentifier": "rds:c7n-test-2022-10-24-03-19",
+                "DBInstanceIdentifier": "c7n-test",
+                "SnapshotCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 10,
+                    "day": 24,
+                    "hour": 3,
+                    "minute": 19,
+                    "second": 52,
+                    "microsecond": 701000
+                },
+                "Engine": "postgres",
+                "AllocatedStorage": 30,
+                "Status": "available",
+                "Port": 5432,
+                "AvailabilityZone": "us-east-2c",
+                "VpcId": "vpc-06fbfb0683669c546",
+                "InstanceCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 12,
+                    "hour": 16,
+                    "minute": 11,
+                    "second": 4,
+                    "microsecond": 358000
+                },
+                "MasterUsername": "root",
+                "EngineVersion": "13.4",
+                "LicenseModel": "postgresql-license",
+                "SnapshotType": "automated",
+                "OptionGroupName": "default:postgres-13",
+                "PercentProgress": 100,
+                "StorageType": "gp2",
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-2:644160558196:key/dd462ea7-52bc-4818-8f97-7d4cbbe95073",
+                "DBSnapshotArn": "arn:aws:rds:us-east-2:644160558196:snapshot:rds:c7n-test-2022-10-24-03-19",
+                "IAMDatabaseAuthenticationEnabled": true,
+                "ProcessorFeatures": [],
+                "DbiResourceId": "db-GV4PVF2U7EQCCJP43MJHX4DLTY",
+                "TagList": [
+                    {
+                        "Key": "Env",
+                        "Value": "dev"
+                    }
+                ],
+                "OriginalSnapshotCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 10,
+                    "day": 24,
+                    "hour": 3,
+                    "minute": 19,
+                    "second": 52,
+                    "microsecond": 701000
+                },
+                "SnapshotTarget": "region"
+            },
+            {
+                "DBSnapshotIdentifier": "this-one-is-manual",
+                "DBInstanceIdentifier": "c7n-test",
+                "SnapshotCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 10,
+                    "day": 24,
+                    "hour": 21,
+                    "minute": 6,
+                    "second": 14,
+                    "microsecond": 883000
+                },
+                "Engine": "postgres",
+                "AllocatedStorage": 30,
+                "Status": "available",
+                "Port": 5432,
+                "AvailabilityZone": "us-east-2c",
+                "VpcId": "vpc-06fbfb0683669c546",
+                "InstanceCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 12,
+                    "hour": 16,
+                    "minute": 11,
+                    "second": 4,
+                    "microsecond": 358000
+                },
+                "MasterUsername": "root",
+                "EngineVersion": "13.4",
+                "LicenseModel": "postgresql-license",
+                "SnapshotType": "manual",
+                "OptionGroupName": "default:postgres-13",
+                "PercentProgress": 100,
+                "StorageType": "gp2",
+                "Encrypted": true,
+                "KmsKeyId": "arn:aws:kms:us-east-2:644160558196:key/dd462ea7-52bc-4818-8f97-7d4cbbe95073",
+                "DBSnapshotArn": "arn:aws:rds:us-east-2:644160558196:snapshot:this-one-is-manual",
+                "IAMDatabaseAuthenticationEnabled": true,
+                "ProcessorFeatures": [],
+                "DbiResourceId": "db-GV4PVF2U7EQCCJP43MJHX4DLTY",
+                "TagList": [
+                    {
+                        "Key": "Env",
+                        "Value": "dev"
+                    }
+                ],
+                "OriginalSnapshotCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 10,
+                    "day": 24,
+                    "hour": 21,
+                    "minute": 6,
+                    "second": 14,
+                    "microsecond": 883000
+                },
+                "SnapshotTarget": "region"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1210,7 +1210,7 @@ class RDSSnapshotTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 2)
         assert (
-            'Automated snapshots cannot be deleted, skipping 1 snapshot(s)'
+            'delete implicitly filtered 1 of 2 resources'
             in log_output.getvalue().strip()
         )
 

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -8,6 +8,7 @@ import re
 import time
 import uuid
 from collections import OrderedDict
+from unittest import mock
 
 import boto3
 import c7n.resources.rds
@@ -1183,7 +1184,8 @@ class RDSSnapshotTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
-    def test_rds_snapshot_trim_skip_automated(self):
+    @mock.patch("c7n.resources.rds.RDSSnapshotDelete.process_snapshot_set")
+    def test_rds_snapshot_trim_skip_automated(self, process_snapshot_set):
         factory = self.replay_flight_data("test_rds_snapshot_delete_skip_automated",
             region="us-east-2")
         log_output = self.capture_logging('custodian.actions')
@@ -1213,6 +1215,43 @@ class RDSSnapshotTest(BaseTest):
             'delete implicitly filtered 1 of 2 resources'
             in log_output.getvalue().strip()
         )
+        assert process_snapshot_set.call_count == 1
+
+    @mock.patch("c7n.resources.rds.RDSSnapshotDelete.process_snapshot_set")
+    def test_rds_snapshot_trim_skip_automated_noop(self, process_snapshot_set):
+        factory = self.replay_flight_data("test_rds_snapshot_delete_skip_automated",
+            region="us-east-2")
+        log_output = self.capture_logging('custodian.actions')
+        p = self.load_policy(
+            {
+                "name": "rds-snapshot-trim-skip-automated-noop",
+                "resource": "rds-snapshot",
+                "filters": [
+                    {
+                        "DBInstanceIdentifier": "c7n-test"
+                    },
+                    {
+                        "SnapshotType": "automated"
+                    },
+                    {
+                        "type": "reduce",
+                        "sort-by": "SnapshotCreateTime",
+                        "limit": 1
+                    }
+                ],
+                "actions": ["delete"],
+            },
+            session_factory=factory,
+            config={"region": "us-east-2"},
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        assert (
+            'delete implicitly filtered 0 of 1 resources'
+            in log_output.getvalue().strip()
+        )
+        assert process_snapshot_set.call_count == 0
 
     def test_rds_snapshot_tag(self):
         factory = self.replay_flight_data("test_rds_snapshot_mark")


### PR DESCRIPTION
Address #7838 by implicitly filtering out automated snapshots at the start of a `delete` action.

Note: @khapp and I considered using [`filter_resources`](https://github.com/cloud-custodian/cloud-custodian/blob/c838e32697b2b5fc63f0f10dfe42a90a05c3f98b/c7n/element.py#L37-L55) here, but thought including the "why" here (you can't delete automated snapshots) was useful context for folks reviewing policy logs.