### PR TITLE
aws - ami - add last-launched-time filter

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -278,6 +278,44 @@ class ImageAgeFilter(AgeFilter):
         days={'type': 'number', 'minimum': 0})
 
 
+# NOTE should refactor a common filter to support all attributes
+@AMI.filter_registry.register('last-launched-time')
+class ImageLastLaunchedTimeFilter(AgeFilter):
+    """Filters images based on the lastLaunchedTime attribute (in days)
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: ami-unuse-recently
+                resource: ami
+                filters:
+                  - type: last-launched-time
+                    days: 30
+    """
+
+    date_attribute = "LastLaunchedTime"
+    schema = type_schema(
+        'last-launched-time',
+        op={'$ref': '#/definitions/filters_common/comparison_operators'},
+        days={'type': 'number', 'minimum': 0})
+    permissions = ('ec2:DescribeImageAttribute',)
+
+    def get_resource_date(self, i):
+        if not i.get(self.date_attribute):
+            client = local_session(self.manager.session_factory).client('ec2')
+            attr = self.manager.retry(
+                client.describe_image_attribute,
+                ImageId=i['ImageId'],
+                Attribute='lastLaunchedTime')
+            i[self.date_attribute] = attr.get('LastLaunchedTime', {}).get("Value")
+        # NOTE have the filter return false when the attr is none
+        if not i.get(self.date_attribute):
+            return None
+        return super(ImageLastLaunchedTimeFilter, self).get_resource_date(i)
+
+
 @AMI.filter_registry.register('unused')
 class ImageUnusedFilter(Filter):
     """Filters images based on usage

--- a/tests/data/placebo/test_ami_with_last_launched_time/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_with_last_launched_time/ec2.DescribeImageAttribute_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "ImageId": "ami-02a11ce792e2bc296",
+        "LastLaunchedTime": {
+            "Value": "2022-10-20T07:07:19Z"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ami_with_last_launched_time/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_ami_with_last_launched_time/ec2.DescribeImages_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "Images": [
+            {
+                "Architecture": "x86_64",
+                "CreationDate": "2022-07-04T12:09:37.000Z",
+                "ImageId": "ami-02a11ce792e2bc296",
+                "ImageLocation": "644160558196/testing_to_be_deleted",
+                "ImageType": "machine",
+                "Public": false,
+                "OwnerId": "644160558196",
+                "PlatformDetails": "Linux/UNIX",
+                "UsageOperation": "RunInstances",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-0b1ddd0e294677f70",
+                            "VolumeSize": 8,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    },
+                    {
+                        "DeviceName": "/dev/sdf",
+                        "Ebs": {
+                            "DeleteOnTermination": false,
+                            "SnapshotId": "snap-0e33daec301202727",
+                            "VolumeSize": 4,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    }
+                ],
+                "EnaSupport": true,
+                "Hypervisor": "xen",
+                "Name": "testing_to_be_deleted",
+                "RootDeviceName": "/dev/xvda",
+                "RootDeviceType": "ebs",
+                "SriovNetSupport": "simple",
+                "VirtualizationType": "hvm"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ami_with_no_last_launched_time/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_with_no_last_launched_time/ec2.DescribeImageAttribute_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ImageId": "ami-02a11ce792e2bc296",
+        "LastLaunchedTime": {},
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ami_with_no_last_launched_time/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_ami_with_no_last_launched_time/ec2.DescribeImages_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "Images": [
+            {
+                "Architecture": "x86_64",
+                "CreationDate": "2022-07-04T12:09:37.000Z",
+                "ImageId": "ami-02a11ce792e2bc296",
+                "ImageLocation": "644160558196/testing_to_be_deleted",
+                "ImageType": "machine",
+                "Public": false,
+                "OwnerId": "644160558196",
+                "PlatformDetails": "Linux/UNIX",
+                "UsageOperation": "RunInstances",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-0b1ddd0e294677f70",
+                            "VolumeSize": 8,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    },
+                    {
+                        "DeviceName": "/dev/sdf",
+                        "Ebs": {
+                            "DeleteOnTermination": false,
+                            "SnapshotId": "snap-0e33daec301202727",
+                            "VolumeSize": 4,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    }
+                ],
+                "EnaSupport": true,
+                "Hypervisor": "xen",
+                "Name": "testing_to_be_deleted",
+                "RootDeviceName": "/dev/xvda",
+                "RootDeviceType": "ebs",
+                "SriovNetSupport": "simple",
+                "VirtualizationType": "hvm"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -159,6 +159,35 @@ class TestAMI(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['ImageId'], 'ami-0515ff4f8f9dbeb31')
 
+    def test_ami_with_last_launched_time(self):
+        factory = self.replay_flight_data('test_ami_with_last_launched_time')
+        p = self.load_policy(
+            {
+                "name": "test-ami-last-launched-time",
+                "resource": "ami",
+                "filters": [{"type": "last-launched-time", "days": 20}],
+            },
+            {"region": "ap-southeast-2"},
+            session_factory=factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['LastLaunchedTime'], '2022-10-20T07:07:19Z')
+
+    def test_ami_with_no_last_launched_time(self):
+        factory = self.replay_flight_data('test_ami_with_no_last_launched_time')
+        p = self.load_policy(
+            {
+                "name": "test-ami-last-launched-time",
+                "resource": "ami",
+                "filters": [{"type": "last-launched-time", "days": 20}],
+            },
+            {"region": "ap-southeast-2"},
+            session_factory=factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
     def test_unused_ami_true(self):
         factory = self.replay_flight_data("test_unused_ami_true")
         p = self.load_policy(


### PR DESCRIPTION
so that we can
```yaml
    filters:
      # NOTE When the AMI is used, there is a 24-hour delay before that usage is reported.
      - type: last-launched-time
        op: gt
        days: 360
```