### PR TITLE
feat: adding support for gcp impersonated credentials

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -47,7 +47,7 @@ def _default_options(p, exclude=[]):
         "--profile",
         help="AWS Account Config File Profile to utilize")
     provider.add_argument("--assume", default=None, dest="assume_role",
-                          help="Role to assume")
+                          help="Role or Service Account to assume")
     provider.add_argument("--external-id", default=None, dest="external_id",
                           help="External Id to provide when assuming a role")
 

--- a/docs/source/gcp/gettingstarted.rst
+++ b/docs/source/gcp/gettingstarted.rst
@@ -76,6 +76,13 @@ using environment variables.
 Follow the steps outlined in the 
 `GCP documentation to configure credentials for service accounts. <https://cloud.google.com/docs/authentication/getting-started>`_
 
+If you are planning to impersonate a service account, then you may configure the environment
+variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` with the service account email address.
+
+.. code-block:: bash
+
+    export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT="impersonated-account@_project_.iam.gserviceaccount.com"
+
 .. _gcp_write-policy:
 
 Write Your First Policy

--- a/docs/source/gcp/gettingstarted.rst
+++ b/docs/source/gcp/gettingstarted.rst
@@ -77,7 +77,8 @@ Follow the steps outlined in the
 `GCP documentation to configure credentials for service accounts. <https://cloud.google.com/docs/authentication/getting-started>`_
 
 If you are planning to impersonate a service account, then you may configure the environment
-variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` with the service account email address.
+variable `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` with the service account email address, you can also 
+pass this the service account email via `--assume` cli flag.
 
 .. code-block:: bash
 

--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -185,6 +185,7 @@ class Session:
         impersonate_credentials = None
         if impersonate_service or GOOGLE_IMPERSONATE_SERVICE_ACCOUNT:
             impersonate_target = impersonate_service or GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+            log.info('using impersonated service account %s', impersonate_target)
             impersonated_credentials = google.auth.impersonated_credentials.Credentials(
                 source_credentials=credentials or default_credentials,
                 target_principal=impersonate_target,

--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -192,7 +192,7 @@ class Session:
                 target_principal=impersonate_target,
                 target_scopes=list(CLOUD_SCOPES))
         target_credentials = impersonated_credentials or credentials or default_credentials
-        if not impersonate_credentials:
+        if not impersonated_credentials:
             # get token with scopes if necessary
             self._credentials = with_scopes_if_required(target_credentials, list(CLOUD_SCOPES))
         else:

--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -187,7 +187,7 @@ class Session:
                 target_principal=GOOGLE_IMPERSONATE_SERVICE_ACCOUNT,
                 target_scopes=list(CLOUD_SCOPES))
         target_credentials = impersonated_credentials or credentials or default_credentials
-        if not impersonated_credentials:
+        if 'impersonated_credentials' not in dir():
             # get token with scopes if necessary
             self._credentials = with_scopes_if_required(target_credentials, list(CLOUD_SCOPES))
         else:

--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -182,7 +182,7 @@ class Session:
             self._use_cached_http = True
             default_credentials, _ = google.auth.default(quota_project_id=project_id or
             get_default_project())
-        impersonate_credentials = None
+        impersonated_credentials = None
         if impersonate_service or GOOGLE_IMPERSONATE_SERVICE_ACCOUNT:
             impersonate_target = impersonate_service or GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
             log.info('using impersonated service account %s', impersonate_target)

--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -179,7 +179,7 @@ class Session:
         if not credentials:
             # Only share the http object when using the default credentials.
             self._use_cached_http = True
-            default_credentials, default_project = google.auth.default(quota_project_id=project_id or
+            default_credentials, _ = google.auth.default(quota_project_id=project_id or
             get_default_project())
         if GOOGLE_IMPERSONATE_SERVICE_ACCOUNT:
             impersonated_credentials = google.auth.impersonated_credentials.Credentials(

--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -180,8 +180,9 @@ class Session:
         if not credentials:
             # Only share the http object when using the default credentials.
             self._use_cached_http = True
-            default_credentials, _ = google.auth.default(quota_project_id=project_id or
-            get_default_project())
+            default_credentials, _ = google.auth.default(
+                quota_project_id=project_id or get_default_project()
+            )
         impersonated_credentials = None
         if impersonate_service or GOOGLE_IMPERSONATE_SERVICE_ACCOUNT:
             impersonate_target = impersonate_service or GOOGLE_IMPERSONATE_SERVICE_ACCOUNT

--- a/tools/c7n_gcp/c7n_gcp/provider.py
+++ b/tools/c7n_gcp/c7n_gcp/provider.py
@@ -26,7 +26,8 @@ class GoogleCloud(Provider):
 
     def get_session_factory(self, options):
         """Get a credential/session factory for api usage."""
-        return partial(Session, project_id=options.account_id)
+        return partial(
+            Session, project_id=options.account_id, impersonate_service=options.assume_role)
 
 
 resources = GoogleCloud.resources


### PR DESCRIPTION
If a service account email address is found in the `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` environment variable, gcp client will attempt to create an oauth token impersonating that service account to use as credentials.

closes https://github.com/cloud-custodian/cloud-custodian/issues/8568