### PR TITLE
gcp - mu - include boto3 in cloudfunctions requirements

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/mu.py
+++ b/tools/c7n_gcp/c7n_gcp/mu.py
@@ -36,6 +36,7 @@ def custodian_archive(packages=None, deps=()):
     # note we pin requirements to the same versions installed locally.
     requirements = set()
     requirements.update((
+        'boto3',
         'jmespath',
         'retrying',
         'python-dateutil',


### PR DESCRIPTION
Closes #8239 

From chatting with @tomarv2 it seems like this issue goes back a while. There may be other changes we can make (like lazily importing modules as we did in https://github.com/cloud-custodian/cloud-custodian/pull/7857) so that we don't need boto3/botocore on the gcp side. But for an initial pass, it seems safer to include it.