### PR TITLE
c7n-left - allow for policy and resource pre execution filtering on cli

### DIFF
--- a/tools/c7n_left/README.md
+++ b/tools/c7n_left/README.md
@@ -83,23 +83,40 @@ Available filters
 
 - `name` - policy name
 - `category` - policy category
-- `severity` - policy severity (unknown, low, medium, high, critical)
+- `severity` - minimum policy severity (unknown, low, medium, high, critical)
 - `type` - resource type, ie. aws_security_group
 - `id` - resource id  ie. aws_vpc.example 
 
+Multiple values for a given filter can be specified as comma separate values, and all filters
+except severity support globbing.
+
 Examples
 ```
-# run all encryption policies on ebs volumes
-c7n-left run -p policy_dir -d terraform --filters="category=encryption type=aws_ebs_volume"
+# run all encryption policies on ebs volumes and sqs queues
+c7n-left run -p policy_dir -d terraform --filters="category=encryption type=aws_ebs_volume,aws_sqs_queue"
 
 # run all medium and higher level policies cost policies
 c7n-left run -p policy_dir -d terraform --filters="severity=medium category=cost"
 ```
 
+policy values for severity and category are specified in its metadata section. ie
+
+```yaml
+policies:
+  - name: check-encryption
+    resource: [aws_ebs_volume, aws_sqs_queue]
+    metadata:
+      category: [encryption, security]
+      severity: high
+    filters:
+       - kms_master_key_id: absent
+```       
+
+
 ## Outputs
 
 if your using this in github actions, we have special output mode
-for reporting annotations directly into the ui with `--output github`
+for reporting annotations directly into pull requests with `--output github`
 
 We also display a summary output after displaying resource matches, there are
 two summary displays available, the default policy summary, and a resource summary

--- a/tools/c7n_left/README.md
+++ b/tools/c7n_left/README.md
@@ -7,7 +7,7 @@ against infrastructure as code source assets.
 It also provides a separate cli for better command line ux for
 source asset evaluation.
 
-# Install
+## Install
 
 We currently only support python 3.10 on mac and linux. We plan to
 expand support for additional operating systems and python versions
@@ -18,21 +18,29 @@ over time.
 pip install c7n_left
 ```
 
-# Usage
+## Usage
 
 ```shell
-$ c7n-left run --help
+❯ c7n-left run --help
 
 Usage: c7n-left run [OPTIONS]
 
-  evaluate policies against iac sources
+  evaluate policies against IaC sources.
+
+  c7n-left -p policy_dir -d terraform_root --filters "severity=HIGH"
+
+  WARNING - CLI interface subject to change.
 
 Options:
   --format TEXT
+  --filters TEXT                  filter policies or resources as k=v pairs
+                                  with globbing
   -p, --policy-dir PATH
   -d, --directory PATH
   -o, --output [cli|github|json]
   --output-file FILENAME
+  --output-query TEXT
+  --summary [policy|resource]
   --help                          Show this message and exit.
 ```
 
@@ -66,8 +74,35 @@ Execution complete 0.01 seconds
 ```
 
 
-# Outputs
+## Filters
+
+Which policies and which resources are evaluated can be controlled via
+command line via `--filters` option.
+
+Available filters
+
+- `name` - policy name
+- `category` - policy category
+- `severity` - policy severity (unknown, low, medium, high, critical)
+- `type` - resource type, ie. aws_security_group
+- `id` - resource id  ie. aws_vpc.example 
+
+Examples
+```
+# run all encryption policies on ebs volumes
+c7n-left run -p policy_dir -d terraform --filters="category=encryption type=aws_ebs_volume"
+
+# run all medium and higher level policies cost policies
+c7n-left run -p policy_dir -d terraform --filters="severity=medium category=cost"
+```
+
+## Outputs
 
 if your using this in github actions, we have special output mode
-for reporting annotations directly into the ui.
+for reporting annotations directly into the ui with `--output github`
+
+We also display a summary output after displaying resource matches, there are
+two summary displays available, the default policy summary, and a resource summary
+which can be enabled via `--summary resource`.
+
 

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -10,7 +10,7 @@ from c7n.config import Config
 
 from .entry import initialize_iac
 from .output import get_reporter, report_outputs, summary_options
-from .core import CollectionRunner
+from .core import CollectionRunner, ExecutionFilter
 from .utils import load_policies
 
 
@@ -52,6 +52,7 @@ def run(
         output_file=output_file,
         output_query=output_query,
         summary=summary,
+        filters=filters,
     )
     exec_filter = ExecutionFilter.parse(config)
     config["exec_filter"] = exec_filter
