### PR TITLE
aws - glue-connection - tag read/write support

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -27,6 +27,9 @@ class GlueConnection(QueryResourceManager):
         date = 'CreationTime'
         arn_type = "connection"
         cfn_type = 'AWS::Glue::Connection'
+        universal_taggable = object()
+
+    augment = universal_augment
 
 
 @GlueConnection.filter_registry.register('subnet')

--- a/tests/data/placebo/test_connection_password_hidden/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_connection_password_hidden/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:glue:us-east-1:644160558196:connection/test",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_connection_tag_untag/glue.GetConnections_1.json
+++ b/tests/data/placebo/test_glue_connection_tag_untag/glue.GetConnections_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "ConnectionList": [
+            {
+                "Name": "test",
+                "ConnectionType": "JDBC",
+                "ConnectionProperties": {
+                    "JDBC_ENFORCE_SSL": "false",
+                    "JDBC_CONNECTION_URL": "jdbc:mysql://database-3-instance-1.cz6wy8cci3uf.us-east-1.rds.amazonaws.com:3306/test",
+                    "USERNAME": "admin"
+                },
+                "PhysicalConnectionRequirements": {
+                    "SubnetId": "subnet-3a334610",
+                    "SecurityGroupIdList": [
+                        "sg-6c7fa917"
+                    ],
+                    "AvailabilityZone": "us-east-1d"
+                },
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 4,
+                    "hour": 20,
+                    "minute": 1,
+                    "second": 0,
+                    "microsecond": 856000
+                },
+                "LastUpdatedTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 4,
+                    "hour": 20,
+                    "minute": 1,
+                    "second": 0,
+                    "microsecond": 856000
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_connection_tag_untag/glue.GetTags_1.json
+++ b/tests/data/placebo/test_glue_connection_tag_untag/glue.GetTags_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": {},
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_connection_tag_untag/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_glue_connection_tag_untag/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:glue:us-east-1:644160558196:connection/test",
+                "Tags": [
+                    {
+                        "Key": "owner",
+                        "Value": "pratyush"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_connection_tag_untag/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_glue_connection_tag_untag/tagging.UntagResources_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "FailedResourcesMap": {},
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_delete_connection/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_glue_delete_connection/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:glue:us-east-1:644160558196:connection/c7n-test-connection",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_sg_filter/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_glue_sg_filter/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:glue:us-east-1:644160558196:connection/c7n-test-connection",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_glue_subnet_filter/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_glue_subnet_filter/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:glue:us-east-1:644160558196:connection/c7n-test-connection",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -84,6 +84,24 @@ class TestGlueConnections(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual('PASSWORD' in resources[0].get('ConnectionProperties'), False)
 
+    def test_glue_connection_tag_untag(self):
+        session_factory = self.replay_flight_data("test_glue_connection_tag_untag")
+        p = self.load_policy(
+            {
+                "name": "glue-connection-tags",
+                "resource": "glue-connection",
+                "filters": [{"tag:owner": "pratyush"}],
+                "actions": [{"type": "remove-tag", 'tags': ['owner']}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = session_factory().client("glue")
+        arn = p.resource_manager.generate_arn(resources[0]['Name'])
+        tags = client.get_tags(ResourceArn=arn)
+        self.assertEqual(tags.get('Tags'), {})
+
 
 class TestGlueDevEndpoints(BaseTest):
 


### PR DESCRIPTION
This PR adds tagging capability for glue-connection.