### PR TITLE
aws - elasticache - skip delete replication group if it is in use

### DIFF
--- a/c7n/resources/elasticache.py
+++ b/c7n/resources/elasticache.py
@@ -149,7 +149,19 @@ class DeleteElastiCacheCluster(BaseAction):
                 'Deleted ElastiCache cluster: %s',
                 cluster['CacheClusterId'])
 
+        cacheClusterIds = set([c["CacheClusterId"] for c in clusters])
         for replication_group in replication_groups_to_delete:
+            # NOTE don't delete the group if it's not empty
+            rg = client.describe_replication_groups(
+                ReplicationGroupId=replication_group)["ReplicationGroups"][0]
+            if not all(cluster in cacheClusterIds for cluster in rg["MemberClusters"]):
+                # NOTE mark members for better presentation on notifications
+                for c in clusters:
+                    if c.get("ReplicationGroupId") == replication_group:
+                        c["MemberClusters"] = rg["MemberClusters"]
+                self.log.info(f'{replication_group} is not empty: {rg["MemberClusters"]}')
+                continue
+
             params = {'ReplicationGroupId': replication_group,
                       'RetainPrimaryCluster': False}
             if not skip:

--- a/tests/data/placebo/test_elasticache_cluster_delete/elasticache.DescribeReplicationGroups_1.json
+++ b/tests/data/placebo/test_elasticache_cluster_delete/elasticache.DescribeReplicationGroups_1.json
@@ -1,0 +1,59 @@
+{
+    "status_code": 200,
+    "data": {
+        "ReplicationGroups": [
+            {
+                "ReplicationGroupId": "myec", 
+                "Description": " ",
+                "GlobalReplicationGroupInfo": {},
+                "Status": "available",
+                "PendingModifiedValues": {},
+                "MemberClusters": [
+                    "myec-001",
+                    "myec-002",
+                    "myec-003"
+                ],
+                "NodeGroups": [
+                    {
+                        "NodeGroupId": "0001",
+                        "Status": "available",
+                        "Slots": "0-5461",
+                        "NodeGroupMembers": [
+                            {
+                                "CacheClusterId": "myec-0001-001",
+                                "CacheNodeId": "0001",
+                                "PreferredAvailabilityZone": "us-east-1b"
+                            },
+                            {
+                                "CacheClusterId": "myec-0001-002",
+                                "CacheNodeId": "0001",
+                                "PreferredAvailabilityZone": "us-east-1a"
+                            },
+                            {
+                                "CacheClusterId": "myec-0001-003",
+                                "CacheNodeId": "0001",
+                                "PreferredAvailabilityZone": "us-east-1d"
+                            }
+                        ]
+                    }
+                ],
+                "AutomaticFailover": "enabled",
+                "MultiAZ": "enabled",
+                "ConfigurationEndpoint": {
+                    "Address": "myec.qgcgte.clustercfg.use1.cache.amazonaws.com",
+                    "Port": 6379
+                },
+                "SnapshotRetentionLimit": 1,
+                "SnapshotWindow": "07:30-08:30",
+                "ClusterEnabled": true,
+                "CacheNodeType": "cache.r6g.large",
+                "AuthTokenEnabled": false,
+                "TransitEncryptionEnabled": false,
+                "AtRestEncryptionEnabled": false,
+                "ARN": "arn:aws:elasticache:us-east-1:644160558196:replicationgroup:myec",
+                "LogDeliveryConfigurations": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_elasticache_cluster_skip_delete/elasticache.DescribeCacheClusters_1.json
+++ b/tests/data/placebo/test_elasticache_cluster_skip_delete/elasticache.DescribeCacheClusters_1.json
@@ -1,0 +1,57 @@
+{
+    "status_code": 200, 
+    "data": {
+        "CacheClusters": [
+            {
+                "Engine": "redis", 
+                "CacheParameterGroup": {
+                    "CacheNodeIdsToReboot": [], 
+                    "CacheParameterGroupName": "default.redis3.2", 
+                    "ParameterApplyStatus": "in-sync"
+                }, 
+                "SnapshotRetentionLimit": 0, 
+                "CacheClusterId": "myec-001", 
+                "CacheSecurityGroups": [], 
+                "NumCacheNodes": 1, 
+                "SnapshotWindow": "08:00-09:00", 
+                "CacheClusterCreateTime": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 21, 
+                    "microsecond": 311000, 
+                    "year": 2017, 
+                    "day": 24, 
+                    "minute": 3
+                }, 
+                "ReplicationGroupId": "myec", 
+                "AutoMinorVersionUpgrade": true, 
+                "CacheClusterStatus": "available", 
+                "PreferredAvailabilityZone": "us-east-1d", 
+                "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:", 
+                "SecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "SecurityGroupId": "sg-4b9ada34"
+                    }
+                ], 
+                "CacheSubnetGroupName": "msg", 
+                "EngineVersion": "3.2.4", 
+                "PendingModifiedValues": {}, 
+                "PreferredMaintenanceWindow": "fri:10:00-fri:11:00", 
+                "CacheNodeType": "cache.r3.large"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "50352271-588a-11e7-84d2-8f9bb7403f07", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "50352271-588a-11e7-84d2-8f9bb7403f07", 
+                "date": "Sat, 24 Jun 2017 03:07:52 GMT", 
+                "content-length": "4727", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticache_cluster_skip_delete/elasticache.DescribeReplicationGroups_1.json
+++ b/tests/data/placebo/test_elasticache_cluster_skip_delete/elasticache.DescribeReplicationGroups_1.json
@@ -1,0 +1,59 @@
+{
+    "status_code": 200,
+    "data": {
+        "ReplicationGroups": [
+            {
+                "ReplicationGroupId": "myec", 
+                "Description": " ",
+                "GlobalReplicationGroupInfo": {},
+                "Status": "available",
+                "PendingModifiedValues": {},
+                "MemberClusters": [
+                    "myec-001",
+                    "myec-002",
+                    "myec-003"
+                ],
+                "NodeGroups": [
+                    {
+                        "NodeGroupId": "0001",
+                        "Status": "available",
+                        "Slots": "0-5461",
+                        "NodeGroupMembers": [
+                            {
+                                "CacheClusterId": "myec-0001-001",
+                                "CacheNodeId": "0001",
+                                "PreferredAvailabilityZone": "us-east-1b"
+                            },
+                            {
+                                "CacheClusterId": "myec-0001-002",
+                                "CacheNodeId": "0001",
+                                "PreferredAvailabilityZone": "us-east-1a"
+                            },
+                            {
+                                "CacheClusterId": "myec-0001-003",
+                                "CacheNodeId": "0001",
+                                "PreferredAvailabilityZone": "us-east-1d"
+                            }
+                        ]
+                    }
+                ],
+                "AutomaticFailover": "enabled",
+                "MultiAZ": "enabled",
+                "ConfigurationEndpoint": {
+                    "Address": "myec.qgcgte.clustercfg.use1.cache.amazonaws.com",
+                    "Port": 6379
+                },
+                "SnapshotRetentionLimit": 1,
+                "SnapshotWindow": "07:30-08:30",
+                "ClusterEnabled": true,
+                "CacheNodeType": "cache.r6g.large",
+                "AuthTokenEnabled": false,
+                "TransitEncryptionEnabled": false,
+                "AtRestEncryptionEnabled": false,
+                "ARN": "arn:aws:elasticache:us-east-1:644160558196:replicationgroup:myec",
+                "LogDeliveryConfigurations": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_elasticache_cluster_skip_delete/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_elasticache_cluster_skip_delete/tagging.GetResources_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PaginationToken": "", 
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:elasticache:us-east-1:644160558196:cluster:myec-001", 
+                "Tags": [
+                    {
+                        "Value": "1", 
+                        "Key": "tagnew1"
+                    }
+                ]
+            }, 
+            {
+                "ResourceARN": "arn:aws:elasticache:us-east-1:644160558196:cluster:myec-002", 
+                "Tags": [
+                    {
+                        "Value": "2", 
+                        "Key": "tagnew2"
+                    }
+                ]
+            }, 
+            {
+                "ResourceARN": "arn:aws:elasticache:us-east-1:644160558196:cluster:myec-003", 
+                "Tags": [
+                    {
+                        "Value": "3", 
+                        "Key": "tagnew3"
+                    }
+                ]
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "5090d705-588a-11e7-b48b-5fbbfc99dbd5", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "5090d705-588a-11e7-b48b-5fbbfc99dbd5", 
+                "date": "Sat, 24 Jun 2017 03:07:53 GMT", 
+                "content-length": "400", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}


### PR DESCRIPTION
In my case, a replication group could contain a few clusters, and some of the clusters are not being used, e.g. no connections. I want to delete those unused clusters if the all clusters in the replication group are not in use. Otherwise, it'd be better to keep it untouched and wait for a manual review. 

The changes in this PR might not ideal because the clusters are still 'deleted' from the `resources.json` point of view. But to skip deleting the entire replication group (which is still in use) is vital.