### PR TITLE
aws - rdscluster - resolve the resource mapping issue in config rule

### DIFF
--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -67,6 +67,7 @@ class RDSCluster(QueryResourceManager):
         arn_separator = ":"
         enum_spec = ('describe_db_clusters', 'DBClusters', None)
         name = id = 'DBClusterIdentifier'
+        config_id = 'DbClusterResourceId'
         dimension = 'DBClusterIdentifier'
         universal_taggable = True
         permissions_enum = ('rds:DescribeDBClusters',)


### PR DESCRIPTION
Resolve the resource mapping issue in AWS Config rule

When we click  PEv2 rule under AWS Config > Rules >Resources in scope
Upon clicking on one of the listed resource links, we see an AWS error saying `Error - The specified resource is either unknown or has not been discovered.`