### PR TITLE
Add `ip-address-usage` filter for `aws.subnet`

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -556,7 +556,7 @@ class SubnetIpAddressUsageFilter(ValueFilter):
 
     def augment(self, resource):
         cidr_block = parse_cidr(resource['CidrBlock'])
-        max_addresses = 2 ** (32 - cidr_block.prefixlen) - self.aws_reserved_addresses
+        max_addresses = cidr_block.num_addresses - self.aws_reserved_addresses
         resource[self.annotation_key] = dict(
             MaxAvailable=max_addresses,
             NumberUsed=max_addresses - resource['AvailableIpAddressCount'],

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -504,6 +504,76 @@ class SubnetVpcFilter(net_filters.VpcFilter):
 
     RelatedIdsExpression = "VpcId"
 
+@Subnet.filter_registry.register('ip-address-usage')
+class SubnetIpAddressUsageFilter(ValueFilter):
+    """Filter subnets based on available IP addresses.
+
+    :example:
+
+    Show subnets with no addresses in use.
+
+    .. code-block:: yaml
+
+            policies:
+              - name: empty-subnets
+                resource: aws.subnet
+                filters:
+                  - type: ip-address-usage
+                    key: NumberUsed
+                    value: 0
+
+    :example:
+
+    Show subnets where 90% or more addresses are in use.
+
+    .. code-block:: yaml
+
+            policies:
+              - name: almost-full-subnets
+                resource: aws.subnet
+                filters:
+                  - type: ip-address-usage
+                    key: PercentUsed
+                    op: greater-than
+                    value: 90
+
+    This filter allows ``key`` to be:
+
+    * ``MaxAvailable``: the number of addresses available based on a subnet's CIDR block size
+      (minus the 5 addresses
+      `reserved by AWS <https://docs.aws.amazon.com/vpc/latest/userguide/subnet-sizing.html>`_)
+    * ``NumberUsed``: ``MaxAvailable`` minus the subnet's ``AvailableIpAddressCount`` value
+    * ``PercentUsed``: ``NumberUsed`` divided by ``MaxAvailable``
+    """
+    annotation_key = 'c7n:IpAddressUsage'
+    aws_reserved_addresses = 5
+    schema_alias = False
+    schema = type_schema(
+        'ip-address-usage',
+        key={'enum': ['MaxAvailable', 'NumberUsed', 'PercentUsed']},
+        rinherit=ValueFilter.schema,
+    )
+
+    def augment(self, resource):
+        cidr_block = parse_cidr(resource['CidrBlock'])
+        max_addresses = 2 ** (32 - cidr_block.prefixlen) - self.aws_reserved_addresses
+        resource[self.annotation_key] = dict(
+            MaxAvailable=max_addresses,
+            NumberUsed=max_addresses - resource['AvailableIpAddressCount'],
+            PercentUsed=round(
+                (max_addresses - resource['AvailableIpAddressCount']) / max_addresses * 100.0,
+                2
+            ),
+        )
+
+    def process(self, resources, event=None):
+        results = []
+        for r in resources:
+            if self.annotation_key not in r:
+                self.augment(r)
+            if self.match(r[self.annotation_key]):
+                results.append(r)
+        return results
 
 class ConfigSG(query.ConfigSource):
 

--- a/tests/data/placebo/test_subnet_ip_address_usage_filter/ec2.DescribeSubnets_1.json
+++ b/tests/data/placebo/test_subnet_ip_address_usage_filter/ec2.DescribeSubnets_1.json
@@ -1,0 +1,156 @@
+{
+    "status_code": 200,
+    "data": {
+        "Subnets": [
+            {
+                "AvailabilityZone": "us-east-2b",
+                "AvailabilityZoneId": "use2-az2",
+                "AvailableIpAddressCount": 507,
+                "CidrBlock": "10.0.2.0/23",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": false,
+                "MapCustomerOwnedIpOnLaunch": false,
+                "State": "available",
+                "SubnetId": "subnet-08e48f2f3b110fadc",
+                "VpcId": "vpc-056651ecc06e0c9d3",
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "dev"
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": "aj"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "dev-private-us-east-2b"
+                    }
+                ],
+                "SubnetArn": "arn:aws:ec2:us-east-2:644160558196:subnet/subnet-08e48f2f3b110fadc",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                }
+            },
+            {
+                "AvailabilityZone": "us-east-2c",
+                "AvailabilityZoneId": "use2-az3",
+                "AvailableIpAddressCount": 212,
+                "CidrBlock": "10.0.103.0/24",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": true,
+                "MapCustomerOwnedIpOnLaunch": false,
+                "State": "available",
+                "SubnetId": "subnet-0e5929766e049d22d",
+                "VpcId": "vpc-056651ecc06e0c9d3",
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "aj"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "dev"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "dev-public-us-east-2c"
+                    }
+                ],
+                "SubnetArn": "arn:aws:ec2:us-east-2:644160558196:subnet/subnet-0e5929766e049d22d",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                }
+            },
+            {
+                "AvailabilityZone": "us-east-2c",
+                "AvailabilityZoneId": "use2-az3",
+                "AvailableIpAddressCount": 20,
+                "CidrBlock": "10.0.4.0/23",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": false,
+                "MapCustomerOwnedIpOnLaunch": false,
+                "State": "available",
+                "SubnetId": "subnet-06b49a4a4f6e2be8f",
+                "VpcId": "vpc-056651ecc06e0c9d3",
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "dev-private-us-east-2c"
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": "aj"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "dev"
+                    }
+                ],
+                "SubnetArn": "arn:aws:ec2:us-east-2:644160558196:subnet/subnet-06b49a4a4f6e2be8f",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                }
+            },
+            {
+                "AvailabilityZone": "us-east-2b",
+                "AvailabilityZoneId": "use2-az2",
+                "AvailableIpAddressCount": 251,
+                "CidrBlock": "10.0.102.0/24",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": true,
+                "MapCustomerOwnedIpOnLaunch": false,
+                "State": "available",
+                "SubnetId": "subnet-0aa79961010e4a387",
+                "VpcId": "vpc-056651ecc06e0c9d3",
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "dev-public-us-east-2b"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "dev"
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": "aj"
+                    }
+                ],
+                "SubnetArn": "arn:aws:ec2:us-east-2:644160558196:subnet/subnet-0aa79961010e4a387",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -825,6 +825,7 @@ class PolicyMetaLint(BaseTest):
                     "instance-uptime",
                     "dead-letter",
                     "list-item",
+                    "ip-address-usage",
                 ):
                     continue
                 qk = "%s.filters.%s" % (k, n)


### PR DESCRIPTION
Add a filter to check for used IP space within a subnet. Note that there's a judgement call here around the "is my subnet _really_ unused?" case. My take is that reliably answering that question is a _lot_ more work and will silently become out of date any time AWS releases a new service that consumes VPC addresses.

Even ruling that out, it's convenient to look at IP space usage over time. Both to look for subnets that appear unused and for the opposite case of subnets whose IP space is nearly exhausted.

Closes #390
Also relates to #5906