### PR TITLE
releng - functional aws tests and slack results

### DIFF
--- a/.github/composites/install/action.yaml
+++ b/.github/composites/install/action.yaml
@@ -46,7 +46,14 @@ runs:
       id: cache_check
       shell: bash
       run: |
-        (poetry run custodian version && echo "venv=success" >> GITHUB_OUTPUT ) || (rm -rf .venv && echo "venv=recreate" >> GITHUB_OUTPUT )
+        if poetry run custodian version ; then
+           echo "venv=success" >> GITHUB_OUTPUT
+           echo "Cache Green"
+        else
+           rm -rf .venv
+           echo "venv==recreate" >> GITHUB_OUTPUT
+           echo "Cache Red"
+        fi
 
     - name: Virtualenv
       if: steps.cache.outputs.cache-hit != 'true' || steps.cache_check.outputs.venv != 'success'

--- a/.github/composites/install/action.yaml
+++ b/.github/composites/install/action.yaml
@@ -47,11 +47,11 @@ runs:
       shell: bash
       run: |
         if poetry run custodian version ; then
-           echo "venv=success" >> GITHUB_OUTPUT
+           echo "venv=success" >> $GITHUB_OUTPUT
            echo "Cache Green"
         else
            rm -rf .venv
-           echo "venv==recreate" >> GITHUB_OUTPUT
+           echo "venv==recreate" >> $GITHUB_OUTPUT
            echo "Cache Red"
         fi
 

--- a/.github/composites/install/action.yaml
+++ b/.github/composites/install/action.yaml
@@ -55,7 +55,7 @@ runs:
            echo "Cache Red"
         fi
 
-    - name: Virtualenv
+    - name: Install
       if: steps.cache.outputs.cache-hit != 'true' || steps.cache_check.outputs.venv != 'success'
       shell: bash
       env:
@@ -67,11 +67,7 @@ runs:
         if [ -d ".venv" ]; then
           mv .venv .venv-old
         fi
-        python -m venv .venv
-
-    - name: Install
-      shell: bash
-      run: |
+        python -m venv .ven
         make install
 
     - name: Output Poetry Version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,3 +30,15 @@ jobs:
           name: ${{ matrix.image }}
           push: true
           platforms: linux/arm64,linux/amd64
+
+      - name: Notify Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_HOOK }}
+        with:
+          status: ${{ job.status }}
+          notification_title: "{workflow} has {status_message}"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Job <{workflow_url}|{job}>"
+          notify_when: "failure,success"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_HOOK }}
         with:
           status: ${{ job.status }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          footer: "Linked Job <{workflow_url}|{job}>"
+          notification_title: "{workflow}:{job} has {status_message}"
+          message_format: "{emoji} *{workflow}:{job}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Logs <{run_url}|{job}>"
           notify_when: "failure,success"

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -29,6 +29,13 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up cache
+        uses: actions/cache@v3
+        id: tfcache
+        with:
+          path: .tfcache
+          key: tf-${{ runner.os }}-${{ hashFiles('**/*.tf') }}            
+
       - name: Functional Tests
         run: |
           mkdir -p .tfcache

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Functional Tests
         run: |
-          pytest -m "terraform and not skiplive" -n auto -v tests
+          pytest -m "terraform and audited and not skiplive" -n auto -v tests
         env:
           C7N_FUNCTIONAL: "true"
           C7N_TEST_RUN: "true"
@@ -43,7 +43,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_HOOK }}
         with:
           status: ${{ job.status }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          footer: "Linked Job <{workflow_url}|{job}>"
+          notification_title: "{workflow}:{job} has {status_message}"
+          message_format: "{emoji} *{workflow}:{job}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Logs <{run_url}|{job}>"
           notify_when: "failure,success"

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Functional Tests
         run: |
+          mkdir -p .tfcache
           pytest -m "terraform and audited and not skiplive" -n auto -v tests
         env:
           C7N_FUNCTIONAL: "true"

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Functional Tests
         run: |
           mkdir -p .tfcache
-          pytest -m "terraform and audited and not skiplive" -n auto -v tests
+          pytest -m "terraform and audited and not skiplive" -v tests
         env:
           C7N_FUNCTIONAL: "true"
           C7N_TEST_RUN: "true"

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -1,12 +1,7 @@
 name: "Functional"
 
-env:
-  C7N_FUNCTIONAL: true
-  C7N_TEST_RUN: true
-
 on:
   workflow_dispatch: {}
-
 jobs:
   AWS:
     runs-on: ubuntu-latest
@@ -16,31 +11,39 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4.2.0
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_FTEST_ROLE }}
           aws-region: us-east-1
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: "${{ env.terraform_version }}"
           terraform_wrapper: false
 
-      - name: Install Requirements
-        run: |
-          mkdir -p .tfcache
-          pip install --cache-dir=./.pip-cache -r requirements.txt
-
-      - name: Test
-        run: |
-          pytest tests -m "not skiplive" -m terraform -n auto --junit-xml=report-aws.xml
-
-      - name: JUnit Report Action
-        uses: mikepenz/action-junit-report@v3.3.3
-        if: always()
+      - name: Install Custodian
+        uses: ./.github/composites/install
         with:
