### PR TITLE
Feature: Add API-Key secret functionality to values_from

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -137,8 +137,8 @@ class ValuesFrom:
         self.cache = manager._cache or NullCache({})
         self.resolver = URIResolver(manager.session_factory, self.cache)
 
-    def _attach_api_key(self, config, headers):
-        api_key = config.get('api_key_secret')
+    def _attach_api_key(self, headers):
+        api_key = self.data.get('api_key_secret')
         if api_key is not None:
             if api_key.startswith('arn:aws:secretsmanager'):
                 client = boto3.client('secretsmanager')
@@ -162,7 +162,7 @@ class ValuesFrom:
             uri=self.data.get('url'),
             headers=self.data.get('headers', {})
         )
-        self._attach_api_key(self.data, params['headers'])
+        self._attach_api_key(params['headers'])
         
         contents = str(self.resolver.resolve(**params))
         return contents, format

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -302,6 +302,7 @@ class SchemaTest(CliTest):
                     'expr': {'oneOf': [
                         {'type': 'integer'},
                         {'type': 'string'}]},
+                    'api_key_secret': {'type': 'string'},
                     'headers': {
                         'type': 'object',
                         'patternProperties': {
@@ -320,6 +321,7 @@ class SchemaTest(CliTest):
                     'expr': {'oneOf': [
                         {'type': 'integer'},
                         {'type': 'string'}]},
+                    'api_key_secret': {'type': 'string'},
                     'headers': {
                         'type': 'object',
                         'patternProperties': {

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -242,19 +242,12 @@ class UrlValueTest(BaseTest):
         self.assertEqual(values.get_values(), {"3"})
 
     def test_value_from_vars(self):
-        api_key_secret = "arn:aws:secretsmanager:<region>:<account>:secret:<name>"
         values = self.get_values_from(
-            {
-                "url": "{account_id}",
-                "expr": '["{region}"][]',
-                "format": "json",
-                "api_key_secret": api_key_secret
-            },
+            {"url": "{account_id}", "expr": '["{region}"][]', "format": "json"},
             json.dumps({"us-east-1": "east-resource"}),
         )
         self.assertEqual(values.get_values(), {"east-resource"})
         self.assertEqual(values.data.get("url", ""), ACCOUNT_ID)
-        self.assertEqual(values.data.get("api_key_secret", ""), api_key_secret)
 
     def test_value_from_caching(self):
         cache = FakeCache()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -242,12 +242,14 @@ class UrlValueTest(BaseTest):
         self.assertEqual(values.get_values(), {"3"})
 
     def test_value_from_vars(self):
+        api_key_secret = "arn:aws:secretsmanager:<region>:<account>:secret:<name>"
         values = self.get_values_from(
-            {"url": "{account_id}", "expr": '["{region}"][]', "format": "json"},
+            {"url": "{account_id}", "expr": '["{region}"][]', "format": "json", "api_key_secret": api_key_secret},
             json.dumps({"us-east-1": "east-resource"}),
         )
         self.assertEqual(values.get_values(), {"east-resource"})
         self.assertEqual(values.data.get("url", ""), ACCOUNT_ID)
+        self.assertEqual(values.data.get("api_key_secret", ""), api_key_secret)
 
     def test_value_from_caching(self):
         cache = FakeCache()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -244,7 +244,12 @@ class UrlValueTest(BaseTest):
     def test_value_from_vars(self):
         api_key_secret = "arn:aws:secretsmanager:<region>:<account>:secret:<name>"
         values = self.get_values_from(
-            {"url": "{account_id}", "expr": '["{region}"][]', "format": "json", "api_key_secret": api_key_secret},
+            {
+                "url": "{account_id}",
+                "expr": '["{region}"][]',
+                "format": "json",
+                "api_key_secret": api_key_secret
+            },
             json.dumps({"us-east-1": "east-resource"}),
         )
         self.assertEqual(values.get_values(), {"east-resource"})


### PR DESCRIPTION
PR provides functionality to resolve API-Keys (passed as Secrets) in `values_from`-Filters at Runtime.
(Currently supports AWS Secrets, but can be extended in the future).
At this moment you can define API-Keys in the `values_from.headers` Block only which means they would be visible to anyone who has access to the Policy.

Before PR:
```
policies:
  - name: test-policy
    resource: aws.ec2
    filters:
      - type: value
        key:  "InstanceId"
        op:   not-in
        value_from:
          url:     <url>
          format:  json
          headers:
            x-api-key: <x-api-key>
```

After PR:
```
policies:
  - name: test-policy
    resource: aws.ec2
    filters:
      - type: value
        key:  "InstanceId"
        op:   not-in
        value_from:
          url:     <url>
          format:  json
          api_key_secret: <arn:aws:secret...>
```