### PR TITLE
core - value filter - add json value_type

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -8,6 +8,7 @@ import datetime
 from datetime import timedelta
 import fnmatch
 import ipaddress
+import json
 import logging
 import operator
 import re
@@ -100,7 +101,7 @@ OPERATORS = {
 VALUE_TYPES = [
     'age', 'integer', 'expiration', 'normalize', 'size',
     'cidr', 'cidr_size', 'swap', 'resource_count', 'expr',
-    'unique_size', 'date', 'version']
+    'unique_size', 'date', 'version', 'json']
 
 
 class FilterRegistry(PluginRegistry):
@@ -730,6 +731,13 @@ class ValueFilter(BaseValueFilter):
             s = ComparableVersion(sentinel)
             v = ComparableVersion(value)
             return s, v
+
+        elif self.vtype == 'json':
+            value = json.loads(value or '{}')
+            if 'value_path' in self.data:
+                value = self.get_path_value(value)
+                sentinel = self.data.get('value')
+            return sentinel, value
 
         return sentinel, value
 

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -53,8 +53,44 @@ There are several ways to get a list of possible keys for each resource.
     you're interested in. The available fields will be listed under the results of that api call.
 
 
+Special Values
+~~~~~~~~~~~~~~
 
-- Comparison operators:
+    These meta-values can be used to test for the presence of a key or empty/null values:
+
+    - ``absent``: matches when a key *is not* present
+    - ``present``: matches when a key *is* present
+    - ``empty``: matches when a value is false, empty, or the key is not present
+    - ``not-null``: matches when a key exists and the value is not empty
+
+    Consider an EC2 instance with the following tags:
+
+    .. code-block:: json
+
+      {
+        "Tags": [{
+          "Environment": "dev",
+          "Name": ""
+        }]
+      }
+
+    All of the following filters would match this instance:
+
+    .. code-block::
+
+      filters:
+        - "tag:Environment": "dev"
+        - "tag:Environment": "not-null"
+        - "tag:Environment": "present"
+        - "tag:Name": "empty"
+        - "tag:Name": "present"
+        - "tag:Owner": "empty"
+        - "tag:Owner": "absent"
+
+
+Comparison Operators
+~~~~~~~~~~~~~~~~~~~~
+
     The generic value filter allows for comparison operators to be used
 
     - ``equal`` or ``eq``
@@ -63,6 +99,7 @@ There are several ways to get a list of possible keys for each resource.
     - ``gte`` or ``ge``
     - ``less-than`` or ``lt``
     - ``lte`` or ``le``
+    - ``contains``
 
   .. code-block:: yaml
 
@@ -72,22 +109,10 @@ There are several ways to get a list of possible keys for each resource.
            value: 36                      ─▶ Value that is being compared
            op: greater-than               ─▶ Comparison Operator
 
-- Other operators:
-    - ``absent``
-    - ``present``
-    - ``not-null``
-    - ``empty``
-    - ``contains``
 
-  .. code-block:: yaml
+Logical Operators
+~~~~~~~~~~~~~~~~~
 
-      filters:
-         - type: value
-           key: CpuOptions.CoreCount      ─▶ The value from the describe call
-           value: present                 ─▶ Checks if key is present
-
-
-- Logical Operators:
     - ``or`` or ``Or``
     - ``and`` or ``And``
     - ``not``
@@ -103,7 +128,9 @@ There are several ways to get a list of possible keys for each resource.
              key: CpuOptions.CoreCount      ─▶ The value from the describe call
              value: 42                      ─▶ Value that is being compared
 
-- List Operators:
+List Operators
+~~~~~~~~~~~~~~
+
     There is a collection of operators that can be used with user supplied lists. The operators
     are evaluated as ``value from key`` in (the operator) ``given value``. If you would like it
     evaluated in the opposite way  ``given value`` in (the operator) ``value from key`` then you
@@ -133,7 +160,9 @@ There are several ways to get a list of possible keys for each resource.
 
 
 
-- Special operators:
+Special Operators
+~~~~~~~~~~~~~~~~~
+
     - ``glob`` - Provides Glob matching support
     - ``regex`` - Provides Regex matching support but ignores case (1)
     - ``regex-case`` - Provides case sensitive Regex matching support (1)
@@ -161,7 +190,9 @@ There are several ways to get a list of possible keys for each resource.
 
   __ https://docs.python.org/3/library/re.html#search-vs-match
 
-- Transformations:
+Transformations
+~~~~~~~~~~~~~~~
+
   Transformations on the value can be done using the ``value_type`` keyword.  The
   following value types are supported:
 
@@ -175,6 +206,7 @@ There are several ways to get a list of possible keys for each resource.
   - ``size`` - the length of an element
   - ``swap`` - swap the value and the evaluated key
   - ``date`` - parse the filter's value as a date.
+  - ``json`` - parse embedded JSON documents
 
   Note that the `age` and `expiration` transformations expect a value given as
   a number of days. Use a floating point value to match time periods shorter than
@@ -261,7 +293,19 @@ There are several ways to get a list of possible keys for each resource.
                  - subnet-1b8474522
                  - subnet-2d2736444
 
-- Value Regex:
+     # This policy parses the JSON redrive policy of an SQS queue
+     - name: sqs-high-redrive-count
+       resource: aws.sqs
+       filters:
+         - type: value
+           key: RedrivePolicy
+           value_type: json
+           value_path: maxReceiveCount
+           op: greater-than
+           value: 5
+
+Value Regex
+~~~~~~~~~~~
 
   When using a Value Filter, a ``value_regex`` can be
   specified. This will mean that the value used for comparison is the output
