### PR TITLE
aws - config - bugfix: add rule_prefix to remediation filter schema

### DIFF
--- a/c7n/resources/config.py
+++ b/c7n/resources/config.py
@@ -181,6 +181,7 @@ class RuleRemediation(Filter):
 
     schema = type_schema('remediation',
         rule_name={'type': 'string'},
+        rule_prefix={'type': 'string'},
         remediation={
             'type': 'object',
             'properties': {


### PR DESCRIPTION
This is a bug fix to the config remediation filter. The `rule_prefix` property is processed in the filter but missing from schema. Thus, users are unable to deploy a policy with this property because it fails the policy validation test.

### Error Log
```
$ custodian run --dryrun -s /dev/shm --cache-period 0 s3-bucket-public-read-prohibited-remediate-event.yml
2023-01-17 13:00:03,859: custodian.commands:ERROR invalid policy file: s3-bucket-public-read-prohibited-remediate-event.yml error: Failed to validate policy s3-bucket-public-read-prohibited-remediate-event
             Error on policy:s3-bucket-public-read-prohibited-remediate-event resource:config-rule
Additional properties are not allowed ('rule_prefix' was unexpected)

            Failed validating 'additionalProperties' in schema[6]:
                {'additionalProperties': False,
                 'properties': {'remediation': {'properties': {'automatic': {'type': 'boolean'},
                                                               'execution_controls': {'type': 'object'},
                                                               'maximum_automatic_attempts': {'maximum': 25,
                                                                                              'minimum': 1,
                                                                                              'type': 'integer'},
                                                               'parameters': {'type': 'object'},
                                                               'retry_attempt_seconds': {'maximum': 2678000,
                                                                                         'minimum': 1,
                                                                                         'type': 'integer'},
                                                               'target_id': {'type': 'string'},
                                                               'target_type': {'type': 'string'}},
                                                'type': 'object'},
                                'rule_name': {'type': 'string'},
                                'type': {'enum': ['remediation']}},
                 'required': ['type'],
                 'type': 'object'}

            On instance:
                {'remediation': {'Automatic': True,
                                 'MaximumAutomaticAttempts': 5,
                                 'Parameters': {'AutomationAssumeRole': {'StaticValue': {'Values': ['arn:aws:iam::{account_id}:role/PolicyEngineV2Role']}},
                                                'S3BucketName': {'ResourceValue': {'Value': 'RESOURCE_ID'}}},
                                 'RetryAttemptSeconds': 211,
                                 'TargetId': 'AWS-DisableS3BucketPublicReadWrite'},
                 'rule_name': 's3-bucket-public-read-prohibited-remediate-event',
                 'rule_prefix': 'ntakeuchi-',
                 'type': 'remediation'}

2023-01-17 13:00:03,859: custodian.commands:ERROR Found 1 errors.  Exiting.
```

### Example Policy
```
policies:
  - name: s3-bucket-public-read-prohibited-remediate-event
    resource: account
    description: |
      Checks if S3 buckets do not allow public read access. When the bucket is evaluated as 'NON_COMPLIANT', the 'AWS-DisableS3BucketPublicReadWrite' action is triggered.
    filters:
      - type: missing
        policy:
          resource: config-rule
          filters:
            - type: remediation
              rule_name: &rule_name 's3-bucket-public-read-prohibited-remediate-event'
              rule_prefix: &rule_prefix 'ntakeuchi-'
              remediation: &remediation-config
                TargetId: AWS-DisableS3BucketPublicReadWrite
                Automatic: true
                MaximumAutomaticAttempts: 5
                RetryAttemptSeconds: 211
                Parameters:
                  AutomationAssumeRole:
                    StaticValue:
                      Values:
                        - arn:aws:iam::{account_id}:role/PolicyEngineV2Role
                  S3BucketName:
                    ResourceValue:
                      Value: RESOURCE_ID
    actions:
      - type: toggle-config-managed-rule
        rule_name: *rule_name
        rule_prefix: *rule_prefix
        managed_rule_id: S3_BUCKET_PUBLIC_READ_PROHIBITED
        resource_types:
          - 'AWS::S3::Bucket'
        rule_parameters: '{}'
        remediation: *remediation-config
```