### PR TITLE
releng - actions - use github.sha for concurrency grouping when not in a pr

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -11,7 +11,7 @@ on:
       - master
       - main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
   Lint:


### PR DESCRIPTION
closees #8278
