### PR TITLE
c7n-left - update test plans

### DIFF
--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -71,7 +71,12 @@ def run(
 @click.option(
     "--filters", help="filter policies or resources as k=v pairs with globbing"
 )
-def test(policy_dir, filters):
+@click.option(
+    "--update-plan/--no-update-plan",
+    help="update test plans based on current findings",
+    default=False,
+)
+def test(policy_dir, filters, update_plan):
     """Run policy tests."""
     policy_dir = Path(policy_dir)
     source_dir = policy_dir / "tests"
@@ -81,6 +86,7 @@ def test(policy_dir, filters):
         policy_dir=policy_dir,
         output_file=sys.stdout,
         filters=filters,
+        update_plan=update_plan,
     )
 
     reporter = TestReporter(None, config)

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -72,9 +72,10 @@ def run(
     "--filters", help="filter policies or resources as k=v pairs with globbing"
 )
 @click.option(
-    "--update-plan/--no-update-plan",
-    help="update test plans based on current findings",
-    default=False,
+    "--update-plan",
+    help="use current findings to update or replace test plans (default: no)",
+    type=click.Choice(["no", "yes", "replace"]),
+    default="no",
 )
 def test(policy_dir, filters, update_plan):
     """Run policy tests."""

--- a/tools/c7n_left/c7n_left/test.py
+++ b/tools/c7n_left/c7n_left/test.py
@@ -76,7 +76,9 @@ class TestRunner:
 
     def load_plan(self, test_dir, plan_path):
         try:
-            plan_data = [] if self.options.update_plan == 'replace' else load_file(plan_path)
+            plan_data = (
+                [] if self.options.update_plan == "replace" else load_file(plan_path)
+            )
             plan = TestPlan(plan_data)
             plan.path = plan_path
             return Test(plan, test_dir)

--- a/tools/c7n_left/c7n_left/test.py
+++ b/tools/c7n_left/c7n_left/test.py
@@ -76,7 +76,7 @@ class TestRunner:
 
     def load_plan(self, test_dir, plan_path):
         try:
-            plan_data = load_file(plan_path)
+            plan_data = [] if self.options.update_plan == 'replace' else load_file(plan_path)
             plan = TestPlan(plan_data)
             plan.path = plan_path
             return Test(plan, test_dir)
@@ -210,7 +210,7 @@ class TestReporter(RichCli):
                 unmatched = dict(unmatched)
                 unmatched.pop("policy")
                 self.console.print(unmatched)
-        if self.config.get("update_plan"):
+        if self.config.get("update_plan", "no") != "no":
             # Preserve any plan entries that were matched this run
             new_plan = [
                 {k: v for f in m.data["filters"] for k, v in f.items()}


### PR DESCRIPTION
Allow c7n-left test to update or replace the test plan with current findings. Build new matchers using the `resource.__tfmeta.filename` and `resource.__tfmeta.path` attributes.