### PR TITLE
releng - publish package using twine rather than poetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ pkg-build-wheel:
 
 pkg-publish-wheel:
 # upload to test pypi
-	poetry publish -r $(PKG_REPO)
-	for pkg in $(PKG_SET); do cd $$pkg && poetry publish -r $(PKG_REPO) && cd ../..; done
+	twine upload -r $(PKG_REPO) dist/*
+	for pkg in $(PKG_SET); do cd $$pkg && twine upload -r $(PKG_REPO) dist/* && cd ../..; done
 
 
 ###


### PR DESCRIPTION
Switch wheel publishing from poetry back to twine. Testing the effects on a local [devpi](https://devpi.net/) server to confirm, I see this today using the poetry publish:

```console
http -j http://localhost:3141/aj/dev/c7n/0.9.25 | jq '.result.requires_dist'
```

```json
[                                                                                                                                                                 
  "boto3 (>=1.12.31,<2.0.0)",                                                    
  "jsonschema (>=3.0.0)",                                                        
  "argcomplete (>=1.12.3)",                                                                                                                                       
  "python-dateutil (>=2.8.2,<3.0.0)",                                            
  "pyyaml (>=5.4.0)",                                                            
  "tabulate (>=0.9.0,<0.10.0)",                                                                                                                                   
  "importlib-metadata (>=5.1,<6.0)",                                             
  "docutils (>=0.18,<0.19)"                                                                                                                                       
]   
```

And this if we switch back to `twine upload`:

```json
[                                                                                                                                                                 
  "argcomplete (==3.0.5)",                                                       
  "boto3 (==1.26.109)",                                                                                                                                           
  "docutils (==0.18.1)",                                                                                                                                          
  "importlib-metadata (==5.2.0)",                                                                                                                                 
  "jsonschema (==4.17.3)",                                                       
  "python-dateutil (==2.8.2)",                                                                                                                                    
  "pyyaml (==6.0)",
  "tabulate (==0.9.0)"                                                           
] 
```

Closes #8483