### PR TITLE
feat: adding flag to allow the inclusion of the azure 'magic' ip range for sql and postgresql

### DIFF
--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -554,6 +554,26 @@ class FirewallRulesFilter(Filter, metaclass=ABCMeta):
                         include:
                             - '131.107.160.2-131.107.160.3'
                             - 10.20.20.0/24
+
+    :example:
+
+    For SQL Server and Postresql Server, Azure represents the service bypass as firewall rule
+    allowing traffic from "0.0.0.0" (this allows traffic from all other azure services). By
+    default the firewall filter for these resources ignores this rule during evaluation. To
+    include it in the evaluation set the "include-azure-services" flag to true. For example,
+    to find all Postgresql Servers where traffic is allowed from all Azure services:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: postgres-servers-open-from-azure
+            resource: azure.sqlserver
+            filters:
+              - type: firewall-rules
+                include-azure-services: true
+                equal:
+                  - '0.0.0.0'
+
     """
 
     schema = {
@@ -565,7 +585,7 @@ class FirewallRulesFilter(Filter, metaclass=ABCMeta):
             'any': {'type': 'array', 'items': {'type': 'string'}},
             'only': {'type': 'array', 'items': {'type': 'string'}},
             'equal': {'type': 'array', 'items': {'type': 'string'}},
-            'include_azure_services_rule': {'type': 'boolean'}
+            'include-azure-services': {'type': 'boolean'}
         },
         'oneOf': [
             {"required": ["type", "include"]},

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -564,7 +564,8 @@ class FirewallRulesFilter(Filter, metaclass=ABCMeta):
             'include': {'type': 'array', 'items': {'type': 'string'}},
             'any': {'type': 'array', 'items': {'type': 'string'}},
             'only': {'type': 'array', 'items': {'type': 'string'}},
-            'equal': {'type': 'array', 'items': {'type': 'string'}}
+            'equal': {'type': 'array', 'items': {'type': 'string'}},
+            'include_azure_services_rule': {'type': 'boolean'}
         },
         'oneOf': [
             {"required": ["type", "include"]},

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
@@ -59,12 +59,6 @@ class PostgresqlServer(ArmResourceManager):
 
 @PostgresqlServer.filter_registry.register('firewall-rules')
 class PostgresqlServerFirewallRulesFilter(FirewallRulesFilter):
-    schema = type_schema(
-        'firewall-rules',
-        rinherit=FirewallRulesFilter.schema,
-        include_azure_services_rule=dict(type='boolean')
-    )
-
     def _query_rules(self, resource):
         query = self.client.firewall_rules.list_by_server(
             resource['resourceGroup'],

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
@@ -66,7 +66,7 @@ class PostgresqlServerFirewallRulesFilter(FirewallRulesFilter):
         resource_rules = IPSet()
         for r in query:
             rule = IPRange(r.start_ip_address, r.end_ip_address)
-            if rule == AZURE_SERVICES and not self.data.get('include_azure_services_rule', False):
+            if rule == AZURE_SERVICES and not self.data.get('include-azure-services', False):
                 # Ignore 0.0.0.0 magic value representing Azure Cloud bypass
                 continue
             resource_rules.add(rule)

--- a/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
+++ b/tools/c7n_azure/c7n_azure/resources/postgresql_server.py
@@ -59,6 +59,12 @@ class PostgresqlServer(ArmResourceManager):
 
 @PostgresqlServer.filter_registry.register('firewall-rules')
 class PostgresqlServerFirewallRulesFilter(FirewallRulesFilter):
+    schema = type_schema(
+        'firewall-rules',
+        rinherit=FirewallRulesFilter.schema,
+        include_azure_services_rule=dict(type='boolean')
+    )
+
     def _query_rules(self, resource):
         query = self.client.firewall_rules.list_by_server(
             resource['resourceGroup'],
@@ -66,7 +72,7 @@ class PostgresqlServerFirewallRulesFilter(FirewallRulesFilter):
         resource_rules = IPSet()
         for r in query:
             rule = IPRange(r.start_ip_address, r.end_ip_address)
-            if rule == AZURE_SERVICES:
+            if rule == AZURE_SERVICES and not self.data.get('include_azure_services_rule', False):
                 # Ignore 0.0.0.0 magic value representing Azure Cloud bypass
                 continue
             resource_rules.add(rule)

--- a/tools/c7n_azure/c7n_azure/resources/sqlserver.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqlserver.py
@@ -262,6 +262,12 @@ class VulnerabilityAssessmentFilter(ValueFilter):
 
 @SqlServer.filter_registry.register('firewall-rules')
 class SqlServerFirewallRulesFilter(FirewallRulesFilter):
+    schema = type_schema(
+        'firewall-rules',
+        rinherit=FirewallRulesFilter.schema,
+        include_azure_services_rule=dict(type='boolean')
+    )
+
     def _query_rules(self, resource):
         query = self.client.firewall_rules.list_by_server(
             resource['resourceGroup'],
@@ -271,7 +277,7 @@ class SqlServerFirewallRulesFilter(FirewallRulesFilter):
 
         for r in query:
             rule = IPRange(r.start_ip_address, r.end_ip_address)
-            if rule == AZURE_SERVICES:
+            if rule == AZURE_SERVICES and not self.data.get('include_azure_services_rule', False):
                 # Ignore 0.0.0.0 magic value representing Azure Cloud bypass
                 continue
             resource_rules.add(rule)

--- a/tools/c7n_azure/c7n_azure/resources/sqlserver.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqlserver.py
@@ -271,7 +271,7 @@ class SqlServerFirewallRulesFilter(FirewallRulesFilter):
 
         for r in query:
             rule = IPRange(r.start_ip_address, r.end_ip_address)
-            if rule == AZURE_SERVICES and not self.data.get('include_azure_services_rule', False):
+            if rule == AZURE_SERVICES and not self.data.get('include-azure-services', False):
                 # Ignore 0.0.0.0 magic value representing Azure Cloud bypass
                 continue
             resource_rules.add(rule)

--- a/tools/c7n_azure/c7n_azure/resources/sqlserver.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqlserver.py
@@ -262,12 +262,6 @@ class VulnerabilityAssessmentFilter(ValueFilter):
 
 @SqlServer.filter_registry.register('firewall-rules')
 class SqlServerFirewallRulesFilter(FirewallRulesFilter):
-    schema = type_schema(
-        'firewall-rules',
-        rinherit=FirewallRulesFilter.schema,
-        include_azure_services_rule=dict(type='boolean')
-    )
-
     def _query_rules(self, resource):
         query = self.client.firewall_rules.list_by_server(
             resource['resourceGroup'],

--- a/tools/c7n_azure/tests_azure/tests_resources/test_postgresql_server.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_postgresql_server.py
@@ -68,8 +68,18 @@ class PostgresqlServerFirewallFilterTest(BaseTest):
         expected = IPSet(['8.8.8.8', '10.0.0.0/16'])
         self.assertEqual(expected, self._get_filter(rules)._query_rules(self.resource))
 
-    def _get_filter(self, rules, mode='equal'):
-        data = {mode: ['10.0.0.0/8', '127.0.0.1']}
+    def test_query_regular_rules_include_magic(self):
+        rules = [IpRange(start_ip_address='10.0.0.0', end_ip_address='10.0.255.255'),
+                 IpRange(start_ip_address='8.8.8.8', end_ip_address='8.8.8.8'),
+                 IpRange(start_ip_address='0.0.0.0', end_ip_address='0.0.0.0')]
+        expected = IPSet(['8.8.8.8', '10.0.0.0/16', '0.0.0.0'])
+        self.assertEqual(
+            expected,
+            self._get_filter(rules, include_magic=True)._query_rules(self.resource)
+        )
+
+    def _get_filter(self, rules, mode='equal', include_magic=False):
+        data = {mode: ['10.0.0.0/8', '127.0.0.1'], 'include_azure_services_rule': include_magic}
         filter = PostgresqlServerFirewallRulesFilter(data, Mock())
         filter.client = Mock()
         filter.client.firewall_rules.list_by_server.return_value = rules

--- a/tools/c7n_azure/tests_azure/tests_resources/test_postgresql_server.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_postgresql_server.py
@@ -79,7 +79,7 @@ class PostgresqlServerFirewallFilterTest(BaseTest):
         )
 
     def _get_filter(self, rules, mode='equal', include_magic=False):
-        data = {mode: ['10.0.0.0/8', '127.0.0.1'], 'include_azure_services_rule': include_magic}
+        data = {mode: ['10.0.0.0/8', '127.0.0.1'], 'include-azure-services': include_magic}
         filter = PostgresqlServerFirewallRulesFilter(data, Mock())
         filter.client = Mock()
         filter.client.firewall_rules.list_by_server.return_value = rules

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqlserver.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqlserver.py
@@ -395,7 +395,7 @@ class SQLServerFirewallFilterTest(BaseTest):
         )
 
     def _get_filter(self, rules, mode='equal', include_magic=False):
-        data = {mode: ['10.0.0.0/8', '127.0.0.1'], 'include_azure_services_rule': include_magic}
+        data = {mode: ['10.0.0.0/8', '127.0.0.1'], 'include-azure-services': include_magic}
         filter = SqlServerFirewallRulesFilter(data, Mock())
         filter.client = Mock()
         filter.client.firewall_rules.list_by_server.return_value = rules

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqlserver.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqlserver.py
@@ -384,8 +384,18 @@ class SQLServerFirewallFilterTest(BaseTest):
         expected = IPSet(['8.8.8.8', '10.0.0.0/16'])
         self.assertEqual(expected, self._get_filter(rules)._query_rules(self.resource))
 
-    def _get_filter(self, rules, mode='equal'):
-        data = {mode: ['10.0.0.0/8', '127.0.0.1']}
+    def test_query_regular_rules_include_magic(self):
+        rules = [IpRange(start_ip_address='10.0.0.0', end_ip_address='10.0.255.255'),
+                 IpRange(start_ip_address='8.8.8.8', end_ip_address='8.8.8.8'),
+                 IpRange(start_ip_address='0.0.0.0', end_ip_address='0.0.0.0')]
+        expected = IPSet(['8.8.8.8', '10.0.0.0/16', '0.0.0.0'])
+        self.assertEqual(
+            expected,
+            self._get_filter(rules, include_magic=True)._query_rules(self.resource)
+        )
+
+    def _get_filter(self, rules, mode='equal', include_magic=False):
+        data = {mode: ['10.0.0.0/8', '127.0.0.1'], 'include_azure_services_rule': include_magic}
         filter = SqlServerFirewallRulesFilter(data, Mock())
         filter.client = Mock()
         filter.client.firewall_rules.list_by_server.return_value = rules


### PR DESCRIPTION
We have a need to check if Azure services are being allowed access via the "magic" IP range, but this range was being explicitly filtered out before hitting the filter logic. This PR adds a flag to allow it to be included if desired.