### PR TITLE
aws - apigw - generate domain name arns

### DIFF
--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -1122,7 +1122,7 @@ class CustomDomainName(query.QueryResourceManager):
 
     class resource_type(query.TypeInfo):
         enum_spec = ('get_domain_names', 'items', None)
-        arn = False
+        arn_type = '/domainnames'
         id = name = 'domainName'
         service = 'apigateway'
         universal_taggable = True
@@ -1133,9 +1133,20 @@ class CustomDomainName(query.QueryResourceManager):
     def get_permissions(cls):
         return ('apigateway:GET',)
 
-    @classmethod
-    def has_arn(self):
-        return False
+    @property
+    def generate_arn(self):
+        """
+         Sample arn: arn:aws:apigateway:us-east-1::/restapis/rest-api-id
+         This method overrides c7n.utils.generate_arn and drops
+         account id from the generic arn.
+        """
+        if self._generate_arn is None:
+            self._generate_arn = functools.partial(
+                generate_arn,
+                self.resource_type.service,
+                region=self.config.region,
+                resource_type=self.resource_type.arn_type)
+        return self._generate_arn
 
 
 @CustomDomainName.action_registry.register('update-security')

--- a/tests/test_apigw.py
+++ b/tests/test_apigw.py
@@ -905,6 +905,33 @@ class TestCustomDomainName(BaseTest):
         result = client.get_domain_name(domainName="bad.example.com")
         self.assertEqual(result['securityPolicy'], 'TLS_1_2')
 
+    def test_arn_format(self):
+        factory = self.replay_flight_data("test_apigw_domain_name_filter_check_tls")
+        p = self.load_policy(
+            {
+                "name": "apigw-domain-name-check-tls",
+                "resource": "apigw-domain-name",
+                "filters": [
+                    {
+                        "not": [
+                            {
+                                "type": "value",
+                                "key": "securityPolicy",
+                                "value": "TLS_1_2"
+                            }
+                        ]
+                    }
+                ]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            p.resource_manager.get_arns(resources)[0],
+            "arn:aws:apigateway:us-east-1::/domainnames/bad.example.com"
+        )
+
 
 class TestResourcePolicy(BaseTest):
     def test_rest_api_default_resource_policy(self):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -203,7 +203,7 @@ class PolicyMetaLint(BaseTest):
         overrides = overrides.difference(
             {'account', 's3', 'hostedzone', 'log-group', 'rest-api', 'redshift-snapshot',
              'rest-stage', 'codedeploy-app', 'codedeploy-group', 'fis-template', 'dlm-policy',
-             'apigwv2', })
+             'apigwv2', 'apigw-domain-name'})
         if overrides:
             raise ValueError("unknown arn overrides in %s" % (", ".join(overrides)))
 
@@ -517,8 +517,11 @@ class PolicyMetaLint(BaseTest):
             # these are valid, but v1 & v2 arns get mangled into the
             # same top level prefix
             'emr-serverless-app',
+            # api gateway resources trip up these checks because they
+            # have leading slashes in the resource type section
             'rest-api',
             'rest-stage',
+            'apigw-domain-name',
             # synthetics ~ ie. c7n introduced since non exist.
             # or in some cases where it exists but not usable in iam.
             'scaling-policy',


### PR DESCRIPTION
Define arn generation for `apigw-domain-name` similar to some other apigw resource types.

Since with this change we'd be overriding `generate_arn()` similarly for 4 different apigw resource types, wonder if it's worth a follow-up change to consolidate that :thinking: .