@@ -289,22 +333,24 @@ There are several ways to get a list of possible keys for each resource.
       op: less-than
       value: 0
 
-- Value From:
+Value From
+~~~~~~~~~~
 
   ``value_from`` allows the use of external values in the Value Filter
 
   .. autodoconly:: c7n.resolver.ValuesFrom
 
-- Value Path:
+Value Path
+~~~~~~~~~~
 
-  Retrieve values using JMESPath. 
-  
-  The filter expects that a properly formatted 'string' is passed 
+  Retrieve values using JMESPath.
+
+  The filter expects that a properly formatted 'string' is passed
   containing a valid JMESPath. (Tutorial here on `JMESPath <http://jmespath.org/tutorial.html>`_ syntax)
 
   When using a Value Filter, a ``value_path`` can be specified.
   This means the value(s) the filter will compare against are
-  calculated during the initialization of the filter. 
+  calculated during the initialization of the filter.
 
   Note that this option only pulls properties of the resource
   currently being filtered.
@@ -335,7 +381,7 @@ describe resource call as is the case in the ValueFilter
 
      - name: no-ec2-public-ips
        resource: aws.ec2
-       mode:make 
+       mode:make
          type: cloudtrail
          events:
              - RunInstances

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -302,7 +302,45 @@ class TestValueFilter(unittest.TestCase):
             "op": "intersect"})
         res = vf.match(resource)
         self.assertEqual(res,False)
-        
+
+    def test_value_type_json(self):
+        iam_policy_json = '''
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": [
+                            "s3:ListAllMyBuckets"
+                        ],
+                        "Effect": "Allow",
+                        "Resource": "*"
+                    }
+                ]
+            }
+        '''
+        resource = {'iam_policy_document': iam_policy_json}
+
+        vf = filters.factory({
+            "type": "value",
+            "key": "iam_policy_document",
+            "value_type": "json",
+            "value_path": "Statement[?Resource == '*'].Action[]",
+            "value": ["s3:ListAllMyBuckets"],
+            "op": "intersect"})
+        res = vf.match(resource)
+        self.assertEqual(res,True)
+
+        vf = filters.factory({
+            "type": "value",
+            "key": "iam_policy_document",
+            "value_type": "json",
+            "value_path": "Statement[?Resource == '*'].Action[]",
+            "value": ["s3:GetObject"],
+            "op": "intersect"})
+        res = vf.match(resource)
+        self.assertEqual(res,False)
+
+
 
 class TestAgeFilter(unittest.TestCase):
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1772,10 +1772,13 @@ class ListItemFilterTest(BaseFilterTest):
                 'key': 'Policy',
                 'json_expr': 'Statement[].Action[].{Action: @}',
                 'attrs': [{
-                    'type': 'value',
-                    'key': 'Action',
-                    'op': 'regex',
-                    'value': '.*List.*',
+                # Use a top-level `or` to test handling of nested filter blocks
+                    'or': [{
+                        'type': 'value',
+                        'key': 'Action',
+                        'op': 'regex',
+                        'value': '.*List.*'
+                    }]
                 }]
             },
             manager=self.get_manager()
@@ -1785,7 +1788,7 @@ class ListItemFilterTest(BaseFilterTest):
         # Targeting a list of strings rather than a list of dicts
         # should still work and match the resource
         f.data['json_expr'] = 'Statement[].Action[]'
-        f.data['attrs'][0]['key'] = '@'
+        f.data['attrs'][0]['or'][0]['key'] = '@'
         self.assertEqual(f(resource), True)
 
         # A json_expr that returns no value should not match


### PR DESCRIPTION
- Add a `json` option for `value_type` to parse keys with embedded JSON documents (see also #8459)
- Add similar functionality to the existing `list-item` filter by adding a `json_expr` option
  - Work around some errors that pop up when using the `list-item` filter against a list of non-dict values

- Update the value filter docs
  - Promote value filter subtopics (transformations, special values/operators, etc) to subheadings for better discoverability (see before/after navbar screenshots)
  - Clarify the distinction between special _values_ (present, absent, empty, not-null) and the various categories of _operators_ (logical, comparison, list...)

Feedback/suggestions welcome on any of this, but this is part solving the immediate need for JSON parsing and part making the value filter docs a _little_ more digestable in response to some recurring community questions.

The piece that I'm _most_ suspicious about is how to handle cases where the `list-item` filter evaluates a list of non-dict items. The `list-item` filter uses annotations to track its internal state, and attribute filters add annotations of their own. At multiple levels Custodian filters expect a resource to be a `dict`. My first thought is wrapping non-dict items in a dict and adjusting filter keys (that's the logic in place in this PR at the moment), though I'm sure there are edge cases that doesn't cover.

An alternative might be forcing policy authors to structure their `list-item` filters in a way that guarantees a list of dicts. That feels safer but also puts more work on the author's shoulders :-/. There may be a better third option I'm not seeing. (I did also consider wrapping those non-dict items in a class rather than a dict, but the semantics of indexing seem to make that dirtier rather than cleaner).

![image](https://user-images.githubusercontent.com/19539955/230786614-8181dcb5-7218-403a-b9d5-616d7e34d74b.png)
![image](https://user-images.githubusercontent.com/19539955/230786627-e006d505-2d4a-4ab8-adee-0e9b93c5aa58.png)
