### PR TITLE
core - validate - report errors per file

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -222,7 +222,7 @@ def validate(options):
         except PolicyValidationError as e:
             log.error("Configuration invalid: {}".format(config_file))
             log.error("%s" % e)
-            errors.append(e)
+            all_errors[config_file] = e
             continue
 
         load_resources(structure.get_resource_types(data))

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -195,11 +195,12 @@ def validate(options):
 
     used_policy_names = set()
     structure = StructureParser()
-    errors = []
+    all_errors = {}
     found_deprecations = False
     footnotes = deprecated.Footnotes()
 
     for config_file in options.configs:
+        errors = []
 
         config_file = os.path.expanduser(config_file)
         if not os.path.exists(config_file):
@@ -270,6 +271,7 @@ def validate(options):
             log.info("Configuration valid: {}".format(config_file))
             continue
 
+        all_errors[config_file] = errors
         log.error("Configuration invalid: {}".format(config_file))
         for e in errors:
             log.error("%s" % e)
@@ -279,7 +281,7 @@ def validate(options):
             log.warning("deprecation footnotes:\n" + notes)
         if options.check_deprecations == deprecated.STRICT:
             sys.exit(1)
-    if errors:
+    if all_errors:
         sys.exit(1)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -55,10 +55,23 @@ class CommandsValidateTest(BaseTest):
             verbose=False,
             check_deprecations="yes",
         )
+        log_output = self.capture_logging("custodian.commands")
         with self.assertRaises((SystemExit, ValueError)) as exit:
             validate_yaml_policies(yaml_validate_options)
         # if there is a bad policy in the batch being validated, there should be an exit 1
         self.assertEqual(exit.exception.code, 1)
+
+        # ...and it should report accurate per-file validation status individually
+        validation_output = log_output.getvalue()
+        self.assertIn(
+            "Configuration invalid: tests/data/test_policies/ebs-BADVALIDATION.yml",
+            validation_output
+        )
+        self.assertIn(
+            "Configuration valid: tests/data/test_policies/ami-GOODVALIDATION.yml",
+            validation_output
+        )
+
         yaml_validate_options.configs.remove(
             "tests/data/test_policies/ebs-BADVALIDATION.yml"
         )


### PR DESCRIPTION
If we run `custodian validate` on multiple files, it loops over those files and builds up a list of errors as it goes. It behaves like a snowball though - once an error shows up it gets reported for that file and every one after it.

This change makes running something like `custodian validate *.y*ml` friendlier by not polluting a file's validation status with errors from earlier files.

I think this behavior is something folks (including myself) have just gotten used to, but #8548 prompted me to see it with fresh eyes.