### PR TITLE
releng - explicitly define bash as the makefile shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 SELF_MAKE := $(lastword $(MAKEFILE_LIST))
 PKG_REPO = testpypi
 PKG_SET := tools/c7n_gcp tools/c7n_kube tools/c7n_openstack tools/c7n_mailer tools/c7n_logexporter tools/c7n_policystream tools/c7n_trailcreator tools/c7n_org tools/c7n_sphinxext tools/c7n_terraform tools/c7n_awscc tools/c7n_tencentcloud tools/c7n_azure


### PR DESCRIPTION
So non-bash users don't get errors like this from [bash-specific syntax](https://github.com/ajkerrigan/cloud-custodian/blob/b9df33ebf185035b6dc4065bb57871d55340935f/Makefile#L26):

```console
❯ make install                                                                                                                                                    
/bin/sh: 1: [[: not found
```