### PR TITLE
aws - route53 - recovery - control - panel: add a safety rule filter

### DIFF
--- a/tests/data/placebo/test_control_panel_safety_rule_filter/route53-recovery-control-config.ListClusters_1.json
+++ b/tests/data/placebo/test_control_panel_safety_rule_filter/route53-recovery-control-config.ListClusters_1.json
@@ -4,27 +4,27 @@
         "ResponseMetadata": {},
         "Clusters": [
             {
-                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/55734b11-cbff-4607-9e5c-bbc025658614",
+                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/e523e948-2cc8-4379-bc27-c491ea17cfa9",
                 "ClusterEndpoints": [
                     {
-                        "Endpoint": "https://71022321.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
-                        "Region": "us-east-1"
-                    },
-                    {
-                        "Endpoint": "https://77a52a9b.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
-                        "Region": "eu-west-1"
-                    },
-                    {
-                        "Endpoint": "https://bb670eac.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
+                        "Endpoint": "https://a5b2e3bf.route53-recovery-cluster.ap-southeast-2.amazonaws.com/v1",
                         "Region": "ap-southeast-2"
                     },
                     {
-                        "Endpoint": "https://25b4ae02.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
-                        "Region": "ap-northeast-1"
+                        "Endpoint": "https://19624cc3.route53-recovery-cluster.us-east-1.amazonaws.com/v1",
+                        "Region": "us-east-1"
                     },
                     {
-                        "Endpoint": "https://604974cc.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
+                        "Endpoint": "https://11d07c2e.route53-recovery-cluster.eu-west-1.amazonaws.com/v1",
+                        "Region": "eu-west-1"
+                    },
+                    {
+                        "Endpoint": "https://10de097d.route53-recovery-cluster.us-west-2.amazonaws.com/v1",
                         "Region": "us-west-2"
+                    },
+                    {
+                        "Endpoint": "https://90f3b78a.route53-recovery-cluster.ap-northeast-1.amazonaws.com/v1",
+                        "Region": "ap-northeast-1"
                     }
                 ],
                 "Name": "NewCluster",

--- a/tests/data/placebo/test_control_panel_safety_rule_filter/route53-recovery-control-config.ListControlPanels_1.json
+++ b/tests/data/placebo/test_control_panel_safety_rule_filter/route53-recovery-control-config.ListControlPanels_1.json
@@ -4,11 +4,11 @@
         "ResponseMetadata": {},
         "ControlPanels": [
             {
-                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/55734b11-cbff-4607-9e5c-bbc025658614",
-                "ControlPanelArn": "arn:aws:route53-recovery-control::644160558196:controlpanel/99e868ad16894953b58bcaea6331222a",
+                "ClusterArn": "arn:aws:route53-recovery-control::644160558196:cluster/e523e948-2cc8-4379-bc27-c491ea17cfa9",
+                "ControlPanelArn": "arn:aws:route53-recovery-control::644160558196:controlpanel/1c3d2533925b4acda7fa00dad9497f2b",
                 "DefaultControlPanel": true,
                 "Name": "DefaultControlPanel",
-                "RoutingControlCount": 0,
+                "RoutingControlCount": 1,
                 "Status": "DEPLOYED"
             }
         ]

--- a/tests/data/placebo/test_control_panel_safety_rule_filter/route53-recovery-control-config.ListSafetyRules_1.json
+++ b/tests/data/placebo/test_control_panel_safety_rule_filter/route53-recovery-control-config.ListSafetyRules_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "SafetyRules": [
+            {
+                "ASSERTION": {
+                    "AssertedControls": [
+                        "arn:aws:route53-recovery-control::644160558196:controlpanel/1c3d2533925b4acda7fa00dad9497f2b/routingcontrol/e2bf72026cc34754"
+                    ],
+                    "ControlPanelArn": "arn:aws:route53-recovery-control::644160558196:controlpanel/1c3d2533925b4acda7fa00dad9497f2b",
+                    "Name": "test-safety-rule",
+                    "RuleConfig": {
+                        "Inverted": false,
+                        "Threshold": 10,
+                        "Type": "ATLEAST"
+                    },
+                    "SafetyRuleArn": "arn:aws:route53-recovery-control::644160558196:controlpanel/1c3d2533925b4acda7fa00dad9497f2b/safetyrule/63031ae7310d47ad",
+                    "Status": "DEPLOYED",
+                    "WaitPeriodMs": 5000
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_control_panel_safety_rule_filter/route53-recovery-control-config.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_control_panel_safety_rule_filter/route53-recovery-control-config.ListTagsForResource_1.json
@@ -2,8 +2,6 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "Tags": {
-            "TestTag": "TestValue"
-        }
+        "Tags": {}
     }
 }

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -594,7 +594,7 @@ class TestControlPanel(BaseTest):
             {
                 "name": "control-panel-safety-rule",
                 "resource": "recovery-control-panel",
-                "filters": [{'type': 'has-safety-rule', 'state': "true"}],
+                "filters": [{'type': 'has-safety-rule', 'state': True}],
             },
             session_factory=session_factory,
         )

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -587,3 +587,16 @@ class TestControlPanel(BaseTest):
         client = session_factory(region="us-west-2").client("route53-recovery-control-config")
         tags = client.list_tags_for_resource(ResourceArn=resources[0]["ControlPanelArn"])['Tags']
         self.assertEqual(len(tags), 0)
+
+    def test_control_panel_safety_rule_filter(self):
+        session_factory = self.replay_flight_data("test_control_panel_safety_rule_filter",)
+        p = self.load_policy(
+            {
+                "name": "control-panel-safety-rule",
+                "resource": "recovery-control-panel",
+                "filters": [{'type': 'has-safety-rule', 'state': "true"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
```
resource: account
    description: |
      Notifies Security and Cloud Admins teams on any AWS root user console logins
    mode:
       type: cloudtrail
       events:
          - ConsoleLogin
    filters:
       - type: event
         key: "detail.userIdentity.type"
         value_type: swap
         op: in
         value: Root
```