### PR TITLE
releng - install mailer extras in docker image

### DIFF
--- a/docker/c7n
+++ b/docker/c7n
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/c7n-kube
+++ b/docker/c7n-kube
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/c7n-kube-distroless
+++ b/docker/c7n-kube-distroless
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/mailer
+++ b/docker/mailer
@@ -79,7 +79,7 @@ RUN mkdir /output
 
 # Install c7n-mailer
 ADD tools/c7n_mailer /src/tools/c7n_mailer
-RUN . /usr/local/bin/activate && cd tools/c7n_mailer && poetry install
+RUN . /usr/local/bin/activate && cd tools/c7n_mailer && poetry install --all-extras
 
 
 FROM ubuntu:22.04

--- a/docker/mailer
+++ b/docker/mailer
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -79,7 +79,7 @@ RUN mkdir /output
 
 # Install c7n-mailer
 ADD tools/c7n_mailer /src/tools/c7n_mailer
-RUN . /usr/local/bin/activate && cd tools/c7n_mailer && poetry install
+RUN . /usr/local/bin/activate && cd tools/c7n_mailer && poetry install --all-extras
 
 
 FROM gcr.io/distroless/python3-debian10

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/policystream
+++ b/docker/policystream
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -16,13 +16,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel &&       pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="gcp azure kube openstack tencentcloud"
 # Add provider packages

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -186,7 +186,7 @@ LABEL "org.opencontainers.image.documentation"="https://cloudcustodian.io/docs"
 BUILD_MAILER = """\
 # Install c7n-mailer
 ADD tools/c7n_mailer /src/tools/c7n_mailer
-RUN . /usr/local/bin/activate && cd tools/c7n_mailer && poetry install
+RUN . /usr/local/bin/activate && cd tools/c7n_mailer && poetry install --all-extras
 
 """
 

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -79,14 +79,11 @@ WORKDIR /src
 
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -U pip
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
 RUN . /usr/local/bin/activate && poetry install --without dev --no-root
-RUN . /usr/local/bin/activate && pip install -q wheel && \
-      pip install -U pip
-RUN . /usr/local/bin/activate && pip install -q aws-xray-sdk psutil jsonpatch
 
 ARG providers="{providers}"
 # Add provider packages


### PR DESCRIPTION
Following #7857 we install `c7n-gcp` and `c7n-azure` as extras for `c7n-mailer`. If we don't use `poetry install --all-extras` when building the mailer docker image, it uninstalls those optional packages. As a side effect, it _also_ removes `setuptools` which leads to this error as reported in Slack:

```
sudo docker run --rm -v $HOME/.aws/config:/home/custodian/.aws/config -v $PWD:/home/custodian cloudcustodian/mailer:latest --config mailer.yml --templates templates/ --update-lambda
Traceback (most recent call last):
  File "/usr/local/bin/c7n-mailer", line 6, in <module>
    sys.exit(main())
  File "/src/tools/c7n_mailer/c7n_mailer/cli.py", line 262, in main
    deploy.provision(mailer_config, functools.partial(session_factory, mailer_config))
  File "/src/tools/c7n_mailer/c7n_mailer/deploy.py", line 86, in provision
    archive = get_archive(config)
  File "/src/tools/c7n_mailer/c7n_mailer/deploy.py", line 48, in get_archive
    archive = PythonPackageArchive(modules=deps)
  File "/src/c7n/mu.py", line 78, in __init__
    self.add_modules(None, modules)
  File "/src/c7n/mu.py", line 122, in add_modules
    module = importlib.import_module(module_name)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'pkg_resources'
```

While tracking down that issue, I also noticed that we were installing `pip` in two separate steps during the Docker build. I kept pip install cleanups in a separate commit in case they're too aggressive or missing something. If necessary we can ditch those changes and stick with just the addition of `--all-extras` to the poetry install.