### PR TITLE
aws - shield - handle elastic ip arn type delta

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -203,7 +203,7 @@ class PolicyMetaLint(BaseTest):
         overrides = overrides.difference(
             {'account', 's3', 'hostedzone', 'log-group', 'rest-api', 'redshift-snapshot',
              'rest-stage', 'codedeploy-app', 'codedeploy-group', 'fis-template', 'dlm-policy',
-             'apigwv2', })
+             'apigwv2', 'shield-protection'})
         if overrides:
             raise ValueError("unknown arn overrides in %s" % (", ".join(overrides)))
 
@@ -615,11 +615,11 @@ class PolicyMetaLint(BaseTest):
     def test_resource_arn_info(self):
         missing = []
         whitelist_missing = {
-            'rest-stage', 'rest-resource', 'rest-vpclink', 'rest-client-certificate'}
+            'rest-stage', 'rest-resource', 'rest-vpclink', 'rest-client-certificate',
+            'shield-protection', 'shield-attack'}
         explicit = []
         whitelist_explicit = {
-            'rest-account', 'shield-protection', 'shield-attack',
-            'dlm-policy', 'efs', 'efs-mount-target', 'gamelift-build',
+            'rest-account', 'dlm-policy', 'efs', 'efs-mount-target', 'gamelift-build',
             'glue-connection', 'glue-dev-endpoint', 'cloudhsm-cluster',
             'snowball-cluster', 'snowball', 'ssm-activation',
             'healthcheck', 'event-rule-target', 'log-metric',


### PR DESCRIPTION
From a [Slack discussion](https://cloud-custodian.slack.com/archives/CAL4P6YE6/p1675203479130419), looks like Shield uses a different ARN "resource type" segment for Elastic IPs. Where the Resource Groups Tagging API and IAM use `elastic-ip`, Shield uses `eip-allocation`.

References:
https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html#amazonec2-elastic-ip
https://docs.aws.amazon.com/waf/latest/DDOSAPIReference/API_CreateProtection.html

Now I don't have a Shield subscription handy, so... I don't actually know if this will fix the issue. Testing/contributions welcome from impacted folks like @naohito-intuit , @darrendao and @StevenGunn .

Some of the logic may need to be tweaked/inverted/etc. If there are any failures, contributing responses for test data would be helpful.