### PR TITLE
aws - security-group - used filter - add interface usage annotation

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -953,7 +953,7 @@ class UsedSecurityGroup(SGUsage):
         if description.startswith('Interface for NAT Gateway'):
             return 'nat'
         if (description == 'RDSNetworkInterface' or
-            description.startswith('Network interface for DBProxy')):
+                description.startswith('Network interface for DBProxy')):
             return 'rds'
         if description == 'RedshiftNetworkInterface':
             return 'redshift'

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -917,47 +917,49 @@ class UsedSecurityGroup(SGUsage):
         instance_id = nic['Attachment'].get('InstanceId')
         # EC2
         if instance_id:
-            return 'ec2'
+            rtype = 'ec2'
         # ELB/ELBv2
-        if description.startswith('ELB app/'):
-            return 'elb-app'
-        if description.startswith('ELB gwy/'):
-            return 'elb-gwy'
-        if description.startswith('ELB'):
-            return 'elb'
+        elif description.startswith('ELB app/'):
+            rtype = 'elb-app'
+        elif description.startswith('ELB gwy/'):
+            rtype = 'elb-gwy'
+        elif description.startswith('ELB'):
+            rtype = 'elb'
         # Other Resources
-        if description == 'ENI managed by APIGateway':
-            return 'apigw'
-        if description.startswith('AWS CodeStar Connections'):
-            return 'codestar'
-        if description.startswith('DAX'):
-            return 'dax'
-        if description.startswith('AWS created network interface for directory'):
-            return 'dir'
-        if description == 'DMSNetworkInterface':
-            return 'dms'
-        if description.startswith('arn:aws:ecs:'):
-            return 'ecs'
-        if description.startswith('EFS mount target for'):
-            return 'fsmt'
-        if description.startswith('ElastiCache'):
-            return 'elasticache'
-        if description.startswith('AWS ElasticMapReduce'):
-            return 'emr'
-        if description.startswith('CloudHSM Managed Interface'):
-            return 'hsm'
-        if description.startswith('CloudHsm ENI'):
-            return 'hsmv2'
-        if description.startswith('AWS Lambda VPC ENI'):
-            return 'lambda'
-        if (description == 'RDSNetworkInterface' or
+        elif description == 'ENI managed by APIGateway':
+            rtype = 'apigw'
+        elif description.startswith('AWS CodeStar Connections'):
+            rtype = 'codestar'
+        elif description.startswith('DAX'):
+            rtype = 'dax'
+        elif description.startswith('AWS created network interface for directory'):
+            rtype = 'dir'
+        elif description == 'DMSNetworkInterface':
+            rtype = 'dms'
+        elif description.startswith('arn:aws:ecs:'):
+            rtype = 'ecs'
+        elif description.startswith('EFS mount target for'):
+            rtype = 'fsmt'
+        elif description.startswith('ElastiCache'):
+            rtype = 'elasticache'
+        elif description.startswith('AWS ElasticMapReduce'):
+            rtype = 'emr'
+        elif description.startswith('CloudHSM Managed Interface'):
+            rtype = 'hsm'
+        elif description.startswith('CloudHsm ENI'):
+            rtype = 'hsmv2'
+        elif description.startswith('AWS Lambda VPC ENI'):
+            rtype = 'lambda'
+        elif (description == 'RDSNetworkInterface' or
                 description.startswith('Network interface for DBProxy')):
-            return 'rds'
-        if description == 'RedshiftNetworkInterface':
-            return 'redshift'
-        if description.startswith('VPC Endpoint Interface'):
-            return 'vpce'
-        return 'unknown'
+            rtype = 'rds'
+        elif description == 'RedshiftNetworkInterface':
+            rtype = 'redshift'
+        elif description.startswith('VPC Endpoint Interface'):
+            rtype = 'vpce'
+        else:
+            rtype = 'unknown'
+        return rtype
 
     def _get_eni_attributes(self):
         enis = []

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -952,7 +952,8 @@ class UsedSecurityGroup(SGUsage):
             return 'lambda'
         if description.startswith('Interface for NAT Gateway'):
             return 'nat'
-        if description == 'RDSNetworkInterface' or description.startswith('Network interface for DBProxy'):
+        if (description == 'RDSNetworkInterface' or
+            description.startswith('Network interface for DBProxy')):
             return 'rds'
         if description == 'RedshiftNetworkInterface':
             return 'redshift'

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -950,15 +950,11 @@ class UsedSecurityGroup(SGUsage):
             return 'hsmv2'
         if description.startswith('AWS Lambda VPC ENI'):
             return 'lambda'
-        if description.startswith('Interface for NAT Gateway'):
-            return 'nat'
         if (description == 'RDSNetworkInterface' or
                 description.startswith('Network interface for DBProxy')):
             return 'rds'
         if description == 'RedshiftNetworkInterface':
             return 'redshift'
-        if description.startswith('Network Interface for Transit Gateway Attachment'):
-            return 'tgw'
         if description.startswith('VPC Endpoint Interface'):
             return 'vpce'
         return 'unknown'

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -824,3 +824,57 @@ def get_support_region(manager):
     elif partition == "aws-cn":
         support_region = "cn-north-1"
     return support_region
+
+
+def get_eni_resource_type(eni):
+    description = eni.get('Description')
+    instance_id = eni['Attachment'].get('InstanceId')
+    # EC2
+    if instance_id:
+        rtype = 'ec2'
+    # ELB/ELBv2
+    elif description.startswith('ELB app/'):
+        rtype = 'elb-app'
+    elif description.startswith('ELB net/'):
+        rtype = 'elb-net'
+    elif description.startswith('ELB gwy/'):
+        rtype = 'elb-gwy'
+    elif description.startswith('ELB'):
+        rtype = 'elb'
+    # Other Resources
+    elif description == 'ENI managed by APIGateway':
+        rtype = 'apigw'
+    elif description.startswith('AWS CodeStar Connections'):
+        rtype = 'codestar'
+    elif description.startswith('DAX'):
+        rtype = 'dax'
+    elif description.startswith('AWS created network interface for directory'):
+        rtype = 'dir'
+    elif description == 'DMSNetworkInterface':
+        rtype = 'dms'
+    elif description.startswith('arn:aws:ecs:'):
+        rtype = 'ecs'
+    elif description.startswith('EFS mount target for'):
+        rtype = 'fsmt'
+    elif description.startswith('ElastiCache'):
+        rtype = 'elasticache'
+    elif description.startswith('AWS ElasticMapReduce'):
+        rtype = 'emr'
+    elif description.startswith('CloudHSM Managed Interface'):
+        rtype = 'hsm'
+    elif description.startswith('CloudHsm ENI'):
+        rtype = 'hsmv2'
+    elif description.startswith('AWS Lambda VPC ENI'):
+        rtype = 'lambda'
+    elif description.startswith('Interface for NAT Gateway'):
+        return 'nat'
+    elif (description == 'RDSNetworkInterface' or
+            description.startswith('Network interface for DBProxy')):
+        rtype = 'rds'
+    elif description == 'RedshiftNetworkInterface':
+        rtype = 'redshift'
+    elif description.startswith('VPC Endpoint Interface'):
+        rtype = 'vpce'
+    else:
+        rtype = 'unknown'
+    return rtype

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -827,8 +827,11 @@ def get_support_region(manager):
 
 
 def get_eni_resource_type(eni):
+    if eni.get('Attachment'):
+        instance_id = eni['Attachment'].get('InstanceId')
+    else:
+        instance_id = None
     description = eni.get('Description')
-    instance_id = eni['Attachment'].get('InstanceId')
     # EC2
     if instance_id:
         rtype = 'ec2'

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -876,6 +876,8 @@ def get_eni_resource_type(eni):
         rtype = 'rds'
     elif description == 'RedshiftNetworkInterface':
         rtype = 'redshift'
+    elif description == 'Network Interface for Transit Gateway Attachment':
+        rtype = 'tgw'
     elif description.startswith('VPC Endpoint Interface'):
         rtype = 'vpce'
     else:

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -876,7 +876,7 @@ def get_eni_resource_type(eni):
         rtype = 'rds'
     elif description == 'RedshiftNetworkInterface':
         rtype = 'redshift'
-    elif description == 'Network Interface for Transit Gateway Attachment':
+    elif description.startswith('Network Interface for Transit Gateway Attachment'):
         rtype = 'tgw'
     elif description.startswith('VPC Endpoint Interface'):
         rtype = 'vpce'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -602,7 +602,7 @@ class UtilTest(BaseTest):
             'dir')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"DMSNetworkInterface"}),
