### PR TITLE
tools/cask - support tencent cloud

### DIFF
--- a/tools/cask/Makefile
+++ b/tools/cask/Makefile
@@ -21,5 +21,11 @@ darwin:
 	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o release/darwin-$(VERSION)/custodian-cask
 
 
+.PHONY: darwin-arm
+darwin-arm:
+	mkdir -p release
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o release/darwin-$(VERSION)/custodian-cask
+
+
 .PHONY: release
-release: windows linux darwin
+release: windows linux darwin darwin-arm

--- a/tools/cask/Makefile
+++ b/tools/cask/Makefile
@@ -3,7 +3,7 @@ test:
 	go test .
 
 BINARY := cask
-VERSION ?= vlatest
+VERSION ?= latest
 
 .PHONY: windows
 windows:
@@ -15,6 +15,11 @@ linux:
 	mkdir -p release
 	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o release/linux-$(VERSION)/custodian-cask
 
+.PHONY: linux-arm
+linux-arm:
+	mkdir -p release
+	GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o release/linux-arm64-$(VERSION)/custodian-cask
+
 .PHONY: darwin
 darwin:
 	mkdir -p release
@@ -24,8 +29,8 @@ darwin:
 .PHONY: darwin-arm
 darwin-arm:
 	mkdir -p release
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION)" -o release/darwin-$(VERSION)/custodian-cask
+	GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION)" -o release/darwin-arm64-$(VERSION)/custodian-cask
 
 
 .PHONY: release
-release: windows linux darwin darwin-arm
+release: windows linux linux-arm darwin darwin-arm

--- a/tools/cask/main.go
+++ b/tools/cask/main.go
@@ -275,7 +275,7 @@ func generateEnvs() []string {
 	var envs []string
 
 	// Bulk include matching variables
-	var re = regexp.MustCompile(`^AWS|^AZURE_|^MSI_|^GOOGLE|CLOUDSDK`)
+	var re = regexp.MustCompile(`^AWS|^AZURE_|^MSI_|^TENCENTCLOUD_|^GOOGLE|CLOUDSDK`)
 	for _, s := range os.Environ() {
 		if re.MatchString(s) {
 			envs = append(envs, s)

--- a/tools/cask/main.go
+++ b/tools/cask/main.go
@@ -110,8 +110,6 @@ func update(ctx context.Context, image string, dockerClient *client.Client) {
 
 		// Skip image pull if we have an image already
 		if len(images) > 0 {
-			fmt.Printf("Skipped image pull - Last checked %d minutes ago.\n\n",
-				uint(now.Sub(info.ModTime()).Minutes()))
 			return
 		}
 	}

--- a/tools/cask/readme.md
+++ b/tools/cask/readme.md
@@ -1,7 +1,7 @@
 cask: easy custodian exec via docker
 ====================================
 
-custodian-cask is a Go wrapper over the `cloudcustodian/c7n:latest`
+custodian-cask is a Go wrapper over the `cloudcustodian/c7n`
 Docker image.  It allows you to use the docker image with the same CLI you
 would use for a local Custodian installation. 
 


### PR DESCRIPTION


pass through on tencent specific env vars for cask usage.


looking through cask, it probably needs a separate update re using os.UserCacheDir with a subdir
as instead of tmp for its cache/timestamp on the image. 

Also we should move the periodic poll here to 24hrs instead of hourly on image freshness, along
with an env var to bypass.


