### PR TITLE
aws - output - set region when using lambda exec options

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -10,6 +10,7 @@ import json
 from c7n.config import Config
 from c7n.structure import StructureParser
 from c7n.resources import load_resources
+from c7n.resources.aws import AWS
 from c7n.policy import PolicyCollection
 from c7n.utils import format_event, get_account_id_from_sts, local_session
 
@@ -128,7 +129,8 @@ def init_config(policy_config):
        and exec_options['metrics_enabled']:
         exec_options['metrics_enabled'] = 'aws'
 
-    return Config.empty(**exec_options)
+    config = Config.empty(**exec_options)
+    return AWS().initialize(config)
 
 
 # One time initilization of global environment settings

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -808,7 +808,14 @@ def join_output(output_dir, suffix):
         return output_dir.rstrip('/')
     if output_dir.endswith('://'):
         return output_dir + suffix
-    return output_dir.rstrip('/') + '/%s' % suffix
+    output_url_parts = urlparse.urlparse(output_dir)
+    # for output urls, the end of the url may be a
+    # query string. make sure we add a suffix to
+    # the path component.
+    output_url_parts = output_url_parts._replace(
+        path = output_url_parts.path.rstrip('/') + '/%s' % suffix
+    )
+    return urlparse.urlunparse(output_url_parts)
 
 
 def fake_session():

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -469,6 +469,11 @@ def test_default_bucket_region_with_explicit_region():
     assert output_dir == conf.output_dir
 
 
+def test_join_output():
+    output_dir = aws.join_output("s3://aws?region=xyz", "suffix")
+    assert output_dir == "s3://aws/suffix?region=xyz"
+
+
 @vcr.use_cassette(
     'tests/data/vcr_cassettes/test_output/default_bucket_region_public.yaml')
 def test_default_bucket_region_is_public():

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -41,7 +41,10 @@ class HandleTest(BaseTest):
              'tracer': 'xray',
              'account_id': '007',
              'region': 'us-east-1',
-             'output_dir': 's3://mybucket/output',
+             # S3 uploads use a session in the output bucket's home region.
+             # When initiating a policy config we expect to identify the
+             # output bucket region so it's available at upload time.
+             'output_dir': 's3://mybucket/output?region=us-east-1',
 
              # defaults
              'external_id': None,
@@ -49,7 +52,7 @@ class HandleTest(BaseTest):
              'profile': None,
              'authorization_file': None,
              'cache': '',
-             'regions': (),
+             'regions': ['us-east-1'],
              'cache_period': 0,
              'log_group': None,
              'metrics': None})


### PR DESCRIPTION
As part of #8289 we started using regional sessions to upload logs to S3 output destinations. We [look for the bucket region](https://github.com/cloud-custodian/cloud-custodian/blob/047d526928b6fe5a3cca721ef775193f95f2fd9d/c7n/resources/aws.py#L696) in the output config, which in turn comes from [parsing the output URL](https://github.com/cloud-custodian/cloud-custodian/blob/047d526928b6fe5a3cca721ef775193f95f2fd9d/c7n/output.py#L500).

In local policy runs we try to find an output bucket's region and add it as a query string parameter to the output URL [during provider initialization](https://github.com/cloud-custodian/cloud-custodian/blob/047d526928b6fe5a3cca721ef775193f95f2fd9d/c7n/resources/aws.py#L724). But we weren't following the same initialization path from Lambda mode policies, leading to issues like the one described in #8414.

**Side Note:** While reproducing and validating this fix locally I ran into a separate issue where we were adding path suffixes to the end (query string) of an output directory rather than the path bit. Fixing that here too. 

Closes #8414