### PR TITLE
aws - filters - add aws-backups filter, consecutive-aws-backups filter to more resource types

### DIFF
--- a/c7n/filters/backup.py
+++ b/c7n/filters/backup.py
@@ -1,32 +1,43 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from .core import Filter
+from .core import ValueFilter, OPERATORS
 from datetime import datetime, timedelta
 from c7n.utils import type_schema, local_session, chunks
 from c7n.query import RetryPageIterator
 
 
-class ConsecutiveAwsBackupsFilter(Filter):
-    """Returns resources where number of consective backups (based on the
-    periodicity defined in the filter) is equal to/or greater than n units.
-    This filter supports the resources that use AWS Backup service for backups.
-    :example:
-    .. code-block:: yaml
-            policies:
-              - name: dynamodb-consecutive-aws-backup-count
-                resource: dynamodb-table
-                filters:
-                  - type: consecutive-aws-backups
-                    count: 7
-                    period: days
-                    status: 'COMPLETED'
+class BackupFilter(ValueFilter):
     """
-    schema = type_schema('consecutive-aws-backups', count={'type': 'number', 'minimum': 1},
-        period={'enum': ['hours', 'days', 'weeks']},
-        status={'enum': ['COMPLETED', 'PARTIAL', 'DELETING', 'EXPIRED']},
-        required=['count', 'period', 'status'])
+    AWS Backups Filter
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: dynamodb-backups
+            resource: aws.dynamodb-table
+            description: find dynamodb tables with no backups through aws backups
+            filters:
+              - type: aws-backups
+                op: eq
+                value: 0
+                value_type: resource_count
+    """
+
+    schema = type_schema('aws-backups', rinherit=ValueFilter.schema)
+
     permissions = ('backup:ListRecoveryPointsByResource', )
     annotation = 'c7n:AwsBackups'
+
+    def match_resource(self, resource):
+        if self.data.get('value_type') == 'resource_count':
+            op = OPERATORS[self.data.get('op')]
+            if op(len(resource), self.data.get('value')):
+                return True
+            else:
+                return False
+            return self.match(resource)
 
     def process_resource_set(self, resources):
         arns = self.manager.get_arns(resources)
@@ -50,24 +61,51 @@ class ConsecutiveAwsBackupsFilter(Filter):
 
     def process(self, resources, event=None):
         results = []
-        retention = self.data.get('count')
-        expected_dates = set()
-        for time in range(1, retention + 1):
-            expected_dates.add(self.get_date(time))
-
         for resource_set in chunks(
                 [r for r in resources if self.annotation not in r], 50):
             self.process_resource_set(resource_set)
 
         for r in resources:
-            backup_dates = set()
-            for backup in r[self.annotation]:
-                if backup['Status'] == self.data.get('status'):
-                    if self.data.get('period') == 'hours':
-                        backup_dates.add(backup['CreationDate'].strftime('%Y-%m-%d-%H'))
-                    else:
-                        backup_dates.add(backup['CreationDate'].strftime('%Y-%m-%d'))
-
-            if expected_dates.issubset(backup_dates):
+            if self.match_resource(r[self.annotation]):
                 results.append(r)
+        return results
+
+
+class ConsecutiveAwsBackupsFilter(BackupFilter):
+    """Returns resources where number of consective backups (based on the
+    periodicity defined in the filter) is equal to/or greater than n units.
+    This filter supports the resources that use AWS Backup service for backups.
+    :example:
+    .. code-block:: yaml
+            policies:
+              - name: dynamodb-consecutive-aws-backup-count
+                resource: dynamodb-table
+                filters:
+                  - type: consecutive-aws-backups
+                    count: 7
+                    period: days
+                    status: 'COMPLETED'
+    """
+    schema = type_schema('consecutive-aws-backups', count={'type': 'number', 'minimum': 1},
+        period={'enum': ['hours', 'days', 'weeks']},
+        status={'enum': ['COMPLETED', 'PARTIAL', 'DELETING', 'EXPIRED']},
+        required=['count', 'period', 'status'])
+
+    def match_resource(self, resource):
+        retention = self.data.get('count')
+        expected_dates = set()
+        for time in range(1, retention + 1):
+            expected_dates.add(self.get_date(time))
+
+        results = []
+        backup_dates = set()
+        for backup in resource[self.annotation]:
+            if backup['Status'] == self.data.get('status'):
+                if self.data.get('period') == 'hours':
+                    backup_dates.add(backup['CreationDate'].strftime('%Y-%m-%d-%H'))
+                else:
+                    backup_dates.add(backup['CreationDate'].strftime('%Y-%m-%d'))
+
+        if expected_dates.issubset(backup_dates):
+            results.append(resource)
         return results

--- a/c7n/resources/cfn.py
+++ b/c7n/resources/cfn.py
@@ -10,6 +10,7 @@ from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
 from c7n.utils import local_session, type_schema
 from c7n.tags import RemoveTag, Tag
+from c7n.filters.backup import ConsecutiveAwsBackupsFilter, BackupFilter
 
 log = logging.getLogger('custodian.cfn')
 
@@ -217,3 +218,7 @@ class CloudFormationRemoveTag(RemoveTag):
     def process_resource_set(self, client, stacks, keys):
         for s in stacks:
             _tag_stack(client, s, remove=keys)
+
+
+CloudFormation.filter_registry.register('aws-backup', BackupFilter)
+CloudFormation.filter_registry.register('consecutive-aws-backup', ConsecutiveAwsBackupsFilter)

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 from c7n.filters import Filter
 from c7n.filters import ValueFilter
 from c7n.query import RetryPageIterator
-from c7n.filters.backup import ConsecutiveAwsBackupsFilter
+from c7n.filters.backup import ConsecutiveAwsBackupsFilter, BackupFilter
 
 
 class ConfigTable(query.ConfigSource):
@@ -749,3 +749,4 @@ class TableConsecutiveBackups(Filter):
 
 
 Table.filter_registry.register('consecutive-aws-backups', ConsecutiveAwsBackupsFilter)
+Table.filter_registry.register('aws-backups', BackupFilter)

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -15,6 +15,7 @@ from c7n.exceptions import PolicyValidationError
 from c7n.filters import (
     CrossAccountAccessFilter, Filter, AgeFilter, ValueFilter,
     ANNOTATION_KEY)
+from c7n.filters.backup import ConsecutiveAwsBackupsFilter, BackupFilter
 from c7n.filters.health import HealthEventFilter
 from c7n.filters.related import RelatedResourceFilter
 
@@ -1645,3 +1646,7 @@ class ModifyVolume(BaseAction):
             if vtype:
                 params['VolumeType'] = vtype
             self.manager.retry(client.modify_volume, **params)
+
+
+EBS.filter_registry.register('aws-backup', BackupFilter)
+EBS.filter_registry.register('consecutive-aws-backup', ConsecutiveAwsBackupsFilter)

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -23,6 +23,7 @@ from c7n.exceptions import PolicyValidationError
 from c7n.filters import (
     FilterRegistry, AgeFilter, ValueFilter, Filter, DefaultVpcBase
 )
+from c7n.filters.backup import ConsecutiveAwsBackupsFilter, BackupFilter
 from c7n.filters.offhours import OffHour, OnHour
 import c7n.filters.vpc as net_filters
 
@@ -2479,3 +2480,6 @@ class HasSpecificManagedPolicy(SpecificIamProfileManagedPolicy):
                 results.append(r)
 
         return results
+
+EC2.filter_registry.register('aws-backup', BackupFilter)
+EC2.filter_registry.register('consecutive-aws-backup', ConsecutiveAwsBackupsFilter)

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -2481,5 +2481,6 @@ class HasSpecificManagedPolicy(SpecificIamProfileManagedPolicy):
 
         return results
 
+
 EC2.filter_registry.register('aws-backup', BackupFilter)
 EC2.filter_registry.register('consecutive-aws-backup', ConsecutiveAwsBackupsFilter)

--- a/c7n/resources/efs.py
+++ b/c7n/resources/efs.py
@@ -15,7 +15,7 @@ from c7n.query import (
 from c7n.tags import universal_augment
 from c7n.utils import local_session, type_schema, get_retry
 from .aws import shape_validate
-from c7n.filters.backup import ConsecutiveAwsBackupsFilter
+from c7n.filters.backup import ConsecutiveAwsBackupsFilter, BackupFilter
 
 
 class EFSDescribe(DescribeSource):
@@ -342,3 +342,4 @@ class EFSHasStatementFilter(HasStatementFilter):
 
 
 ElasticFileSystem.filter_registry.register('consecutive-aws-backups', ConsecutiveAwsBackupsFilter)
+ElasticFileSystem.filter_registry.register('aws-backups', BackupFilter)

--- a/c7n/resources/fsx.py
+++ b/c7n/resources/fsx.py
@@ -11,6 +11,7 @@ from c7n.actions import BaseAction
 from c7n.tags import Tag, TagDelayedAction, RemoveTag, coalesce_copy_user_tags, TagActionFilter
 from c7n.utils import type_schema, local_session, chunks
 from c7n.filters import Filter
+from c7n.filters.backup import ConsecutiveAwsBackupsFilter, BackupFilter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.filters.vpc import SubnetFilter
 
@@ -442,3 +443,7 @@ class ConsecutiveBackups(Filter):
 class Subnet(SubnetFilter):
 
     RelatedIdsExpression = 'SubnetIds[]'
+
+
+FSx.filter_registry.register('aws-backup', BackupFilter)
+FSx.filter_registry.register('consecutive-aws-backup', ConsecutiveAwsBackupsFilter)

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -62,6 +62,7 @@ from c7n.utils import (
     local_session, type_schema, get_retry, chunks, snapshot_identifier, merge_dict_list)
 from c7n.resources.kms import ResourceKmsKeyAlias
 from c7n.resources.securityhub import OtherResourcePostFinding
+from c7n.filters.backups import BackupFilter, ConsecutiveAwsBackupsFilter
 
 log = logging.getLogger('custodian.rds')
 
@@ -2063,3 +2064,7 @@ class DbOptionGroups(ValueFilter):
                     break
 
         return results
+
+
+filters.register('consecutive-aws-backups', ConsecutiveAwsBackupsFilter)
+filters.register('aws-backups', BackupFilter)

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 
 from c7n.actions import BaseAction
 from c7n.filters import AgeFilter, CrossAccountAccessFilter, Filter, ValueFilter
+from c7n.filters.backups import BackupFilter, ConsecutiveAwsBackupsFilter
 from c7n.filters.offhours import OffHour, OnHour
 import c7n.filters.vpc as net_filters
 from c7n.manager import resources
@@ -701,3 +702,7 @@ class ClusterParameterFilter(ParameterFilter):
                     self.data.get('key'))
                 results.append(resource)
         return results
+
+
+RDSCluster.filter_registry.register('consecutive-aws-backups', ConsecutiveAwsBackupsFilter)
+RDSCluster.filter_registry.register('aws-backups', BackupFilter)

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -54,6 +54,7 @@ from c7n.exceptions import PolicyValidationError, PolicyExecutionError
 from c7n.filters import (
     FilterRegistry, Filter, CrossAccountAccessFilter, MetricsFilter,
     ValueFilter)
+from c7n.filters.backup import ConsecutiveAwsBackupsFilter, BackupFilter
 import c7n.filters.policystatement as polstmt_filter
 from c7n.manager import resources
 from c7n.output import NullBlobOutput
@@ -3457,3 +3458,7 @@ class BucketOwnershipControls(BucketFilterBase, ValueFilter):
                 raise
             controls = {}
         b[self.annotation_key] = controls.get('OwnershipControls')
+
+
+filters.register('aws-backup', BackupFilter)
+filters.register('consecutive-aws-backup', ConsecutiveAwsBackupsFilter)


### PR DESCRIPTION
adds support for more resource types, also adds a generic 'aws-backups' filter to operate against resources with backups