### PR TITLE
aws - vpc - bug fix security-groups-used filter with in-use eni having no attachments

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -926,7 +926,10 @@ class UsedSecurityGroup(SGUsage):
         enis = []
         for nic in self.nics:
             if nic['Status'] == 'in-use':
-                instance_owner_id = nic['Attachment']['InstanceOwnerId']
+                if nic.get('Attachment'):
+                    instance_owner_id = nic['Attachment']['InstanceOwnerId']
+                else:
+                    instance_owner_id = ''
                 interface_resource_type = get_eni_resource_type(nic)
             else:
                 instance_owner_id = ''

--- a/tests/data/placebo/test_security_group_used/ec2.DescribeNetworkInterfaces_1.json
+++ b/tests/data/placebo/test_security_group_used/ec2.DescribeNetworkInterfaces_1.json
@@ -142,6 +142,54 @@
                 "SubnetId": "subnet-193bdf43",
                 "TagSet": [],
                 "VpcId": "vpc-0e03e277"
+            },            
+            {
+                "AvailabilityZone": "us-west-2c",
+                "Description": "aws-k8s-branch-eni",
+                "Groups": [
+                    {
+                        "GroupName": "default",
+                        "GroupId": "sg-f9cc4d9f"
+                    },
+                    {
+                        "GroupName": "InstanceSecurityGroup-1A6Y8I3R4AP02",
+                        "GroupId": "sg-0a2cb503a229c31c1"
+                    }
+                ],
+                "InterfaceType": "branch",
+                "Ipv6Addresses": [],
+                "MacAddress": "0a:e1:96:2a:14:03",
+                "NetworkInterfaceId": "eni-05f8e0f783bfe84f0",
+                "OwnerId": "01234567890",
+                "PrivateDnsName": "ip-100-71-36-229.us-west-2.compute.internal",
+                "PrivateIpAddress": "100.71.36.229",
+                "PrivateIpAddresses": [
+                    {
+                        "Primary": true,
+                        "PrivateDnsName": "ip-100-71-36-229.us-west-2.compute.internal",
+                        "PrivateIpAddress": "100.71.36.229"
+                    }
+                ],
+                "RequesterId": "01234567890",
+                "RequesterManaged": false,
+                "SourceDestCheck": true,
+                "Status": "in-use",
+                "SubnetId": "subnet-193bdf43",
+                "TagSet": [
+                    {
+                        "Key": "vpcresources.k8s.aws/vlan-id",
+                        "Value": "1"
+                    },
+                    {
+                        "Key": "eks:eni:owner",
+                        "Value": "eks-vpc-resource-controller"
+                    },
+                    {
+                        "Key": "vpcresources.k8s.aws/trunk-eni-id",
+                        "Value": "eni-0e769e3bf64c37e57"
+                    }
+                ],
+                "VpcId": "vpc-0e03e277"
             }
         ]
     }


### PR DESCRIPTION
This should fix https://github.com/cloud-custodian/cloud-custodian/issues/8099 and https://github.com/cloud-custodian/cloud-custodian/issues/7973