+                {"Description": "DMSNetworkInterface"}),
             'dms')
         self.assertEqual(
             utils.get_eni_resource_type(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -566,7 +566,7 @@ class UtilTest(BaseTest):
     def test_get_eni_resource_type(self):
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Attachment": {"InstanceId": "i-0e040de7dfabbcc8c"},"Description": ""}),
+                {"Attachment": {"InstanceId": "i-0e040de7dfabbcc8c"}, "Description": ""}),
             'ec2')
         self.assertEqual(
             utils.get_eni_resource_type(
@@ -610,7 +610,7 @@ class UtilTest(BaseTest):
             'ecs')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description": "EFS mount target for"}),
+                {"Description": "EFS mount target for fs-f9b8d350 (fsmt-b716661e)"}),
             'fsmt')
         self.assertEqual(
             utils.get_eni_resource_type(
@@ -650,12 +650,17 @@ class UtilTest(BaseTest):
             'redshift')
         self.assertEqual(
             utils.get_eni_resource_type(
+                {"Description": "Network Interface for Transit Gateway Attachment tgw-attach-XXX"}),
+            'tgw')
+        self.assertEqual(
+            utils.get_eni_resource_type(
                 {"Description": "VPC Endpoint Interface vpce-0472c5d3fc4ce1de4"}),
             'vpce')
         self.assertEqual(
             utils.get_eni_resource_type(
                 {"Description": ""}),
             'unknown')
+
 
 def test_parse_date_floor():
     # bulk of parse date tests are actually in test_filters

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -564,9 +564,106 @@ class UtilTest(BaseTest):
         self.assertEqual("cn-north-1", res)
 
 
+    def test_get_eni_resource_type(self):
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Attachment":{"InstanceId":"i-0e040de7dfabbcc8c"},"Description":""}),
+            'ec2')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"ELB app/"}),
+            'elb-app')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"ELB net/"}),
+            'elb-net')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"ELB gwy/"}),
+            'elb-gwy')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"ELB"}),
+            'elb')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"ENI managed by APIGateway"}),
+            'apigw')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"AWS CodeStar Connections"}),
+            'codestar')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"DAX"}),
+            'dax')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"AWS created network interface for directory"}),
+            'dir')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"DMSNetworkInterface"}),
+            'dms')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"arn:aws:ecs:"}),
+            'ecs')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"EFS mount target for"}),
+            'fsmt')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"ElastiCache"}),
+            'elasticache')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"AWS ElasticMapReduce"}),
+            'emr')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"CloudHSM Managed Interface"}),
+            'hsm')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"CloudHsm ENI"}),
+            'hsmv2')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"AWS Lambda VPC ENI"}),
+            'lambda')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"Interface for NAT Gateway"}),
+            'nat')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"RDSNetworkInterface"}),
+            'rds')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"Network interface for DBProxy"}),
+            'rds')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"RedshiftNetworkInterface"}),
+            'redshift')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":"VPC Endpoint Interface"}),
+            'vpce')
+        self.assertEqual(
+            utils.get_eni_resource_type(
+                {"Description":""}),
+            'unknown')
+
+
 def test_parse_date_floor():
     # bulk of parse date tests are actually in test_filters
     assert utils.parse_date(30) is None
     assert utils.parse_date(1) is None
     assert utils.parse_date('3000') is None
     assert utils.parse_date('30') is None
