### PR TITLE
aws - s3 - handle access denied errors in check-public-block filter

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1370,7 +1370,19 @@ class FilterPublicBlock(Filter):
                 config = s3.get_public_access_block(
                     Bucket=bucket['Name'])['PublicAccessBlockConfiguration']
             except ClientError as e:
-                if e.response['Error']['Code'] != 'NoSuchPublicAccessBlockConfiguration':
+                error_code = e.response['Error']['Code']
+                if error_code == 'NoSuchPublicAccessBlockConfiguration':
+                    pass
+                elif error_code == 'AccessDenied':
+                    # Follow the same logic as `assemble_bucket` - log and continue on access
+                    # denied errors rather than halting a policy altogether
+                    method = 'GetPublicAccessBlock'
+                    log.warning(
+                        "Bucket:%s unable to invoke method:%s error:%s ",
+                        bucket['Name'], method, e.response['Error']['Message']
+                    )
+                    bucket.setdefault('c7n:DeniedMethods', []).append(method)
+                else:
                     raise
             bucket[self.annotation_key] = config
         return self.matches_filter(config)

--- a/tests/data/placebo/test_s3_check_public_block/s3.GetPublicAccessBlock_1.json
+++ b/tests/data/placebo/test_s3_check_public_block/s3.GetPublicAccessBlock_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Code": "NoSuchPublicAccessBlockConfiguration",
+            "Message": "The public access block configuration was not found",
+            "BucketName": "644160558196-us-east-1-s3-logs"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_check_public_block/s3.GetPublicAccessBlock_2.json
+++ b/tests/data/placebo/test_s3_check_public_block/s3.GetPublicAccessBlock_2.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "PublicAccessBlockConfiguration": {
+            "BlockPublicAcls": true,
+            "IgnorePublicAcls": false,
+            "BlockPublicPolicy": true,
+            "RestrictPublicBuckets": true
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_check_public_block/s3.GetPublicAccessBlock_3.json
+++ b/tests/data/placebo/test_s3_check_public_block/s3.GetPublicAccessBlock_3.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 403,
+    "data": {
+        "Error": {
+            "Code": "AccessDenied",
+            "Message": "Access Denied"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_check_public_block/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_check_public_block/s3.ListBuckets_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Buckets": [
+            {
+                "Name": "644160558196-us-east-1-s3-logs",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 10,
+                    "day": 19,
+                    "hour": 18,
+                    "minute": 6,
+                    "second": 8,
+                    "microsecond": 0
+                }
+            },
+            {
+                "Name": "644160558196-us-east-2-s3-logs",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 10,
+                    "day": 19,
+                    "hour": 15,
+                    "minute": 22,
+                    "second": 50,
+                    "microsecond": 0
+                }
+            },
+            {
+                "Name": "my-locked-down-bucket",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 8,
+                    "day": 31,
+                    "hour": 12,
+                    "minute": 35,
+                    "second": 48,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "Owner": {
+            "DisplayName": "aws-backoffice+sandbox-aj",
+            "ID": "e46bca81657fdc9f58bc5bab457564bb66f16636bd724a9f51d212fa2185a2b0"
+        }
+    }
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1820,7 +1820,7 @@ class S3Test(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 3)
         locked_down_bucket = next(r for r in resources if r["Name"] == "my-locked-down-bucket")
-        self.assertIn("GetPublicAccessBlock", locked_down_bucket["c7n:DeniedMethods"])
+        self.assertIn("GetPublicAccessBlock", locked_down_bucket.get("c7n:DeniedMethods", []))
 
     def test_set_public_block_enable_all(self):
         bname = 'mypublicblock'

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1789,6 +1789,39 @@ class S3Test(BaseTest):
         for rule in response['ReplicationConfiguration']['Rules']:
             self.assertEqual(rule['Status'], 'Disabled')
 
+    def test_check_public_block(self):
+        """Handle cases where public block details are missing or unavailable
+
+        The default check-public-block filter should match buckets
+        in any of the following conditions:
+
+        - There is a public block configuration, but some settings are not
+          enabled
+        - There is no public block configuration set
+        - A strict bucket policy prevents Custodian from reading the public block configuration
+        """
+        self.patch(s3.S3, "executor_factory", MainThreadExecutor)
+        self.patch(s3, "S3_AUGMENT_TABLE", [])
+
+        session_factory = self.replay_flight_data("test_s3_check_public_block")
+        p = self.load_policy(
+            {
+                "name": "check-public-block",
+                "resource": "s3",
+                "filters": [
+                    {
+                        "type": "check-public-block",
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+
+        resources = p.run()
+        self.assertEqual(len(resources), 3)
+        locked_down_bucket = next(r for r in resources if r["Name"] == "my-locked-down-bucket")
+        self.assertIn("GetPublicAccessBlock", locked_down_bucket["c7n:DeniedMethods"])
+
     def test_set_public_block_enable_all(self):
         bname = 'mypublicblock'
 


### PR DESCRIPTION
Have the `check-public-block` filter log/warn/continue when it can't fetch the public block configuration for a bucket.

Closed #6678 