### PR TITLE
releng - policy stream fix test oddity - use explicit rm

### DIFF
--- a/tools/c7n_policystream/tests/test_policystream.py
+++ b/tools/c7n_policystream/tests/test_policystream.py
@@ -62,7 +62,7 @@ class GitRepo:
             self._run(['git', 'add', path])
 
     def rm(self, path):
-        os.remove(os.path.join(self.repo_path, path))
+        self._run(['git', 'rm', path])
 
     def repo(self):
         return pygit2.Repository(os.path.join(self.repo_path, '.git'))


### PR DESCRIPTION

There's something odd that's been changed in the git configuration in the github action images this past week. its caused a few test issues on various prs and main merges. Post the additional debugging output in #8409 it appears the 
issue is that "git commit -a" is not picking up modified files in the working directory. as a work around, use an explicit git rm when removing files, to ensure the removal is staged.

```
subprocess.CalledProcessError: Command '['git', 'commit', '-am', 'remove file']' returned non-zero exit status 1.
----------------------------- Captured stdout call -----------------------------
Initialized empty Git repository in /tmp/tmpp2tv743e/.git/
[main (root-commit) 7d161ab] init
 1 file changed, 1 insertion(+)
 create mode 100644 example.yml
[main 4937235] add something
 1 file changed, 1 insertion(+), 1 deletion(-)
[main 75e24c9] switch
 1 file changed, 1 insertion(+), 1 deletion(-)
On branch main
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    example.yml
no changes added to commit (use "git add" and/or "git commit -a")
```
