### PR TITLE
aws - route53.recovery-cluster - add resource and tagging support

### DIFF
--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -166,6 +166,7 @@ ResourceMap = {
     "aws.rds-subscription": "c7n.resources.rds.RDSSubscription",
     "aws.rds-proxy": "c7n.resources.rds.RDSProxy",
     "aws.readiness-check": "c7n.resources.route53.ReadinessCheck",
+    "aws.recovery-cluster": "c7n.resources.route53.RecoveryCluster",
     "aws.redshift": "c7n.resources.redshift.Redshift",
     "aws.redshift-snapshot": "c7n.resources.redshift.RedshiftSnapshot",
     "aws.redshift-subnet-group": "c7n.resources.redshift.RedshiftSubnetGroup",

--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -794,7 +794,7 @@ class RecoveryClusterAddTag(Tag):
                 key: DesiredTag
                 value: DesiredValue
     """
-    permissions = ('route53-recovery-control-config:TagResource',)
+    permissions = ('route53-recovery-control:TagResource',)
 
     def get_client(self):
         return self.manager.get_client()
@@ -824,7 +824,7 @@ class RecoveryClusterRemoveTag(RemoveTag):
               - type: remove-tag
                 tags: ['ExpiredTag']
     """
-    permissions = ('route53-recovery-control-config:UntagResource',)
+    permissions = ('route53-recovery-control:UntagResource',)
 
     def get_client(self):
         return self.manager.get_client()

--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -794,7 +794,7 @@ class RecoveryClusterAddTag(Tag):
                 key: DesiredTag
                 value: DesiredValue
     """
-    permissions = ('route53-recovery-control:TagResource',)
+    permissions = ('route53-recovery-control-config:TagResource',)
 
     def get_client(self):
         return self.manager.get_client()
@@ -824,7 +824,7 @@ class RecoveryClusterRemoveTag(RemoveTag):
               - type: remove-tag
                 tags: ['ExpiredTag']
     """
-    permissions = ('route53-recovery-control:UntagResource',)
+    permissions = ('route53-recovery-control-config:UntagResource',)
 
     def get_client(self):
         return self.manager.get_client()

--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -668,6 +668,9 @@ class ReadinessAddTag(Tag):
     """
     permissions = ('route53-recovery-readiness:TagResource',)
 
+    def get_client(self):
+        return self.manager.get_client()
+
     def process_resource_set(self, client, readiness_checks, tags):
         Tags = {r['Key']: r['Value'] for r in tags}
         for r in readiness_checks:
@@ -695,6 +698,9 @@ class ReadinessCheckRemoveTag(RemoveTag):
     """
     permissions = ('route53-recovery-readiness:UntagResource',)
 
+    def get_client(self):
+        return self.manager.get_client()
+
     def process_resource_set(self, client, readiness_checks, keys):
         for r in readiness_checks:
             client.untag_resource(
@@ -702,8 +708,18 @@ class ReadinessCheckRemoveTag(RemoveTag):
                 TagKeys=keys)
 
 
-ReadinessCheck.action_registry.register('mark-for-op', tags.TagDelayedAction)
-ReadinessCheck.filter_registry.register('marked-for-op', tags.TagActionFilter)
+@ReadinessCheck.action_registry.register('mark-for-op')
+class MarkForOpReadinessCheck(tags.TagDelayedAction):
+
+    def get_client(self):
+        return self.manager.get_client()
+
+
+@ReadinessCheck.filter_registry.register('marked-for-op')
+class MarkedForOpReadinessCheck(tags.TagActionFilter):
+
+    def get_client(self):
+        return self.manager.get_client()
 
 
 @ReadinessCheck.filter_registry.register('cross-account')

--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -781,8 +781,7 @@ class RecoveryClusterAddTag(Tag):
     permissions = ('route53-recovery-control-config:TagResource',)
 
     def get_client(self):
-        return local_session(self.manager.session_factory) \
-            .client('route53-recovery-control-config', region_name=ARC_REGION)
+        return self.manager.get_client()
 
     def process_resource_set(self, client, clusters, tags):
         Tags = {r['Key']: r['Value'] for r in tags}
@@ -812,8 +811,7 @@ class RecoveryClusterRemoveTag(RemoveTag):
     permissions = ('route53-recovery-control-config:UntagResource',)
 
     def get_client(self):
-        return local_session(self.manager.session_factory) \
-            .client('route53-recovery-control-config', region_name=ARC_REGION)
+        return self.manager.get_client()
 
     def process_resource_set(self, client, readiness_checks, keys):
         for r in readiness_checks:

--- a/tests/data/iam-actions.json
+++ b/tests/data/iam-actions.json
@@ -8688,6 +8688,9 @@
     "ListControlPanels",
     "ListRoutingControls",
     "ListSafetyRules",
+    "ListTagsForResource",
+    "TagResource",
+    "UntagResource",
     "UpdateControlPanel",
     "UpdateRoutingControl",
     "UpdateSafetyRule"

--- a/tests/data/placebo/test_readiness_check_add_tag/route53-recovery-readiness.ListTagsForResources_2.json
+++ b/tests/data/placebo/test_readiness_check_add_tag/route53-recovery-readiness.ListTagsForResources_2.json
@@ -1,7 +1,26 @@
 {
     "status_code": 200,
     "data": {
-        "ResponseMetadata": {},
+        "ResponseMetadata": {
+            "RequestId": "c5db8cba-5e05-4acf-b61a-34cf611166a1",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "content-length": "32",
+                "connection": "keep-alive",
+                "date": "Mon, 20 Feb 2023 04:14:32 GMT",
+                "x-amzn-requestid": "c5db8cba-5e05-4acf-b61a-34cf611166a1",
+                "access-control-allow-origin": "*",
+                "x-amz-apigw-id": "AnsCWEOXvHcFvsQ=",
+                "access-control-expose-headers": "x-amzn-ErrorType, x-amzn-RequestId, x-amzn-ErrorMessage, x-amzn-Trace-Id, x-amz-apigw-id, Date",
+                "x-amzn-trace-id": "Root=1-63f2f3a8-2cae4a32412b18a520935cc2;Sampled=0",
+                "x-cache": "Miss from cloudfront",
+                "via": "1.1 0fd782cbc1c3c43778f2ac89b2bfb444.cloudfront.net (CloudFront)",
+                "x-amz-cf-pop": "IAD12-P2",
+                "x-amz-cf-id": "vqKINSncZ4vasonOHFuHO1XDFAfRSCRFEHGyr-8MdU_So2Wil_hYNg=="
+            },
+            "RetryAttempts": 0
+        },
         "Tags": {
             "TestTag": "TestValue"
         }

--- a/tests/data/placebo/test_readiness_check_marked_for_op/route53-recovery-readiness.ListReadinessChecks_1.json
+++ b/tests/data/placebo/test_readiness_check_marked_for_op/route53-recovery-readiness.ListReadinessChecks_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ReadinessChecks": [
+            {
+                "ReadinessCheckArn": "arn:aws:route53-recovery-readiness::644160558196:readiness-check/sample_check",
+                "ReadinessCheckName": "sample_check",
+                "ResourceSet": "sample_rs",
+                "Tags": {
+                    "TestTag": "Resource does not meet policy: notify@2023/02/22"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_readiness_check_marked_for_op/route53-recovery-readiness.ListTagsForResources_1.json
+++ b/tests/data/placebo/test_readiness_check_marked_for_op/route53-recovery-readiness.ListTagsForResources_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Tags": {
+            "TestTag": "Resource does not meet policy: notify@2023/02/22"
+        }
+    }
+}

--- a/tests/data/placebo/test_readiness_check_markop/route53-recovery-readiness.ListTagsForResources_2.json
+++ b/tests/data/placebo/test_readiness_check_markop/route53-recovery-readiness.ListTagsForResources_2.json
@@ -1,9 +1,28 @@
 {
     "status_code": 200,
     "data": {
-        "ResponseMetadata": {},
+        "ResponseMetadata": {
+            "RequestId": "9996f49b-b18c-4d3b-a235-195d47ffb8ae",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "content-length": "71",
+                "connection": "keep-alive",
+                "date": "Mon, 20 Feb 2023 04:29:28 GMT",
+                "x-amzn-requestid": "9996f49b-b18c-4d3b-a235-195d47ffb8ae",
+                "access-control-allow-origin": "*",
+                "x-amz-apigw-id": "AnuOaET0PHcFiXw=",
+                "access-control-expose-headers": "x-amzn-ErrorType, x-amzn-RequestId, x-amzn-ErrorMessage, x-amzn-Trace-Id, x-amz-apigw-id, Date",
+                "x-amzn-trace-id": "Root=1-63f2f728-639dd75c117a5d8531c9bb87;Sampled=0",
+                "x-cache": "Miss from cloudfront",
+                "via": "1.1 8a5a55219dfdbca831a0a40e05aaa842.cloudfront.net (CloudFront)",
+                "x-amz-cf-pop": "IAD12-P2",
+                "x-amz-cf-id": "vMwnuknz1DiMVuV_SEMg4k9T3nwXXik34EIoWxxukFPi8JWLwC5XCQ=="
+            },
+            "RetryAttempts": 0
+        },
         "Tags": {
-            "TestTag": "Resource does not meet policy: notify@2022/12/29"
+            "TestTag": "Resource does not meet policy: notify@2023/02/22"
         }
     }
 }

