### PR TITLE
Adds ECR repository policy to saved resource for reporting

### DIFF
--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -22,6 +22,11 @@ class DescribeECR(DescribeSource):
             try:
                 r['Tags'] = client.list_tags_for_resource(
                     resourceArn=r['repositoryArn']).get('tags')
+                try:
+                    r['repositoryPolicy'] = json.loads(client.get_repository_policy(
+                        repositoryName=r["repositoryName"])["policyText"])
+                except client.exceptions.RepositoryPolicyNotFoundException:
+                    r['repositoryPolicy'] = {}
                 results.append(r)
             except client.exceptions.RepositoryNotFoundException:
                 continue


### PR DESCRIPTION
I wanted the ability to report on aspects of the existing policies, so added `repositoryPolicy` to the saved resource.

Is there a different approach you would rather see?