### PR TITLE
core - fix memory cache reference data issue causing policy issues

### DIFF
--- a/c7n/cache.py
+++ b/c7n/cache.py
@@ -80,10 +80,12 @@ class InMemoryCache(Cache):
         return True
 
     def get(self, key):
-        return self.data.get(encode(key))
+        data = self.data.get(encode(key))
+        if data:
+            return pickle.loads(data)
 
     def save(self, key, data):
-        self.data[encode(key)] = data
+        self.data[encode(key)] = encode(data)
 
     def size(self):
         return sum(map(len, self.data.values()))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -33,7 +33,7 @@ class MemCacheTest(TestCase):
     def test_get_set(self):
         mem_cache = cache.InMemoryCache({})
         mem_cache.save({'region': 'us-east-1'}, {'hello': 'world'})
-        self.assertEqual(mem_cache.size(), 1)
+        self.assertEqual(mem_cache.size(), len(pickle.dumps({'hello': 'world'})))
         self.assertEqual(mem_cache.load(), True)
 
         mem_cache = cache.InMemoryCache({})


### PR DESCRIPTION
Updated memory cache to deep copy data before storing it, this ensures references within the structure aren't updated for values in the cache.

This fix was done in our version of cloud custodian some time ago by @Sutto but not PR'd upstream.

We found this caused issues with `iam-user` related checks when those checks added or modified `c7n:` values to data which is cached. Subsequent policies using this data would omit results due to unexpected values.