### PR TITLE
Add api-key feature to values_from

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -140,6 +140,7 @@ class ValuesFrom:
     def _add_api_key(self, headers):
         secret = self.data.get('api_key_secret')
         if secret is not None:
+          # if secret.startswith('arn:aws:ssm'):
             if secret.startswith('arn:aws:secretsmanager'):
                 client = boto3.client('secretsmanager')
                 apiKey = client.get_secret_value(SecretId=secret)['SecretString']

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -15,6 +15,8 @@ from contextlib import closing
 from c7n.cache import NullCache
 from c7n.utils import format_string_values
 
+import boto3
+
 log = logging.getLogger('custodian.resolver')
 
 ZIP_OR_GZIP_HEADER_DETECT = zlib.MAX_WBITS | 32
@@ -115,6 +117,7 @@ class ValuesFrom:
             'expr': {'oneOf': [
                 {'type': 'integer'},
                 {'type': 'string'}]},
+            'api_key_secret': {'type': 'string'},
             'headers': {
                 'type': 'object',
                 'patternProperties': {
@@ -134,6 +137,14 @@ class ValuesFrom:
         self.cache = manager._cache or NullCache({})
         self.resolver = URIResolver(manager.session_factory, self.cache)
 
+    def _add_api_key(self, headers):
+        secret = self.data.get('api_key_secret')
+        if secret is not None:
+            if secret.startswith('arn:aws:secretsmanager'):
+                client = boto3.client('secretsmanager')
+                apiKey = client.get_secret_value(SecretId=secret)['SecretString']
+                headers.update({'x-api-key': apiKey})
+
     def get_contents(self):
         _, format = os.path.splitext(self.data['url'])
 
@@ -151,6 +162,7 @@ class ValuesFrom:
             uri=self.data.get('url'),
             headers=self.data.get('headers', {})
         )
+        self._add_api_key(params['headers'])
         
         contents = str(self.resolver.resolve(**params))
         return contents, format

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -302,6 +302,7 @@ class SchemaTest(CliTest):
                     'expr': {'oneOf': [
                         {'type': 'integer'},
                         {'type': 'string'}]},
+                    'api_key_secret': {'type': 'string'},
                     'headers': {
                         'type': 'object',
                         'patternProperties': {
@@ -320,6 +321,7 @@ class SchemaTest(CliTest):
                     'expr': {'oneOf': [
                         {'type': 'integer'},
                         {'type': 'string'}]},
+                    'api_key_secret': {'type': 'string'},
                     'headers': {
                         'type': 'object',
                         'patternProperties': {


### PR DESCRIPTION
PR provides feature to resolve/load API-Keys (passed as Secrets) in `values_from` at Runtime.
(Currently supports AWS Secrets, but can be extended in the future).
At this moment you can define API-Keys in the `values_from.headers` section only which means they would be visible to anyone who has access to the Policy.

Before PR:
```
policies:
  - name:     ec2-test
    resource: ec2
    filters:
      - type: value
        key:  "InstanceId"
        op:   not-in
        value_from:
          url:     <url>
          format:  json
          headers:
            x-api-key: <x-api-key>
```

After PR:
```
policies:
  - name:     ec2-test
    resource: ec2
    filters:
      - type: value
        key:  "InstanceId"
        op:   not-in
        value_from:
          url:     <url>
          format:  json
          api_key_secret: <arn:aws:secret...>
```