### PR TITLE
aws - tag variable interpolation fix

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -430,7 +430,7 @@ class Tag(Action):
             'account_id': self.manager.config.account_id,
             'now': utils.FormatDate.utcnow(),
             'region': self.manager.config.region}
-        return tag.format(**params)
+        return str(tag).format(**params)
 
     def interpolate_values(self, tags):
         """Interpolate in a list of tags - 'old' ec2 format

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -688,6 +688,9 @@ class FormatDate:
     def __init__(self, d=None):
         self._d = d
 
+    def __str__(self):
+        return str(self._d)
+
     @property
     def datetime(self):
         return self._d

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -949,7 +949,7 @@ class PolicyLambdaProvision(Publish):
                 "MemorySize": 512,
                 "Role": "",
                 "Runtime": "python3.9",
-                "Architectures": ["x86_64"],
+                "Architectures": [platform.machine()],
                 "Tags": {},
                 "Timeout": 900,
                 "TracingConfig": {"Mode": "PassThrough"},

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -938,6 +938,11 @@ class PolicyLambdaProvision(Publish):
     def test_config_defaults(self):
         p = PolicyLambda(Bag({"name": "hello", "data": {"mode": {}}}))
         self.maxDiff = None
+        default_arch = platform.machine()
+        if default_arch in ('aarch64', 'arm64'):
+            default_arch = 'arm64'
+        else:
+            default_arch = 'x86_64'
         self.assertEqual(
             p.get_config(),
             {
@@ -949,7 +954,7 @@ class PolicyLambdaProvision(Publish):
                 "MemorySize": 512,
                 "Role": "",
                 "Runtime": "python3.9",
-                "Architectures": [platform.machine()],
+                "Architectures": [default_arch],
                 "Tags": {},
                 "Timeout": 900,
                 "TracingConfig": {"Mode": "PassThrough"},

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -80,6 +80,7 @@ class TagInterpolationTest(BaseTest):
             },
             session_factory=mock_factory,
         )
+        policy.expand_variables(policy.get_variables())
         policy.resource_manager.actions[0].process(resources)
 
         return (create_tags, tag_resources)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,6 +230,7 @@ class UtilTest(BaseTest):
         self.assertEqual(json.dumps(utils.FormatDate(d),
                                     cls=utils.DateTimeEncoder, indent=2),
                          '"2018-02-02T12:00:00"')
+        self.assertEqual(str(d), '2018-02-02 12:00:00')
 
     def test_group_by(self):
         items = [{}, {"Type": "a"}, {"Type": "a"}, {"Type": "b"}]


### PR DESCRIPTION
closes #8318

this provides a workaround for the issue, but it still feels like layering complexity, albeit this is probably the simplest point solution.

custodian's variable support has evolved over time. Some actions originally supported their own variable formatting (notify, set-s3-logging-action, 
mark-for-op). Then we added policy variables that were builtin (account_id, region) while attempting to pass through on extant action specific variables. Then 
we added support in c7n-org for user defined variables. Then we added specific handling around user defined variables preserving types. 

Wrt to futures, and we're looking at letting users add user defined variables with c7n as well. We also have a separate issue long 
standing issue about when to interpolate variables, as some want to be evaluated when provisioning a lambda policy and others want runtime evaluation when the policy is executed.

we probably need a proposal to rationalize/unify all of this, while preserving compatiblity.
