### PR TITLE
c7n-left - Fix matches resources on the cli and docs related to traverse

### DIFF
--- a/c7n/resources/connect.py
+++ b/c7n/resources/connect.py
@@ -52,6 +52,7 @@ class ConnectInstanceAttributeFilter(ValueFilter):
             if self.annotation_key not in r:
                 instance_attribute = client.describe_instance_attribute(InstanceId=r['Id'],
                                 AttributeType=str.upper(self.data.get('attribute_type')))
+                instance_attribute.pop('ResponseMetadata', None)
                 r[self.annotation_key] = instance_attribute
 
             if self.match(r[self.annotation_key]):

--- a/tools/c7n_left/c7n_left/filters.py
+++ b/tools/c7n_left/c7n_left/filters.py
@@ -24,7 +24,7 @@ class Traverse(Filter):
           filters:
             - not:
                - type: traverse
-                 resource: aws_s3_bucket_server_side_encryption_configuration
+                 resources: aws_s3_bucket_server_side_encryption_configuration
                  attrs:
                   - rule.apply_server_side_encryption_by_default.sse_algorithm: aws:kms
 
@@ -40,7 +40,7 @@ class Traverse(Filter):
           filters:
             - network_configuration: present
             - type: traverse
-              resource: [aws_apprunner_vpc_connector, aws_subnet, aws_vpc]
+              resources: [aws_apprunner_vpc_connector, aws_subnet, aws_vpc]
               attrs:
                - type: value
                  key: tag:Env

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -94,7 +94,7 @@ class RichCli(Output):
     def on_execution_ended(self):
         message = "[green]Success[green]"
         if self.matches:
-            message = "[red]%d Failures[/red]" % len(self.matches)
+            message = "[red]%d Failures[/red]" % self.matches
         self.console.print(
             "Evaluation complete %0.2f seconds -> %s"
             % (time.time() - self.started, message)


### PR DESCRIPTION
This PR fixes a small bug. `matches` is of type int here and len() is not compatible. I also squeezed in the removal of ResponseMetadata re: `connect-instance`, `filter: instance-attribute`