### PR TITLE
aws - Support CloudTrail mode for aws.transit-attachment

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1910,6 +1910,7 @@ class TransitGatewayAttachment(query.ChildResourceManager):
         name = id = 'TransitGatewayAttachmentId'
         arn = False
         cfn_type = 'AWS::EC2::TransitGatewayAttachment'
+        supports_trailevents = True
 
 
 @resources.register('peering-connection')

--- a/tests/data/cwe/event-transit-gateway-delete-vpc-attachment.json
+++ b/tests/data/cwe/event-transit-gateway-delete-vpc-attachment.json
@@ -1,0 +1,68 @@
+{
+    "version": "0",
+    "id": "f6c00f02-bf83-11c3-6476-188a4462be21",
+    "detail-type": "AWS API Call via CloudTrail",
+    "source": "aws.ec2",
+    "account": "012345678912",
+    "time": "2022-11-09T09:24:20Z",
+    "region": "us-west-2",
+    "resources": [],
+    "detail": {
+        "eventVersion": "1.08",
+        "userIdentity": {
+            "type": "AssumedRole",
+            "principalId": "AROA3OCGVC4GCMEU2DIEW:pmuniswamy",
+            "arn": "arn:aws:sts::012345678912:assumed-role/c7nbot/pmuniswamy",
+            "accountId": "012345678912",
+            "accessKeyId": "ASIA3OCGVC4GKK15OTHH3",
+            "sessionContext": {
+                "sessionIssuer": {
+                    "type": "Role",
+                    "principalId": "AROA3OCGVC4GCMEU2DKK1",
+                    "arn": "arn:aws:iam::012345678912:role/c7nbot",
+                    "accountId": "012345678912",
+                    "userName": "c7nbot"
+                },
+                "webIdFederationData": {},
+                "attributes": {
+                    "creationDate": "2022-11-09T08:48:05Z",
+                    "mfaAuthenticated": "false"
+                }
+            }
+        },
+        "eventTime": "2022-11-09T09:24:20Z",
+        "eventSource": "ec2.amazonaws.com",
+        "eventName": "DeleteTransitGatewayVpcAttachment",
+        "awsRegion": "us-west-2",
+        "sourceIPAddress": "AWS Internal",
+        "userAgent": "AWS Internal",
+        "requestParameters": {
+            "DelTGwVpcAttachReq": {
+                "TransitGatewayAttachmentId": "tgw-attach-0814a77755bf02f0e"
+            }
+        },
+        "responseElements": {
+            "DeleteTransitGatewayVpcAttachmentResponse": {
+                "xmlns": "http://ec2.amazonaws.com/doc/2016-11-15/",
+                "transitGatewayVpcAttachment": {
+                    "creationTime": "2022-11-09T09:23:12.000Z",
+                    "transitGatewayAttachmentId": "tgw-attach-0814a77755bf02f0e",
+                    "transitGatewayId": "tgw-008fe7d47ebe2dbeb",
+                    "vpcId": "vpc-0e2a18296548d753e",
+                    "state": "deleting",
+                    "vpcOwnerId": "012345678912"
+                },
+                "requestId": "61682dec-77d6-4be2-823a-81b218e55755"
+            }
+        },
+        "requestID": "61682dec-77d6-4be2-823a-81b218e55755",
+        "eventID": "10fe783b-14ea-4f67-8dbc-b1596716e57c",
+        "readOnly": false,
+        "eventType": "AwsApiCall",
+        "managementEvent": true,
+        "recipientAccountId": "012345678912",
+        "eventCategory": "Management",
+        "sessionCredentialFromConsole": "true"
+    },
+    "debug": true
+}

