### PR TITLE
azure - session - add _run_command timeout parameter

### DIFF
--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -90,7 +90,7 @@ class AzureCredential:
         elif self._auth_params.get('enable_cli_auth'):
             auth_name = 'Azure CLI'
             self._credential = AzureCliCredential()
-            account_info = _run_command('az account show --output json')
+            account_info = _run_command('az account show --output json', timeout=10)
             account_json = json.loads(account_info)
             self._auth_params['subscription_id'] = account_json['id']
             self._auth_params['tenant_id'] = account_json['tenantId']

--- a/tools/c7n_azure/tests_azure/test_session.py
+++ b/tools/c7n_azure/tests_azure/test_session.py
@@ -9,7 +9,7 @@ from adal import AdalError
 from azure.core.credentials import AccessToken
 from azure.identity import (ClientSecretCredential, ManagedIdentityCredential)
 from c7n_azure import constants
-from c7n_azure.session import Session
+from c7n_azure.session import Session, _run_command
 from mock import patch
 from msrest.exceptions import AuthenticationError
 from msrestazure.azure_cloud import (AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD)
@@ -86,6 +86,10 @@ class SessionTest(BaseTest):
             s = Session()
             self.assertEqual(s.get_subscription_id(), DEFAULT_SUBSCRIPTION_ID)
             self.assertEqual(s.get_tenant_id(), DEFAULT_TENANT_ID)
+
+    def test_run_command(self):
+        """Catch signature changes in the internal method we use for CLI auth"""
+        _run_command('az version', timeout=10)
 
     @patch('azure.identity.ClientSecretCredential.get_token')
     @patch('c7n_azure.session.log.error')


### PR DESCRIPTION
Add a new required parameter following upstream SDK changes.

Closes #8619, #8630