### PR TITLE
Run cloudcustodian from python with arguments

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -333,10 +333,14 @@ def _setup_logger(options):
     logging.getLogger('urllib3').setLevel(logging.ERROR)
 
 
-def main():
+def main(args=None):
     parser = setup_parser()
     argcomplete.autocomplete(parser)
-    options = parser.parse_args()
+    if args:
+        options = parser.parse_args(args=args)
+    else:
+        options = parser.parse_args()
+
     if options.subparser is None:
         parser.print_help(file=sys.stderr)
         return sys.exit(2)

--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -336,11 +336,7 @@ def _setup_logger(options):
 def main(args=None):
     parser = setup_parser()
     argcomplete.autocomplete(parser)
-    if args:
-        options = parser.parse_args(args=args)
-    else:
-        options = parser.parse_args()
-
+    options = parser.parse_args(args=args)
     if options.subparser is None:
         parser.print_help(file=sys.stderr)
         return sys.exit(2)


### PR DESCRIPTION
Hello,
Currently I'm running cloudcustodian in a multi-thread environment (3 parallel execution).
To do that I'm setting:

```py
from c7n.cli import main

def th_function(region):
      args = [
          "cc_runner",
          "run",
          "--help",
          "--region",
          region
      ]
      sys.argv = args
      main()
```

However I believe that multiple threads are accessing/editing sys.argv at the same time, so that's why cloud custodian sometimes is running on the same region. With my PR it's possible to run it without occurring in this problem in this way:

```py
from c7n.cli import main
main(["run", "--help"])
```