### PR TITLE
fix input typo

### DIFF
--- a/.github/composites/docs-publish/action.yaml
+++ b/.github/composites/docs-publish/action.yaml
@@ -1,5 +1,6 @@
 name: "Publish Docs"
 description: "Publish docs to cloudcustodian.io"
+inputs:
   aws-role:
     description: 'AWS Credential Access Role'
     required: true


### PR DESCRIPTION
doc publish pr has a typo. we should probably try a staging bucket till the website repo is also working with this nicely.

