### PR TITLE
aws - iam-user - add include-via option to policy filter

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1956,7 +1956,8 @@ class UserPolicy(ValueFilter):
                 include-via: true
     """
 
-    schema = type_schema('policy', rinherit=ValueFilter.schema)
+    schema = type_schema('policy', rinherit=ValueFilter.schema, 
+        **{'include-via': {'type': 'boolean'}})
     schema_alias = False
     permissions = (
         'iam:ListAttachedUserPolicies',

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1965,14 +1965,18 @@ class UserPolicy(ValueFilter):
     )
 
     def user_groups_policies(self, client, u):
+        if 'c7n:GroupsPolicies' not in u:
+            u['c7n:GroupsPolicies'] = []
+
         u['c7n:Groups'] = client.list_groups_for_user(
             UserName=u['UserName'])['Groups']
         for ug in u['c7n:Groups']:
             aps = client.list_attached_group_policies(
                 GroupName=ug['GroupName'])['AttachedPolicies']
             for ap in aps:
-                u['c7n:Policies'].append(
+                u['c7n:GroupsPolicies'].append(
                     client.get_policy(PolicyArn=ap['PolicyArn'])['Policy'])
+
         return u
 
     def user_policies(self, user_set):
@@ -2000,6 +2004,10 @@ class UserPolicy(ValueFilter):
             for p in r['c7n:Policies']:
                 if self.match(p) and r not in matched:
                     matched.append(r)
+            if self.data.get('include-via'):
+                for p in r['c7n:GroupsPolicies']:
+                    if self.match(p) and r not in matched:
+                        matched.append(r)
         return matched
 
 

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1985,7 +1985,9 @@ class UserPolicy(ValueFilter):
             for ap in aps:
                 policy_arn = ap['PolicyArn']
                 policy_searched = self.find_policy_in_user_set(u, 'c7n:Policies', policy_arn)
-                group_policy_searched = self.find_policy_in_user_set(u, 'c7n:GroupsPolicies', policy_arn)
+                group_policy_searched = self.find_policy_in_user_set(
+                    u, 'c7n:GroupsPolicies', policy_arn
+                )
 
                 if policy_searched and group_policy_searched is None:
                     u['c7n:GroupsPolicies'].append(policy_searched)

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1969,7 +1969,7 @@ class UserPolicy(ValueFilter):
             UserName=u['UserName'])['Groups']
         for ug in u['c7n:Groups']:
             aps = client.list_attached_group_policies(
-                UserName=ug['GroupName'])['AttachedPolicies']
+                GroupName=ug['GroupName'])['AttachedPolicies']
             for ap in aps:
                 u['c7n:Policies'].append(
                     client.get_policy(PolicyArn=ap['PolicyArn'])['Policy'])

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.GetPolicy_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.GetPolicy_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": {
+            "PolicyName": "AdministratorAccess", 
+            "Description": "Provides full access to AWS services and resources.", 
+            "CreateDate": {
+                "hour": 18, 
+                "__class__": "datetime", 
+                "month": 2, 
+                "second": 46, 
+                "microsecond": 0, 
+                "year": 2015, 
+                "day": 6, 
+                "minute": 39
+            }, 
+            "AttachmentCount": 2, 
+            "IsAttachable": true, 
+            "PolicyId": "ANPAIWMBCKSKIEE64ZLYK", 
+            "DefaultVersionId": "v1", 
+            "Path": "/", 
+            "Arn": "arn:aws:iam::aws:policy/AdministratorAccess", 
+            "UpdateDate": {
+                "hour": 18, 
+                "__class__": "datetime", 
+                "month": 2, 
+                "second": 46, 
+                "microsecond": 0, 
+                "year": 2015, 
+                "day": 6, 
+                "minute": 39
+            }
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "138aff10-d69b-11e6-ba70-050a502ea605", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "138aff10-d69b-11e6-ba70-050a502ea605", 
+                "date": "Mon, 09 Jan 2017 18:40:21 GMT", 
+                "content-length": "766", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.GetPolicy_2.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.GetPolicy_2.json
@@ -1,0 +1,48 @@
+{
+    "status_code": 200,
+    "data": {
+        "Policy": {
+            "PolicyName": "AWSHealthFullAccess",
+            "PolicyId": "ANPAI3CUMPCPEUPCSXC4Y",
+            "Arn": "arn:aws:iam::aws:policy/AWSHealthFullAccess",
+            "Path": "/",
+            "DefaultVersionId": "v3",
+            "AttachmentCount": 0,
+            "PermissionsBoundaryUsageCount": 0,
+            "IsAttachable": true,
+            "Description": "Allows full access to the AWS Health Apis and Notifications and the Personal Health Dashboard",
+            "CreateDate": {
+                "__class__": "datetime",
+                "year": 2016,
+                "month": 12,
+                "day": 6,
+                "hour": 12,
+                "minute": 30,
+                "second": 31,
+                "microsecond": 0
+            },
+            "UpdateDate": {
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 11,
+                "day": 16,
+                "hour": 18,
+                "minute": 11,
+                "second": 34,
+                "microsecond": 0
+            },
+            "Tags": []
+        },
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "138aff10-d69b-11e6-ba70-050a502ea608", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "138aff10-d69b-11e6-ba70-050a502ea608", 
+                "date": "Mon, 09 Jan 2017 18:45:21 GMT", 
+                "content-length": "766", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.GetUser_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.GetUser_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "User": {
+            "Path": "/",
+            "UserName": "alphabet_soup",
+            "UserId": "AIDAJEZOTH6YPO3DY45QW",
+            "Arn": "arn:aws:iam::644160558196:user/alphabet_soup",
+            "CreateDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 12,
+                "day": 6,
+                "hour": 16,
+                "minute": 6,
+                "second": 5,
+                "microsecond": 0
+            },
+            "Tags": [
+                {
+                    "Key": "Role",
+                    "Value": "Dev"
+                }
+            ]
+        },
+        "ResponseMetadata": {
+            "RequestId": "a59813a6-1f5c-11e9-b74d-b5201ef1df02",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "a59813a6-1f5c-11e9-b74d-b5201ef1df02",
+                "content-type": "text/xml",
+                "content-length": "576",
+                "date": "Wed, 23 Jan 2019 22:17:18 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.GetUser_2.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.GetUser_2.json
@@ -3,9 +3,9 @@
     "data": {
         "User": {
             "Path": "/",
-            "UserName": "alphabet_soup_1",
-            "UserId": "AIDAJEZOTH6YPO3DY45QW",
-            "Arn": "arn:aws:iam::644160558196:user/alphabet_soup_1",
+            "UserName": "alphabet_soup_2",
+            "UserId": "AIDAJEZOTH6YPO3DY45QE",
+            "Arn": "arn:aws:iam::644160558196:user/alphabet_soup_2",
             "CreateDate": {
                 "__class__": "datetime",
                 "year": 2017,
@@ -24,13 +24,13 @@
             ]
         },
         "ResponseMetadata": {
-            "RequestId": "a59813a6-1f5c-11e9-b74d-b5201ef1df02",
+            "RequestId": "a59813a6-1f5c-11e9-b74d-b5201ef1df03",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
-                "x-amzn-requestid": "a59813a6-1f5c-11e9-b74d-b5201ef1df02",
+                "x-amzn-requestid": "a59813a6-1f5c-11e9-b74d-b5201ef1df03",
                 "content-type": "text/xml",
                 "content-length": "576",
-                "date": "Wed, 23 Jan 2019 22:17:18 GMT"
+                "date": "Wed, 23 Jan 2019 22:17:19 GMT"
             },
             "RetryAttempts": 0
         }

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedGroupPolicies_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedGroupPolicies_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AttachedPolicies": [
+            {
+                "PolicyName": "AdministratorAccess", 
+                "PolicyArn": "arn:aws:iam::aws:policy/AdministratorAccess"
+            }
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "137c0ac8-d69b-11e6-ba70-050a502ea607", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "137c0ac8-d69b-11e6-ba70-050a502ea607", 
+                "date": "Mon, 09 Jan 2017 18:40:23 GMT", 
+                "content-length": "542", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedGroupPolicies_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedGroupPolicies_1.json
@@ -5,6 +5,10 @@
             {
                 "PolicyName": "AdministratorAccess", 
                 "PolicyArn": "arn:aws:iam::aws:policy/AdministratorAccess"
+            },
+            {
+                "PolicyName": "AWSHealthFullAccess", 
+                "PolicyArn": "arn:aws:iam::aws:policy/AWSHealthFullAccess"                
             }
         ], 
         "IsTruncated": false, 

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedUserPolicies_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedUserPolicies_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AttachedPolicies": [], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "137c0ac8-d69b-11e6-ba70-050a502ea605", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "137c0ac8-d69b-11e6-ba70-050a502ea605", 
+                "date": "Mon, 09 Jan 2017 18:40:21 GMT", 
+                "content-length": "542", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedUserPolicies_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedUserPolicies_1.json
@@ -1,7 +1,12 @@
 {
     "status_code": 200, 
     "data": {
-        "AttachedPolicies": [], 
+        "AttachedPolicies": [
+            {
+                "PolicyName": "AdministratorAccess", 
+                "PolicyArn": "arn:aws:iam::aws:policy/AdministratorAccess"
+            }            
+        ], 
         "IsTruncated": false, 
         "ResponseMetadata": {
             "RetryAttempts": 0, 

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedUserPolicies_2.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListAttachedUserPolicies_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AttachedPolicies": [], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "137c0ac8-d69b-11e6-ba70-050a502ea605", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "137c0ac8-d69b-11e6-ba70-050a502ea605", 
+                "date": "Mon, 09 Jan 2017 18:40:21 GMT", 
+                "content-length": "542", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListGroupsForUser_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListGroupsForUser_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "Groups": [
+            {
+                "Path": "/",
+                "GroupName": "AdminGroup",
+                "GroupId": "AGPAJHYEJ6DMZRAVTSRQA",
+                "Arn": "arn:aws:iam::123456789000:group/AdminGroup",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2016,
+                    "month": 6,
+                    "day": 7,
+                    "hour": 5,
+                    "minute": 54,
+                    "second": 38,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "137c0ac8-d69b-11e6-ba70-050a502ea606", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "137c0ac8-d69b-11e6-ba70-050a502ea606", 
+                "date": "Mon, 09 Jan 2017 18:40:22 GMT", 
+                "content-length": "542", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListGroupsForUser_2.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListGroupsForUser_2.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "Groups": [
+            {
+                "Path": "/",
+                "GroupName": "AdminGroup",
+                "GroupId": "AGPAJHYEJ6DMZRAVTSRQA",
+                "Arn": "arn:aws:iam::123456789000:group/AdminGroup",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2016,
+                    "month": 6,
+                    "day": 7,
+                    "hour": 5,
+                    "minute": 54,
+                    "second": 38,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "137c0ac8-d69b-11e6-ba70-050a502ea606", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "137c0ac8-d69b-11e6-ba70-050a502ea606", 
+                "date": "Mon, 09 Jan 2017 18:40:22 GMT", 
+                "content-length": "542", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListUsers_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListUsers_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Users": [
+            {
+                "UserName": "alphabet_soup", 
+                "PasswordLastUsed": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 5, 
+                    "minute": 4
+                }, 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 8, 
+                    "minute": 36
+                }, 
+                "UserId": "AIDAI4HREXSL6KOVVKGGU", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::185106417252:user/alphabet_soup"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "132b529d-d69b-11e6-a2e1-0d01db4c604b", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "132b529d-d69b-11e6-a2e1-0d01db4c604b", 
+                "date": "Mon, 09 Jan 2017 18:40:20 GMT", 
+                "content-length": "939", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListUsers_1.json
+++ b/tests/data/placebo/test_iam_user_admin_policy_include_via/iam.ListUsers_1.json
@@ -3,7 +3,7 @@
     "data": {
         "Users": [
             {
-                "UserName": "alphabet_soup", 
+                "UserName": "alphabet_soup_1", 
                 "PasswordLastUsed": {
                     "hour": 15, 
                     "__class__": "datetime", 
@@ -26,7 +26,33 @@
                 }, 
                 "UserId": "AIDAI4HREXSL6KOVVKGGU", 
                 "Path": "/", 
-                "Arn": "arn:aws:iam::185106417252:user/alphabet_soup"
+                "Arn": "arn:aws:iam::185106417252:user/alphabet_soup_1"
+            },
+            {
+                "UserName": "alphabet_soup_2", 
+                "PasswordLastUsed": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 5, 
+                    "minute": 4
+                }, 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 8, 
+                    "minute": 36
+                }, 
+                "UserId": "AIDAI4HREXSL6KOVVKGGI", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::185106417252:user/alphabet_soup_2"
             }
         ], 
         "ResponseMetadata": {

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1051,6 +1051,7 @@ class IamUserTest(BaseTest):
         )
         resources = p.run()
         self.assertEqual(resources[0]["UserName"], "alphabet_soup")
+        self.assertEqual(len(resources[0]["c7n:GroupsPolicies"]), 2)
 
     def test_iam_user_access_key_filter(self):
         session_factory = self.replay_flight_data("test_iam_user_access_key_active")

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1031,6 +1031,27 @@ class IamUserTest(BaseTest):
         resources = p.run()
         self.assertEqual(resources[0]["UserName"], "alphabet_soup")
 
+    def test_iam_user_policy_include_via(self):
+        session_factory = self.replay_flight_data("test_iam_user_admin_policy_include_via")
+        self.patch(UserPolicy, "executor_factory", MainThreadExecutor)
+        p = self.load_policy(
+            {
+                "name": "iam-user-policy",
+                "resource": "iam-user",
+                "filters": [
+                    {
+                        "type": "policy",
+                        "key": "PolicyName",
+                        "value": "AdministratorAccess",
+                        "include-via": True,
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(resources[0]["UserName"], "alphabet_soup")
+
     def test_iam_user_access_key_filter(self):
         session_factory = self.replay_flight_data("test_iam_user_access_key_active")
         self.patch(UserAccessKey, "executor_factory", MainThreadExecutor)

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1050,8 +1050,11 @@ class IamUserTest(BaseTest):
             session_factory=session_factory,
         )
         resources = p.run()
-        self.assertEqual(resources[0]["UserName"], "alphabet_soup")
-        self.assertEqual(len(resources[0]["c7n:GroupsPolicies"]), 2)
+        self.assertEqual(len(resources), 2)
+        self.assertEqual(resources[0]["UserName"], "alphabet_soup_1")
+        self.assertEqual(len(resources[0]["c7n:Policies"]), 2)
+        self.assertEqual(resources[1]["UserName"], "alphabet_soup_2")
+        self.assertEqual(len(resources[1]["c7n:Policies"]), 2)
 
     def test_iam_user_access_key_filter(self):
         session_factory = self.replay_flight_data("test_iam_user_access_key_active")


### PR DESCRIPTION
- Background
  - There are two cases in which permission is added to iam-user as an attached policy `attached directly`, `attached via`.
  - In the case of `attached via`, iam-user inherits the policy attached to the group.
  - Now, in the iam-user's policy filter, cannot filter the policy attached to the group.
  - Cases of attached policy to iam-user.
    - directly : true, via : false
    - directly : false, via : true (now, can not filter this case)
    - directly : true, via : true
- Resolved
  - It can be also filter for `attached via` by setting options.
  ```
   policies:
     - name: iam-users-with-admin-access
        resource: iam-user
        filters:
          - type: policy
             key: PolicyName
             value: AdministratorAccess
             include-via: true
  ```