### PR TITLE
c7n-left - policy testing allow filters

### DIFF
--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -68,22 +68,25 @@ def run(
 
 @cli.command()
 @click.option("-p", "--policy-dir", type=click.Path(), required=True)
-def test(policy_dir):
+@click.option(
+    "--filters", help="filter policies or resources as k=v pairs with globbing"
+)
+def test(policy_dir, filters):
     """Run policy tests."""
     policy_dir = Path(policy_dir)
     source_dir = policy_dir / "tests"
+
     config = Config.empty(
         source_dir=source_dir,
         policy_dir=policy_dir,
         output_file=sys.stdout,
-        # output=output,
-        # output_file=output_file,
-        # output_query=output_query,
-        # summary=summary,
-        # filters=filters,
+        filters=filters,
     )
+
     reporter = TestReporter(None, config)
-    policies = load_policies(policy_dir, config)
+    exec_filter = ExecutionFilter.parse(config)
+    config["exec_filter"] = exec_filter
+    policies = exec_filter.filter_policies(load_policies(policy_dir, config))
     runner = TestRunner(policies, config, reporter)
     sys.exit(int(runner.run()))
 

--- a/tools/c7n_left/tests/test_left_test.py
+++ b/tools/c7n_left/tests/test_left_test.py
@@ -32,7 +32,7 @@ def test_test_reporter_discovery(capsys):
 
     reporter.on_tests_discovered(runner, [1])
     captured = capsys.readouterr()
-    assert 'Discovered 1 Tests' in captured.out
+    assert "Discovered 1 Tests" in captured.out
 
 
 def test_test_reporter_result():
@@ -111,7 +111,7 @@ def test_cli_test_assertion_not_used(tmp_path):
     (test_case_dir / "left.plan.yaml").write_text(
         """
         - "resource.__tfmeta.path": "google_pubsub_topic.example"
-        - "resource.__tfmeta.path": "google_pubsub_topic.example2"        
+        - "resource.__tfmeta.path": "google_pubsub_topic.example2"
         """
     )
 

--- a/tools/c7n_left/tests/test_left_test.py
+++ b/tools/c7n_left/tests/test_left_test.py
@@ -26,16 +26,13 @@ except ImportError:
 data_dir = Path(os.curdir).absolute() / "data"
 
 
-def test_test_reporter_discovery():
+def test_test_reporter_discovery(capsys):
     reporter = left_test.TestReporter(None, Bag(output_file=sys.stdout))
-
     runner = Bag(unmatched_policies=[1], policies=[2, 3], unmatched_tests=[1])
 
-    console = MagicMock()
-    reporter.console = console
     reporter.on_tests_discovered(runner, [1])
-
-    console.print.assert_called_once()
+    captured = capsys.readouterr()
+    assert 'Discovered 1 Tests' in captured.out
 
 
 def test_test_reporter_result():


### PR DESCRIPTION
- when running tests, allow filtering by policy name or resource id
- some minor output changes