+
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -563,43 +563,42 @@ class UtilTest(BaseTest):
         res = utils.get_support_region(mock_manager)
         self.assertEqual("cn-north-1", res)
 
-
     def test_get_eni_resource_type(self):
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Attachment":{"InstanceId":"i-0e040de7dfabbcc8c"},"Description":""}),
+                {"Attachment": {"InstanceId": "i-0e040de7dfabbcc8c"},"Description": ""}),
             'ec2')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"ELB app/"}),
+                {"Description": "ELB app/test-alb/3d20737b50b4b66e"}),
             'elb-app')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"ELB net/"}),
+                {"Description": "ELB net/test-nlb/c973bda47de90e99"}),
             'elb-net')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"ELB gwy/"}),
+                {"Description": "ELB gwy/test-glb/3a85ce44e6caa0af"}),
             'elb-gwy')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"ELB"}),
+                {"Description": "ELB test-elb"}),
             'elb')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"ENI managed by APIGateway"}),
+                {"Description": "ENI managed by APIGateway"}),
             'apigw')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"AWS CodeStar Connections"}),
+                {"Description": "AWS CodeStar Connections"}),
             'codestar')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"DAX"}),
+                {"Description": "DAX"}),
             'dax')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"AWS created network interface for directory"}),
+                {"Description": "AWS created network interface for directory"}),
             'dir')
         self.assertEqual(
             utils.get_eni_resource_type(
@@ -607,57 +606,56 @@ class UtilTest(BaseTest):
             'dms')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"arn:aws:ecs:"}),
