### PR TITLE
aws - fix transit-user resource type metadata

### DIFF
--- a/c7n/resources/transfer.py
+++ b/c7n/resources/transfer.py
@@ -172,7 +172,7 @@ class TransferUser(ChildResourceManager):
         arn = 'Arn'
         arn_type = 'user'
         enum_spec = ('list_users', 'Users', None)
-        detail_spec = ('describe_user', 'UserName', None)
+        detail_spec = ('describe_user', 'UserName', 'UserName', 'User')
         parent_spec = ('transfer-server', 'ServerId', True)
         name = id = 'UserName'
         cfn_type = 'AWS::Transfer::User'

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -116,6 +116,19 @@ class PolicyMetaLint(BaseTest):
         except Exception:
             self.fail("Failed to serialize schema")
 
+    def test_detail_spec_format(self):
+
+        failed = []
+        for k, v in manager.resources.items():
+            detail_spec = getattr(v.resource_type, 'detail_spec', None)
+            if not detail_spec:
+                continue
+            if not len(detail_spec) == 4:
+                failed.append(k)
+        if failed:
+            self.fail(
+                "%s resources have invalid detail_specs" % ", ".join(failed))
+
     def test_resource_augment_universal_mask(self):
         # universal tag had a potential bad patterm of masking
         # resource augmentation, scan resources to ensure


### PR DESCRIPTION
also add a meta test to catch these typos in future.