### PR TITLE
tools/c7n_mailer - handle lambda container images

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -382,9 +382,10 @@ def resource_format(resource, resource_type):
             resource['InternetGatewayId'],
             len(resource['Attachments']))
     elif resource_type == 'lambda':
-        return "Name: %s  RunTime: %s  \n" % (
+        return "Name: %s  PackageType: %s  RunTime: %s  \n" % (
             resource['FunctionName'],
-            resource['Runtime'])
+            resource['PackageType'],
+            resource.get('Runtime', 'N/A'))
     elif resource_type == 'service-quota':
         try:
             return "ServiceName: %s QuotaName: %s Quota: %i Usage: %i\n" % (

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -382,7 +382,7 @@ def resource_format(resource, resource_type):
             resource['InternetGatewayId'],
             len(resource['Attachments']))
     elif resource_type == 'lambda':
-        return "Name: %s  PackageType: %s  RunTime: %s  \n" % (
+        return "Name: %s  Package Type: %s  Runtime: %s  \n" % (
             resource['FunctionName'],
             resource['PackageType'],
             resource.get('Runtime', 'N/A'))

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -112,14 +112,12 @@ class ResourceFormat(unittest.TestCase):
             "PackageType": "Zip",
         }
         self.assertEqual(
-            utils.resource_format(image_func, "aws.lambda"
-            ),
-            "Function Name:  my-image-based-function  Package Type: Image  Runtime: N/A",
+            utils.resource_format(image_func, "aws.lambda").strip(),
+            "Name: my-image-based-function  Package Type: Image  Runtime: N/A",
         )
         self.assertEqual(
-            utils.resource_format(zip_func, "aws.lambda"
-            ),
-            "Function Name:  my-zip-based-function  Package Type: Zip  Runtime: python3.8",
+            utils.resource_format(zip_func, "aws.lambda").strip(),
+            "Name: my-zip-based-function  Package Type: Zip  Runtime: python3.8",
         )
 
     def test_rds_cluster(self):

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -101,6 +101,27 @@ class ResourceFormat(unittest.TestCase):
             "id: igw-x  attachments: 0",
         )
 
+    def test_lambda(self):
+        image_func = {
+            "FunctionName": "my-image-based-function",
+            "PackageType": "Image",
+        }
+        zip_func = {
+            "FunctionName": "my-zip-based-function",
+            "Runtime": "python3.8",
+            "PackageType": "Zip",
+        }
+        self.assertEqual(
+            utils.resource_format(image_func, "aws.lambda"
+            ),
+            "Function Name:  my-image-based-function  Package Type: Image  Runtime: N/A",
+        )
+        self.assertEqual(
+            utils.resource_format(zip_func, "aws.lambda"
+            ),
+            "Function Name:  my-zip-based-function  Package Type: Zip  Runtime: python3.8",
+        )
+
     def test_rds_cluster(self):
         self.assertEqual(
             utils.resource_format(


### PR DESCRIPTION
- Include `PackageType` in the default reporting fields for Lambda functions to distinguish between Zip and Image-based functions
- Provide a default value for the Runtime field, which is not present on image-based functions