### PR TITLE
enabling 'missing' filter for gcp

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
@@ -11,6 +11,7 @@ from c7n_gcp.query import QueryResourceManager, TypeInfo
 from c7n.resolver import ValuesFrom
 from c7n.utils import type_schema, local_session
 from c7n.filters.core import ValueFilter
+from c7n.filters.missing import Missing
 
 
 @resources.register('organization')
@@ -128,6 +129,9 @@ class Project(QueryResourceManager):
             for child in self.data.get('query'):
                 if 'filter' in child:
                     return {'filter': child['filter']}
+
+
+Project.filter_registry.register('missing', Missing)
 
 
 @Project.filter_registry.register('iam-policy')

--- a/tools/c7n_gcp/tests/data/flights/test_project_missing_filter_false/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/test_project_missing_filter_false/get-storage-v1-b_1.json
@@ -1,0 +1,100 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "storage#bucket", 
+        "name": "staging.cloud-custodian.appspot.com",
+        "timeCreated": "2019-02-28T14:45:53.549Z", 
+        "updated": "2019-02-28T14:45:53.549Z", 
+        "projectNumber": "518122731295", 
+        "defaultObjectAcl": [
+          {
+            "kind": "storage#objectAccessControl", 
+            "projectTeam": {
+              "projectNumber": "518122731295", 
+              "team": "owners"
+            }, 
+            "role": "OWNER", 
+            "etag": "CAE=", 
+            "entity": "project-owners-518122731295"
+          }, 
+          {
+            "kind": "storage#objectAccessControl", 
+            "projectTeam": {
+              "projectNumber": "518122731295", 
+              "team": "editors"
+            }, 
+            "role": "OWNER", 
+            "etag": "CAE=", 
+            "entity": "project-editors-518122731295"
+          }, 
+          {
+            "kind": "storage#objectAccessControl", 
+            "projectTeam": {
+              "projectNumber": "518122731295", 
+              "team": "viewers"
+            }, 
+            "role": "READER", 
+            "etag": "CAE=", 
+            "entity": "project-viewers-518122731295"
+          }
+        ], 
+        "metageneration": "1", 
+        "location": "EU", 
+        "iamConfiguration": {
+          "bucketPolicyOnly": {
+            "enabled": false
+          }
+        }, 
+        "owner": {
+          "entity": "project-owners-518122731295"
+        }, 
+        "etag": "CAE=", 
+        "lifecycle": {
+          "rule": [
+            {
+              "action": {
+                "type": "Delete"
+              }, 
+              "condition": {
+                "age": 15
+              }
+            }
+          ]
+        }, 
+        "acl": [
+          {
+            "kind": "storage#bucketAccessControl", 
+            "bucket": "staging.cloud-custodian.appspot.com",
+            "entity": "project-owners-518122731295", 
+            "etag": "CAE=", 
+            "role": "OWNER", 
+            "projectTeam": {
+              "projectNumber": "518122731295", 
+              "team": "owners"
+            }, 
+            "id": "staging.cloud-custodian.appspot.com/project-owners-518122731295",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/staging.cloud-custodian.appspot.com/acl/project-owners-518122731295"
+          }
+        ], 
+        "id": "staging.cloud-custodian.appspot.com",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/staging.cloud-custodian.appspot.com",
+        "storageClass": "STANDARD"
+      }
+    ], 
+    "kind": "storage#buckets"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "5925", 
+    "content-location": "https://www.googleapis.com/storage/v1/b?project=cloud-custodian&alt=json&projection=full",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "expires": "Thu, 07 Mar 2019 11:45:31 GMT", 
+    "vary": "Origin, X-Origin", 
+    "server": "UploadServer", 
+    "x-guploader-uploadid": "AEnB2UpSR4IxdUFknZKIuoaduRvzAopNX4xp8naqUMiEoJLbFtIEXsOiwruUHPaErWHiW4XvHgE0UfjPHI2uzlZpKfMi2S6Cow", 
+    "date": "Thu, 07 Mar 2019 11:45:31 GMT", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/test_project_missing_filter_false/get-v1-projects_1.json
+++ b/tools/c7n_gcp/tests/data/flights/test_project_missing_filter_false/get-v1-projects_1.json
@@ -1,0 +1,34 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Nov 2020 16:18:18 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=92",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "301",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v1/projects?filter=id%3Ahautomation&alt=json"
+  },
+  "body": {
+    "projects": [
+      {
+        "projectNumber": "518122731295",
+        "projectId": "hautomation",
+        "lifecycleState": "ACTIVE",
+        "name": "hautomation",
+        "createTime": "2020-10-23T02:19:32.329Z",
+        "parent": {
+          "type": "folder",
+          "id": "389734459213"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/test_project_missing_filter_true/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/test_project_missing_filter_true/get-storage-v1-b_1.json
@@ -1,0 +1,19 @@
+{
+  "body": {
+    "items": [],
+    "kind": "storage#buckets"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "5925", 
+    "content-location": "https://www.googleapis.com/storage/v1/b?project=cloud-custodian&alt=json&projection=full",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "expires": "Thu, 07 Mar 2019 11:45:31 GMT", 
+    "vary": "Origin, X-Origin", 
+    "server": "UploadServer", 
+    "x-guploader-uploadid": "AEnB2UpSR4IxdUFknZKIuoaduRvzAopNX4xp8naqUMiEoJLbFtIEXsOiwruUHPaErWHiW4XvHgE0UfjPHI2uzlZpKfMi2S6Cow", 
+    "date": "Thu, 07 Mar 2019 11:45:31 GMT", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/test_project_missing_filter_true/get-v1-projects_1.json
+++ b/tools/c7n_gcp/tests/data/flights/test_project_missing_filter_true/get-v1-projects_1.json
@@ -1,0 +1,34 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Nov 2020 16:18:18 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=92",
+    "alt-svc": "h3-Q050=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "301",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v1/projects?filter=id%3Ahautomation&alt=json"
+  },
+  "body": {
+    "projects": [
+      {
+        "projectNumber": "518122731295",
+        "projectId": "hautomation",
+        "lifecycleState": "ACTIVE",
+        "name": "hautomation",
+        "createTime": "2020-10-23T02:19:32.329Z",
+        "parent": {
+          "type": "folder",
+          "id": "389734459213"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/test_resource.py
+++ b/tools/c7n_gcp/tests/test_resource.py
@@ -13,7 +13,7 @@ from c7n_gcp.provider import resources
 ALLOWED_NOPERM = set((
     'or', 'and', 'not', 'value', 'reduce',
     'offhour', 'onhour', 'marked-for-op',
-    'event', 'webhook'))
+    'event', 'webhook', 'missing'))
 
 
 class ResourceMetaTest(BaseTest):

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -407,3 +407,41 @@ class ProjectTest(BaseTest):
 
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_project_missing_filter_false(self):
+        factory = self.replay_flight_data('test_project_missing_filter_false')
+
+        p = self.load_policy(
+            {
+                'name': 'resource',
+                'resource': 'gcp.project',
+                'filters': [{
+                    'type': 'missing',
+                    'policy': {
+                        'resource': 'gcp.bucket'}
+                }]
+            },
+            session_factory=factory
+        )
+
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    def test_project_missing_filter_true(self):
+        factory = self.replay_flight_data('test_project_missing_filter_true')
+
+        p = self.load_policy(
+            {
+                'name': 'resource',
+                'resource': 'gcp.project',
+                'filters': [{
+                    'type': 'missing',
+                    'policy': {
+                        'resource': 'gcp.bucket'}
+                }]
+            },
+            session_factory=factory
+        )
+
+        resources = p.run()
+        self.assertEqual(len(resources), 1)

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -445,3 +445,22 @@ class ProjectTest(BaseTest):
 
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_project_missing_filter_permissions(self):
+
+        p = self.load_policy(
+            {
+                'name': 'resource',
+                'resource': 'gcp.project',
+                'filters': [{
+                    'type': 'missing',
+                    'policy': {
+                        'resource': 'gcp.bucket'}
+                }]
+            }
+        )
+
+        perms = p.resource_manager.filters[0].get_permissions()
+
+        if not perms:
+            self.fail('missing permissions on \"missing\" filter')


### PR DESCRIPTION
'missing' filter exists and works for AWS, but it doesn't work for GCP. 
This PR is to enable that filter for GCP so we can use that filter in GCP policies as well.