--- a/tests/data/placebo/test_readiness_check_remove_tag/route53-recovery-readiness.ListTagsForResources_2.json
+++ b/tests/data/placebo/test_readiness_check_remove_tag/route53-recovery-readiness.ListTagsForResources_2.json
@@ -1,7 +1,26 @@
 {
     "status_code": 200,
     "data": {
-        "ResponseMetadata": {},
+        "ResponseMetadata": {
+            "RequestId": "015c516a-aef0-457d-ac4f-091bf05e23b1",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "content-length": "11",
+                "connection": "keep-alive",
+                "date": "Mon, 20 Feb 2023 04:15:06 GMT",
+                "x-amzn-requestid": "015c516a-aef0-457d-ac4f-091bf05e23b1",
+                "access-control-allow-origin": "*",
+                "x-amz-apigw-id": "AnsHtHloPHcFZgA=",
+                "access-control-expose-headers": "x-amzn-ErrorType, x-amzn-RequestId, x-amzn-ErrorMessage, x-amzn-Trace-Id, x-amz-apigw-id, Date",
+                "x-amzn-trace-id": "Root=1-63f2f3ca-4cf765ad348b20db5b1382b7;Sampled=0",
+                "x-cache": "Miss from cloudfront",
+                "via": "1.1 0cba74644cedf83bb6fb7dc90d8b0980.cloudfront.net (CloudFront)",
+                "x-amz-cf-pop": "IAD12-P2",
+                "x-amz-cf-id": "3XdVJp7pHB9Vp95DtQteHhY0FFOiawTz0o6nqlTXyb05hSyR294kwg=="
+            },
+            "RetryAttempts": 0
+        },
         "Tags": {}
     }
 }

