### PR TITLE
policy - support include, format vars after load

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -45,7 +45,7 @@ log = logging.getLogger('custodian.utils')
 try:
     from yamlinclude import YamlIncludeConstructor
     YamlIncludeConstructor.add_to_loader_class(loader_class=SafeLoader)
-except:
+except ImportError:
     log.warn("pyyaml-include not found, !include tag will not be supported.")
 
 

--- a/tests/data/vars-test.yml
+++ b/tests/data/vars-test.yml
@@ -1,5 +1,5 @@
 policies:
 - name: unit-test-policy
-  resource: {resource}
+  resource: "{resource}"
   comment: |
     Test policy for unit tests

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -495,10 +495,9 @@ class UtilTest(BaseTest):
         data = utils.load_file(yml_file, vars={"resource": resource})
         self.assertTrue(data["policies"][0]["resource"] == resource)
 
-        # Fail to substitute
-        self.assertRaises(
-            utils.VarsSubstitutionError, utils.load_file, yml_file, vars={"foo": "bar"}
-        )
+        # Keep the var if not found
+        data = utils.load_file(yml_file, vars={"foo": "bar"})
+        self.assertTrue(data["policies"][0]["resource"] == "{resource}")
 
         # JSON load
         json_file = os.path.join(os.path.dirname(__file__), "data", "ec2-instance.json")

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -36,6 +36,12 @@ from c7n_org.utils import environ, account_tags
 
 log = logging.getLogger('c7n_org')
 
+try:
+    from yamlinclude import YamlIncludeConstructor
+    YamlIncludeConstructor.add_to_loader_class(loader_class=yaml.SafeLoader)
+except:
+    log.warn("pyyaml-include not found, !include tag will not be supported.")
+
 # Workaround OSX issue, note this exists for py2 but there
 # isn't anything we can do in that case.
 # https://bugs.python.org/issue33725

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -39,7 +39,7 @@ log = logging.getLogger('c7n_org')
 try:
     from yamlinclude import YamlIncludeConstructor
     YamlIncludeConstructor.add_to_loader_class(loader_class=yaml.SafeLoader)
-except:
+except ImportError:
     log.warn("pyyaml-include not found, !include tag will not be supported.")
 
 # Workaround OSX issue, note this exists for py2 but there


### PR DESCRIPTION
I find this feature useful in DRY my policies. Please see #8033 for a policy example

NOTE:
The `pyyaml-include` is not included in the `pyproject.toml` because I am not sure if people feel comfortable with the `yaml.SafeLoader` overriding. So people who need this feature will have to install `pyyaml-include` by themselves. 