### PR TITLE
aws - docs - add example policies for the `finding` filter

### DIFF
--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -27,6 +27,50 @@ log = logging.getLogger('c7n.securityhub')
 
 class SecurityHubFindingFilter(Filter):
     """Check if there are Security Hub Findings related to the resources
+
+    :example:
+
+    By default, this filter checks to see if *any* findings exist for a given
+    resource:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: iam-roles-with-findings
+            resource: aws.iam-role
+            filters:
+              - finding
+
+    :example:
+
+    The ``query`` parameter can look for specific findings. Consult this
+    `reference <https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_AwsSecurityFindingFilters.html>`_
+    for more information about available filters and their structure. Note that when matching
+    by finding Id, it can be helpful to combine ``PREFIX`` comparisons with parameterized
+    account and region information:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: iam-roles-with-global-kms-decrypt
+            resource: aws.iam-role
+            filters:
+              - type: finding
+                query:
+                  Id:
+                    - Comparison: PREFIX
+                      Value: 'arn:aws:securityhub:{region}:{account_id}:subscription/aws-foundational-security-best-practices/v/1.0.0/KMS.2'  # noqa
+                  Title:
+                    - Comparison: EQUALS
+                      Value: >-
+                        KMS.2 IAM principals should not have IAM inline policies
+                        that allow decryption actions on all KMS keys
+                  ComplianceStatus:
+                    - Comparison: EQUALS
+                      Value: 'FAILED'
+                  RecordState:
+                    - Comparison: EQUALS
+                      Value: 'ACTIVE'
     """
     schema = type_schema(
         'finding',

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -31,7 +31,7 @@ class SecurityHubFindingFilter(Filter):
     :example:
 
     By default, this filter checks to see if *any* findings exist for a given
-    resource:
+    resource.
 
     .. code-block:: yaml
 
@@ -47,7 +47,7 @@ class SecurityHubFindingFilter(Filter):
     `reference <https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_AwsSecurityFindingFilters.html>`_
     for more information about available filters and their structure. Note that when matching
     by finding Id, it can be helpful to combine ``PREFIX`` comparisons with parameterized
-    account and region information:
+    account and region information.
 
     .. code-block:: yaml
 

--- a/tools/c7n_azure/c7n_azure/resources/alertlogs.py
+++ b/tools/c7n_azure/c7n_azure/resources/alertlogs.py
@@ -25,6 +25,7 @@ class AlertLogs(ArmResourceManager):
     """
 
     class resource_type(ArmResourceManager.resource_type):
+        doc_groups = ['Alerts Management']
 
         service = 'azure.mgmt.monitor'
         client = 'MonitorManagementClient'


### PR DESCRIPTION
Add example policies based on a question and follow-up discussion [in Slack](https://cloud-custodian.slack.com/archives/CAL4P6YE6/p1674566498920799) (also available through the [Linen public archive](https://linen.dev/s/cloud-custodian/t/8541950/is-anyone-familiar-with-using-the-aws-security-hub-with-cust)).

Also define `doc_groups` for the recently added `azure.alert-logs` resource. Without that property defined, I was seeing this error locally while testing the doc build:

```
Traceback (most recent call last):
  File "/home/aj/code/cloud-custodian/tools/c7n_sphinxext/c7n_sphinxext/docgen.py", line 254, in main
    _main(provider, output_dir, group_by)
  File "/home/aj/code/cloud-custodian/tools/c7n_sphinxext/c7n_sphinxext/docgen.py", line 337, in _main
    for key, group in sorted(groups.items()):
                      ^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

(That also meant there were no docs rendered for `azure.alert-logs`)

We might benefit from some combination of defining `doc_groups` by default or meta-testing Azure resources to ensure that each one defines its own doc groups, but that's a separate issue.