### PR TITLE
Fixes Azure function initialization fails with boto3 module not found error #8203

### DIFF
--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -275,7 +275,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
             self.function_params.function_app['name'])
 
         requirements = generate_requirements('c7n-azure',
-                                             ignore=['boto3', 'botocore', 'pywin32'],
+                                             ignore=['pywin32'],
                                              exclude='c7n')
         package = FunctionPackage(self.policy_name, target_sub_ids=target_subscription_ids)
         package.build(self.policy.data,


### PR DESCRIPTION
My understanding is that `boto3` and `botocore` are needed in the initialization phase when trying to authenticate against the cloud provider.
