### PR TITLE
releng - github actions use concurrency option to only run on latest push

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -10,7 +10,9 @@ on:
     branches:
       - master
       - main
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   Lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
goal - perserve github action workers 

normal behavior when pushing to a pr branch that already has a workflow/ci running is to queue an additional run of the 
workflow/ci and all jobs for each push. this can result in a single pr exhausting all available workers, and a user
waiting on ci to finish for a previous commit in the pr, when the general preference is to get a complete run of just the 
latest pr. using https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
we can cancel the in progress runs, and free up workers to run workflow/ci for the latest push sha.