--- a/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_1.json
+++ b/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TransitGatewayAttachments": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_2.json
+++ b/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_2.json
@@ -1,0 +1,122 @@
+{
+    "status_code": 200,
+    "data": {
+        "TransitGatewayAttachments": [
+            {
+                "TransitGatewayAttachmentId": "tgw-attach-015493eec8d86e8f7",
+                "TransitGatewayId": "tgw-008fe7d47ebe2dbeb",
+                "TransitGatewayOwnerId": "644160558196",
+                "ResourceOwnerId": "644160558196",
+                "ResourceType": "vpc",
+                "ResourceId": "vpc-0e2a48216548d753e",
+                "State": "deleted",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 11,
+                    "day": 9,
+                    "hour": 9,
+                    "minute": 14,
+                    "second": 34,
+                    "microsecond": 0
+                },
+                "Tags": []
+            },
+            {
+                "TransitGatewayAttachmentId": "tgw-attach-0814a77755bf02f0e",
+                "TransitGatewayId": "tgw-008fe7d47ebe2dbeb",
+                "TransitGatewayOwnerId": "644160558196",
+                "ResourceOwnerId": "644160558196",
+                "ResourceType": "vpc",
+                "ResourceId": "vpc-0e2a48216548d753e",
+                "State": "deleted",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 11,
+                    "day": 9,
+                    "hour": 9,
+                    "minute": 23,
+                    "second": 12,
+                    "microsecond": 0
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "test2"
+                    }
+                ]
+            },
+            {
+                "TransitGatewayAttachmentId": "tgw-attach-09c4d7c5461572bed",
+                "TransitGatewayId": "tgw-008fe7d47ebe2dbeb",
+                "TransitGatewayOwnerId": "644160558196",
+                "ResourceOwnerId": "644160558196",
+                "ResourceType": "vpc",
+                "ResourceId": "vpc-0e2a48216548d753e",
+                "State": "deleted",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 11,
+                    "day": 9,
+                    "hour": 8,
+                    "minute": 56,
+                    "second": 19,
+                    "microsecond": 0
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "test"
+                    }
+                ]
+            },
+            {
+                "TransitGatewayAttachmentId": "tgw-attach-0bdbce74e86c071be",
+                "TransitGatewayId": "tgw-008fe7d47ebe2dbeb",
+                "TransitGatewayOwnerId": "644160558196",
+                "ResourceOwnerId": "644160558196",
+                "ResourceType": "vpc",
+                "ResourceId": "vpc-0e2a48216548d753e",
+                "State": "available",
+                "Association": {
+                    "TransitGatewayRouteTableId": "tgw-rtb-0dd49d1ea80803d53",
+                    "State": "associated"
+                },
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 11,
+                    "day": 9,
+                    "hour": 9,
+                    "minute": 36,
+                    "second": 42,
+                    "microsecond": 0
+                },
+                "Tags": []
+            },
+            {
+                "TransitGatewayAttachmentId": "tgw-attach-0df5f90f7a0ea284a",
+                "TransitGatewayId": "tgw-008fe7d47ebe2dbeb",
+                "TransitGatewayOwnerId": "644160558196",
+                "ResourceOwnerId": "644160558196",
+                "ResourceType": "vpc",
+                "ResourceId": "vpc-0e2a48216548d753e",
+                "State": "deleted",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 11,
+                    "day": 9,
+                    "hour": 9,
+                    "minute": 10,
+                    "second": 12,
+                    "microsecond": 0
+                },
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_3.json
+++ b/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_3.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TransitGatewayAttachments": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_4.json
+++ b/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_4.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TransitGatewayAttachments": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_5.json
+++ b/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_5.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TransitGatewayAttachments": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_6.json
+++ b/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGatewayAttachments_6.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TransitGatewayAttachments": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGateways_1.json
+++ b/tests/data/placebo/test_transit_gateway_attachment_query_cwe/ec2.DescribeTransitGateways_1.json
@@ -1,0 +1,181 @@
+{
+    "status_code": 200,
+    "data": {
+        "TransitGateways": [
+            {
+                "TransitGatewayId": "tgw-00857fd89ceffdad7",
+                "TransitGatewayArn": "arn:aws:ec2:us-west-2:644160558196:transit-gateway/tgw-00857fd89ceffdad7",
+                "State": "available",
+                "OwnerId": "644160558196",
+                "Description": "tgw-data-test-dev1",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 3,
+                    "day": 22,
+                    "hour": 17,
+                    "minute": 4,
+                    "second": 14,
+                    "microsecond": 0
+                },
+                "Options": {
+                    "AmazonSideAsn": 64512,
+                    "AutoAcceptSharedAttachments": "enable",
+                    "DefaultRouteTableAssociation": "enable",
+                    "AssociationDefaultRouteTableId": "tgw-rtb-0c2d6c71cda2431d0",
+                    "DefaultRouteTablePropagation": "enable",
+                    "PropagationDefaultRouteTableId": "tgw-rtb-0c2d6c71cda2431d0",
+                    "VpnEcmpSupport": "enable",
+                    "DnsSupport": "enable",
+                    "MulticastSupport": "disable"
+                },
+                "Tags": []
+            },
+            {
+                "TransitGatewayId": "tgw-008fe7d47ebe2dbeb",
+                "TransitGatewayArn": "arn:aws:ec2:us-west-2:644160558196:transit-gateway/tgw-008fe7d47ebe2dbeb",
+                "State": "available",
+                "OwnerId": "644160558196",
+                "Description": "A TGW sample",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 9,
+                    "day": 1,
+                    "hour": 16,
+                    "minute": 44,
+                    "second": 29,
+                    "microsecond": 0
+                },
+                "Options": {
+                    "AmazonSideAsn": 64512,
+                    "AutoAcceptSharedAttachments": "enable",
+                    "DefaultRouteTableAssociation": "enable",
+                    "AssociationDefaultRouteTableId": "tgw-rtb-0dd49d1ea80803d53",
+                    "DefaultRouteTablePropagation": "enable",
+                    "PropagationDefaultRouteTableId": "tgw-rtb-0dd49d1ea80803d53",
+                    "VpnEcmpSupport": "enable",
+                    "DnsSupport": "enable",
+                    "MulticastSupport": "disable"
+                },
+                "Tags": []
+            },
+            {
+                "TransitGatewayId": "tgw-089825ccd90d171ea",
+                "TransitGatewayArn": "arn:aws:ec2:us-west-2:644160558196:transit-gateway/tgw-089825ccd90d171ea",
+                "State": "available",
+                "OwnerId": "644160558196",
+                "Description": "tgw-data-test-dev2",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 3,
+                    "day": 22,
+                    "hour": 17,
+                    "minute": 7,
+                    "second": 2,
+                    "microsecond": 0
+                },
+                "Options": {
+                    "AmazonSideAsn": 64512,
+                    "AutoAcceptSharedAttachments": "enable",
+                    "DefaultRouteTableAssociation": "enable",
+                    "AssociationDefaultRouteTableId": "tgw-rtb-0b118049ce185461a",
+                    "DefaultRouteTablePropagation": "enable",
+                    "PropagationDefaultRouteTableId": "tgw-rtb-0b118049ce185461a",
+                    "VpnEcmpSupport": "enable",
+                    "DnsSupport": "enable",
+                    "MulticastSupport": "disable"
+                },
+                "Tags": []
+            },
+            {
+                "TransitGatewayId": "tgw-0a1b4d3f1a66473e6",
+                "TransitGatewayArn": "arn:aws:ec2:us-west-2:644160558196:transit-gateway/tgw-0a1b4d3f1a66473e6",
+                "State": "available",
+                "OwnerId": "644160558196",
+                "Description": "Test E2E TransitGateway",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 6,
+                    "day": 20,
+                    "hour": 22,
+                    "minute": 17,
+                    "second": 26,
+                    "microsecond": 0
+                },
+                "Options": {
+                    "AmazonSideAsn": 65252,
+                    "AutoAcceptSharedAttachments": "enable",
+                    "DefaultRouteTableAssociation": "enable",
+                    "AssociationDefaultRouteTableId": "tgw-rtb-096e26da3b58f6ab5",
+                    "DefaultRouteTablePropagation": "disable",
+                    "VpnEcmpSupport": "enable",
+                    "DnsSupport": "enable",
+                    "MulticastSupport": "disable"
+                },
+                "Tags": []
+            },
+            {
+                "TransitGatewayId": "tgw-0ae92474bae91f567",
+                "TransitGatewayArn": "arn:aws:ec2:us-west-2:644160558196:transit-gateway/tgw-0ae92474bae91f567",
+                "State": "available",
+                "OwnerId": "644160558196",
+                "Description": "tgw-data-test-dev3",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 3,
+                    "day": 22,
+                    "hour": 17,
+                    "minute": 14,
+                    "second": 7,
+                    "microsecond": 0
+                },
+                "Options": {
+                    "AmazonSideAsn": 64512,
+                    "AutoAcceptSharedAttachments": "enable",
+                    "DefaultRouteTableAssociation": "enable",
+                    "AssociationDefaultRouteTableId": "tgw-rtb-0260f577f316babfd",
+                    "DefaultRouteTablePropagation": "enable",
+                    "PropagationDefaultRouteTableId": "tgw-rtb-0260f577f316babfd",
+                    "VpnEcmpSupport": "enable",
+                    "DnsSupport": "enable",
+                    "MulticastSupport": "disable"
+                },
+                "Tags": []
+            },
+            {
+                "TransitGatewayId": "tgw-0f96ed6067afecc1b",
+                "TransitGatewayArn": "arn:aws:ec2:us-west-2:644160558196:transit-gateway/tgw-0f96ed6067afecc1b",
+                "State": "available",
+                "OwnerId": "644160558196",
+                "Description": "tgw-data-test-dev4",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 3,
+                    "day": 22,
+                    "hour": 17,
+                    "minute": 0,
+                    "second": 21,
+                    "microsecond": 0
+                },
+                "Options": {
+                    "AmazonSideAsn": 64512,
+                    "AutoAcceptSharedAttachments": "enable",
+                    "DefaultRouteTableAssociation": "enable",
+                    "AssociationDefaultRouteTableId": "tgw-rtb-0e5b01ca3d51a4631",
+                    "DefaultRouteTablePropagation": "enable",
+                    "PropagationDefaultRouteTableId": "tgw-rtb-0e5b01ca3d51a4631",
+                    "VpnEcmpSupport": "enable",
+                    "DnsSupport": "enable",
+                    "MulticastSupport": "disable"
+                },
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -729,6 +729,24 @@ class TransitGatewayTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['ResourceId'], 'vpc-f1516b97')
 
