### PR TITLE
add everyone_only as a filter for EBS snapshots

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -238,12 +238,19 @@ class SnapshotCrossAccountAccess(CrossAccountAccessFilter):
 
     def process_resource_set(self, client, resource_set):
         results = []
+        everyone_only = self.data.get('everyone_only', False)
         for r in resource_set:
             attrs = self.manager.retry(
                 client.describe_snapshot_attribute,
                 SnapshotId=r['SnapshotId'],
                 Attribute='createVolumePermission')['CreateVolumePermissions']
-            shared_accounts = {
+            shared_accounts = set()
+            if everyone_only:
+                for g in attrs:
+                    if g.get('Group') == 'all':
+                        shared_accounts = {g.get('Group')}
+            else:
+                shared_accounts = {
                 g.get('Group') or g.get('UserId') for g in attrs}
             delta_accounts = shared_accounts.difference(self.accounts)
             if delta_accounts:

--- a/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.DescribeSnapshotAttribute_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.DescribeSnapshotAttribute_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "CreateVolumePermissions": [
+            {
+                "Group": "all"
+            }
+        ],
+        "SnapshotId": "snap-af0eb71b",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.DescribeSnapshotAttribute_2.json
+++ b/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.DescribeSnapshotAttribute_2.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "CreateVolumePermissions": [
+            {
+                "UserId": "112233445566"
+            },
+            {
+                "UserId": "665544332211"
+            }
+        ],
+        "SnapshotId": "snap-0ac64f0a1f16af706",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.DescribeSnapshotAttribute_3.json
+++ b/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.DescribeSnapshotAttribute_3.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "CreateVolumePermissions": [],
+        "SnapshotId": "snap-af0eb71b",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.DescribeSnapshots_1.json
@@ -1,0 +1,48 @@
+{
+    "status_code": 200,
+    "data": {
+        "Snapshots": [
+            {
+                "Description": "",
+                "Encrypted": false,
+                "OwnerId": "644160558196",
+                "Progress": "100%",
+                "SnapshotId": "snap-af0eb71b",
+                "StartTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 10,
+                    "day": 14,
+                    "hour": 21,
+                    "minute": 8,
+                    "second": 19,
+                    "microsecond": 177000
+                },
+                "State": "completed",
+                "VolumeId": "vol-af0eb71b",
+                "VolumeSize": 8
+            },
+            {
+                "Description": "",
+                "Encrypted": false,
+                "OwnerId": "644160558196",
+                "Progress": "100%",
+                "SnapshotId": "snap-0ac64f0a1f16af706",
+                "StartTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 10,
+                    "day": 14,
+                    "hour": 21,
+                    "minute": 8,
+                    "second": 19,
+                    "microsecond": 177000
+                },
+                "State": "completed",
+                "VolumeId": "vol-0309e0368c8e7c1b0",
+                "VolumeSize": 8
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.ModifySnapshotAttribute_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_set_permissions_matched_everyone_only/ec2.ModifySnapshotAttribute_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -194,7 +194,6 @@ class SnapshotAccessTest(BaseTest):
         # pre conditions, 2 snapshots one shared to a separate account, and one
         # shared publicly. 2 non matching volumes, one not shared, one shared
         # explicitly to its own account.
-        self.patch(CopySnapshot, "executor_factory", MainThreadExecutor)
         factory = self.replay_flight_data("test_ebs_cross_account")
         p = self.load_policy(
             {


### PR DESCRIPTION
This PR is meant to solve the following issue: https://github.com/cloud-custodian/cloud-custodian/issues/4072

I also tested this against an AWS account where I had created 3 snapshots in ou-test: 1 public, 1 shared with another account and 1 private. I use this policy:
```
policies:
    - name: aws_ebs-shared-public-snaphots
      description: Find public snapshots
      resource: aws.ebs-snapshot
      filters:
        - type: cross-account
          everyone_only: True
```
And I get:
```
(.venv) $ cat resources.json
[
  {
    "Description": "public-snapshot",
    "Encrypted": false,
    "OwnerId": "REDACTED",
    "Progress": "100%",
    "SnapshotId": "snap-REDACTED",
    "StartTime": "2023-05-04T16:38:33.861000+00:00",
    "State": "completed",
    "VolumeId": "vol-REDACTED",
    "VolumeSize": 8,
    "StorageTier": "standard",
    "c7n:CrossAccountViolations": [
      "all"
    ]
  }
]
```