-          report_paths: 'report-aws.xml'
+          python-version: "3.11"
+
+      - name: Functional Tests
+        run: |
+          pytest -m "terraform and not skiplive" -n auto -v tests
+        env:
+          C7N_FUNCTIONAL: "true"
+          C7N_TEST_RUN: "true"
+
+      - name: Notify Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_HOOK }}
+        with:
+          status: ${{ job.status }}
+          notification_title: "{workflow} has {status_message}"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Job <{workflow_url}|{job}>"
+          notify_when: "failure,success"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ exclude = ["__init__.py"]
 [tool.pytest.ini_options]
 junit_family = "xunit2"
 addopts = "--tb=native"
-markers = ["functional", "skiplive"]
+markers = ["functional", "skiplive", "audited"]
 python_files = "test_*.py"
 norecursedirs = ["data", "cassettes", "templates", "terraform"]
 

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from dateutil import tz as tzutil
 
 import jmespath
+import pytest
 from pytest_terraform import terraform
 
 from .common import BaseTest
@@ -106,6 +107,7 @@ class AutoScalingTemplateTest(BaseTest):
             LaunchInfo(p.resource_manager).get_launch_id(d), ("lt-0877401c93c294001", "4"))
 
 
+@pytest.mark.audited
 @terraform('aws_asg')
 def test_asg_propagate_tag_action(test, aws_asg):
 
@@ -132,6 +134,7 @@ def test_asg_propagate_tag_action(test, aws_asg):
     assert itags['Owner'] == 'Kapil'
 
 
+@pytest.mark.audited
 @terraform("aws_asg_update")
 def test_aws_asg_update(test, aws_asg_update):
     factory = test.replay_flight_data("test_aws_asg_update")

--- a/tests/test_cwe.py
+++ b/tests/test_cwe.py
@@ -3,6 +3,7 @@
 import json
 import jmespath
 import jmespath.parser
+import pytest
 from pytest_terraform import terraform
 from unittest import TestCase
 
@@ -19,6 +20,7 @@ class JmespathEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
+@pytest.mark.audited
 @terraform('event_bridge_bus')
 def test_event_bus_describe(test, event_bridge_bus):
     factory = test.replay_flight_data('test_cwe_bus_xaccount')

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -6,9 +6,11 @@ from c7n.resources.cw import LogMetricAlarmFilter
 from .common import BaseTest, functional
 from unittest.mock import MagicMock
 
+import pytest
 from pytest_terraform import terraform
 
 
+@pytest.mark.audited
 @terraform('log_delete', teardown=terraform.TEARDOWN_IGNORE)
 def test_tagged_log_group_delete(test, log_delete):
     factory = test.replay_flight_data(

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -21,6 +21,7 @@ import pytest
 from pytest_terraform import terraform
 
 
+@pytest.mark.audited
 @terraform('ec2_stop_protection_enabled')
 def test_ec2_stop_protection_enabled(test, ec2_stop_protection_enabled):
     aws_region = 'us-east-1'

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -64,6 +64,7 @@ def test_ec2_stop_protection_enabled(test, ec2_stop_protection_enabled):
     )
 
 
+@pytest.mark.audited
 @terraform('ec2_stop_protection_disabled')
 def test_ec2_stop_protection_disabled(test, ec2_stop_protection_disabled):
     aws_region = 'us-east-1'

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -20,8 +20,8 @@ from .common import BaseTest
 import pytest
 from pytest_terraform import terraform
 
-
-@pytest.mark.audited
+# this one doesn't work as a functional test as it enables stop protection, which prevents
+# the terraform teardown, we would need to also remove the stop protection in the test.
 @terraform('ec2_stop_protection_enabled')
 def test_ec2_stop_protection_enabled(test, ec2_stop_protection_enabled):
     aws_region = 'us-east-1'

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -117,6 +117,7 @@ class Route53HostedZoneTest(BaseTest):
         self.assertTrue("abc" in tags["ResourceTagSet"]["Tags"][0].values())
 
 
+@pytest.mark.audited
 @terraform('route53_hostedzone_delete', teardown=terraform.TEARDOWN_IGNORE)
 def test_route53_hostedzone_delete(test, route53_hostedzone_delete):
     session_factory = test.replay_flight_data("test_route53_hostedzone_delete")

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -3848,6 +3848,7 @@ class S3LifecycleTest(BaseTest):
             client.get_bucket_lifecycle_configuration(Bucket=bname)
 
 
+@pytest.mark.audited
 @terraform('aws_s3_encryption_audit')
 def test_s3_encryption_audit(test, aws_s3_encryption_audit):
     test.patch(s3.S3, "executor_factory", MainThreadExecutor)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -15,6 +15,7 @@ from unittest import TestCase
 from contextlib import suppress
 from botocore.exceptions import ClientError
 from dateutil.tz import tzutc
+import pytest
 from pytest_terraform import terraform
 
 from c7n.exceptions import PolicyExecutionError, PolicyValidationError
