### PR TITLE
aws - rds - include db instance option values

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -2034,30 +2034,30 @@ class DbOptionGroups(ValueFilter):
     policy_annotation = 'c7n:MatchedDBOptionGroups'
 
     def handle_optiongroup_cache(self, client, paginator, option_groups):
-        pgcache = {}
+        ogcache = {}
         cache = self.manager._cache
 
         with cache:
-            for pg in option_groups:
+            for og in option_groups:
                 cache_key = {
                     'region': self.manager.config.region,
                     'account_id': self.manager.config.account_id,
-                    'rds-pg': pg}
-                pg_values = cache.get(cache_key)
-                if pg_values is not None:
-                    pgcache[pg] = pg_values
+                    'rds-pg': og}
+                og_values = cache.get(cache_key)
+                if og_values is not None:
+                    ogcache[og] = og_values
                     continue
                 option_list = list(itertools.chain(*[p['OptionGroupsList']
-                    for p in paginator.paginate(OptionGroupName=pg)]))
+                    for p in paginator.paginate(OptionGroupName=og)]))
 
-                pgcache[pg] = {}
+                ogcache[og] = {}
                 for option in option_list:
                     if option['Options']:
                         for p in option['Options']:
-                            pgcache[pg].update(p)
-                cache.save(cache_key, pgcache[pg])
+                            ogcache[og].update(p)
+                cache.save(cache_key, ogcache[og])
 
-        return pgcache
+        return ogcache
 
     def process(self, resources, event=None):
         results = []
@@ -2068,11 +2068,13 @@ class DbOptionGroups(ValueFilter):
         optioncache = self.handle_optiongroup_cache(client, paginator, option_groups)
 
         for resource in resources:
-            for pg in resource['OptionGroupMemberships']:
-                pg_values = optioncache[pg['OptionGroupName']]
-                if self.match(pg_values):
+            for og in resource['OptionGroupMemberships']:
+                og_values = optioncache[og['OptionGroupName']]
+                if self.match(og_values):
                     resource.setdefault(self.policy_annotation, []).append({
-                        self.data.get('key'): self.data.get('value')})
+                        k: jmespath.search(k, og_values)
+                        for k in {'OptionName', self.data.get('key')}
+                    })
                     results.append(resource)
                     break
 

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -2040,7 +2040,7 @@ class DbOptionGroups(ValueFilter):
                 for option in option_list:
                     if option['Options']:
                         for p in option['Options']:
-                            pgcache[pg].update({'OptionName': p['OptionName']})
+                            pgcache[pg].update(p)
                 cache.save(cache_key, pgcache[pg])
 
         return pgcache

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -2012,6 +2012,20 @@ class DbOptionGroups(ValueFilter):
                 key: OptionName
                 value: NATIVE_NETWORK_ENCRYPTION
                 op: eq
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: rds-oracle-encryption-in-transit
+            resource: aws.rds
+            filters:
+              - Engine: oracle-ee
+              - type: db-option-groups
+                key: OptionSettings[?Name == 'SQLNET.ENCRYPTION_SERVER'].Value
+                value:
+                  - REQUIRED
     """
 
     schema = type_schema('db-option-groups', rinherit=ValueFilter.schema)

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -21,7 +21,6 @@ log = logging.getLogger("c7n.iac")
 
 
 class IACSourceProvider(Provider):
-
     display_name = "IAC"
 
     def get_session_factory(self, options):
@@ -93,7 +92,6 @@ class PolicyMetadata:
 
 
 class ExecutionFilter:
-
     supported_filters = ("policy", "type", "severity", "category", "id")
 
     def __init__(self, filters):
@@ -298,7 +296,6 @@ class PolicyResourceResult:
 
 
 class IACResourceManager(ResourceManager):
-
     filter_registry = FilterRegistry("iac.filters")
     action_registry = ActionRegistry("iac.actions")
     log = log
@@ -319,7 +316,6 @@ IACResourceManager.filter_registry.register("traverse", Traverse)
 
 
 class IACResourceMap(object):
-
     resource_class = None
 
     def __init__(self, prefix):

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -304,7 +304,6 @@ class MultiOutput:
 
 
 class GithubFormat(Output):
-
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
 
     def on_results(self, results):

--- a/tools/c7n_left/c7n_left/providers/terraform/graph.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/graph.py
@@ -7,7 +7,6 @@ from .resource import TerraformResource
 
 
 class TerraformGraph(ResourceGraph):
-
     resolver = None
 
     def __len__(self):

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -27,13 +27,11 @@ class TerraformResourceManager(IACResourceManager):
 
 
 class TerraformResourceMap(IACResourceMap):
-
     resource_class = TerraformResourceManager
 
 
 @clouds.register("terraform")
 class TerraformProvider(IACSourceProvider):
-
     display_name = "Terraform"
     resource_prefix = "terraform"
     resource_map = TerraformResourceMap(resource_prefix)
@@ -58,5 +56,4 @@ class TerraformProvider(IACSourceProvider):
 
 @execution.register("terraform-source")
 class TerraformSource(IACSourceMode):
-
     schema = type_schema("terraform-source")

--- a/tools/c7n_left/c7n_left/providers/terraform/resource.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/resource.py
@@ -4,7 +4,6 @@
 
 
 class TerraformResource(dict):
-
     __slots__ = ("name", "data", "location")
 
     # pygments lexer

--- a/tools/c7n_left/c7n_left/utils.py
+++ b/tools/c7n_left/c7n_left/utils.py
@@ -10,7 +10,6 @@ SEVERITY_LEVELS = {"critical": 0, "high": 10, "medium": 20, "low": 30, "unknown"
 
 
 def load_policies(policy_dir, options):
-
     loader = DirectoryLoader(config=options)
     policies = loader.load_directory(policy_dir)
     if not policies:


### PR DESCRIPTION
Include the entire DBOptionGroup structure. Allows for filtering on facets other than the group name.

For example, this change enables filters like

```
- type: db-option-groups
  key: OptionSettings[?Name == 'SQLNET.ENCRYPTION_SERVER'].Value
  value:
    - REQUIRED
  op: ne
 ```