### PR TITLE
aws - wafv2 - add scope param to list_web_acls call in lambda modes

### DIFF
--- a/c7n/resources/waf.py
+++ b/c7n/resources/waf.py
@@ -27,6 +27,10 @@ class DescribeWafV2(DescribeSource):
             q = {'Scope': 'REGIONAL'}
         return q
 
+    def get_resources(self, ids):
+        resources = self.query.filter(self.manager, **self.get_query_params(None))
+        return [r for r in resources if r[self.manager.resource_type.id] in ids]
+
 
 @resources.register('waf')
 class WAF(QueryResourceManager):

--- a/tests/data/placebo/test_wafv2_resolve_resources/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_wafv2_resolve_resources/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_wafv2_resolve_resources/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_wafv2_resolve_resources/wafv2.ListWebACLs_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "NextMarker": "dont-match-me",
+        "WebACLs": [
+            {
+                "Name": "match-me",
+                "Id": "624e04d2-8b45-45ee-b4ad-e853dac6d070",
+                "Description": "",
+                "LockToken": "ad4ae4ab-aba8-4499-88e9-059d4f9a4c60",
+                "ARN": "arn:aws:wafv2:us-east-2:644160558196:regional/webacl/match-me/624e04d2-8b45-45ee-b4ad-e853dac6d070"
+            },
+            {
+                "Name": "dont-match-me",
+                "Id": "889cae83-d5e5-41e9-bb6f-00ea0f726637",
+                "Description": "",
+                "LockToken": "a33055a6-2e0a-4e5f-aa8c-abe3a5ce26d8",
+                "ARN": "arn:aws:wafv2:us-east-2:644160558196:regional/webacl/dont-match-me/889cae83-d5e5-41e9-bb6f-00ea0f726637"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_waf.py
+++ b/tests/test_waf.py
@@ -17,6 +17,19 @@ class WAFTest(BaseTest):
         )
         self.assertEqual(resources[0]["DefaultAction"], {"Type": "BLOCK"})
 
+    def test_wafv2_resolve_resources(self):
+        session_factory = self.replay_flight_data(
+            "test_wafv2_resolve_resources",
+            region="us-east-2"
+        )
+        p = self.load_policy(
+            {"name": "wafv2test", "resource": "aws.wafv2"},
+            session_factory=session_factory,
+            config={"region": "us-east-2"}
+        )
+        resources = p.resource_manager.get_resources(["624e04d2-8b45-45ee-b4ad-e853dac6d070"])
+        assert len(resources) == 1
+
     def test_wafv2_logging_configuration(self):
         session_factory = self.replay_flight_data(
             'test_wafv2_logging_configuration')


### PR DESCRIPTION
`SCOPE` is a required parameter for `list_web_acls()` calls in WAFv2. We [add that parameter](https://github.com/cloud-custodian/cloud-custodian/blob/8e265ba77bb844417fe96ba5bf83f013307e8552/c7n/resources/waf.py#L20-L28) in the describe source to cover pull mode executions.

This change ensures that param also gets added when we're matching IDs during Lambda mode executions.

Closes #8118