### PR TITLE
Fix issue dumping FormatDate objs as JSON.

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -213,6 +213,8 @@ class DateTimeEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
             return obj.isoformat()
+        if isinstance(obj, FormatDate):
+            return obj.datetime.isoformat()
         return json.JSONEncoder.default(self, obj)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -224,6 +224,10 @@ class UtilTest(BaseTest):
 
         self.assertEqual("{:+5M%M}".format(utils.FormatDate(d)), "05")
 
+        self.assertEqual(json.dumps(utils.FormatDate(d),
+                                    cls=utils.DateTimeEncoder, indent=2),
+                         '"2018-02-02T12:00:00"')
+
     def test_group_by(self):
         items = [{}, {"Type": "a"}, {"Type": "a"}, {"Type": "b"}]
         self.assertEqual(list(utils.group_by(items, "Type").keys()), [None, "a", "b"])


### PR DESCRIPTION
This is a trivial change to ensure that the FormatDate objects used are formatted correctly.

Fixes #7916 