### PR TITLE
ensuring webacl detail is present for wafv2 resources

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -1157,7 +1157,8 @@ class ListItemFilter(Filter):
             matched_indicies = [r['c7n:_id'] for r in list_resources]
             for idx, list_value in enumerate(list_values):
                 list_value.pop('c7n:_id')
-            if self.data.get('count'):
+            # "is not None" makes it possible to use count == 0
+            if self.data.get('count') is not None:
                 count = self.data['count']
                 op = OPERATORS[self.data.get('count_op', 'eq')]
                 if op(len(list_resources), count):

--- a/c7n/resources/waf.py
+++ b/c7n/resources/waf.py
@@ -15,7 +15,7 @@ class DescribeRegionalWaf(DescribeSource):
 
 class DescribeWafV2(DescribeSource):
     def augment(self, resources):
-        return universal_augment(self.manager, resources)
+        return universal_augment(self.manager, super().augment(resources))
 
     # set REGIONAL for Scope as default
     def get_query_params(self, query):

--- a/tests/data/placebo/test_wafv2_logging_configuration/wafv2.GetWebACL_1.json
+++ b/tests/data/placebo/test_wafv2_logging_configuration/wafv2.GetWebACL_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "WebACL": {
+            "Name": "WVvF5qejaoARvhMU",
+            "Id": "ebf41215-9625-436d-938c-c2172c665718",
+            "Description": "Example of a managed rule.",
+            "LockToken": "237b131c-16e7-4e3c-9017-6f352f654823",
+            "ARN": "arn:aws:wafv2:us-east-1:644160558196:regional/webacl/WVvF5qejaoARvhMU/ebf41215-9625-436d-938c-c2172c665718",
+            "DefaultAction": {
+                "Allow": {}
+            },
+            "Rules": [
+                {
+                    "Name": "rule-1",
+                    "Priority": 1,
+                    "Statement": {
+                        "ManagedRuleGroupStatement": {
+                            "VendorName": "AWS",
+                            "Name": "AWSManagedRulesKnownBadInputsRuleSet"
+                        }
+                    },
+                    "OverrideAction": {
+                        "None": {}
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": false,
+                        "CloudWatchMetricsEnabled": false,
+                        "MetricName": "WVvF5qejaoARvhMU"
+                    }
+                }
+            ],
+            "VisibilityConfig": {
+                "SampledRequestsEnabled": false,
+                "CloudWatchMetricsEnabled": false,
+                "MetricName": "WVvF5qejaoARvhMU"
+            },
+            "Capacity": 200,
+            "ManagedByFirewallManager": false,
+            "LabelNamespace": "awswaf:123456789012:webacl:WVvF5qejaoARvhMU:"
+        },
+        "LockToken": "ddcb6c85-3a5e-4f3e-87c9-e03fbeb7afe6",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_wafv2_no_logging_configuration/wafv2.GetWebACL_1.json
+++ b/tests/data/placebo/test_wafv2_no_logging_configuration/wafv2.GetWebACL_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "WebACL": {
+            "Name": "WVvF5qejaoARvhMU",
+            "Id": "ebf41215-9625-436d-938c-c2172c665718",
+            "Description": "Example of a managed rule.",
+            "LockToken": "237b131c-16e7-4e3c-9017-6f352f654823",
+            "ARN": "arn:aws:wafv2:us-east-1:644160558196:regional/webacl/WVvF5qejaoARvhMU/ebf41215-9625-436d-938c-c2172c665718",
+            "DefaultAction": {
+                "Allow": {}
+            },
+            "Rules": [
+                {
+                    "Name": "rule-1",
+                    "Priority": 1,
+                    "Statement": {
+                        "ManagedRuleGroupStatement": {
+                            "VendorName": "AWS",
+                            "Name": "AWSManagedRulesKnownBadInputsRuleSet"
+                        }
+                    },
+                    "OverrideAction": {
+                        "None": {}
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": false,
+                        "CloudWatchMetricsEnabled": false,
+                        "MetricName": "WVvF5qejaoARvhMU"
+                    }
+                }
+            ],
+            "VisibilityConfig": {
+                "SampledRequestsEnabled": false,
+                "CloudWatchMetricsEnabled": false,
+                "MetricName": "WVvF5qejaoARvhMU"
+            },
+            "Capacity": 200,
+            "ManagedByFirewallManager": false,
+            "LabelNamespace": "awswaf:123456789012:webacl:WVvF5qejaoARvhMU:"
+        },
+        "LockToken": "ddcb6c85-3a5e-4f3e-87c9-e03fbeb7afe6",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_wafv2_resolve_resources/wafv2.GetWebACL_1.json
+++ b/tests/data/placebo/test_wafv2_resolve_resources/wafv2.GetWebACL_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "WebACL": {
+            "Name": "match-me",
+            "Id": "624e04d2-8b45-45ee-b4ad-e853dac6d070",
+            "Description": "",
+            "LockToken": "ad4ae4ab-aba8-4499-88e9-059d4f9a4c60",
+            "ARN": "arn:aws:wafv2:us-east-2:644160558196:regional/webacl/match-me/624e04d2-8b45-45ee-b4ad-e853dac6d070",
+            "DefaultAction": {
+                "Allow": {}
+            },
+            "Rules": [],
+            "VisibilityConfig": {
+                "SampledRequestsEnabled": false,
+                "CloudWatchMetricsEnabled": false,
+                "MetricName": "WVvF5qejaoARvhMU"
+            },
+            "Capacity": 200,
+            "ManagedByFirewallManager": false,
+            "LabelNamespace": "awswaf:123456789012:webacl:WVvF5qejaoARvhMU:"
+        },
+        "LockToken": "ddcb6c85-3a5e-4f3e-87c9-e03fbeb7afe6",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_wafv2_resolve_resources/wafv2.GetWebACL_2.json
+++ b/tests/data/placebo/test_wafv2_resolve_resources/wafv2.GetWebACL_2.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "WebACL": {
+            "Name": "dont-match-me",
+            "Id": "889cae83-d5e5-41e9-bb6f-00ea0f726637",
+            "Description": "",
+            "LockToken": "a33055a6-2e0a-4e5f-aa8c-abe3a5ce26d8",
+            "ARN": "arn:aws:wafv2:us-east-2:644160558196:regional/webacl/dont-match-me/889cae83-d5e5-41e9-bb6f-00ea0f726637",
+            "DefaultAction": {
+                "Allow": {}
+            },
+            "Rules": [],
+            "VisibilityConfig": {
+                "SampledRequestsEnabled": false,
+                "CloudWatchMetricsEnabled": false,
+                "MetricName": "WVvF5qejaoARvhMU"
+            },
+            "Capacity": 200,
+            "ManagedByFirewallManager": false,
+            "LabelNamespace": "awswaf:123456789012:webacl:WVvF5qejaoARvhMU:"
+        },
+        "LockToken": "ddcb6c85-3a5e-4f3e-87c9-e03fbeb7afe6",
+        "ResponseMetadata": {}
+    }
+}


### PR DESCRIPTION
Also includes a small change to the `list-item` filter to support `count == 0`