### PR TITLE
fix - flake8/pyflakes bump removed type comments linting

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions/logic_app.py
+++ b/tools/c7n_azure/c7n_azure/actions/logic_app.py
@@ -1,8 +1,6 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-from azure.mgmt.logic import LogicManagementClient
-
 from c7n.actions.webhook import Webhook
 from c7n.utils import type_schema
 
@@ -59,7 +57,6 @@ class LogicAppAction(Webhook):
     def get_callback_url(self, resource_group, workflow_name):
         """ Gets the logic app invoke trigger with secrets using RBAC """
 
-        # type: LogicManagementClient
         client = self.manager.get_client(
             'azure.mgmt.logic.LogicManagementClient')
 

--- a/tools/c7n_azure/tests_azure/tests_resources/test_app_service_plan.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_app_service_plan.py
@@ -1,6 +1,5 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from azure.mgmt.web import WebSiteManagementClient
 from ..azure_common import BaseTest, arm_template, cassette_name
 from c7n_azure.session import Session
 from mock import patch
@@ -15,7 +14,7 @@ class AppServicePlanTest(BaseTest):
         super(AppServicePlanTest, self).setUp()
         self.session = local_session(Session)
         self.client = local_session(Session).client(
-            'azure.mgmt.web.WebSiteManagementClient')  # type: WebSiteManagementClient
+            'azure.mgmt.web.WebSiteManagementClient')
         self.update_mock_path =\
             'azure.mgmt.web.v{}.operations._app_service_plans_operations.' \
             'AppServicePlansOperations.update'\

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ exclude = setup.py,.git,venv,python2.7,bin,docs,__init__.py,.tox,tools/c7n_azure
 ; E231 is missing whitespace after  ,/:
 ; E251 is unexpected spaces around keywords
 ; E275 is missing whitespace after keyword
-; ignore = E401,E128,E203,E221,E251
+; ignore = E401,E128,E203,E221,E251,F723
 ignore = E128,E401,W503,W504,E741,E275
 max-line-length = 100
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ exclude = setup.py,.git,venv,python2.7,bin,docs,__init__.py,.tox,tools/c7n_azure
 ; E231 is missing whitespace after  ,/:
 ; E251 is unexpected spaces around keywords
 ; E275 is missing whitespace after keyword
-; ignore = E401,E128,E203,E221,E251,F723
+; ignore = E401,E128,E203,E221,E251
 ignore = E128,E401,W503,W504,E741,E275
 max-line-length = 100
 


### PR DESCRIPTION
pyflakes bumped to 3.0.0 and dropped support for python 2:

https://github.com/PyCQA/pyflakes/issues/740

flake8 6.0.0 uses pyflakes which caused lint to fail. The extant type comments were confined to the azure provider and didn't provide much in the way of useful comments