### PR TITLE
quick update to example for bucket policy

### DIFF
--- a/tools/c7n_tencentcloud/c7n_tencentcloud/resources/cos.py
+++ b/tools/c7n_tencentcloud/c7n_tencentcloud/resources/cos.py
@@ -101,7 +101,7 @@ class HasStatementFilter(BucketFilterBase):
                 - type: has-statement
                   statements:
                     - Effect: Deny
-                    - Action: name/cos:GetObject
+                      Action: name/cos:GetObject
 
     """
     schema = type_schema(


### PR DESCRIPTION
revised filter example for COS bucket policies, it had an extra "-" making the example not work.