--- a/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListClusters_1.json
+++ b/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListClusters_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Clusters": [
+            {
+                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/2559d9eb-429c-45e2-89be-6fb020716f20",
+                "ClusterEndpoints": [
+                    {
+                        "Endpoint": "https://a95a6f5b.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
+                        "Region": "ap-northeast-1"
+                    },
+                    {
+                        "Endpoint": "https://ba6e5449.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
+                        "Region": "eu-west-1"
+                    },
+                    {
+                        "Endpoint": "https://6c579e4d.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
+                        "Region": "ap-southeast-2"
+                    },
+                    {
+                        "Endpoint": "https://b3cd7535.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
+                        "Region": "us-east-1"
+                    },
+                    {
+                        "Endpoint": "https://534e088e.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
+                        "Region": "us-west-2"
+                    }
+                ],
+                "Name": "NewCluster",
+                "Status": "DEPLOYED"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListClusters_1.json
+++ b/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListClusters_1.json
@@ -4,27 +4,27 @@
         "ResponseMetadata": {},
         "Clusters": [
             {
-                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/2559d9eb-429c-45e2-89be-6fb020716f20",
+                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/a8154032-3e3f-4b8b-b526-9c845792e809",
                 "ClusterEndpoints": [
                     {
-                        "Endpoint": "https://a95a6f5b.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
-                        "Region": "ap-northeast-1"
-                    },
-                    {
-                        "Endpoint": "https://ba6e5449.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
-                        "Region": "eu-west-1"
-                    },
-                    {
-                        "Endpoint": "https://6c579e4d.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
-                        "Region": "ap-southeast-2"
-                    },
-                    {
-                        "Endpoint": "https://b3cd7535.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
+                        "Endpoint": "https://ae816ff1.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
                         "Region": "us-east-1"
                     },
                     {
-                        "Endpoint": "https://534e088e.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
+                        "Endpoint": "https://d55930f5.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
+                        "Region": "eu-west-1"
+                    },
+                    {
+                        "Endpoint": "https://4e65bc59.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
+                        "Region": "ap-northeast-1"
+                    },
+                    {
+                        "Endpoint": "https://438ed78c.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
                         "Region": "us-west-2"
+                    },
+                    {
+                        "Endpoint": "https://3741c1ad.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
+                        "Region": "ap-southeast-2"
                     }
                 ],
                 "Name": "NewCluster",

--- a/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListTagsForResource_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Tags": {}
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListTagsForResource_2.json
@@ -2,24 +2,24 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RequestId": "c1999c89-1441-471a-9590-eb8078bac5f5",
+            "RequestId": "70775081-53ab-4741-b464-d584e5f52cb1",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
                 "content-type": "application/json",
                 "content-length": "34",
                 "connection": "keep-alive",
-                "date": "Fri, 17 Feb 2023 23:41:33 GMT",
-                "x-amzn-requestid": "c1999c89-1441-471a-9590-eb8078bac5f5",
+                "date": "Mon, 20 Feb 2023 02:45:35 GMT",
+                "x-amzn-requestid": "70775081-53ab-4741-b464-d584e5f52cb1",
                 "access-control-allow-origin": "*",
                 "access-control-allow-headers": "*,Authorization,Date,X-Amz-Date,X-Amz-Security-Token,X-Amz-Target,content-type,x-amz-content-sha256,x-amz-user-agent,x-amzn-platform-id,x-amzn-trace-id",
-                "x-amz-apigw-id": "AgeLFHLNvHcFpmw=",
+                "x-amz-apigw-id": "AnfAgEcBPHcFbbg=",
                 "access-control-allow-methods": "OPTIONS,POST,GET,PUT,DELETE",
                 "access-control-expose-headers": "x-amzn-errortype,x-amzn-requestid,x-amzn-errormessage,x-amzn-trace-id,x-amzn-requestid,x-amz-apigw-id,date",
-                "x-amzn-trace-id": "Root=1-63f010ad-461e3d197b613281360e4fbd;Sampled=1",
+                "x-amzn-trace-id": "Root=1-63f2decf-65fa25b501e3bcd202888d3e;Sampled=1",
                 "x-cache": "Miss from cloudfront",
-                "via": "1.1 fcb94596db202c75ac0e559b3183be72.cloudfront.net (CloudFront)",
-                "x-amz-cf-pop": "IAD12-P1",
-                "x-amz-cf-id": "5eVo3bwgq9cOsGhAidkj4I95YR7DVrVOBGklIho0TVtmmcEorq9IXw=="
+                "via": "1.1 9d2dee9b44718f249b789987d2cbe62c.cloudfront.net (CloudFront)",
+                "x-amz-cf-pop": "IAD12-P3",
+                "x-amz-cf-id": "WjMvHj0b9Zl6l2WZqdcDY8by01z_TFVQXAnEEQ5SayBlY6kJgcI8PA=="
             },
             "RetryAttempts": 0
         },

--- a/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.ListTagsForResource_2.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "c1999c89-1441-471a-9590-eb8078bac5f5",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "content-length": "34",
+                "connection": "keep-alive",
+                "date": "Fri, 17 Feb 2023 23:41:33 GMT",
+                "x-amzn-requestid": "c1999c89-1441-471a-9590-eb8078bac5f5",
+                "access-control-allow-origin": "*",
+                "access-control-allow-headers": "*,Authorization,Date,X-Amz-Date,X-Amz-Security-Token,X-Amz-Target,content-type,x-amz-content-sha256,x-amz-user-agent,x-amzn-platform-id,x-amzn-trace-id",
+                "x-amz-apigw-id": "AgeLFHLNvHcFpmw=",
+                "access-control-allow-methods": "OPTIONS,POST,GET,PUT,DELETE",
+                "access-control-expose-headers": "x-amzn-errortype,x-amzn-requestid,x-amzn-errormessage,x-amzn-trace-id,x-amzn-requestid,x-amz-apigw-id,date",
+                "x-amzn-trace-id": "Root=1-63f010ad-461e3d197b613281360e4fbd;Sampled=1",
+                "x-cache": "Miss from cloudfront",
+                "via": "1.1 fcb94596db202c75ac0e559b3183be72.cloudfront.net (CloudFront)",
+                "x-amz-cf-pop": "IAD12-P1",
+                "x-amz-cf-id": "5eVo3bwgq9cOsGhAidkj4I95YR7DVrVOBGklIho0TVtmmcEorq9IXw=="
+            },
+            "RetryAttempts": 0
+        },
+        "Tags": {
+            "TestTag": "TestValue"
+        }
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.TagResource_1.json
+++ b/tests/data/placebo/test_recovery_cluster_add_tag/route53-recovery-control-config.TagResource_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_markop/route53-recovery-control-config.ListClusters_1.json
+++ b/tests/data/placebo/test_recovery_cluster_markop/route53-recovery-control-config.ListClusters_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Clusters": [
+            {
+                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/2559d9eb-429c-45e2-89be-6fb020716f20",
+                "ClusterEndpoints": [
+                    {
+                        "Endpoint": "https://ba6e5449.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
+                        "Region": "eu-west-1"
+                    },
+                    {
+                        "Endpoint": "https://a95a6f5b.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
+                        "Region": "ap-northeast-1"
+                    },
+                    {
+                        "Endpoint": "https://534e088e.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
+                        "Region": "us-west-2"
+                    },
+                    {
+                        "Endpoint": "https://b3cd7535.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
+                        "Region": "us-east-1"
+                    },
+                    {
+                        "Endpoint": "https://6c579e4d.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
+                        "Region": "ap-southeast-2"
+                    }
+                ],
+                "Name": "NewCluster",
+                "Status": "DEPLOYED"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_markop/route53-recovery-control-config.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_recovery_cluster_markop/route53-recovery-control-config.ListTagsForResource_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Tags": {
+            "string": "notify@2023/02/23",
+            "string23": "Resourcedoesnotmeetpolicy"
+        }
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_markop/route53-recovery-control-config.TagResource_1.json
+++ b/tests/data/placebo/test_recovery_cluster_markop/route53-recovery-control-config.TagResource_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Message": "Invalid request body",
+            "Code": "BadRequestException"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListClusters_1.json
+++ b/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListClusters_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Clusters": [
+            {
+                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/2559d9eb-429c-45e2-89be-6fb020716f20",
+                "ClusterEndpoints": [
+                    {
+                        "Endpoint": "https://534e088e.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
+                        "Region": "us-west-2"
+                    },
+                    {
+                        "Endpoint": "https://b3cd7535.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
+                        "Region": "us-east-1"
+                    },
+                    {
+                        "Endpoint": "https://ba6e5449.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
+                        "Region": "eu-west-1"
+                    },
+                    {
+                        "Endpoint": "https://6c579e4d.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
+                        "Region": "ap-southeast-2"
+                    },
+                    {
+                        "Endpoint": "https://a95a6f5b.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
+                        "Region": "ap-northeast-1"
+                    }
+                ],
+                "Name": "NewCluster",
+                "Status": "DEPLOYED"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListClusters_1.json
+++ b/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListClusters_1.json
@@ -4,27 +4,27 @@
         "ResponseMetadata": {},
         "Clusters": [
             {
-                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/2559d9eb-429c-45e2-89be-6fb020716f20",
+                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/a8154032-3e3f-4b8b-b526-9c845792e809",
                 "ClusterEndpoints": [
                     {
-                        "Endpoint": "https://534e088e.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
+                        "Endpoint": "https://438ed78c.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
                         "Region": "us-west-2"
                     },
                     {
-                        "Endpoint": "https://b3cd7535.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
-                        "Region": "us-east-1"
-                    },
-                    {
-                        "Endpoint": "https://ba6e5449.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
+                        "Endpoint": "https://d55930f5.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
                         "Region": "eu-west-1"
                     },
                     {
-                        "Endpoint": "https://6c579e4d.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
-                        "Region": "ap-southeast-2"
+                        "Endpoint": "https://4e65bc59.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
+                        "Region": "ap-northeast-1"
                     },
                     {
-                        "Endpoint": "https://a95a6f5b.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
-                        "Region": "ap-northeast-1"
+                        "Endpoint": "https://ae816ff1.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
+                        "Region": "us-east-1"
+                    },
+                    {
+                        "Endpoint": "https://3741c1ad.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
+                        "Region": "ap-southeast-2"
                     }
                 ],
                 "Name": "NewCluster",

--- a/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListTagsForResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Tags": {
+            "TestTag": "TestValue"
+        }
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListTagsForResource_2.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "67cc9963-6fa7-4d34-bd9a-6ec16841e7b2",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "content-length": "12",
+                "connection": "keep-alive",
+                "date": "Fri, 17 Feb 2023 23:43:36 GMT",
+                "x-amzn-requestid": "67cc9963-6fa7-4d34-bd9a-6ec16841e7b2",
+                "access-control-allow-origin": "*",
+                "access-control-allow-headers": "*,Authorization,Date,X-Amz-Date,X-Amz-Security-Token,X-Amz-Target,content-type,x-amz-content-sha256,x-amz-user-agent,x-amzn-platform-id,x-amzn-trace-id",
+                "x-amz-apigw-id": "AgeebEsOPHcFjmg=",
+                "access-control-allow-methods": "OPTIONS,POST,GET,PUT,DELETE",
+                "access-control-expose-headers": "x-amzn-errortype,x-amzn-requestid,x-amzn-errormessage,x-amzn-trace-id,x-amzn-requestid,x-amz-apigw-id,date",
+                "x-amzn-trace-id": "Root=1-63f01128-74f61fad398b2f6501dffbee;Sampled=1",
+                "x-cache": "Miss from cloudfront",
+                "via": "1.1 a53ebc5c4d12bc9682b9c11ea18dccbe.cloudfront.net (CloudFront)",
+                "x-amz-cf-pop": "IAD12-P1",
+                "x-amz-cf-id": "DNa4cStM-FmOBG0_-jegJTcaPg5XWjAdp87Y7r_WX2pN_Xn_iKbQlQ=="
+            },
+            "RetryAttempts": 0
+        },
+        "Tags": {}
+    }
+}

