### PR TITLE
tools/c7n_org - exit early on an empty list of accounts or policies

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -712,6 +712,13 @@ def run(config, use, output_dir, accounts, not_accounts, tags, region,
     accounts_config, custodian_config, executor = init(
         config, use, debug, verbose, accounts, tags, policy, policy_tags=policy_tags,
         not_accounts=not_accounts)
+    if not (accounts_config["accounts"] and custodian_config["policies"]):
+        log.info(
+            "Targeting accounts: %d, policies: %d. Nothing to do." %
+            (len(accounts_config["accounts"]), len(custodian_config["policies"]))
+        )
+        return
+
     policy_counts = Counter()
     success = True
 


### PR DESCRIPTION
If after filtering accounts and policies we have an empty list of either, there's no point in continuing a c7n-org run. Bailing early should avoid some unnecessary work (along with some errors that might come up when trying to operate on an empty list of targets).

Closes #8441 
Closes #8486