### PR TITLE
docs - fix sidebar formatting for c7n_kube

### DIFF
--- a/tools/c7n_kube/readme.md
+++ b/tools/c7n_kube/readme.md
@@ -3,7 +3,7 @@
 Cloud Custodian can run policies directly inside your cluster, reporting on 
 resources that violate those policies, or blocking them altogether.
 
-# Running the server 
+## Running the server
 
 c7n-kates can be run and installed via poetry. `poetry install && poetry run c7n-kates`.  
 
@@ -17,7 +17,7 @@ c7n-kates can be run and installed via poetry. `poetry install && poetry run c7n
 | --ca-cert      |           | Path to the CA's certificate.                                |
 | --cert-key     |           | Path to the certificate's key.                               |
 
-# Generate a MutatingWebhookConfiguration
+## Generate a MutatingWebhookConfiguration
 
 After the server is running, you'll need to configure and install the 
 MutatingWebhookConfiguration manually. To generate a webhook configuration, you
@@ -28,7 +28,7 @@ Note: some modification of the webhook configuration may be required. See the
 [documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) 
 on webhooks for more configuration.
 
-# Development
+## Development
 
 You can use [skaffold](https://github.com/GoogleContainerTools/skaffold/) to 
 assist with testing and debugging this controller. Run `skaffold dev` in this


### PR DESCRIPTION
Fixing the way some of the c7n_kube headers are currently being shown at the parent level, instead of being nested under `Custodian Kubernetes Support`. 

<details>
<summary>Before</summary>

![Screenshot from 2023-04-26 21-38-59](https://user-images.githubusercontent.com/7545665/234739980-ee717710-4bfe-4c07-90b2-c3cb44f4052d.png)

</details>

<details>
<summary>After</summary>

![Screenshot from 2023-04-26 21-42-02](https://user-images.githubusercontent.com/7545665/234740001-667c0cab-c1e1-43d1-85cb-a13fac58c409.png)

</details>

Thank you all for maintaining this project! Just starting to use it, and am finding it handy to use for saving costs.