--- a/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.ListTagsForResource_2.json
@@ -2,24 +2,24 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "RequestId": "67cc9963-6fa7-4d34-bd9a-6ec16841e7b2",
+            "RequestId": "e6db3442-08ed-429d-a33c-c05c0610911e",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
                 "content-type": "application/json",
                 "content-length": "12",
                 "connection": "keep-alive",
-                "date": "Fri, 17 Feb 2023 23:43:36 GMT",
-                "x-amzn-requestid": "67cc9963-6fa7-4d34-bd9a-6ec16841e7b2",
+                "date": "Mon, 20 Feb 2023 02:46:47 GMT",
+                "x-amzn-requestid": "e6db3442-08ed-429d-a33c-c05c0610911e",
                 "access-control-allow-origin": "*",
                 "access-control-allow-headers": "*,Authorization,Date,X-Amz-Date,X-Amz-Security-Token,X-Amz-Target,content-type,x-amz-content-sha256,x-amz-user-agent,x-amzn-platform-id,x-amzn-trace-id",
-                "x-amz-apigw-id": "AgeebEsOPHcFjmg=",
+                "x-amz-apigw-id": "AnfLrHwZvHcFcXQ=",
                 "access-control-allow-methods": "OPTIONS,POST,GET,PUT,DELETE",
                 "access-control-expose-headers": "x-amzn-errortype,x-amzn-requestid,x-amzn-errormessage,x-amzn-trace-id,x-amzn-requestid,x-amz-apigw-id,date",
