### PR TITLE
aws - autotag action - autotag user with value

### DIFF
--- a/c7n/actions/autotag.py
+++ b/c7n/actions/autotag.py
@@ -60,8 +60,14 @@ class AutoTagUser(EventAction):
                       ]}},
            'update': {'type': 'boolean'},
            'tag': {'type': 'string'},
-           'principal_id_tag': {'type': 'string'}
-           }
+           'principal_id_tag': {'type': 'string'},
+           'value': {'type': 'string',
+                     'enum': [
+                         'userName',
+                         'arn',
+                         'sourceIPAddress'
+            ]}
+        }
     )
 
     def get_permissions(self):
@@ -79,6 +85,25 @@ class AutoTagUser(EventAction):
             raise PolicyValidationError(
                 "auto-tag action requires 'tag'")
         return self
+
+    def get_user_info_value(self, utype, event):
+        value = None
+
+        vtype = self.data.get('value', None)
+        if vtype is None:
+            return
+
+        if vtype == "userName":
+            if utype == "IAMUser":
+                value = event['userIdentity'].get('userName', '')
+            elif utype == "AssumedRole" or utype == "FederatedUser":
+                value = event['userIdentity'].get('sessionContext', {}).get('sessionIssuer', {}).get('userName', '')
+        elif vtype == "arn":
+            value = event['userIdentity'].get('arn', '')
+        elif vtype == "sourceIPAddress":
+            value = event.get('sourceIPAddress', '')
+
+        return value
 
     def get_tag_value(self, event):
         event = event['detail']
@@ -101,8 +126,10 @@ class AutoTagUser(EventAction):
             elif user.startswith('awslambda'):
                 return
 
+        value = self.get_user_info_value(utype, event)
+
         # if the auto-tag-user policy set update to False (or it's unset) then we
-        return {'user': user, 'id': principal_id_value}
+        return {'user': user, 'id': principal_id_value, 'value': value}
 
     def process(self, resources, event):
         if event is None:
@@ -128,7 +155,9 @@ class AutoTagUser(EventAction):
             untagged_resources = resources
 
         new_tags = {}
-        if user_info['user']:
+        if user_info['value']:
+            new_tags[self.data['tag']] = user_info['value']
+        elif user_info['user']:
             new_tags[self.data['tag']] = user_info['user']
 
         # if principal_id_key is set (and value), we'll set the principalId tag.


### PR DESCRIPTION
- Refer : https://github.com/cloud-custodian/cloud-custodian/issues/7950
- event
```
{
...
"userIdentity": {
    "type": "AssumedRole",
    "principalId": "AROAIDPPEZS35WEXAMPLE:AssumedRoleSessionName",
    "arn": "arn:aws:sts::123456789012:assumed-role/RoleToBeAssumed/MySessionName",
    "accountId": "123456789012",
    "accessKeyId": "",
    "sessionContext": {
      "attributes": {
        "mfaAuthenticated": "false",
        "creationDate": "20131102T010628Z"
      },
      "sessionIssuer": {
        "type": "Role",
        "principalId": "AROAIDPPEZS35WEXAMPLE",
        "arn": "arn:aws:iam::123456789012:role/RoleToBeAssumed",
        "accountId": "123456789012",
        "userName": "RoleToBeAssumed"
      }
    }
},
"sourceIPAddress": "1.2.3.4"
...
}
```
- policy
```
  actions:
  - type: auto-tag-user
    tag: c7n_AutoTag_Creator
  - type: auto-tag-user
    tag: c7n_AutoTag_Arn
    value: arn
  - type: auto-tag-user
    tag: c7n_AutoTag_Username
    value: userName
  - type: auto-tag-user
    tag: c7n_AutoTag_IP
    value: sourceIPAddress
```
- tag result
```
- c7n_AutoTag_Creator : AssumedRoleSessionName
- c7n_AutoTag_Arn : arn:aws:sts::123456789012:assumed-role/RoleToBeAssumed/MySessionName
- c7n_AutoTag_Username : RoleToBeAssumed
- c7n_AutoTag_IP : 1.2.3.4
```