### PR TITLE
releng - docker test image needs new oci name field

### DIFF
--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -139,6 +139,7 @@ def test_image_metadata(image_name):
         "org.opencontainers.image.description",
         "org.opencontainers.image.documentation",
         "org.opencontainers.image.licenses",
+        "org.opencontainers.image.ref.name",
         "org.opencontainers.image.title",
         "org.opencontainers.image.source",
         "org.opencontainers.image.revision",


### PR DESCRIPTION
trunk docker images builds were failing during tests due to a new (?) oci image field in the metadata
for org.opencontainers.image.ref.name. add that to the test so the test can pass.

