### PR TITLE
output - strip trailing slashes from s3 output url paths

### DIFF
--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -170,8 +170,10 @@ def get_bucket_url_with_region(bucket_url, region):
     query = f"region={region}"
     if parsed.query:
         query = parsed.query + f"&region={region}"
-    parts = list(parsed)
-    parts[4] = query
+    parts = parsed._replace(
+        path=parsed.path.strip("/"),
+        query=query
+    )
     return urlparse.urlunparse(parts)
 
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -521,6 +521,9 @@ def test_get_bucket_url_s3_cross_region():
     assert aws.get_bucket_url_with_region(
         "s3://slack.cloudcustodian.io",
         "us-west-2") == "s3://slack.cloudcustodian.io?region=us-east-1"
+    assert aws.get_bucket_url_with_region(
+        "s3://slack.cloudcustodian.io/",
+        "us-west-2") == "s3://slack.cloudcustodian.io?region=us-east-1"
 
 
 @vcr.use_cassette(
@@ -533,3 +536,7 @@ def test_get_bucket_url_s3_same_region():
     assert aws.get_bucket_url_with_region(
         "s3://slack.cloudcustodian.io?param=x",
         "us-east-1") == "s3://slack.cloudcustodian.io?param=x&region=us-east-1"
+
+    assert aws.get_bucket_url_with_region(
+        "s3://slack.cloudcustodian.io/logs/?param=x",
+        "us-east-1") == "s3://slack.cloudcustodian.io/logs?param=x&region=us-east-1"


### PR DESCRIPTION
The existing logic that strips trailing slashes from output dirs was firing after we tacked on a region query string. Strip the path component while we're building a bucket URL instead.