### PR TITLE
aws-efs-mount-target-add-cloudtrail-mode

### DIFF
--- a/c7n/resources/efs.py
+++ b/c7n/resources/efs.py
@@ -61,6 +61,7 @@ class ElasticFileSystemMountTarget(ChildResourceManager):
         filter_type = 'scalar'
         arn = False
         cfn_type = 'AWS::EFS::MountTarget'
+        supports_trailevents = True
 
 
 @ElasticFileSystemMountTarget.filter_registry.register('subnet')


### PR DESCRIPTION
Add cloudtrail mode support for aws efs-mount-target resource.