### PR TITLE
releng - directly publish docs instead of merging back to gh-pages branch

### DIFF
--- a/.github/composites/docs-publish/action.yaml
+++ b/.github/composites/docs-publish/action.yaml
@@ -13,7 +13,12 @@ runs:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}
 
-    - name: Setup aws cli
+    - name: Install Deps
+      shell: bash
+      run: |
+        pip install -U awscli
+
+    - name: Publish
       shell: bash
       run: |
         aws s3 sync docs/build/html s3://cloudcustodian.io/docs

--- a/.github/composites/docs-publish/action.yaml
+++ b/.github/composites/docs-publish/action.yaml
@@ -1,0 +1,19 @@
+name: "Publish Docs"
+description: "Publish docs to cloudcustodian.io"
+  aws-role:
+    description: 'AWS Credential Access Role'
+    required: true
+  aws-region:
+    default: 'us-east-1'
+runs:
+  using: "composite"
+  steps:
+    - uses: aws-actions/configure-aws-credentials@v1.7.0
+      with:
+        role-to-assume: ${{ inputs.aws-role }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Setup aws cli
+      shell: bash
+      run: |
+        aws s3 sync docs/build/html s3://cloudcustodian.io/docs

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -52,6 +52,9 @@ jobs:
   Docs:
     runs-on: ubuntu-latest
     needs: Lint
+    permissions:
+      id-token: write
+      contents: read    
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -116,11 +116,10 @@ jobs:
 
       - name: Deploy Docs
         if: ${{ github.event_name == 'push' }}
-        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        uses: ./.github/composites/docs-publish
         with:
-          branch: gh-pages
-          folder: docs/build/html
-          target-folder: docs
+          aws-role: ${{ secrets.DOC_PUBLISH_ROLE }}
+
 
   Tests:
     runs-on: "${{ matrix.os }}"


### PR DESCRIPTION
addresses #8136

instead of building up hundreds of mbs of generated ref docs and commiting back to gh pages, instead
directly publish the build output to the docs website.

