### PR TITLE
aws - vpc - sg : Add Batch (un)used filter

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -825,7 +825,6 @@ class SGUsage(Filter):
         return sg_ids
 
     def get_batch_sgs(self):
-        sg_ids = set()
         expr = jmespath.compile('[].computeResources.securityGroupIds[]')
         resources = self.manager.get_resource_manager('aws.batch-compute').resources(augment=False)
         return set(expr.search(resources) or [])

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -826,14 +826,9 @@ class SGUsage(Filter):
 
     def get_batch_sgs(self):
         sg_ids = set()
-        expr = jmespath.compile(
-            'computeResources.securityGroupIds[]')
-        for compute in self.manager.get_resource_manager(
-                'aws.batch-compute').resources(augment=False):
-            ids = expr.search(compute)
-            if ids:
-                sg_ids.update(ids)
-        return sg_ids
+        expr = jmespath.compile('[].computeResources.securityGroupIds[]')
+        resources = self.manager.get_resource_manager('aws.batch-compute').resources(augment=False)
+        return set(expr.search(resources) or [])
 
 
 @SecurityGroup.filter_registry.register('unused')

--- a/tests/data/placebo/test_security_group_batch_unused/batch.DescribeComputeEnvironments_1.json
+++ b/tests/data/placebo/test_security_group_batch_unused/batch.DescribeComputeEnvironments_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "computeEnvironments": [
+            {
+                "computeEnvironmentName": "test-compute-env",
+                "computeEnvironmentArn": "arn:aws:batch:us-east-1:644160558196:compute-environment/test-compute-env",
+                "ecsClusterArn": "arn:aws:ecs:us-east-1:644160558196:cluster/AWSBatch-test-compute-env-11111111-2222-3333-4444-555555555555",
+                "tags": {
+                },
+                "type": "MANAGED",
+                "state": "ENABLED",
+                "status": "VALID",
+                "statusReason": "ComputeEnvironment Healthy",
+                "computeResources": {
+                    "type": "FARGATE",
+                    "maxvCpus": 32,
+                    "subnets": [
+                        "subnet-8e261cb2",
+                        "subnet-8e261cb3",
+                        "subnet-8e261cb4"
+                    ],
+                    "securityGroupIds": [
+                        "sg-0f026884bba48e351"
+                    ],
+                    "tags": {},
+                    "ec2Configuration": []
+                },
+                "serviceRole": "arn:aws:iam::644160558196:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch",
+                "containerOrchestrationType": "ECS",
+                "uuid": "11111111-2222-3333-4444-555555555555"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_security_group_batch_unused/ec2.DescribeSecurityGroupReferences_1.json
+++ b/tests/data/placebo/test_security_group_batch_unused/ec2.DescribeSecurityGroupReferences_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroupReferenceSet": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_security_group_batch_unused/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/test_security_group_batch_unused/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,83 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "PrefixListIds": [],
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "UserIdGroupPairs": [],
+                        "Ipv6Ranges": []
+                    }
+                ],
+                "Description": "inbound access",
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [],
+                        "FromPort": 443,
+                        "IpRanges": [
+                            {
+                                "CidrIp": "10.42.1.0/24"
+                            },
+                            {
+                                "CidrIp": "10.42.2.0/24"
+                            }
+                        ],
+                        "ToPort": 443,
+                        "IpProtocol": "tcp",
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "644160558196",
+                                "GroupId": "sg-e2842c8b"
+                            }
+                        ],
+                        "Ipv6Ranges": []
+                    }
+                ],
+                "GroupName": "allow-some-ingress",
+                "VpcId": "vpc-c25285ab",
+                "OwnerId": "644160558196",
+                "GroupId": "sg-0f026884bba48e351"
+            },
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "PrefixListIds": [],
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ],
+                        "UserIdGroupPairs": [],
+                        "Ipv6Ranges": []
+                    }
+                ],
+                "Description": "inbound ref access",
+                "IpPermissions": [],
+                "GroupName": "allowed-reference",
+                "VpcId": "vpc-c25285ab",
+                "OwnerId": "644160558196",
+                "GroupId": "sg-e2842c8b"
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "353bba5f-d0ca-4610-82ff-3f374778e796",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Thu, 05 Jan 2017 02:25:39 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_security_group_unused/batch.DescribeComputeEnvironments_1.json
+++ b/tests/data/placebo/test_security_group_unused/batch.DescribeComputeEnvironments_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "computeEnvironments": []
+    }
+}

--- a/tests/data/placebo/test_security_group_used/batch.DescribeComputeEnvironments_1.json
+++ b/tests/data/placebo/test_security_group_used/batch.DescribeComputeEnvironments_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "computeEnvironments": []
+    }
+}


### PR DESCRIPTION
Augment `security-group.unused` filter to take into account the `Batch` resources (in particular, the [`compute-environment`](https://docs.aws.amazon.com/batch/latest/userguide/create-compute-environment.html)) that are referencing existing security groups.

Cf #4796 and #2768
