### PR TITLE
aws - autotag action - add principalId as option for value field

### DIFF
--- a/c7n/actions/autotag.py
+++ b/c7n/actions/autotag.py
@@ -65,7 +65,8 @@ class AutoTagUser(EventAction):
                      'enum': [
                          'userName',
                          'arn',
-                         'sourceIPAddress'
+                         'sourceIPAddress',
+                         'principalId'
                      ]},
            }
     )
@@ -103,6 +104,8 @@ class AutoTagUser(EventAction):
             value = event['userIdentity'].get('arn', '')
         elif vtype == "sourceIPAddress":
             value = event.get('sourceIPAddress', '')
+        elif vtype == "principalId":
+            value = event['userIdentity'].get('principalId', '')
 
         return value
 


### PR DESCRIPTION
As seen in the code [here](https://github.com/cloud-custodian/cloud-custodian/blob/ab940b15f2a8a2afb2fd4eeabc11f92c38943834/c7n/actions/autotag.py#L122), the `principal_id_tag` added by Cloud Custodian is sometimes not equal to the value of `principalId` in the event JSON. My use-case is similar to that given in the issue [here](https://github.com/cloud-custodian/cloud-custodian/issues/3691) in that I want to use the tag for IAM enforcement based on creator identity. This PR gives the ability to do so by passing the exact value of `principalId` through to the tag which Cloud Custodian adds.