### PR TITLE
chore: Have the arg names the same as the base class.

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -460,8 +460,8 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
 
     source_mapping = sources
 
-    def __init__(self, data, options):
-        super(QueryResourceManager, self).__init__(data, options)
+    def __init__(self, ctx, data):
+        super(QueryResourceManager, self).__init__(ctx, data)
         self.source = self.get_source(self.source_type)
 
     @property

--- a/tools/c7n_azure/c7n_azure/query.py
+++ b/tools/c7n_azure/c7n_azure/query.py
@@ -222,8 +222,8 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
     class resource_type(TypeInfo):
         pass
 
-    def __init__(self, data, options):
-        super(QueryResourceManager, self).__init__(data, options)
+    def __init__(self, ctx, data):
+        super(QueryResourceManager, self).__init__(ctx, data)
         self.source = self.get_source(self.source_type)
         self._session = None
 

--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -154,8 +154,8 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
     type: str
     resource_type: 'TypeInfo'
 
-    def __init__(self, data, options):
-        super(QueryResourceManager, self).__init__(data, options)
+    def __init__(self, ctx, data):
+        super(QueryResourceManager, self).__init__(ctx, data)
         self.source = self.get_source(self.source_type)
 
     def get_permissions(self):

--- a/tools/c7n_kube/c7n_kube/query.py
+++ b/tools/c7n_kube/c7n_kube/query.py
@@ -68,8 +68,8 @@ class QueryMeta(type):
 
 
 class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
-    def __init__(self, data, options):
-        super(QueryResourceManager, self).__init__(data, options)
+    def __init__(self, ctx, data):
+        super(QueryResourceManager, self).__init__(ctx, data)
         self.source = self.get_source(self.source_type)
 
     def get_permissions(self):

--- a/tools/c7n_openstack/c7n_openstack/query.py
+++ b/tools/c7n_openstack/c7n_openstack/query.py
@@ -63,8 +63,8 @@ class QueryMeta(type):
 
 
 class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
-    def __init__(self, data, options):
-        super(QueryResourceManager, self).__init__(data, options)
+    def __init__(self, ctx, data):
+        super(QueryResourceManager, self).__init__(ctx, data)
         self.source = self.get_source(self.source_type)
 
     def get_permissions(self):


### PR DESCRIPTION
While traversing the code up from policy `load_resource_manager` I got confused when I hit the `QueryResourceManager` because the args for `__init__` didn't match what was being passed into the factory (the class itself).

On further reading, those args were just being passed into the base `__init__` method on ResourceManager, which did what I expected.

This change just makes the arg names consistent. 