@@ -60,7 +61,7 @@ def run(
         log.warning("no policies found")
         sys.exit(1)
     reporter = get_reporter(config)
-    runner = CollectionRunner(policies, config, reporter, exec_filter)
+    runner = CollectionRunner(policies, config, reporter)
     sys.exit(int(runner.run()))
 
 

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -63,11 +63,18 @@ class PolicyMetadata:
         categories = self.policy.data.get("metadata", {}).get("category", [])
         if isinstance(categories, str):
             categories = [categories]
+        if not isinstance(categories, list) or (
+            categories and not isinstance(categories[0], str)
+        ):
+            categories = []
         return categories
 
     @property
     def severity(self):
-        return self.policy.data.get("metadata", {}).get("severity", "").lower()
+        value = self.policy.data.get("metadata", {}).get("severity", "")
+        if isinstance(value, str):
+            return value.lower()
+        return ""
 
     @property
     def title(self):
@@ -159,7 +166,7 @@ class ExecutionFilter:
             return policies
 
         def filter_severity(p):
-            p_slevel = SEVERITY_LEVELS[p.severity or "unknown"]
+            p_slevel = SEVERITY_LEVELS.get(p.severity) or SEVERITY_LEVELS.get("unknown")
             f_slevel = SEVERITY_LEVELS[self.filters["severity"][0]]
             return p_slevel <= f_slevel
 

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -60,7 +60,7 @@ class PolicyMetadata:
 
     @property
     def severity(self):
-        return self.policy.data.get("metadata", {}).get("severity", "unknown").lower()
+        return self.policy.data.get("metadata", {}).get("severity", "").lower()
 
     @property
     def title(self):
@@ -141,7 +141,7 @@ class ExecutionFilter:
             return policies
 
         def filter_severity(p):
-            p_slevel = SEVERITY_LEVELS[p.severity]
+            p_slevel = SEVERITY_LEVELS[p.severity] or "unknown"
             f_slevel = SEVERITY_LEVELS[self.filters["severity"][0]]
             return p_slevel <= f_slevel
 

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -76,9 +76,9 @@ class PolicyMetadata:
             return title
         title = f"{self.resource_type} - policy:{self.name}"
         if self.categories:
-            title += f"category:{self.display_category}"
+            title += f" category:{self.display_category}"
         if self.severity:
-            title += f"severity:{self.severity}"
+            title += f" severity:{self.severity}"
         return title
 
     def __repr__(self):

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -171,7 +171,7 @@ class ExecutionFilter:
         # since its a controlled vocab.
         fseverities = set(self.filters["severity"])
         for p in policies:
-            if p.serverity not in fseverities:
+            if (p.severity or "unknown") not in fseverities:
                 continue
             results.append(p)
         return results

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -13,6 +13,7 @@ from rich.table import Table
 from rich.text import Text
 
 from .core import CollectionRunner
+from .utils import SEVERITY_LEVELS
 from c7n.output import OutputRegistry
 
 
@@ -153,8 +154,12 @@ class Summary(Output):
 
         resource_count = 0
         for rtype, resources in graph.get_resources_by_type():
+            resources = self.options.exex_filter(rtype, resources)
             if "_" not in rtype:
                 continue
+            if not resources:
+                continue
+
             resource_count += len(resources)
             type_counts[rtype] = len(resources)
             for p in policies:
@@ -192,8 +197,6 @@ class Summary(Output):
         self.console.print(msg)
 
 
-severity_levels = {"critical": 0, "high": 10, "medium": 20, "low": 30, "unknown": 40}
-
 severity_colors = {
     "critical": "red",
     "high": "yellow",
@@ -204,7 +207,7 @@ severity_colors = {
 
 
 def severity_key(a):
-    return severity_levels.get(a.severity.lower(), severity_levels["unknown"])
+    return SEVERITY_LEVELS.get(a.severity.lower(), SEVERITY_LEVELS["unknown"])
 
 
 def get_severity_color(policy):

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -112,6 +112,7 @@ class Summary(Output):
         type_policies = Counter()
 
         resource_count = 0
+
         for rtype, resources in graph.get_resources_by_type():
             resources = self.config.exec_filter.filter_resources(rtype, resources)
             if "_" not in rtype:
@@ -127,6 +128,7 @@ class Summary(Output):
                 else:
                     type_policies[rtype] += 1
                     policy_resources[p.name] = len(resources)
+
         self.counter_unevaluated_by_type = unevaluated
         self.counter_resources_by_type = type_counts
         self.counter_resources_by_policy = policy_resources
@@ -139,11 +141,10 @@ class Summary(Output):
             self.resource_name_matches.add(r.resource.name)
 
     def on_execution_ended(self):
-        unevaluated = sum(self.counter_unevaluated_by_type.values())
+        unevaluated = sum([v for k, v in self.counter_unevaluated_by_type.items() if k not in set(self.counter_policies_by_type)])
         compliant = (
             self.count_total_resources - len(self.resource_name_matches) - unevaluated
         )
-
         msg = "%d compliant of %d total" % (compliant, self.count_total_resources)
         if self.resource_name_matches:
             msg += ", %d resources have %d policy violations" % (

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -141,7 +141,13 @@ class Summary(Output):
             self.resource_name_matches.add(r.resource.name)
 
     def on_execution_ended(self):
-        unevaluated = sum([v for k, v in self.counter_unevaluated_by_type.items() if k not in set(self.counter_policies_by_type)])
+        unevaluated = sum(
+            [
+                v
+                for k, v in self.counter_unevaluated_by_type.items()
+                if k not in set(self.counter_policies_by_type)
+            ]
+        )
         compliant = (
             self.count_total_resources - len(self.resource_name_matches) - unevaluated
         )

--- a/tools/c7n_left/c7n_left/utils.py
+++ b/tools/c7n_left/c7n_left/utils.py
@@ -6,6 +6,9 @@ from c7n.provider import clouds
 from c7n.loader import DirectoryLoader
 
 
+SEVERITY_LEVELS = {"critical": 0, "high": 10, "medium": 20, "low": 30, "unknown": 40}
+
+
 def load_policies(policy_dir, options):
 
     loader = DirectoryLoader(config=options)

--- a/tools/c7n_left/notes.md
+++ b/tools/c7n_left/notes.md
@@ -1,4 +1,15 @@
+---
 
+ctx with reporter and selection
+
+summary index ~ composition
+
+provider tag flow
+
+policy from zip / url
+
+variable support
+---
 
 # core
 

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -259,7 +259,7 @@ def test_multi_resource_policy(tmp_path):
     assert len(data["results"]) == 2
 
 
-def write_output_test_policy(tmp_path, policy=None):
+def write_output_test_policy(tmp_path, policy=None, policy_path="policy.json"):
     policies = (
         policy
         and {"policies": [policy]}
@@ -274,7 +274,7 @@ def write_output_test_policy(tmp_path, policy=None):
             ]
         }
     )
-    (tmp_path / "policy.json").write_text(json.dumps(policies))
+    (tmp_path / policy_path).write_text(json.dumps(policies))
 
 
 def test_cli_no_policies(tmp_path, caplog):

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -600,6 +600,32 @@ def test_selection_resource_filter(policy_env):
     assert resources[0]["__tfmeta"]["path"] == "aws_vpc.example"
 
 
+def test_selection_policy_invalid_values(policy_env):
+    policy_env.write_policy(
+        {
+            "name": "test-a",
+            "resource": "terraform.aws_vpc",
+            "metadata": {"severity": "abc", "category": True},
+        }
+    )
+
+    policy_env.write_policy(
+        {
+            "name": "test-b",
+            "resource": "terraform.aws_vpc",
+            "metadata": {"severity": ["abc"], "category": 1},
+        }
+    )
+
+    policies = policy_env.get_policies()
+
+    selection = policy_env.get_selection("severity=unknown")
+    assert {p.name for p in selection.filter_policies(policies)} == {"test-a", "test-b"}
+
+    selection = policy_env.get_selection("category=cost")
+    assert {p.name for p in selection.filter_policies(policies)} == set()
+
+
 def test_selection_policy_filter(policy_env):
     policy_env.write_policy(
         {

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -452,3 +452,9 @@ def test_cli_output_json(tmp_path):
             },
         }
     ]
+
+
+class TestExecution:
+    def test_empty_parse(self):
+        filters = core.ExecutionFilter.parse(Config.empty(filters=None))
+        assert len(filters) == 0


### PR DESCRIPTION
c7n-left support filtering on the cli via passing k=v pairs, also support multiple values (comma separated) and globbing.

```shell
c7n-left --filter "type=aws_rds*,aws_sqs_queue"
c7n-left --filter "severity=high"
c7n-left --filter "policy=*encryption*"
c7n-left --filter "id=aws_vpc.example"
```


todo 

- [x] resource id filter
- [x] policy category
- [x] move severity/category to policy metadata
