### PR TITLE
Fix naming conflict between validate argument and imported function

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -34,7 +34,7 @@ def load(options, path, format=None, validate=True, vars=None):
     if not os.path.exists(path):
         raise IOError("Invalid path for config %r" % path)
 
-    from c7n.schema import validate, StructureParser
+    from c7n.schema import validate as schema_validate, StructureParser
     if os.path.isdir(path):
         from c7n.loader import DirectoryLoader
         collection = DirectoryLoader(options).load_directory(path)
@@ -55,7 +55,7 @@ def load(options, path, format=None, validate=True, vars=None):
         return None
 
     if validate:
-        errors = validate(data, resource_types=rtypes)
+        errors = schema_validate(data, resource_types=rtypes)
         if errors:
             raise PolicyValidationError(
                 "Failed to validate policy %s \n %s" % (

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -37,7 +37,7 @@ def load(options, path, format=None, validate=True, vars=None):
     from c7n.schema import validate as schema_validate, StructureParser
     if os.path.isdir(path):
         from c7n.loader import DirectoryLoader
-        collection = DirectoryLoader(options).load_directory(path)
+        collection = DirectoryLoader(options).load_directory(path, validate)
         if validate:
             [p.validate() for p in collection]
         return collection


### PR DESCRIPTION
The `validate` argument of `c7n.policy.load()` conflicts with the import statement on line 37 importing `c7n.schema.validate()`. Subsequent if expressions that appear to test the argument are actually testing that the callable `c7n.schema.validate()` function exists. This prevents anything calling `load()` with `validate=False` from preventing validation as expected.

The fix here is to import _as_ to rename the callable rather than rename the argument which might break other things calling the `load()` function.

This will only change the behavior of anything calling `load()` with `validate=False` so that validation does not occur as intended.