### PR TITLE
aws - cloudtrail mode - support glob patterns for event and source

### DIFF
--- a/c7n/cwe.py
+++ b/c7n/cwe.py
@@ -1,5 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+from fnmatch import fnmatch
+
 import jmespath
 
 
@@ -115,9 +117,9 @@ class CloudWatchEvents:
                 if info:
                     return info['ids'].search(event)
                 continue
-            if event_name != e.get('event'):
+            if not fnmatch(event_name, e.get('event')):
                 continue
-            if event_source != e.get('source'):
+            if not fnmatch(event_source, e.get('source')):
                 continue
 
             id_query = e.get('ids')


### PR DESCRIPTION
We've had a few cases come up in the past following this pattern:

"Notify me when _any_ event happens that matches this pattern"

Where "this pattern" might be:

- Access denied errors
- Actions taken from the console
- Actions taken outside a blessed set of regions/services (as an infogathering step on the way to SCPs / permission boundaries)

These cases are challenging today because we require event names and sources to be explicitly listed in the policy. One potential way forward would be to support glob matches, which in combination with `pattern` overrides would open up some pretty interesting policies. For example, a policy like this could send a notification in response to any non-readonly actions taken in the console:

```yaml
policies:
  - name: console-actions
    resource: aws.account
    description: |
      Identifies actions originating from the AWS Console
    mode:
      type: cloudtrail
      events:
        - event: "*"
          source: "*"
          ids: userIdentity.arn
      role: custodian-remediations
      pattern:
        detail:
          eventSource:
            - exists: true
          eventName:
            - exists: true
          sessionCredentialFromConsole:
            - "true"
          readOnly:
            - false
    actions:
      - type: notify
        template: default.html
        priority_header: 1
        subject: "There is ClickOps afoot! [custodian {{ account }} - {{ region }}]"
        to:
          - CloudAdmins@Company.com
          - SecurityTeam@Company.com
        transport:
          type: sqs
          queue: https://sqs.us-east-2.amazonaws.com/123456789012/c7n-mailer
          region: us-east-2
```

This isn't the _only_ way to support this, and we could likely use [eventbridge content filtering](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) constructs like `exists`/`prefix`/`suffix` to avoid `pattern` overrides in some common cases. But this feels worth talking through.

_One alternative would be to support full value filter semantics, though that's probably overkill._