### PR TITLE
aws - s3 output bucket region determination refactor

### DIFF
--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -150,7 +150,7 @@ class MetricsFilter(Filter):
         schedule defined here:
 
         https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Metric
-        """ # noqa: E501
+        """  # noqa: E501
 
         duration = timedelta(self.days)
         now = datetime.utcnow()

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -21,7 +21,7 @@ from abc import ABC, abstractmethod
 
 from c7n.exceptions import InvalidOutputConfig
 from c7n.registry import PluginRegistry
-from c7n.utils import parse_url_config
+from c7n.utils import parse_url_config, join_output_path
 
 try:
     import psutil
@@ -511,9 +511,10 @@ class BlobOutput(DirectoryOutput):
 
     def get_output_path(self, output_url):
         if '{' not in output_url:
-            date_path = datetime.datetime.utcnow().strftime('%Y/%m/%d/%H')
-            return "/".join(
-                [s.strip('/') for s in [output_url, self.ctx.policy.name, date_path]]
+            return join_output_path(
+                output_url.strip('/'),
+                self.ctx.policy.name,
+                datetime.datetime.utcnow().strftime('%Y/%m/%d/%H')
             )
         return output_url.format(**self.get_output_vars()).rstrip('/')
 

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -25,6 +25,7 @@ from c7n import deprecated, utils
 from c7n.version import version
 from c7n.query import RetryPageIterator
 from c7n.varfmt import VarFormat
+from c7n.utils import get_policy_provider
 
 log = logging.getLogger('c7n.policy')
 
@@ -1151,13 +1152,7 @@ class Policy:
 
     @property
     def provider_name(self) -> str:
-        if isinstance(self.resource_type, list):
-            provider_name, _ = self.resource_type[0].split('.', 1)
-        elif '.' in self.resource_type:
-            provider_name, resource_type = self.resource_type.split('.', 1)
-        else:
-            provider_name = 'aws'
-        return provider_name
+        return get_policy_provider(self.data)
 
     def is_runnable(self, event=None):
         return self.conditions.evaluate(event)

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -57,7 +57,7 @@ class URIResolver:
         if parsed.query:
             params.update(dict(parse_qsl(parsed.query)))
         region = params.pop('region', None)
-        client = self.session_factory().client('s3', region_name=region) 
+        client = self.session_factory().client('s3', region_name=region)
         result = client.get_object(**params)
         body = result['Body'].read()
         if isinstance(body, str):

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -57,7 +57,7 @@ class URIResolver:
         if parsed.query:
             params.update(dict(parse_qsl(parsed.query)))
         region = params.pop('region', None)
-        client = self.session_factory().client('s3', region=region) 
+        client = self.session_factory().client('s3', region_name=region) 
         result = client.get_object(**params)
         body = result['Body'].read()
         if isinstance(body, str):

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -51,12 +51,13 @@ class URIResolver:
 
     def get_s3_uri(self, uri):
         parsed = urlparse(uri)
-        client = self.session_factory().client('s3')
         params = dict(
             Bucket=parsed.netloc,
             Key=parsed.path[1:])
         if parsed.query:
             params.update(dict(parse_qsl(parsed.query)))
+        region = params.pop('region', None)
+        client = self.session_factory().client('s3', region=region) 
         result = client.get_object(**params)
         body = result['Body'].read()
         if isinstance(body, str):

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -174,7 +174,7 @@ def get_bucket_url_with_region(bucket_url, region):
     return urlparse.urlunparse(parts)
     
 
-def inspect_bucket_region(bucket, s3_endpoint):
+def inspect_bucket_region(bucket, s3_endpoint, allow_public=False):
     """Attempt to determine a bucket region without a client
 
     We can make an unauthenticated HTTP HEAD request to S3 in an attempt to find a bucket's
@@ -215,7 +215,10 @@ def inspect_bucket_region(bucket, s3_endpoint):
         # we can ignore those specific checks.
         #
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected # noqa
-        urlopen(request)  # nosec B310
+        response = urlopen(request)  # nosec B310
+        region = response.headers.get('x-amz-bucket-region')
+        if not allow_public:
+            raise ValueError("bucket: '{bucket}' is publicly accessible")
     except HTTPError as err:
         # Returns 404 'Not Found' for buckets that don't exist
         if err.status == 404:

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -125,7 +125,10 @@ def _default_bucket_region(options):
     if parsed.query and s3_conf.get('region'):
         return
 
-    client = boto3.client('s3', region_name=options.regions[0])
+    params = {}
+    if options.regions:
+        params['region_name'] = options.regions[0]
+    client = boto3.client('s3', **params)
     region = get_bucket_region_clientless(s3_conf.netloc, client.meta.endpoint_url)
     if not region:
         try:

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -622,6 +622,22 @@ def parse_url_config(url):
     return conf
 
 
+def join_output_path(output_path, *parts):
+    # allow users to specify interpolated output paths
+    if '{' in output_path:
+        return output_path
+
+    if "://" not in output_path:
+        return os.path.join(output_path, *parts)
+
+    # handle urls with query strings
+    parsed = urlparse.urlparse(output_path)
+    updated_path = os.path.join(parsed.path, *parts)
+    parts = list(parsed)
+    parts[2] = updated_path
+    return urlparse.urlunparse(parts)
+
+
 def get_policy_provider(policy_data):
     if isinstance(policy_data['resource'], list):
         provider_name, _ = policy_data['resource'][0].split('.', 1)

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -631,6 +631,7 @@ def get_policy_provider(policy_data):
         provider_name = 'aws'
     return provider_name
 
+
 def get_proxy_url(url):
     proxies = getproxies()
     parsed = urlparse.urlparse(url)

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -622,6 +622,15 @@ def parse_url_config(url):
     return conf
 
 
+def get_policy_provider(policy_data):
+    if isinstance(policy_data['resource'], list):
+        provider_name, _ = policy_data['resource'][0].split('.', 1)
+    elif '.' in policy_data['resource']:
+        provider_name, resource_type = policy_data['resource'].split('.', 1)
+    else:
+        provider_name = 'aws'
+    return provider_name
+
 def get_proxy_url(url):
     proxies = getproxies()
     parsed = urlparse.urlparse(url)

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -632,7 +632,7 @@ def join_output_path(output_path, *parts):
 
     # handle urls with query strings
     parsed = urlparse.urlparse(output_path)
-    updated_path = "/".join(parsed.path, *parts)
+    updated_path = "/".join((parsed.path, *parts))
     parts = list(parsed)
     parts[2] = updated_path
     return urlparse.urlunparse(parts)

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -632,7 +632,7 @@ def join_output_path(output_path, *parts):
 
     # handle urls with query strings
     parsed = urlparse.urlparse(output_path)
-    updated_path = os.path.join(parsed.path, *parts)
+    updated_path = "/".join(parsed.path, *parts)
     parts = list(parsed)
     parts[2] = updated_path
     return urlparse.urlunparse(parts)

--- a/docs/source/aws/usage.rst
+++ b/docs/source/aws/usage.rst
@@ -85,7 +85,7 @@ To send your logs to a region in the master account use::
 
 This will set up a stream for every region/account you run custodian against within the specified log group. 
 
-The default log stream format looks like this:
+The default log stream format looks like this::
 
   account_id/region/policy_name
 
@@ -93,7 +93,8 @@ If you want to override this then you can pass the the log stream parameter like
 
   custodian run --log-group="aws://master/<log-group-name>?region=<region>&stream=custodian_{region}_{account}_{policy} <policyfile>.yml"
 
-it currently accepts these variables:
+it currently accepts these variables::
+
   {account}: the account where the check was executed.
   {region}: the region where the check was executed.
   {policy}: the name of the policy that was executed.
@@ -108,6 +109,32 @@ with its log files for archival purposes.
 The S3 bucket and prefix can be specified via parameters::
 
   custodian run --output-dir s3://<my-bucket>/<my-prefix> <policyfile>.yml
+
+
+Custodian will attempt to auto detect the bucket's region, but it can
+also be explicitly specified by adding a query parameter region::
+
+  custodian run --output-dir s3://some-bucket/some-prefix?region=us-west-2 mypolicies.yml
+
+
+By default the output location suffix is {policy_name}/{now:%Y}/{now:%m}/{now:%d}/{now:%H}
+
+.. warning::
+
+   The customizing the default s3 output location is incompatible with the report
+   commands.
+
+It can be customized by specifying a custom output location::
+
+   custodian run --output-dir s3://some-bucket/some-prefix/{account}/{now:%Y}-{now:%m}/{uuid}
+
+it currently accepts these variables::
+
+  {account}: the account where the check was executed.
+  {region}: the region where the check was executed.
+  {policy_name}: the name of the policy that was executed.
+  {now}: a datetime representing utc timestamp (see formatting options https://pyformat.info/#datetime)
+  {uuid}: a one time uuid
 
 Reports
 -------

--- a/tests/data/vcr_cassettes/test_output/bucket_not_found.yaml
+++ b/tests/data/vcr_cassettes/test_output/bucket_not_found.yaml
@@ -1,0 +1,32 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:57:29 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - 4ol7/6QWURYnvhOGJkpDirDrY5P/WDIc+0WDEWkAJY+7cUzWsdU5wCM4L0/J6ZsE6boOnq8pB+U=
+      x-amz-request-id:
+      - E1PJ4QBA7P4JGVDD
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/data/vcr_cassettes/test_output/cross_region.yaml
+++ b/tests/data/vcr_cassettes/test_output/cross_region.yaml
@@ -1,0 +1,162 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.us-west-2.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.us-west-2.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:52:09 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - MkXiMw1yTeyVvSEbKz0u+mt98At8XaW2X11amisH7vcIr8983i+EiZ7csCsyndmNdZJs7aOWpMI=
+      x-amz-request-id:
+      - 8DGDM3HQBFKE238B
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.us-west-2.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.us-west-2.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:54:12 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - tfwwGq2B5HoIFQ862G1hI3Oju5/inpw3+BRlDqbpZCgR6HyWXh9Y2xa5hPoRmH3S7WlcTJjci0M=
+      x-amz-request-id:
+      - YNH9286KRVVN4694
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.us-west-2.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.us-west-2.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:55:23 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - zJrNdEMDQNmGSLSzoCCN2idTVcODWw3MwwgtFtKLa7NkVBepEZ9yqK8SUgYBrMJT4bNNuJCioJ8=
+      x-amz-request-id:
+      - JZT2F8K3JB00AMK8
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.us-west-2.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.us-west-2.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:57:20 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - iBf20guJUvSFI6lBuVcIatIF65zv37698qytK47kiMT40jh3+gVSFEZMnNnqslVzrWB1ZXn3/fI=
+      x-amz-request-id:
+      - 25XQ74ST20F0M8H3
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.us-west-2.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.us-west-2.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:57:29 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - /+Kqysguj3jBVzyBenGhpXCmHTlh1SuEJKdY03zQOPBQzsY8LYlBawCl2Buk+iy77nz0ytsyPSg=
+      x-amz-request-id:
+      - E1PGBG8RFDGK3C9F
+    status:
+      code: 301
+      message: Moved Permanently
+version: 1

--- a/tests/data/vcr_cassettes/test_output/default_bucket_not_found.yaml
+++ b/tests/data/vcr_cassettes/test_output/default_bucket_not_found.yaml
@@ -239,4 +239,64 @@ interactions:
     status:
       code: 404
       message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.us-west-2.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.us-west-2.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 23:31:03 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - mT3g8cYh+V9SLCP+nNfRfa1fud7+6Pk48HY5WV+zljjnC8S9aE0XnmJVtZfEbugjbOwZpO6ZeH0=
+      x-amz-request-id:
+      - JDG2B7NZFVRKWNDW
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.us-west-2.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.us-west-2.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 23:31:29 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - ouq5nPVXnW+nEj1kk8OFp2mW6oVp4Atj3tGJLkrnLNam8MprSIb6T0vaELcR921dNblKmFIz21E=
+      x-amz-request-id:
+      - C3YPBM27CZEYHE86
+    status:
+      code: 404
+      message: Not Found
 version: 1

--- a/tests/data/vcr_cassettes/test_output/default_bucket_not_found.yaml
+++ b/tests/data/vcr_cassettes/test_output/default_bucket_not_found.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:15:20 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - dNeyY3qL6g/bDknlhnP4om7TwMk3NaYsOv3pn/aBaSllwSOXzT//WhzKNgoarJ33AOT/cP5kfGk=
+      x-amz-request-id:
+      - 4VSPMH9HR96ZB89B
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:15:53 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - dJFdoSMBEH4PQlDC3Xrktg/nr381ojwSCZomart0yIe0KAJxGz5KBS1AT4d7lixk2LRJsARs7os=
+      x-amz-request-id:
+      - KD3ZWXHDKJTREN5J
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:18:09 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - kLTAD15uDe0a3eFH+FMVJhC4wXX7ua+D4giKH+/JzR6AnhUqdZzlAoeksFjCg5NKpCAWa4vo8Vg=
+      x-amz-request-id:
+      - 3RE7F4PKWGCF582K
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:19:16 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - 4l/w4ZniBcELzdjAG74n7+8gWaZ8jGztqRyv6i3OSCrU7156Dp+AMlQSpokCWu5eIQxaAr6O1IU=
+      x-amz-request-id:
+      - 21FS96B2NEFR99X0
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:19:59 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - nhTP2ytcgvUh1YjDq6KFChZMXf+qEom98ZFq3f7IITh51mJxDi3OJ2MNoeHTE8X8NqMixFXouLI=
+      x-amz-request-id:
+      - GJKAB3VM8S19VGR2
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:21:27 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - qoPgO3cMnZOIZajqHhjD3THNjOMWU25440waH/9ALJ/KLzKZ3dQjRQ+wMr0q8AL4PwgVx5K3wj0=
+      x-amz-request-id:
+      - P4CQXSR2AMQF1PNN
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:21:51 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - U+4dui0rn9LxGXqdrfwG84AaLvS8m2rntk1Sd8m2RF2X/Y0H1RqxlmSJQ9s/3VyrRX4vRpEjRrU=
+      x-amz-request-id:
+      - WXP4MY2E9GC9NK0K
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/myfakebucketdoesnotexist
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:22:20 GMT
+      Server:
+      - AmazonS3
+      x-amz-id-2:
+      - EWP4pQaIQLpAForvZGOPZyc/Xkhw8t3b1H3PbnmhzxVJqvX4kL7Ngq9TUtDXG6joINh4I2rOuwc=
+      x-amz-request-id:
+      - 6NSKCCNF9NHVNPZ0
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/data/vcr_cassettes/test_output/default_bucket_region.yaml
+++ b/tests/data/vcr_cassettes/test_output/default_bucket_region.yaml
@@ -1,0 +1,34 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 20:15:53 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - oCOfF7Wy17vhW/vYIxbjks3NfruzKqkz0XqA2pJRbMXrqNUBQwhNnlBLHZLXvFdFO3cvX0wt6ac=
+      x-amz-request-id:
+      - KD3SNKAVPCH5VM14
+    status:
+      code: 403
+      message: Forbidden
+version: 1

--- a/tests/data/vcr_cassettes/test_output/same_region.yaml
+++ b/tests/data/vcr_cassettes/test_output/same_region.yaml
@@ -1,0 +1,290 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:52:10 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - vrKJRR0kU4W31aWya0CR2HT/Sm2jKJL9diIrmuO8JIXqL0f+bCb6zDXNIgqeTF6/CL+617AGkBM=
+      x-amz-request-id:
+      - 8DG2X16KE26FE8QT
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:54:13 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - H/sCZgZEuAgj2EQKpQOsb+JS6Zetyf+2zyahqyCmyK8CGGuxShEpznof1Wo/eVl6LrN7gGJZxUI=
+      x-amz-request-id:
+      - YNH0BCK95XBWJF5B
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:54:13 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - HcxVZdlrv1QoUb8T9UHi/by7iHrqX3VO4fFoqj/BqnQpZ/EDHSHW+K9lhaPbypw8cJz6+aZO1sg=
+      x-amz-request-id:
+      - YNHDZ33556EB72YN
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:55:24 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - /602elliXP0akMShquY9niZ0rH4knzrivCpIIwBkkRvl4XehxFGd5WY3QjFIBdcD3BBqmunINSg=
+      x-amz-request-id:
+      - JZT48WFZHQE91W94
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:55:24 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - D6VC3jIDnL2Uh9jhVp8rgP2O4VWfgPZIIl8gpltkdROsuOQUw2z4KbDUrucAS+azB2uW7zpFPuw=
+      x-amz-request-id:
+      - JZTE849MNEYQRZ78
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:57:19 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - a6DEElQhOOdLdx7xCUyYLu/fyGvgLmrHVTHeV855LzWDdXlZDe4Eqc4F7FT8rBMxe8QIup9Cz3U=
+      x-amz-request-id:
+      - 25XK0QCKJH7FSDD6
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:57:19 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - Tnl+AJNjafTzfCPa4nI2xCUwPQ5k66Bc/cWbs/69hDKVtqc/PzPx5jdR4G1D2L4k+z7GSp18FsU=
+      x-amz-request-id:
+      - 25XGYYAAQW3YY87Y
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:57:30 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - HywbAjl7c4ppyylvY7YEq8JcURGc9XAtLa+TSU9r66yVfbQA85B06qUhIQ0SQcpX6FaDnKy4YRk=
+      x-amz-request-id:
+      - E1PKD7EM0NJ4C1W5
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - s3.amazonaws.com
+      User-Agent:
+      - Python-urllib/3.10
+    method: HEAD
+    uri: https://s3.amazonaws.com/slack.cloudcustodian.io
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Date:
+      - Thu, 16 Feb 2023 19:57:30 GMT
+      Server:
+      - AmazonS3
+      x-amz-bucket-region:
+      - us-east-1
+      x-amz-id-2:
+      - TUv6JHrn6wWtS01ZY4Vb40f9BXi3xHS7KQTriQEF8Os/LqtVKLR0VJZhmnEn5djkCeDXq6Q7dE4=
+      x-amz-request-id:
+      - E1PSMX799YXAD8SQ
+    status:
+      code: 403
+      message: Forbidden
+version: 1

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -394,7 +394,7 @@ def test_default_bucket_region_with_explicit_region():
     'tests/data/vcr_cassettes/test_output/default_bucket_region_public.yaml', record_mode='all')
 def test_default_bucket_region_is_public():
     output_dir = "s3://awsapichanges.info"
-    conf = Config.empty(output_dir=output_dir, region="us-west-2")
+    conf = Config.empty(output_dir=output_dir, regions=["us-east-1"])
     with pytest.raises(InvalidOutputConfig) as ecm:
         aws._default_bucket_region(conf)
 
@@ -405,7 +405,7 @@ def test_default_bucket_region_is_public():
     'tests/data/vcr_cassettes/test_output/default_bucket_region.yaml', record_mode='none')
 def test_default_bucket_region_s3():
     output_dir = "s3://slack.cloudcustodian.io"
-    conf = Config.empty(output_dir=output_dir, region="all")
+    conf = Config.empty(output_dir=output_dir, regions=["all"])
     aws._default_bucket_region(conf)
     assert conf.output_dir == output_dir + "?region=us-east-1"
 
@@ -414,7 +414,7 @@ def test_default_bucket_region_s3():
     'tests/data/vcr_cassettes/test_output/default_bucket_not_found.yaml', record_mode='none')
 def test_default_bucket_region_not_found():
     output_dir = "s3://myfakebucketdoesnotexist"
-    conf = Config.empty(output_dir=output_dir, region="us-west-2")
+    conf = Config.empty(output_dir=output_dir, regions=["us-west-2"])
     with pytest.raises(InvalidOutputConfig) as ecm:
         aws._default_bucket_region(conf)
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -469,7 +469,7 @@ def test_default_bucket_region_with_explicit_region():
 
 
 @vcr.use_cassette(
-    'tests/data/vcr_cassettes/test_output/default_bucket_region_public.yaml', record_mode='all')
+    'tests/data/vcr_cassettes/test_output/default_bucket_region_public.yaml')
 def test_default_bucket_region_is_public():
     output_dir = "s3://awsapichanges.info"
     conf = Config.empty(output_dir=output_dir, regions=["us-east-1"])
@@ -480,7 +480,7 @@ def test_default_bucket_region_is_public():
 
 
 @vcr.use_cassette(
-    'tests/data/vcr_cassettes/test_output/default_bucket_region.yaml', record_mode='none')
+    'tests/data/vcr_cassettes/test_output/default_bucket_region.yaml')
 def test_default_bucket_region_s3():
     output_dir = "s3://slack.cloudcustodian.io"
     conf = Config.empty(output_dir=output_dir, regions=["all"])
@@ -489,7 +489,7 @@ def test_default_bucket_region_s3():
 
 
 @vcr.use_cassette(
-    'tests/data/vcr_cassettes/test_output/default_bucket_not_found.yaml', record_mode='none')
+    'tests/data/vcr_cassettes/test_output/default_bucket_not_found.yaml')
 def test_default_bucket_region_not_found():
     output_dir = "s3://myfakebucketdoesnotexist"
     conf = Config.empty(output_dir=output_dir, regions=["us-west-2"])
@@ -500,7 +500,7 @@ def test_default_bucket_region_not_found():
 
 
 @vcr.use_cassette(
-    'tests/data/vcr_cassettes/test_output/bucket_not_found.yaml', record_mode='none')
+    'tests/data/vcr_cassettes/test_output/bucket_not_found.yaml')
 def test_get_bucket_url_s3_not_found():
     with pytest.raises(ValueError) as ecm:
         aws.get_bucket_url_with_region(
@@ -510,7 +510,7 @@ def test_get_bucket_url_s3_not_found():
 
 
 @vcr.use_cassette(
-    'tests/data/vcr_cassettes/test_output/cross_region.yaml', record_mode='none')
+    'tests/data/vcr_cassettes/test_output/cross_region.yaml')
 def test_get_bucket_url_s3_cross_region():
     assert aws.get_bucket_url_with_region(
         "s3://slack.cloudcustodian.io",
@@ -518,7 +518,7 @@ def test_get_bucket_url_s3_cross_region():
 
 
 @vcr.use_cassette(
-    'tests/data/vcr_cassettes/test_output/same_region.yaml', record_mode='none')
+    'tests/data/vcr_cassettes/test_output/same_region.yaml')
 def test_get_bucket_url_s3_same_region():
     assert aws.get_bucket_url_with_region(
         "s3://slack.cloudcustodian.io?",

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -414,6 +414,7 @@ def test_url_socket_retry(monkeypatch):
         42
     ]
 
+
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_http_socket_retry(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda x: x)
@@ -432,7 +433,7 @@ def test_http_socket_retry(monkeypatch):
 
     assert 'Unknown' in str(ecm.value)
 
-    # case for retry exhaustion    
+    # case for retry exhaustion
     fvalues[:] = [
         HTTPError('https://lwn.net', 503, 'Slow Down', {}, None),
         HTTPError('https://lwn.net', 503, 'Slow Down', {}, None),
@@ -443,7 +444,7 @@ def test_http_socket_retry(monkeypatch):
     # this is really an indirect assertion that is ascertained via
     # coverage.
     with pytest.raises(URLError) as ecm:
-        aws.url_socket_retry(freturns)    
+        aws.url_socket_retry(freturns)
 
     # case for success
     fvalues[:] = [

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -391,6 +391,17 @@ def test_default_bucket_region_with_explicit_region():
 
 
 @vcr.use_cassette(
+    'tests/data/vcr_cassettes/test_output/default_bucket_region_public.yaml', record_mode='all')
+def test_default_bucket_region_is_public():
+    output_dir = "s3://awsapichanges.info"
+    conf = Config.empty(output_dir=output_dir, region="us-west-2")
+    with pytest.raises(InvalidOutputConfig) as ecm:
+        aws._default_bucket_region(conf)
+
+    assert "is publicly accessible" in str(ecm.value)
+
+
+@vcr.use_cassette(
     'tests/data/vcr_cassettes/test_output/default_bucket_region.yaml', record_mode='none')
 def test_default_bucket_region_s3():
     output_dir = "s3://slack.cloudcustodian.io"

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -5,6 +5,7 @@ import json
 import time
 import threading
 import socket
+import sys
 from urllib.error import URLError, HTTPError
 from unittest.mock import Mock
 
@@ -413,6 +414,7 @@ def test_url_socket_retry(monkeypatch):
         42
     ]
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_http_socket_retry(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda x: x)
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -7,12 +7,10 @@ import mock
 import shutil
 import os
 
-from contextlib import nullcontext as no_exception
 from dateutil.parser import parse as date_parse
 
 from c7n.ctx import ExecutionContext
 from c7n.config import Config
-from c7n.exceptions import InvalidOutputConfig
 from c7n.output import DirectoryOutput, BlobOutput, LogFile, metrics_outputs
 from c7n.resources.aws import S3Output, MetricsOutput, get_bucket_region_clientless
 from c7n.testing import mock_datetime_now, TestUtils

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -12,7 +12,7 @@ from dateutil.parser import parse as date_parse
 from c7n.ctx import ExecutionContext
 from c7n.config import Config
 from c7n.output import DirectoryOutput, BlobOutput, LogFile, metrics_outputs
-from c7n.resources.aws import S3Output, MetricsOutput, get_bucket_region_clientless
+from c7n.resources.aws import S3Output, MetricsOutput, inspect_bucket_region
 from c7n.testing import mock_datetime_now, TestUtils
 
 from .common import Bag, BaseTest
@@ -51,7 +51,7 @@ class S3OutputTest(TestUtils):
     def get_s3_output(self, output_url=None, cleanup=True, klass=S3Output):
         if output_url is None:
             output_url = "s3://cloud-custodian/policies"
-        with mock.patch('c7n.resources.aws.get_bucket_region_clientless', return_value='us-east-1'):
+        with mock.patch('c7n.resources.aws.inspect_bucket_region', return_value='us-east-1'):
             output = klass(
                 ExecutionContext(
                     lambda assume=False, region="us-east-1": mock.MagicMock(),
@@ -215,5 +215,5 @@ def test_get_bucket_region_http(bucket, endpoint, expected_region, request):
         f'tests/data/vcr_cassettes/test_output/{request.node.name}.yaml',
         record_mode='none'
     ):
-        region = get_bucket_region_clientless(bucket, endpoint)
+        region = inspect_bucket_region(bucket, endpoint)
         assert region == expected_region

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -685,4 +685,4 @@ def test_output_path_join():
 
     output_dir = './local-dir'
     assert utils.join_output_path(output_dir, 'Samuel', 'us-east-1') == (
-        "./local-dir/Samuel/us-east-1")
+        f"./local-dir{os.sep}Samuel{os.sep}us-east-1")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -671,3 +671,13 @@ def test_parse_date_floor():
     assert utils.parse_date(1) is None
     assert utils.parse_date('3000') is None
     assert utils.parse_date('30') is None
+
+
+def test_output_path_join():
+    assert utils.join_output_path(
+        's3://cross-region-c7n/iam-check?region=us-east-2',
+        'Samuel',
+        'us-east-1'
+    ) == 's3://cross-region-c7n/iam-check/Samuel/us-east-1?region=us-east-2'
+        
+    

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -679,5 +679,10 @@ def test_output_path_join():
         'Samuel',
         'us-east-1'
     ) == 's3://cross-region-c7n/iam-check/Samuel/us-east-1?region=us-east-2'
-        
-    
+
+    output_dir = 's3://cross-region-c7n/iam-checks/{account}/{now:%Y-%m}/{uuid}'
+    assert utils.join_output_path(output_dir, 'Samuel', 'us-east-1') == output_dir
+
+    output_dir = './local-dir'
+    assert utils.join_output_path(output_dir, 'Samuel', 'us-east-1') == (
+        "./local-dir/Samuel/us-east-1")

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -31,7 +31,8 @@ from c7n.policy import PolicyCollection
 from c7n.provider import get_resource_class, clouds as cloud_providers
 from c7n.reports.csvout import Formatter, fs_record_set, record_set, strip_output_path
 from c7n.resources import load_available
-from c7n.utils import CONN_CACHE, dumps, filter_empty, format_string_values, get_policy_provider, join_output_path
+from c7n.utils import (
+    CONN_CACHE, dumps, filter_empty, format_string_values, get_policy_provider, join_output_path)
 
 from c7n_org.utils import environ, account_tags
 

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -661,12 +661,13 @@ def run_account(account, region, policies_config, output_path,
 
 
 def initialize_provider_output(policies_config, output_dir, regions):
-    """attempt to allow the provider an opportunity to initialize the output directory.
+    """allow the provider an opportunity to initialize the output config.
     """
-    # most of this function is hideous :/
-
-    # use just enough configuration to attempt to limit initialization to the output
-    # dir.
+    # use just enough configuration to attempt to limit initialization
+    # to the output dir. we pass in dummy values for several settings
+    # that if missing would cause at least the aws or azure provider
+    # to do additional dynamic lookups that aren't meaningful in the
+    # context of c7n-org.
     policy_config = Config.empty(
         account_id='112233445566',
         output_dir=output_dir,

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -32,7 +32,7 @@ from c7n.reports.csvout import Formatter, fs_record_set, record_set, strip_outpu
 from c7n.resources import load_available
 from c7n.utils import CONN_CACHE, dumps, filter_empty, format_string_values
 
-from c7n_org.utils import environ, account_tags
+from c7n_org.utils import environ, account_tags, get_policy_provider
 
 log = logging.getLogger('c7n_org')
 
@@ -672,12 +672,8 @@ def initialize_provider_output(policies_config, output_dir, regions):
         output_dir=output_dir,
         region=regions and regions[0] or "us-east-1"
     )
-    # We just need one policy to get the provider, might be useful to have a utility for
-    # this purpose that can operate directly on data without the initialization.
-    provider_policy = {'policies': [policies_config['policies'][0]]}
-    policies = list(PolicyCollection.from_data(provider_policy, policy_config))
-
-    provider = cloud_providers[policies[0].provider_name]()
+    provider_name = get_policy_provider(policies_config['policies'][0])
+    provider = cloud_providers[provider_name]()
     provider.initialize(policy_config)
     return policy_config.output_dir
 

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -30,9 +30,9 @@ from c7n.policy import PolicyCollection
 from c7n.provider import get_resource_class, clouds as cloud_providers
 from c7n.reports.csvout import Formatter, fs_record_set, record_set, strip_output_path
 from c7n.resources import load_available
-from c7n.utils import CONN_CACHE, dumps, filter_empty, format_string_values
+from c7n.utils import CONN_CACHE, dumps, filter_empty, format_string_values, get_policy_provider
 
-from c7n_org.utils import environ, account_tags, get_policy_provider
+from c7n_org.utils import environ, account_tags
 
 log = logging.getLogger('c7n_org')
 

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -9,7 +9,6 @@ from datetime import timedelta, datetime
 import logging
 import os
 import time
-from urllib import parse as urlparse
 import subprocess  # nosec
 import sys
 


### PR DESCRIPTION
# Tldr

this changes output bucket region detection, and moves it to an option that can be explicitly configured (ie. `?region=us-west-2` ) or autodetected at provider initialization, outside of policy execution to reduce cardinality of detection attempts. Additionally it removes attempts to use s3 api calls to detect (source of AccessDenied) in favor of unauthenticated detection, and adds handling for socket retries in the case of common proxy issues. 

# S3 Errors

We've been on a wandering journey dealing with this for a while, in a series of cascading different issues all linked.

`IllegalLocationConstraintException`when trying to use put objects for output,
which represents mismatch between the client's region and the bucket's
region. Its region dependent, because of how the s3 endpoints will
attempt to perform redirects, but that behavior is not the same across
regions.
https://repost.aws/questions/QUKgr9fG6fSimVSUqK9fvkwQ/illegal-location-constraint-exception-error-when-using-s-3-create-bucket-code
https://github.com/cloud-custodian/cloud-custodian/issues/6028

Which led us to try and determine the bucket's region using
get_bucket_location in  https://github.com/cloud-custodian/cloud-custodian/pull/7524

This also introduced new errors of the form.

`AccessDenied` when trying to get the bucket location, primarily i
suspect because the user executing custodian / c7n-org did not have
permissions to use GetBucketLocation. ie. we changed the permissions
needed to run custodian with s3 outputs, but users hadn't changed
their permissions (in some cases needed on both bucket and iam role
when doing cross account), none of the common documentation examples
for buckets policies cover GetBucketLocation afaicr. Additionally the 
credentials/principal we use to determine the bucket region, are sans any role assumption that
might be specified on the cli or in accounts.yaml.

https://github.com/cloud-custodian/cloud-custodian/issues/7593

This led to us trying to use http client checks to the bucket without
any active credentials. But this endpoint use without authentication is
rate limited. https://github.com/cloud-custodian/cloud-custodian/pull/7682

The final issue is self induced, because the initial attempt to
determine bucket region via apis and subsequent changes to http client
requests was done in the s3 output's initializer (__init__), which is
created as a flyweight for policy execution, leading to lots of
spurious api calls triggering rate limits, which led to secondary path
that led to access denied.

https://github.com/cloud-custodian/cloud-custodian/issues/7870
