### PR TITLE
aws - elasticsearch - enable support for server-side query filtering

### DIFF
--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -9,7 +9,7 @@ from c7n.exceptions import PolicyValidationError
 from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter, VpcFilter, Filter
 from c7n.manager import resources
 from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
-from c7n.utils import chunks, local_session, type_schema
+from c7n.utils import chunks, local_session, type_schema, merge_dict_list
 from c7n.tags import Tag, RemoveTag, TagActionFilter, TagDelayedAction
 from c7n.filters.kms import KmsRelatedFilter
 import c7n.filters.policystatement as polstmt_filter
@@ -57,6 +57,13 @@ class ElasticSearchDomain(QueryResourceManager):
         name = 'Name'
         dimension = "DomainName"
         cfn_type = config_type = 'AWS::Elasticsearch::Domain'
+
+    def resources(self, query=None):
+        if 'query' in self.data:
+            query = merge_dict_list(self.data['query'])
+        elif query is None:
+            query = {}
+        return super(ElasticSearchDomain, self).resources(query=query)
 
     source_mapping = {
         'describe': DescribeDomain,

--- a/tests/data/placebo/test_elasticsearch_with_prequery_filter/es.DescribeElasticsearchDomains_1.json
+++ b/tests/data/placebo/test_elasticsearch_with_prequery_filter/es.DescribeElasticsearchDomains_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DomainStatusList": [
+            {
+                "ElasticsearchClusterConfig": {
+                    "DedicatedMasterEnabled": false, 
+                    "InstanceCount": 1, 
+                    "ZoneAwarenessEnabled": false, 
+                    "InstanceType": "m4.large.elasticsearch"
+                }, 
+                "Endpoint": "search-c7n-test-opensearch-yt65782hjbs2wwrktaea543re67fd.us-east-1.es.amazonaws.com", 
+                "Created": true, 
+                "Deleted": false, 
+                "DomainName": "c7n-test-opensearch", 
+                "EBSOptions": {
+                    "VolumeSize": 20, 
+                    "VolumeType": "gp2", 
+                    "EBSEnabled": true
+                }, 
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 0
+                }, 
+                "DomainId": "644160558196/c7n-test-opensearch", 
+                "AccessPolicies": "", 
+                "Processing": false, 
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true"
+                }, 
+                "ElasticsearchVersion": "OpenSearch_1.3", 
+                "ARN": "arn:aws:es:us-east-1:644160558196:domain/c7n-test-opensearch"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "4092ee91-477b-11e7-b0ab-1f7d120d52ca", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "4092ee91-477b-11e7-b0ab-1f7d120d52ca", 
+                "date": "Fri, 02 Jun 2017 10:07:14 GMT", 
+                "content-length": "752", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_with_prequery_filter/es.ListDomainNames_1.json
+++ b/tests/data/placebo/test_elasticsearch_with_prequery_filter/es.ListDomainNames_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "407fb4ad-477b-11e7-b0ab-1f7d120d52ca", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "407fb4ad-477b-11e7-b0ab-1f7d120d52ca", 
+                "date": "Fri, 02 Jun 2017 10:07:14 GMT", 
+                "content-length": "43", 
+                "content-type": "application/json"
+            }
+        }, 
+        "DomainNames": [
+            {
+                "DomainName": "c7n-test-opensearch",
+                "EngineType": "OpenSearch"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_with_prequery_filter/es.ListTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_with_prequery_filter/es.ListTags_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "40a36990-477b-11e7-af14-5b416669625e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "40a36990-477b-11e7-af14-5b416669625e", 
+                "date": "Fri, 02 Jun 2017 10:07:14 GMT", 
+                "content-length": "41", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Dev", 
+                "Key": "Env"
+            }
+        ]
+    }
+}

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -56,6 +56,22 @@ class ElasticSearch(BaseTest):
             )
         )
 
+    def test_elasticsearch_with_prequery_filter(self):
+        factory = self.replay_flight_data("test_elasticsearch_with_prequery_filter")
+        p = self.load_policy(
+            {
+                "name": "es-query-2",
+                "resource": "elasticsearch",
+                "query": [{"EngineType": "OpenSearch"}],
+            },
+            session_factory=factory,
+        )
+        print(dir(p.resource_manager))
+        resources = p.run()
+        print(resources)
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["DomainName"], "c7n-test-opensearch")
+
     def test_metrics_domain(self):
         factory = self.replay_flight_data("test_elasticsearch_delete")
         p = self.load_policy(

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -66,9 +66,7 @@ class ElasticSearch(BaseTest):
             },
             session_factory=factory,
         )
-        print(dir(p.resource_manager))
         resources = p.run()
-        print(resources)
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["DomainName"], "c7n-test-opensearch")
 


### PR DESCRIPTION
Similar  in requirements to the issue raised in [PR-7696](https://github.com/cloud-custodian/cloud-custodian/pull/7696), we need to distinguish the ES cluster based on the engine type (OpenSearch|Elasticsearch) for one of our config based policy. So need to add the pre-query filter for either of the engine types.