### PR TITLE
aws - ami - add image attribute valuefilter

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -14,7 +14,7 @@ import jmespath
 from c7n.actions import BaseAction
 from c7n.exceptions import ClientError, PolicyValidationError
 from c7n.filters import (
-    AgeFilter, Filter, CrossAccountAccessFilter)
+    AgeFilter, ValueFilter, Filter, CrossAccountAccessFilter)
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, DescribeSource, TypeInfo
 from c7n.resolver import ValuesFrom
@@ -609,3 +609,72 @@ class AmiCrossAccountFilter(CrossAccountAccessFilter):
                     continue
                 results.extend(f.result())
         return results
+
+
+@AMI.filter_registry.register('image-attribute')
+class ImageAttribute(ValueFilter):
+    """AMI Image Value Filter on a given image attribute.
+
+    Filters AMI's with the given AMI attribute
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: ami-unused-recently
+                resource: ami
+                filters:
+                  - type: image-attribute
+                    attribute: lastLaunchedTime
+                    key: "Value"
+                    op: gte
+                    value_type: age
+                    value: 30
+    """
+
+    valid_attrs = (
+        'kernel',
+        'ramdisk',
+        'launchPermissions',
+        'productCodes',
+        'blockDeviceMapping',
+        'sriovNetSupport',
+        'bootMode',
+        'tpmSupport',
+        'uefiData',
+        'lastLaunchedTime',
+        'imdsSupport'
+    )
+
+    schema = type_schema(
+        'image-attribute',
+        rinherit=ValueFilter.schema,
+        attribute={'enum': valid_attrs},
+        required=('attribute',))
+    schema_alias = False
+
+    def get_permissions(self):
+        return ('ec2:DescribeImageAttribute',)
+
+    def process(self, resources, event=None):
+        attribute = self.data['attribute']
+        self.get_image_attribute(resources, attribute)
+        return [resource for resource in resources
+                if self.match(resource['c7n:attribute-%s' % attribute])]
+
+    def get_image_attribute(self, resources, attribute):
+        client = local_session(
+            self.manager.session_factory).client('ec2')
+
+        for resource in resources:
+            image_id = resource['ImageId']
+            fetched_attribute = self.manager.retry(
+                client.describe_image_attribute,
+                ImageId=image_id,
+                Attribute=attribute)
+            keys = list(fetched_attribute.keys())
+            keys.remove('ResponseMetadata')
+            keys.remove('ImageId')
+            resource['c7n:attribute-%s' % attribute] = fetched_attribute[
+                keys[0]]

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -634,6 +634,7 @@ class ImageAttribute(ValueFilter):
     """
 
     valid_attrs = (
+        'description',
         'kernel',
         'ramdisk',
         'launchPermissions',
@@ -673,8 +674,5 @@ class ImageAttribute(ValueFilter):
                 client.describe_image_attribute,
                 ImageId=image_id,
                 Attribute=attribute)
-            keys = list(fetched_attribute.keys())
-            keys.remove('ResponseMetadata')
-            keys.remove('ImageId')
-            resource['c7n:attribute-%s' % attribute] = fetched_attribute[
-                keys[0]]
+            keys = set(fetched_attribute) - {'ResponseMetadata', 'ImageId'}
+            resource['c7n:attribute-%s' % attribute] = fetched_attribute[keys.pop()]

--- a/tests/data/placebo/test_ami_with_last_launched_time/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_with_last_launched_time/ec2.DescribeImageAttribute_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "ImageId": "ami-02a11ce792e2bc296",
+        "LastLaunchedTime": {
+            "Value": "2022-10-20T07:07:19Z"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ami_with_last_launched_time/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_ami_with_last_launched_time/ec2.DescribeImages_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "Images": [
+            {
+                "Architecture": "x86_64",
+                "CreationDate": "2022-07-04T12:09:37.000Z",
+                "ImageId": "ami-02a11ce792e2bc296",
+                "ImageLocation": "644160558196/testing_to_be_deleted",
+                "ImageType": "machine",
+                "Public": false,
+                "OwnerId": "644160558196",
+                "PlatformDetails": "Linux/UNIX",
+                "UsageOperation": "RunInstances",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-0b1ddd0e294677f70",
+                            "VolumeSize": 8,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    },
+                    {
+                        "DeviceName": "/dev/sdf",
+                        "Ebs": {
+                            "DeleteOnTermination": false,
+                            "SnapshotId": "snap-0e33daec301202727",
+                            "VolumeSize": 4,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    }
+                ],
+                "EnaSupport": true,
+                "Hypervisor": "xen",
+                "Name": "testing_to_be_deleted",
+                "RootDeviceName": "/dev/xvda",
+                "RootDeviceType": "ebs",
+                "SriovNetSupport": "simple",
+                "VirtualizationType": "hvm"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ami_with_no_last_launched_time/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_with_no_last_launched_time/ec2.DescribeImageAttribute_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ImageId": "ami-02a11ce792e2bc296",
+        "LastLaunchedTime": {},
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ami_with_no_last_launched_time/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_ami_with_no_last_launched_time/ec2.DescribeImages_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "Images": [
+            {
+                "Architecture": "x86_64",
+                "CreationDate": "2022-07-04T12:09:37.000Z",
+                "ImageId": "ami-02a11ce792e2bc296",
+                "ImageLocation": "644160558196/testing_to_be_deleted",
+                "ImageType": "machine",
+                "Public": false,
+                "OwnerId": "644160558196",
+                "PlatformDetails": "Linux/UNIX",
+                "UsageOperation": "RunInstances",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-0b1ddd0e294677f70",
+                            "VolumeSize": 8,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    },
+                    {
+                        "DeviceName": "/dev/sdf",
+                        "Ebs": {
+                            "DeleteOnTermination": false,
+                            "SnapshotId": "snap-0e33daec301202727",
+                            "VolumeSize": 4,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    }
+                ],
+                "EnaSupport": true,
+                "Hypervisor": "xen",
+                "Name": "testing_to_be_deleted",
+                "RootDeviceName": "/dev/xvda",
+                "RootDeviceType": "ebs",
+                "SriovNetSupport": "simple",
+                "VirtualizationType": "hvm"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -352,6 +352,46 @@ class TestAMI(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['ImageId'], 'ami-0515ff4f8f9dbeb31')
 
+    def test_ami_with_last_launched_time(self):
+        factory = self.replay_flight_data('test_ami_with_last_launched_time')
+        p = self.load_policy(
+            {
+                "name": "test-ami-last-launched-time",
+                "resource": "ami",
+                "filters": [{"type": "image-attribute",
+                             "attribute": "lastLaunchedTime",
+                             "key": "Value",
+                             "op": "gte",
+                             "value_type": "age",
+                             "value": 1}],
+            },
+            {"region": "ap-southeast-2"},
+            session_factory=factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['c7n:attribute-lastLaunchedTime']
+                         ['Value'], '2022-10-20T07:07:19Z')
+
+    def test_ami_with_no_last_launched_time(self):
+        factory = self.replay_flight_data('test_ami_with_no_last_launched_time')
+        p = self.load_policy(
+            {
+                "name": "test-ami-last-launched-time",
+                "resource": "ami",
+                "filters": [{"type": "image-attribute",
+                             "attribute": "lastLaunchedTime",
+                             "key": "Value",
+                             "op": "gte",
+                             "value_type": "age",
+                             "value": 1}],
+            },
+            {"region": "ap-southeast-2"},
+            session_factory=factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
     def test_unused_ami_true(self):
         factory = self.replay_flight_data("test_unused_ami_true")
         p = self.load_policy(


### PR DESCRIPTION
This adds an image-attribute filter to AWS AMI's.  This could be used a number of ways using the existing image attributes available in https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-image-attribute.html#options but this was primarily intended to be an alternative implementation to #8021 which would allow the user to filter based on AMI `lastLaunchedTime`.  I shamelessly stole the test data and test from #8021 with some minor reswizzling after reading some other <item> attribute examples.

```
                filters:
                  - type: image-attribute
                    attribute: lastLaunchedTime
                    key: "Value"
                    op: gte
                    value_type: age
                    value: 30
```