### PR TITLE
feat: get header's value from AWS SecretManager secret

### DIFF
--- a/tests/data/placebo/get_headers_from_secretsmanager_secret/secretsmanager.GetSecretValue_1.json
+++ b/tests/data/placebo/get_headers_from_secretsmanager_secret/secretsmanager.GetSecretValue_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "ARN": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+        "Name": "secretsmanager_secret_string",
+        "VersionId": "9AACC73C-2EC2-4055-B051-BA7039E01A57",
+        "SecretString": "1234567890",
+        "VersionStages": [
+            "AWSCURRENT"
+        ],
+        "CreatedDate": {
+            "__class__": "datetime",
+            "year": 2023,
+            "month": 5,
+            "day": 6,
+            "hour": 18,
+            "minute": 14,
+            "second": 20,
+            "microsecond": 220000
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/get_headers_from_secretsmanager_secret/main.tf
+++ b/tests/terraform/get_headers_from_secretsmanager_secret/main.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "this" {
+  name = "secretsmanager_secret_string"
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = "1234567890"
+}

--- a/tests/terraform/get_headers_from_secretsmanager_secret/tf_resources.json
+++ b/tests/terraform/get_headers_from_secretsmanager_secret/tf_resources.json
@@ -1,0 +1,38 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_secretsmanager_secret": {
+            "this": {
+                "arn": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+                "description": "",
+                "force_overwrite_replica_secret": false,
+                "id": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+                "kms_key_id": "",
+                "name": "secretsmanager_secret_string",
+                "name_prefix": "",
+                "policy": "",
+                "recovery_window_in_days": 30,
+                "replica": [],
+                "rotation_enabled": false,
+                "rotation_lambda_arn": "",
+                "rotation_rules": [],
+                "tags": null,
+                "tags_all": {}
+            }
+        },
+        "aws_secretsmanager_secret_version": {
+            "this": {
+                "arn": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+                "id": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo|9AACC73C-2EC2-4055-B051-BA7039E01A57",
+                "secret_binary": "",
+                "secret_id": "arn:aws:secretsmanager:us-east-1:644160558196:secret:secretsmanager_secret_string-XSQFTo",
+                "secret_string": "1234567890",
+                "version_id": "9AACC73C-2EC2-4055-B051-BA7039E01A57",
+                "version_stages": [
+                    "AWSCURRENT"
+                ]
+            }
+        }
+    }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,8 +305,24 @@ class SchemaTest(CliTest):
                     'headers': {
                         'type': 'object',
                         'patternProperties': {
-                            '': {'type': 'string'},
-                        },
+                            '': {
+                                'oneOf': [
+                                    {'type': 'string'},
+                                    {
+                                        'type': 'object',
+                                        'required': ['value_from'],
+                                        'additionalProperties': 'False',
+                                        'properties': {
+                                            'value_from': {
+                                                'type': 'string',
+                                                'pattern':
+                                                    '^arn:aws:secretsmanager:.+:\\d+:secret:.+$'
+                                            },
+                                        },
+                                    },
+                                ]
+                            }
+                        }
                     },
                 }
             },
@@ -323,8 +339,24 @@ class SchemaTest(CliTest):
                     'headers': {
                         'type': 'object',
                         'patternProperties': {
-                            '': {'type': 'string'},
-                        },
+                            '': {
+                                'oneOf': [
+                                    {'type': 'string'},
+                                    {
+                                        'type': 'object',
+                                        'required': ['value_from'],
+                                        'additionalProperties': 'False',
+                                        'properties': {
+                                            'value_from': {
+                                                'type': 'string',
+                                                'pattern':
+                                                    '^arn:aws:secretsmanager:.+:\\d+:secret:.+$'
+                                            },
+                                        },
+                                    },
+                                ]
+                            }
+                        }
                     },
                 }
             }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -496,6 +496,36 @@ class SchemaTest(BaseTest):
         errors = list(self.get_validator(data).iter_errors(data))
         self.assertEqual(len(errors), 0)
 
+    def test_value_from_headers(self):
+        secret_arn = 'arn:aws:secretsmanager:us-east-1:123456789012:secret:name-asdfgh'
+        data = {
+            "policies": [
+                {
+                    "name": "example",
+                    "resource": "ec2",
+                    "filters": [
+                        {
+                            'type': 'value',
+                            'key': 'InstanceId',
+                            'op': 'not-in',
+                            'value_from': {
+                                'url': 'example',
+                                'format': 'json',
+                                'headers': {
+                                    'header_1': 'example',
+                                    'header_2': {
+                                        'value_from': secret_arn
+                                    },
+                                },
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+        errors = list(self.get_validator(data).iter_errors(data))
+        self.assertEqual(len(errors), 0)
+
     def test_mark_for_op(self):
         data = {
             "policies": [


### PR DESCRIPTION
Add possibility to retrieve value for a header in `value_from` parameter of filter from AWS SecretManager secrets (it can be extended later on demand).

This functionality is needed if you want to get values from API where authentication is required. As a result, you can store API token encrypted in AWS SecretManager secret rather than hardcode plain-text value in policy configuration file.

Before PR:

```yaml
policies:
  - name:     ec2-test
    resource: ec2
    filters:
      - type: value
        key:  "InstanceId"
        op:   not-in
        value_from:
          url:     <url>
          format:  json
          headers:
            non_secret_header: <value_1> # plain-text value
            secret_header: <value_2> # plain-text value
```

After PR:
```yaml
policies:
  - name:     ec2-test
    resource: ec2
    filters:
      - type: value
        key:  "InstanceId"
        op:   not-in
        value_from:
          url:     <url>
          format:  json
          headers:
             non_secret_header: <value_1> # plain-text value like it was done before
             secret_header:
               value_from: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:name-asdfgh' # get value from this SecretManager secret
```

This PR is based on requirements of #8420 and issue #8212 but it provides more common approach (not only for 1 specific header)