### PR TITLE
aws - route53 - define rrset and healthcheck as global resources

### DIFF
--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -104,6 +104,7 @@ class HealthCheck(Route53Base, QueryResourceManager):
         name = id = 'Id'
         universal_taggable = True
         cfn_type = 'AWS::Route53::HealthCheck'
+        global_resource = True
 
 
 @resources.register('rrset')
@@ -116,6 +117,7 @@ class ResourceRecordSet(ChildResourceManager):
         enum_spec = ('list_resource_record_sets', 'ResourceRecordSets', None)
         name = id = 'Name'
         cfn_type = 'AWS::Route53::RecordSet'
+        global_resource = True
 
 
 @resources.register('r53domain')


### PR DESCRIPTION
Custodian currently defines four Route 53 resource types:

- `aws.hostedzone`
- `aws.healthcheck`
- `aws.rrset`
- `aws.r53domain`

Currently only 2 of the 4 are defined as global resources. This updates the other 2 so that _all_ Route 53 types are defined as global.

What does this impact for policy authors? Practically defining a resource as global does a couple things:
- Leaves the region blank [when generating ARNs](https://github.com/cloud-custodian/cloud-custodian/blob/09efdd72b675010c0d5f3c30d60f7e4e40aa51a4/c7n/query.py#L636)
- Forces a `us-east-1`-based client for bulk tagging operations (which includes [fetching tags during augment](https://github.com/cloud-custodian/cloud-custodian/blob/09efdd72b675010c0d5f3c30d60f7e4e40aa51a4/c7n/tags.py#L74-L79), [tagging](https://github.com/cloud-custodian/cloud-custodian/blob/09efdd72b675010c0d5f3c30d60f7e4e40aa51a4/c7n/tags.py#L891-L895), [untagging](https://github.com/cloud-custodian/cloud-custodian/blob/09efdd72b675010c0d5f3c30d60f7e4e40aa51a4/c7n/tags.py#L907-L911) or [mark-for-op](https://github.com/cloud-custodian/cloud-custodian/blob/09efdd72b675010c0d5f3c30d60f7e4e40aa51a4/c7n/tags.py#L981-L985)).

Unless I'm missing something, I don't think this will break anything for authors. Typically folks add a region condition limiting global resources to `us-east-1` in any case.

Closes #7961 