### PR TITLE
add example policy to add lifecycle policy on bucket delete to empty bucket

### DIFF
--- a/docs/source/aws/examples/s3lifecyclepolicyonbucketdelete.rst
+++ b/docs/source/aws/examples/s3lifecyclepolicyonbucketdelete.rst
@@ -1,0 +1,44 @@
+S3 - Add lifecycle policy on bucket delete
+==================
+
+When a bucket is attempted to be deleted, add a lifecycle policy to empty the bucket. This is useful for more "ephemeral" environments to allow for async deletion of bucket objects which removes the need for consumers to manually empty buckets.
+
+Permissions required:
+
+- `"s3:GetBucketTagging"`
+- `"s3:GetLifecycleConfiguration"`
+- `"s3:ListAllMyBuckets"`
+- `"s3:PutLifecycleConfiguration"`
+
+
+.. code-block:: yaml
+
+  policies:
+    - name: add-lifecycle-policy-on-bucket-delete
+      comments: |
+        In dev, let's start emptying the bucket as soon as delete is requested so that we can have a more ephmeral environment for standup/teardown
+      resource: s3
+      mode:
+        type: cloudtrail
+        events:
+          - source: s3.amazonaws.com
+            event: DeleteBucket
+            ids: 'requestParameters.bucketName'
+        # Default behavior bails early due to the error code of BucketNotEmpty being present.
+        environment:
+          Variables:
+            C7N_SKIP_ERR_EVENT: 'no'
+      # Only put policy on buckets that have the env = dev tag for safety to ensure only "dev" environment buckets are targeted.
+      filters:
+        - tag:env: dev
+      actions:
+        - type: configure-lifecycle
+          rules:
+            - ID: empty-bucket
+              Status: Enabled
+              Filter:
+                Prefix: ''
+              Expiration:
+                Days: 1
+              NoncurrentVersionExpiration:
+                NoncurrentDays: 1


### PR DESCRIPTION
This PR adds an example custodian policy which adds an S3 lifecycle policy to a S3 buckets when a `DeleteBucket` event is triggered. This is a useful example for environments that are designed for standup/teardown and are more ephemeral in nature. It's a manual process to empty buckets and is much more efficient to have AWS do the work behind the scenes.

It took me a bit to get this together and working so I thought it would be good for other consumers to reference if they had a similar use case.