### PR TITLE
tencentcloud - cbs-snapshot, security-group - fix service in resource type

### DIFF
--- a/tools/c7n_tencentcloud/c7n_tencentcloud/resources/cbs_snapshot.py
+++ b/tools/c7n_tencentcloud/c7n_tencentcloud/resources/cbs_snapshot.py
@@ -32,7 +32,7 @@ class CBSSnapshot(QueryResourceManager):
         """resource_type"""
         id = "SnapshotId"
         endpoint = "cbs.tencentcloudapi.com"
-        service = "cvm"
+        service = "cbs"
         version = "2017-03-12"
         enum_spec = ("DescribeSnapshots", "Response.SnapshotSet[]", {})
         paging_def = {"method": PageMethod.Offset, "limit": {"key": "Limit", "value": 20}}

--- a/tools/c7n_tencentcloud/c7n_tencentcloud/resources/security_group.py
+++ b/tools/c7n_tencentcloud/c7n_tencentcloud/resources/security_group.py
@@ -33,7 +33,7 @@ class SecurityGroup(QueryResourceManager):
         """resource_type"""
         id = "SecurityGroupId"
         endpoint = "vpc.tencentcloudapi.com"
-        service = "security-group"
+        service = "vpc"
         version = "2017-03-12"
         enum_spec = ("DescribeSecurityGroups", "Response.SecurityGroupSet[]", {})
         paging_def = {"method": PageMethod.Offset, "limit": {"key": "Limit", "value": "20"}}


### PR DESCRIPTION
fixes the following error:

```
2023-01-09 10:31:35,566: custodian.output:ERROR Error while executing policy
Traceback (most recent call last):
  File "/Users/sonny/dev/thisisshi/cloud-custodian/tools/c7n_tencentcloud/c7n_tencentcloud/query.py", line 108, in paged_filter
    resp = cli.execute_paged_query(action,
  File "/Users/sonny/dev/thisisshi/cloud-custodian/tools/c7n_tencentcloud/c7n_tencentcloud/client.py", line 102, in execute_paged_query
    result = self.execute_query(action, params)
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.10/lib/python3.10/site-packages/retrying.py", line 56, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.10/lib/python3.10/site-packages/retrying.py", line 257, in call
    return attempt.get(self._wrap_exception)
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.10/lib/python3.10/site-packages/retrying.py", line 301, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.10/lib/python3.10/site-packages/six.py", line 719, in reraise
    raise value
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.10/lib/python3.10/site-packages/retrying.py", line 251, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/Users/sonny/dev/thisisshi/cloud-custodian/tools/c7n_tencentcloud/c7n_tencentcloud/client.py", line 66, in execute_query
    resp = self._cli.call_json(action, params)
  File "/Users/sonny/Library/Caches/pypoetry/virtualenvs/c7n-LMB99nsW-py3.10/lib/python3.10/site-packages/tencentcloud/common/abstract_client.py", line 416, in call_json
    raise TencentCloudSDKException(code, message, reqid)
tencentcloud.common.exception.tencent_cloud_sdk_exception.TencentCloudSDKException: [TencentCloudSDKException] code:AuthFailure.InvalidAuthorization message:The request `Authorization` header does not conform to tencentcloud standards: `Service` in Credential not valid. requestId:62b45b6c-ca9f-4993-9418-4386162befe3
```

policies:

```yaml
policies:
  - name: tc-security-group
    resource: tencentcloud.security-group
  - name: tc-cbs-snapshot
    resource: tencentcloud.cbs-snapshot
```

while testing it seems like the tag action doesnt work properly for security group but i'll open a separate pr to address that