### PR TITLE
gcp - deployment-manager normalize label format

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -180,7 +180,10 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
                 'component': self.resource_type.component}
 
     def get_resource(self, resource_info):
-        return self.resource_type.get(self.get_client(), resource_info)
+        resource = self.resource_type.get(self.get_client(), resource_info)
+        if resource:
+            self.augment((resource,))
+        return resource
 
     @property
     def source_type(self):

--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -180,10 +180,7 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
                 'component': self.resource_type.component}
 
     def get_resource(self, resource_info):
-        resource = self.resource_type.get(self.get_client(), resource_info)
-        if resource:
-            self.augment((resource,))
-        return resource
+        return self.resource_type.get(self.get_client(), resource_info)
 
     @property
     def source_type(self):

--- a/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
@@ -23,6 +23,13 @@ class DMDeployment(QueryResourceManager):
         default_report_fields = ['name', 'description', 'insertTime', 'updateTime']
         urn_component = "deployment"
 
+        def augment(self, resources):
+            # normalize labels from array to mapping like other gcp resources.
+            for r in resources:
+                if isinstance(r.get('labels'), list):
+                    r['labels'] = {l['key']: l['value'] for l in r['labels']}
+            return resources
+
         @staticmethod
         def get(client, resource_info):
             return client.execute_command(

--- a/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
@@ -36,6 +36,12 @@ class DMDeployment(QueryResourceManager):
                 r['labels'] = {l['key']: l['value'] for l in r['labels']}
         return resources
 
+    def get_resource(self, resource_info):
+        resource = self.resource_type.get(self.get_client(), resource_info)
+        if resource:
+            self.augment((resource,))
+        return resource
+
 
 @DMDeployment.action_registry.register('delete')
 class DeleteInstanceGroupManager(MethodAction):

--- a/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/deploymentmanager.py
@@ -23,18 +23,18 @@ class DMDeployment(QueryResourceManager):
         default_report_fields = ['name', 'description', 'insertTime', 'updateTime']
         urn_component = "deployment"
 
-        def augment(self, resources):
-            # normalize labels from array to mapping like other gcp resources.
-            for r in resources:
-                if isinstance(r.get('labels'), list):
-                    r['labels'] = {l['key']: l['value'] for l in r['labels']}
-            return resources
-
         @staticmethod
         def get(client, resource_info):
             return client.execute_command(
                 'get', {'project': resource_info['project_id'],
                         'deployment': resource_info['name']})
+
+    def augment(self, resources):
+        # normalize labels from array to mapping like other gcp resources.
+        for r in resources:
+            if isinstance(r.get('labels'), list):
+                r['labels'] = {l['key']: l['value'] for l in r['labels']}
+        return resources
 
 
 @DMDeployment.action_registry.register('delete')

--- a/tools/c7n_gcp/tests/data/flights/dm-deployment-augment/get-deploymentmanager-v2-projects-cloud-custodian-global-deployments-example-deployment5_1.json
+++ b/tools/c7n_gcp/tests/data/flights/dm-deployment-augment/get-deploymentmanager-v2-projects-cloud-custodian-global-deployments-example-deployment5_1.json
@@ -1,0 +1,52 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 08 May 2023 13:15:48 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1378",
+    "-content-encoding": "gzip",
+    "content-location": "https://deploymentmanager.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/deployments/example-deployment5?alt=json"
+  },
+  "body": {
+    "id": "6178572056300702896",
+    "name": "example-deployment5",
+    "operation": {
+      "kind": "deploymentmanager#operation",
+      "id": "0",
+      "name": "operation-1683550815448-5fb2e3850ef79-57f6be7e-86639a53",
+      "operationType": "insert",
+      "targetLink": "https://www.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/deployments/example-deployment5",
+      "targetId": "6178572056300702896",
+      "status": "DONE",
+      "user": "kapil@stacklet.io",
+      "progress": 100,
+      "insertTime": "1969-12-31T16:00:00.000-08:00",
+      "startTime": "2023-05-08T06:00:15.589-07:00",
+      "endTime": "2023-05-08T06:00:29.580-07:00",
+      "selfLink": "https://www.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/operations/operation-1683550815448-5fb2e3850ef79-57f6be7e-86639a53"
+    },
+    "fingerprint": "5m6QgnZFs4zABHEjyyqNyg==",
+    "manifest": "https://www.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/deployments/example-deployment5/manifests/manifest-1683550815513",
+    "insertTime": "2023-05-08T06:00:15.500-07:00",
+    "updateTime": "2023-05-08T06:00:29.536-07:00",
+    "labels": [
+      {
+        "key": "environment",
+        "value": "production"
+      },
+      {
+        "key": "storage",
+        "value": "media"
+      }
+    ],
+    "selfLink": "https://www.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/deployments/example-deployment5"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/dm-deployment-augment/get-deploymentmanager-v2-projects-cloud-custodian-global-deployments_1.json
+++ b/tools/c7n_gcp/tests/data/flights/dm-deployment-augment/get-deploymentmanager-v2-projects-cloud-custodian-global-deployments_1.json
@@ -1,0 +1,56 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 08 May 2023 13:15:48 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1541",
+    "-content-encoding": "gzip",
+    "content-location": "https://deploymentmanager.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/deployments?alt=json"
+  },
+  "body": {
+    "deployments": [
+      {
+        "id": "6178572056300702896",
+        "name": "example-deployment5",
+        "operation": {
+          "kind": "deploymentmanager#operation",
+          "id": "0",
+          "name": "operation-1683550815448-5fb2e3850ef79-57f6be7e-86639a53",
+          "operationType": "insert",
+          "targetLink": "https://www.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/deployments/example-deployment5",
+          "targetId": "6178572056300702896",
+          "status": "DONE",
+          "user": "kapil@stacklet.io",
+          "progress": 100,
+          "insertTime": "1969-12-31T16:00:00.000-08:00",
+          "startTime": "2023-05-08T06:00:15.589-07:00",
+          "endTime": "2023-05-08T06:00:29.580-07:00",
+          "selfLink": "https://www.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/operations/operation-1683550815448-5fb2e3850ef79-57f6be7e-86639a53"
+        },
+        "fingerprint": "5m6QgnZFs4zABHEjyyqNyg==",
+        "manifest": "https://www.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/deployments/example-deployment5/manifests/manifest-1683550815513",
+        "insertTime": "2023-05-08T06:00:15.500-07:00",
+        "updateTime": "2023-05-08T06:00:29.536-07:00",
+        "labels": [
+          {
+            "key": "environment",
+            "value": "production"
+          },
+          {
+            "key": "storage",
+            "value": "media"
+          }
+        ],
+        "selfLink": "https://www.googleapis.com/deploymentmanager/v2/projects/cloud-custodian/global/deployments/example-deployment5"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/test_deploymentmanager.py
+++ b/tools/c7n_gcp/tests/test_deploymentmanager.py
@@ -29,8 +29,8 @@ class DMDeploymentTest(BaseTest):
         )
 
     def test_deployment_augment(self):
-        project_id = 'stacklet-kapilt'
-        session_factory = self.record_flight_data('dm-deployment-augment', project_id=project_id)
+        project_id = 'cloud-custodian'
+        session_factory = self.replay_flight_data('dm-deployment-augment', project_id=project_id)
 
         policy = self.load_policy(
             {'name': 'one-deployment', 'resource': 'gcp.dm-deployment'},

--- a/tools/c7n_gcp/tests/test_deploymentmanager.py
+++ b/tools/c7n_gcp/tests/test_deploymentmanager.py
@@ -28,6 +28,24 @@ class DMDeploymentTest(BaseTest):
             ],
         )
 
+    def test_deployment_augment(self):
+        project_id = 'stacklet-kapilt'
+        session_factory = self.record_flight_data('dm-deployment-augment', project_id=project_id)
+
+        policy = self.load_policy(
+            {'name': 'one-deployment', 'resource': 'gcp.dm-deployment'},
+            session_factory=session_factory)
+
+        deployment = policy.resource_manager.get_resource({
+            'project_id': project_id,
+            'name': 'example-deployment5'
+        })
+        assert deployment['labels'] == {'environment': 'production', 'storage': 'media'}
+
+        resources = policy.run()
+        assert len(resources) == 1
+        assert resources[0]['labels'] == {'environment': 'production', 'storage': 'media'}
+
     def test_deployment_get(self):
         project_id = 'cloud-custodian'
         session_factory = self.replay_flight_data('dm-deployment-get', project_id=project_id)


### PR DESCRIPTION
for other resource types gcp uses a mapping for label, for deployment manager it comes back as an array of mapping with key/value keys, normalize to a mapping to match other gcp resources.
