### PR TITLE
c7n_left - github action output annotation fixes

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,8 +101,8 @@ Navigate below to your cloud provider and get started with Cloud Custodian!
    :caption: Tools
 
    tools/c7n-org
-   tools/cask
-   tools/c7n-mailer   
+   tools/c7n-mailer
+   tools/c7n-left
    tools/c7n-logexporter
    tools/c7n-trailcreator
    tools/c7n-policystream   

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -20,7 +20,7 @@ log = logging.getLogger("c7n.iac")
 @click.group()
 def cli():
     """Shift Left Policy"""
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
     initialize_iac()
 
 

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -37,13 +37,14 @@ class CollectionRunner:
         self.options = options
         self.reporter = reporter
 
-    def run(self):
+    def run(self) -> bool:
+        # return value is used to signal process exit code.
         event = self.get_event()
         provider = self.get_provider()
 
         if not provider.match_dir(self.options.source_dir):
             log.warning("no %s source files found" % provider.type)
-            return 1
+            return True
 
         graph = provider.parse(self.options.source_dir)
 

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -42,9 +42,8 @@ class CollectionRunner:
         provider = self.get_provider()
 
         if not provider.match_dir(self.options.source_dir):
-            raise NotImplementedError(
-                "no %s source files found" % provider.provider_name
-            )
+            log.warning("no %s source files found" % provider.type)
+            return 1
 
         graph = provider.parse(self.options.source_dir)
 

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -51,7 +51,7 @@ class CollectionRunner:
             p.expand_variables(p.get_variables())
             p.validate()
 
-        self.reporter.on_execution_started(self.policies)
+        self.reporter.on_execution_started(self.policies, graph)
         # consider inverting this order to allow for results grouped by policy
         # at the moment, we're doing results grouped by resource.
         found = False
@@ -175,6 +175,9 @@ class ResourceGraph:
     def __init__(self, resource_data, src_dir):
         self.resource_data = resource_data
         self.src_dir = src_dir
+
+    def __len__(self):
+        raise NotImplementedError()
 
     def get_resource_by_type(self):
         raise NotImplementedError()

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -139,9 +139,9 @@ class Github(Output):
         md = PolicyMetadata(result.policy)
         filename = resource.src_dir / resource.filename
         title = md.title
-        message = md.description or ""
+        message = md.description or md.title
 
-        return f"::error file={filename} line={resource.line_start} lineEnd={resource.line_end} title={title}::{message}"  # noqa
+        return f"::error file={filename},line={resource.line_start},lineEnd={resource.line_end}::{message}"  # noqa
 
 
 class JSONEncoder(json.JSONEncoder):

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -92,16 +92,12 @@ class RichCli(Output):
         self.started = time.time()
 
     def on_execution_ended(self):
+        message = "[green]Success[green]"
+        if self.matches:
+            message = "[red]%d Failures[/red]" % len(self.matches)
         self.console.print(
             "Evaluation complete %0.2f seconds -> %s"
-            % (
-                time.time() - self.started,
-                (
-                    not self.matches
-                    and "[green]Success[green]"
-                    or "[red]%d Failures[/red]" % len(self.matches)
-                ),
-            )
+            % (time.time() - self.started, message)
         )
 
     def on_results(self, results):

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -47,7 +47,7 @@ class TerraformProvider(IACSourceProvider):
     def parse(self, source_dir):
         graph = TerraformGraph(load_from_path(source_dir), source_dir)
         graph.build()
-        log.debug("Loaded %d resources", len(graph))
+        log.debug("Loaded %d %s resources", len(graph), self.type)
         return graph
 
     def match_dir(self, source_dir):

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "c7n_left"
-version = "0.1.1"
+version = "0.1.2"
 description = "Custodian policies for IAAC definitions"
 authors = ["Cloud Custodian Project"]
 license = "Apache-2"

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -37,7 +37,7 @@ class ResultsReporter:
     def __init__(self):
         self.results = []
 
-    def on_execution_started(self, policies):
+    def on_execution_started(self, policies, graph):
         pass
 
     def on_execution_ended(self):

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -327,10 +327,11 @@ def test_cli_output_github(tmp_path):
         ],
     )
     assert result.exit_code == 1
-    assert result.output == (
-        "::error file=tests/terraform/aws_s3_encryption_audit/main.tf line=25 lineEnd=28"
-        " title=terraform.aws_s3_bucket - policy:check-bucket::a description\n"
+    expected = (
+        "::error file=tests/terraform/aws_s3_encryption_audit/main.tf,line=25,lineEnd=28,"
+        "title=terraform.aws_s3_bucket - policy:check-bucket::a description"
     )
+    assert expected in result.output
 
 
 def test_cli_output_json_query(tmp_path):


### PR DESCRIPTION
This fixes a few usability things found while doing testing/demos.

- github action annotation format fixes, and also includes cli output
- gracefully log / exit 1, when no terraform/iac files found.
- ensure docs are part of public website.
- better default log level (info)
- Success/Fail summary at end of execution.
