### PR TITLE
policy - have conditions support vars

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -1271,6 +1271,10 @@ class Policy:
 
         # Update ourselves in place
         self.data = updated
+
+        # NOTE rebuild the policy conditions base on the new self.data
+        self.conditions = PolicyConditions(self, self.data)
+
         # Reload filters/actions using updated data, we keep a reference
         # for some compatiblity preservation work.
         m = self.resource_manager


### PR DESCRIPTION
with the support of vars, we may have policy conditions like below
```yaml
  - type: value
    key: now
    op: less-than
    value_type: date
    value: "{holiday_start}"
```