### PR TITLE
c7n-org - cli - support not-accounts option

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -153,7 +153,7 @@ class LogFilter:
         return 0
 
 
-def init(config, use, debug, verbose, accounts, tags, policies, resource=None, policy_tags=()):
+def init(config, use, debug, verbose, accounts, tags, policies, resource=None, policy_tags=(), not_accounts=None):
     level = verbose and logging.DEBUG or logging.INFO
     logging.basicConfig(
         level=level,
@@ -188,7 +188,7 @@ def init(config, use, debug, verbose, accounts, tags, policies, resource=None, p
 
     accounts_config['accounts'] = list(accounts_iterator(accounts_config))
     filter_policies(custodian_config, policy_tags, policies, resource)
-    filter_accounts(accounts_config, tags, accounts)
+    filter_accounts(accounts_config, tags, accounts, not_accounts)
 
     load_available()
     MainThreadExecutor.c7n_async = False
@@ -261,9 +261,9 @@ def filter_accounts(accounts_config, tags, accounts, not_accounts=None):
     accounts = comma_expand(accounts)
     not_accounts = comma_expand(not_accounts)
     for a in accounts_config.get('accounts', ()):
-        if not_accounts and a['name'] in not_accounts:
-            continue
         account_id = a.get('account_id') or a.get('project_id') or a.get('subscription_id') or ''
+        if not_accounts and (a['name'] in not_accounts or account_id in not_accounts):
+            continue
         if accounts and a['name'] not in accounts and account_id not in accounts:
             continue
         if tags:
@@ -656,6 +656,7 @@ def run_account(account, region, policies_config, output_path,
 @click.option("-u", "--use", required=True)
 @click.option('-s', '--output-dir', required=True, type=click.Path())
 @click.option('-a', '--accounts', multiple=True, default=None)
+@click.option('--not-accounts', multiple=True, default=None)
 @click.option('-t', '--tags', multiple=True, default=None, help="Account tag filter")
 @click.option('-r', '--region', default=None, multiple=True)
 @click.option('-p', '--policy', multiple=True)
@@ -673,12 +674,13 @@ def run_account(account, region, policies_config, output_path,
 @click.option("--dryrun", default=False, is_flag=True)
 @click.option('--debug', default=False, is_flag=True)
 @click.option('-v', '--verbose', default=False, help="Verbose", is_flag=True)
-def run(config, use, output_dir, accounts, tags, region,
+def run(config, use, output_dir, accounts, not_accounts, tags, region,
         policy, policy_tags, cache_period, cache_path, metrics,
         dryrun, debug, verbose, metrics_uri):
     """run a custodian policy across accounts"""
     accounts_config, custodian_config, executor = init(
-        config, use, debug, verbose, accounts, tags, policy, policy_tags=policy_tags)
+        config, use, debug, verbose, accounts, tags, policy, policy_tags=policy_tags,
+        not_accounts=not_accounts)
     policy_counts = Counter()
     success = True
 

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -230,8 +230,10 @@ class OrgTest(TestUtils):
 
         d = {'accounts': [
             {'name': 'dev',
+             'account_id': '123456789012',
              'tags': ['blue', 'red']},
             {'name': 'prod',
+             'account_id': '123456789013',
              'tags': ['green', 'red']}]}
 
         t1 = copy.deepcopy(d)
@@ -257,3 +259,15 @@ class OrgTest(TestUtils):
         self.assertEqual(
             [a['name'] for a in t4['accounts']],
             ['dev'])
+
+        t5 = copy.deepcopy(d)
+        org.filter_accounts(t5, [], [], ['123456789013'])
+        self.assertEqual(
+            [a['name'] for a in t5['accounts']],
+            ['dev'])
+
+        t6 = copy.deepcopy(d)
+        org.filter_accounts(t6, [], [], ['dev'])
+        self.assertEqual(
+            [a['name'] for a in t6['accounts']],
+            ['prod'])


### PR DESCRIPTION
In my case, I find this feature useful because I don't have to tag those accounts ad-hoc.

```
❯ c7n-org run --help
Usage: c7n-org run [OPTIONS]

  run a custodian policy across accounts

Options:
  -c, --config TEXT       Accounts config file  [required]
  -u, --use TEXT          [required]
  -s, --output-dir PATH   [required]
  -a, --accounts TEXT
  --not-accounts TEXT
  ...
```