### PR TITLE
aws - redshift - Fix the issue with snapshot collection

### DIFF
--- a/c7n/resources/redshift.py
+++ b/c7n/resources/redshift.py
@@ -1011,7 +1011,7 @@ class ClusterConsecutiveSnapshots(Filter):
     def process_resource_set(self, client, resources, lbdate):
         paginator = client.get_paginator('describe_cluster_snapshots')
         paginator.PAGE_ITERATOR_CLS = RetryPageIterator
-        rs_snapshots = paginator.paginate(EndTime=lbdate).build_full_result().get(
+        rs_snapshots = paginator.paginate(StartTime=lbdate).build_full_result().get(
             'Snapshots', [])
 
         cluster_map = {}


### PR DESCRIPTION
As part of the 'consecutive-snapshots" filter for redshift we collect all the snapshots created after the cutoff date using the `describe_cluster_snapshots` api call with `StartTime` filter to limit the number of snapshots to relevant snapshots.  However I inadvertently ended up using the `Endtime` filter.

```
StartTime (datetime) --
A value that requests only snapshots created at or after the specified time. The time value is specified in ISO 8601 format. For more information about ISO 8601, go to the [ISO8601 Wikipedia page.](http://en.wikipedia.org/wiki/ISO_8601)

Example: 2012-07-16T18:00:00Z

EndTime (datetime) --
A time value that requests only snapshots created at or before the specified time. The time value is specified in ISO 8601 format. For more information about ISO 8601, go to the [ISO8601 Wikipedia page.](http://en.wikipedia.org/wiki/ISO_8601)

Example: 2012-07-16T18:00:00Z
```