@@ -33,6 +34,7 @@ from .common import (
 )
 
 
+@pytest.mark.audited
 @terraform('s3_tag')
 def test_s3_tag(test, s3_tag):
     test.patch(s3.S3, "executor_factory", MainThreadExecutor)
@@ -3895,6 +3897,7 @@ def test_s3_encryption_audit(test, aws_s3_encryption_audit):
     assert actual_names == expected_names
 
 
+@pytest.mark.audited
 @terraform('s3_ownership', scope='class')
 class TestBucketOwnership:
     def test_s3_ownership_empty(self, test, s3_ownership):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -3848,7 +3848,6 @@ class S3LifecycleTest(BaseTest):
             client.get_bucket_lifecycle_configuration(Bucket=bname)
 
 
-@pytest.mark.audited
 @terraform('aws_s3_encryption_audit')
 def test_s3_encryption_audit(test, aws_s3_encryption_audit):
     test.patch(s3.S3, "executor_factory", MainThreadExecutor)
@@ -3861,6 +3860,14 @@ def test_s3_encryption_audit(test, aws_s3_encryption_audit):
             "name": "s3-audit",
             "resource": "s3",
             "filters": [
+                {"type": "value",
+                 "key": "Name",
+                 "op": "in",
+                 "value": [
+                     'c7n-aws-s3-encryption-audit-test-a',
+                     'c7n-aws-s3-encryption-audit-test-b',
+                     'c7n-aws-s3-encryption-audit-test-c',
+                 ]},
                 {
                     "or": [
                         {

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -3,7 +3,6 @@
 from .common import BaseTest, functional, event_data, placebo_dir
 from datetime import datetime
 from dateutil.tz import tzutc
-import pytest
 from pytest_terraform import terraform
 from botocore.exceptions import ClientError
 

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -135,7 +135,7 @@ def test_sqs_set_encryption_options(test):
                                'KmsMasterKeyId': 'arn:aws:kms:us-east-1:1122334455:key/fb5bc39f-3cdb-438b-b959-3b812ae71628'}  # noqa
 
 
-@pytest.mark.audited
+# running functionally seems to get an error on mismatched key ids
 @terraform('sqs_set_encryption')
 def test_sqs_set_encryption(test, sqs_set_encryption):
     session_factory = test.replay_flight_data("test_sqs_set_encryption", region='us-west-2')

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -3,6 +3,7 @@
 from .common import BaseTest, functional, event_data, placebo_dir
 from datetime import datetime
 from dateutil.tz import tzutc
+import pytest
 from pytest_terraform import terraform
 from botocore.exceptions import ClientError
 
@@ -61,6 +62,7 @@ def test_sqs_config_translate(test):
     }
 
 
+@pytest.mark.audited
 @terraform('sqs_delete', teardown=terraform.TEARDOWN_IGNORE)
 def test_sqs_delete(test, sqs_delete):
     session_factory = test.replay_flight_data("test_sqs_delete", region='us-east-2')
@@ -166,6 +168,7 @@ def test_sqs_set_encryption(test, sqs_set_encryption):
     test.assertEqual(check_master_key, key_id)
 
 
+@pytest.mark.audited
 @terraform('sqs_remove_matched')
 def test_sqs_remove_matched(test, sqs_remove_matched):
     session_factory = test.replay_flight_data("test_sqs_remove_matched", region="us-east-2")

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -135,6 +135,7 @@ def test_sqs_set_encryption_options(test):
                                'KmsMasterKeyId': 'arn:aws:kms:us-east-1:1122334455:key/fb5bc39f-3cdb-438b-b959-3b812ae71628'}  # noqa
 
 
+@pytest.mark.audited
 @terraform('sqs_set_encryption')
 def test_sqs_set_encryption(test, sqs_set_encryption):
     session_factory = test.replay_flight_data("test_sqs_set_encryption", region='us-west-2')

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -12,9 +12,12 @@ from c7n.exceptions import PolicyExecutionError, PolicyValidationError
 from c7n.utils import yaml_load
 
 from .common import BaseTest
+
+import pytest
 from pytest_terraform import terraform
 
 
+@pytest.mark.audited
 @terraform('tag_action_filter_call')
 def test_tag_action_filter_call(test, tag_action_filter_call):
     aws_region = 'us-east-1'


### PR DESCRIPTION
functional - use new cncf cloud infra aws account for running functional tests, this is scoped to  power user access only atm.

closes #8325

functional tests can be executed by any maintainer on the cli by running
`gh workflow run  functional.yaml` within a checkout of the repo.

we start with the terraform tests (population 31) and filtered down to those that don't need to create iam roles, we also have a bunch of tests marked functional (population ~70), but those require a bit more inspection to enable. We do want to add a few more of those as our functional tests of lambda policies do rely on those, but that can be in a followup.

ci - fix cache usage in install component, generally sees a minute speed up per runner.

closes #8354 

![Screenshot 2023-03-09 at 10 26 37 AM](https://user-images.githubusercontent.com/21650/224071912-2830c3cb-e272-4f3d-955f-96f8882466b8.png)

