### PR TITLE
Pass validate to c7n.loader.PolicyLoader.load_data

### DIFF
--- a/c7n/loader.py
+++ b/c7n/loader.py
@@ -225,7 +225,7 @@ class DirectoryLoader(PolicyLoader):
             else:
                 names.append(p['name'])
 
-        return self.load_data({'policies': policies}, directory)
+        return self.load_data({'policies': policies}, directory, validate=validate)
 
 
 def is_hidden(path):


### PR DESCRIPTION
Pass validate to load_data so intent to validate a policy against the schema or not is respected.

Root cause is that validation occurs at multiple places when loading a policy. If loading a dir of policies via policy.load, each policy is validated against the schema 3 times.
* policy.load()
* DirectoryLoader.load_directory._load()
* PolicyLoader.load_data()
So value of policy.load() validate argument must be passed all the way down the chain.

Removing the extra validations for this particular path may break one of the many other code paths that touch these methods and should probably be part of a broader refactor/update effort.