### PR TITLE
releng - require urllib3 <2.0 to speed up dependency resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ custodian = 'c7n.cli:main'
 [tool.poetry.dependencies]
 python = "^3.7"
 boto3 = "^1.12.31"
+# set an upper bound on urllib3 to avoid long dependency resolution times
+# botocore accepts a narrow range of urllib3 versions, while packages
+# like docker/requests/twine are happy with 2.0.
+urllib3 = "<2.0"
 jsonschema = ">=3.0.0"
 argcomplete = ">=1.12.3"
 python-dateutil = "^2.8.2"


### PR DESCRIPTION
Updating dependencies currently takes a very long time (20+ minutes) because:

- docker/requests/twine/botocore all depend on urllib3
- everyone _except_ botocore is happy with urllib3 2.x
- poetry initially selects urllib3 2.x, then fruitlessly churns through hundreds of botocore versions to see if any will work before giving up and choosing urllib3 1.x

We could also try to handle this by tweaking our boto3 constraint, but this seems like an explicit way to avoid a lot of running into walls.