+    def test_tgw_attachment_cloudtrail(self):
+        factory = self.replay_flight_data('test_transit_gateway_attachment_query_cwe')
+        p = self.load_policy(
+            {
+                "name": "test-tgw-att-cwe",
+                "resource": "transit-attachment",
+                "mode": {
+                    "type": "cloudtrail",
+                    "events": [{
+                        "event": "DeleteTransitGatewayVpcAttachment",
+                        "ids": "requestParameters.DelTGwVpcAttachReq.TransitGatewayAttachmentId",
+                        "source": "ec2.amazonaws.com"
+                    }]},
+            },
+            config={'region': 'us-west-2'}, session_factory=factory)
+        resources = p.push(event_data("event-transit-gateway-delete-vpc-attachment.json"))
+        self.assertEqual(len(resources), 1)
+
 
 class NetworkInterfaceTest(BaseTest):
 


### PR DESCRIPTION
To support CloudTrail mode policies for **Resource: aws.transit-attachment** 

### **Error:**
```
// % custodian run -v --cache-period=0 -d -s . -r us-west-2 -c tgw-vpc-attachment.yml
2022-11-03 09:33:33,900: custodian.cache:DEBUG Disabling cache
2022-11-03 09:33:33,900: custodian.commands:ERROR problem loading policy file (tgw-vpc-attachment.yml) 
error: resource:aws.transit-attachment does not support cloudtrail mode policies
2022-11-03 09:33:33,900: custodian.commands:ERROR Found 1 errors.  Exiting. 
```
### **Example:**
```
policies:
  - name: transitgw-vpc-attachment-delete
    resource: aws.transit-attachment
    mode:
      type: cloudtrail
      events:
        - event: DeleteTransitGatewayVpcAttachment
           ids: responseElements.DeleteTransitGatewayVpcAttachmentResponse.transitGatewayVpcAttachment.transitGatewayAttachmentId
          source: ec2.amazonaws.com
    filters:
      - type: event
        key: detail.responseElements.DeleteTransitGatewayVpcAttachmentResponse.transitGatewayVpcAttachment.transitGatewayId
        op: in
        value: ["tgw-1234e7d47ebe21234"]
```
          
Issue: #6493