+                {"Description": "arn:aws:ecs:us-west-2:123456789012:attachment/XXXX"}),
             'ecs')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"EFS mount target for"}),
+                {"Description": "EFS mount target for"}),
             'fsmt')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"ElastiCache"}),
+                {"Description": "ElastiCache test-1"}),
             'elasticache')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"AWS ElasticMapReduce"}),
+                {"Description": "AWS ElasticMapReduce"}),
             'emr')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"CloudHSM Managed Interface"}),
+                {"Description": "CloudHSM Managed Interface"}),
             'hsm')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"CloudHsm ENI"}),
+                {"Description": "CloudHsm ENI"}),
             'hsmv2')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"AWS Lambda VPC ENI"}),
+                {"Description": "AWS Lambda VPC ENI-test-XXX"}),
             'lambda')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"Interface for NAT Gateway"}),
+                {"Description": "Interface for NAT Gateway nat-06f54d43caf44bf8d"}),
             'nat')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"RDSNetworkInterface"}),
+                {"Description": "RDSNetworkInterface"}),
             'rds')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"Network interface for DBProxy"}),
+                {"Description": "Network interface for DBProxy proxy-XXX-database-1"}),
             'rds')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"RedshiftNetworkInterface"}),
+                {"Description": "RedshiftNetworkInterface"}),
             'redshift')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":"VPC Endpoint Interface"}),
+                {"Description": "VPC Endpoint Interface vpce-0472c5d3fc4ce1de4"}),
             'vpce')
         self.assertEqual(
             utils.get_eni_resource_type(
-                {"Description":""}),
+                {"Description": ""}),
             'unknown')
-
 
 def test_parse_date_floor():
     # bulk of parse date tests are actually in test_filters
@@ -665,5 +663,3 @@ def test_parse_date_floor():
     assert utils.parse_date(1) is None
     assert utils.parse_date('3000') is None
     assert utils.parse_date('30') is None
-
-

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1320,6 +1320,9 @@ class SecurityGroupTest(BaseTest):
             {"sg-f9cc4d9f", "sg-13de8f75", "sg-ce548cb7", "sg-0a2cb503a229c31c1", "sg-1c8a186c"},
             {r["GroupId"] for r in resources},
         )
+        self.assertIn("amazon-aws", resources[2]["c7n:InstanceOwnerIds"])
+        self.assertIn("vpc_endpoint", resources[2]["c7n:InterfaceTypes"])
+        self.assertIn("ec2", resources[2]["c7n:InterfaceResourceTypes"])
 
     def test_unused_ecs(self):
         factory = self.replay_flight_data("test_security_group_ecs_unused")


### PR DESCRIPTION
Following up on #7919, further enhancement to the `used` filter to annotate interface usage information extracted from the `Description` attribute in the ENI resource. The resource mapping is based on the [zerodark example](https://github.com/cloud-custodian/cloud-custodian/blob/e9410542cda9714d76d32e8e6770349cb5119e3e/tools/sandbox/zerodark/zerodark/ipdb.py#L101-L174). The resource usage is determined only by the `Description` attribute except for `ec2`. It intentionally ignores to reference other attributes such as `InstanceOwnerId` or `InterfaceType`.

**Changes from the zerodark example**
- Rename resources
  - `alb` -> `elb-app`
  - `nlb` -> `elb-net`
  - `efs-mount` -> `fsmt`
- Add `apigw`, `codestar`, `elb-gwy`, `tgw`
- Update matching patterns

**Example**
```yaml
policies:
  - name: security-group-used-by-alb
    resource: security-group
    filters:
      - type: used
      - type: value
        key: c7n:InterfaceResourceTypes
        op: intersect
        value:
          - elb-app
```