### PR TITLE
Correct typo in setup.py python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url="https://github.com/cloud-custodian/cloud-custodian",
     license="Apache-2.0",
     packages=find_packages(),
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3, !=3.4, !=3.5, <4'",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3, !=3.4, !=3.5, <4",
     entry_points={
         'console_scripts': [
             'custodian = c7n.cli:main']},


### PR DESCRIPTION
The trailing single-quote in the python_requires string causes build errors when parsed in setuptools>=61 which causes build failures.

It would be really awesome for those of us that still rely on the 0.8.x releases if this could be fixed and possibly released as a minor version, if possible.