### PR TITLE
aws - config rule support preventative evaluation mode

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -1728,6 +1728,8 @@ class ConfigRule(AWSEventBase):
                 'MessageType': 'ScheduledNotification'
             }]
             params['MaximumExecutionFrequency'] = self.data['schedule']
+        if self.data.get('evaluation'):
+            params['EvaluationModes'] = [{'Mode': e.upper()} for e in self.data['evaluation']]
         return params
 
     def get(self, rule_name):

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -948,7 +948,10 @@ class ConfigRuleMode(LambdaMode):
     See `AWS Config <https://aws.amazon.com/config/>`_ for more details.
     """
     cfg_event = None
-    schema = utils.type_schema('config-rule', rinherit=LambdaMode.schema)
+    schema = utils.type_schema(
+        'config-rule',
+        evaluation={'type': 'array', 'items': {'enum': ['proactive', 'detective']}},
+        rinherit=LambdaMode.schema)
 
     def validate(self):
         super(ConfigRuleMode, self).validate()


### PR DESCRIPTION

support preventative evaluation on custodian config rules.

