### PR TITLE
aws - rds - bug fix in consecutive-snapshots filter

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1931,7 +1931,7 @@ class ConsecutiveSnapshots(Filter):
         client = local_session(self.manager.session_factory).client('rds')
         results = []
         retention = self.data.get('days')
-        utcnow = datetime.utcnow()
+        utcnow = datetime.datetime.utcnow()
         expected_dates = set()
         for days in range(1, retention + 1):
             expected_dates.add((utcnow - timedelta(days=days)).strftime('%Y-%m-%d'))

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -37,8 +37,9 @@ import logging
 import operator
 import jmespath
 import re
+import datetime
 
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 from decimal import Decimal as D, ROUND_HALF_UP
 
@@ -716,7 +717,7 @@ class DbInstanceFinding(PostFinding):
         for f in fields:
             if r.get(f):
                 value = r[f]
-                if isinstance(r[f], datetime):
+                if isinstance(r[f], datetime.datetime):
                     value = r[f].isoformat()
                 details.setdefault(f, value)
 
@@ -1930,7 +1931,7 @@ class ConsecutiveSnapshots(Filter):
         client = local_session(self.manager.session_factory).client('rds')
         results = []
         retention = self.data.get('days')
-        utcnow = datetime.utcnow()
+        utcnow = datetime.datetime.utcnow()
         expected_dates = set()
         for days in range(1, retention + 1):
             expected_dates.add((utcnow - timedelta(days=days)).strftime('%Y-%m-%d'))

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -37,9 +37,8 @@ import logging
 import operator
 import jmespath
 import re
-import datetime
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 from decimal import Decimal as D, ROUND_HALF_UP
 
@@ -717,7 +716,7 @@ class DbInstanceFinding(PostFinding):
         for f in fields:
             if r.get(f):
                 value = r[f]
-                if isinstance(r[f], datetime.datetime):
+                if isinstance(r[f], datetime):
                     value = r[f].isoformat()
                 details.setdefault(f, value)
 
@@ -1931,7 +1930,7 @@ class ConsecutiveSnapshots(Filter):
         client = local_session(self.manager.session_factory).client('rds')
         results = []
         retention = self.data.get('days')
-        utcnow = datetime.datetime.utcnow()
+        utcnow = datetime.utcnow()
         expected_dates = set()
         for days in range(1, retention + 1):
             expected_dates.add((utcnow - timedelta(days=days)).strftime('%Y-%m-%d'))

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -11,7 +11,6 @@ from collections import OrderedDict
 from unittest import mock
 
 import boto3
-import c7n.resources.rds
 from botocore.exceptions import ClientError
 from c7n import tags
 from c7n.exceptions import PolicyValidationError
@@ -881,7 +880,7 @@ class RDSTest(BaseTest):
             },
             session_factory=factory,
         )
-        with mock_datetime_now(parser.parse("2022-03-30T00:00:00+00:00"), c7n.resources.rds):
+        with mock_datetime_now(parser.parse("2022-03-30T00:00:00+00:00"), datetime):
             resources = p.run()
         self.assertEqual(len(resources), 1)
 


### PR DESCRIPTION
This will resolve the bug in the 'consecutive-snapshot' filter  in usage of datetime module.