-                "x-amzn-trace-id": "Root=1-63f01128-74f61fad398b2f6501dffbee;Sampled=1",
+                "x-amzn-trace-id": "Root=1-63f2df17-3e3b2e873734802a7812eafb;Sampled=1",
                 "x-cache": "Miss from cloudfront",
-                "via": "1.1 a53ebc5c4d12bc9682b9c11ea18dccbe.cloudfront.net (CloudFront)",
-                "x-amz-cf-pop": "IAD12-P1",
-                "x-amz-cf-id": "DNa4cStM-FmOBG0_-jegJTcaPg5XWjAdp87Y7r_WX2pN_Xn_iKbQlQ=="
+                "via": "1.1 bcfffcf7e0fc8cd9cfe4125369a9f036.cloudfront.net (CloudFront)",
+                "x-amz-cf-pop": "IAD12-P3",
+                "x-amz-cf-id": "wEIiUT2D0vbsoJDouddL-PQ4MlMU1aYVfcIXYvFS8Husmzi2Q1aBSg=="
             },
             "RetryAttempts": 0
         },

--- a/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.UntagResource_1.json
+++ b/tests/data/placebo/test_recovery_cluster_remove_tag/route53-recovery-control-config.UntagResource_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -471,3 +471,40 @@ class Route53RecoveryReadinessCheckTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['c7n:CrossAccountViolations'], ['222222222222'])
+
+
+class Route53RecoveryClusterTest(BaseTest):
+
+    def test_recovery_cluster_add_tag(self):
+        session_factory = self.replay_flight_data("test_recovery_cluster_add_tag",)
+        p = self.load_policy(
+            {
+                "name": "recovery-cluster-add-tag",
+                "resource": "recovery-cluster",
+                "filters": [{"tag:TestTag": "absent"}],
+                "actions": [{"type": "tag", "key": "TestTag", "value": "TestValue"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = session_factory(region="us-west-2").client("route53-recovery-control-config")
+        tags = client.list_tags_for_resource(ResourceArn=resources[0]["ClusterArn"])['Tags']
+        self.assertEqual(tags, {"TestTag": "TestValue"})
+
+    def test_recovery_cluster_remove_tag(self):
+        session_factory = self.replay_flight_data("test_recovery_cluster_remove_tag",)
+        p = self.load_policy(
+            {
+                "name": "recovery-cluster-remove-tag",
+                "resource": "recovery-cluster",
+                "filters": [{"tag:TestTag": "present"}],
+                "actions": [{"type": "remove-tag", "tags": ["TestTag"]}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = session_factory(region="us-west-2").client("route53-recovery-control-config")
+        tags = client.list_tags_for_resource(ResourceArn=resources[0]["ClusterArn"])['Tags']
+        self.assertEqual(len(tags), 0)

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -451,7 +451,27 @@ class Route53RecoveryReadinessCheckTest(BaseTest):
         client = session_factory(region="us-west-2").client("route53-recovery-readiness")
         tags = client.list_tags_for_resources(ResourceArn=resources[0]["ReadinessCheckArn"])['Tags']
         self.assertEqual(len(tags), 1)
-        self.assertEqual(tags, {'TestTag': 'Resource does not meet policy: notify@2022/12/29'})
+        self.assertEqual(tags, {'TestTag': 'Resource does not meet policy: notify@2023/02/22'})
+
+    def test_readiness_check_markedforop(self):
+        session_factory = self.replay_flight_data("test_readiness_check_marked_for_op")
+        p = self.load_policy(
+            {
+                "name": "readiness-check-markedforop",
+                "resource": "readiness-check",
+                "filters": [
+                    {
+                        "type": "marked-for-op",
+                        "tag": "TestTag",
+                        "op": "notify",
+                        "skew": 3,
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
 
     def test_readiness_cross_account(self):
         session_factory = self.replay_flight_data("test_readiness_cross_account")


### PR DESCRIPTION
This PR will add new resource route53 ARC recovery cluster. It will close issue (https://github.com/cloud-custodian/cloud-custodian/issues/8295). In addition, it fixes the bug to get_client in readiness_check tagging actions.