### PR TITLE
aws - asg - let valid/invalid filters work in explicit pull mode

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -15,6 +15,7 @@ from c7n.exceptions import PolicyValidationError
 from c7n.filters import ValueFilter, AgeFilter, Filter
 from c7n.filters.offhours import OffHour, OnHour
 import c7n.filters.vpc as net_filters
+import c7n.policy
 
 from c7n.manager import resources
 from c7n import query
@@ -244,7 +245,8 @@ class ConfigValidFilter(Filter):
                       'app-elb-target-group', 'ebs-snapshot', 'ami')]))
 
     def validate(self):
-        if self.manager.data.get('mode'):
+        execution_mode = self.manager.data.get('mode', {'type': 'pull'})['type']
+        if issubclass(c7n.policy.execution.get(execution_mode), c7n.policy.LambdaMode):
             raise PolicyValidationError(
                 "invalid-config makes too many queries to be run in lambda")
         return self

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -245,8 +245,7 @@ class ConfigValidFilter(Filter):
                       'app-elb-target-group', 'ebs-snapshot', 'ami')]))
 
     def validate(self):
-        execution_mode = self.manager.data.get('mode', {'type': 'pull'})['type']
-        if issubclass(c7n.policy.execution.get(execution_mode), c7n.policy.LambdaMode):
+        if isinstance(self.manager.ctx.policy.get_execution_mode(), c7n.policy.LambdaMode):
             raise PolicyValidationError(
                 "invalid-config makes too many queries to be run in lambda")
         return self

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -844,6 +844,8 @@ class AutoScalingTest(BaseTest):
             "filters": ["invalid"],
         }
 
+        # Policy should validate cleanly for pull mode, whether it's the implicit
+        # default mode or specified explicitly.
         p = self.load_policy(base_policy)
         p.validate()
         p = self.load_policy({**base_policy, "mode": {"type": "pull"}})

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -832,6 +832,31 @@ class AutoScalingTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
+    def test_asg_invalid_filter_validation(self):
+        """Validate policy execution mode
+
+        The valid/invalid filters should cause Lambda mode policies to fail, but
+        pass for other execution modes whether specified explicitly or not.
+        """
+        base_policy = {
+            "name": "asg-invalid-filter",
+            "resource": "asg",
+            "filters": ["invalid"],
+        }
+
+        p = self.load_policy(base_policy)
+        p.validate()
+        p = self.load_policy({**base_policy, "mode": {"type": "pull"}})
+        p.validate()
+
+        with self.assertRaisesRegex(
+            PolicyValidationError, "too many queries to be run in lambda"
+        ):
+            p = self.load_policy(
+                {**base_policy, "mode": {"type": "periodic", "schedule": "rate(1 day)"}}
+            )
+            p.validate()
+
     def test_asg_invalid_filter_good(self):
         factory = self.replay_flight_data("test_asg_invalid_filter_good")
         p = self.load_policy(


### PR DESCRIPTION
The `valid` and `invalid` filters for `aws.asg` currently fail validation if a policy has an explicit execution mode. The intent is slightly different though: we only want to fail validation for Lambda mode policies.

Today that means "everything except pull mode" will/should fail, but this change allows policies with an _explicit_ pull mode to pass validation.