### PR TITLE
mailer - format py code with black -l 100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,9 @@ docs/source/tools/assets/
 .tfcache
 .env
 .python-version
-
+# files generated during "make test"
+label-pod
+test-admission
+test-admission-2
+test-admission-pod
+tests/data/vcr_cassettes/test_output/default_bucket_region_public.yaml

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/__init__.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 
-logging.getLogger('azure.storage.common.storageclient').setLevel(logging.WARNING)
+logging.getLogger("azure.storage.common.storageclient").setLevel(logging.WARNING)

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/azure_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/azure_queue_processor.py
@@ -24,12 +24,11 @@ except ImportError:
 
 
 class MailerAzureQueueProcessor(MessageTargetMixin):
-
     def __init__(self, config, logger, session=None, max_num_processes=16):
         self.max_num_processes = max_num_processes
         self.config = config
         self.logger = logger
-        self.receive_queue = self.config['queue_url']
+        self.receive_queue = self.config["queue_url"]
         self.batch_size = 16
         self.max_message_retry = 3
         self.session = session or Session()
@@ -41,35 +40,42 @@ class MailerAzureQueueProcessor(MessageTargetMixin):
         self.logger.info("Downloading messages from the Azure Storage queue.")
         queue_settings = StorageUtilities.get_queue_client_by_uri(self.receive_queue, self.session)
         queue_messages = StorageUtilities.get_queue_messages(
-            *queue_settings, num_messages=self.batch_size)
+            *queue_settings, num_messages=self.batch_size
+        )
 
         while len(queue_messages) > 0:
             for queue_message in queue_messages:
                 self.logger.debug("Message id: %s received" % queue_message.id)
 
                 if (
-                    self.process_azure_queue_message(
-                        queue_message, str(queue_message.inserted_on)) or
-                        queue_message.dequeue_count > self.max_message_retry):
+                    self.process_azure_queue_message(queue_message, str(queue_message.inserted_on))
+                    or queue_message.dequeue_count > self.max_message_retry
+                ):
                     # If message handled successfully or max retry hit, delete
                     StorageUtilities.delete_queue_message(*queue_settings, message=queue_message)
 
             queue_messages = StorageUtilities.get_queue_messages(
-                *queue_settings, num_messages=self.batch_size)
+                *queue_settings, num_messages=self.batch_size
+            )
 
-        self.logger.info('No messages left on the azure storage queue, exiting c7n_mailer.')
+        self.logger.info("No messages left on the azure storage queue, exiting c7n_mailer.")
 
     def process_azure_queue_message(self, encoded_azure_queue_message, timestamp):
         queue_message = json.loads(
-            zlib.decompress(base64.b64decode(encoded_azure_queue_message.content)))
+            zlib.decompress(base64.b64decode(encoded_azure_queue_message.content))
+        )
 
-        self.logger.debug("Got account:%s message:%s %s:%d policy:%s recipients:%s" % (
-            queue_message.get('account', 'na'),
-            encoded_azure_queue_message.id,
-            queue_message['policy']['resource'],
-            len(queue_message['resources']),
-            queue_message['policy']['name'],
-            ', '.join(queue_message['action'].get('to', []))))
+        self.logger.debug(
+            "Got account:%s message:%s %s:%d policy:%s recipients:%s"
+            % (
+                queue_message.get("account", "na"),
+                encoded_azure_queue_message.id,
+                queue_message["policy"]["resource"],
+                len(queue_message["resources"]),
+                queue_message["policy"]["name"],
+                ", ".join(queue_message["action"].get("to", [])),
+            )
+        )
 
         self.handle_targets(queue_message, timestamp, email_delivery=False, sns_delivery=False)
 
@@ -85,16 +91,17 @@ class MailerAzureQueueProcessor(MessageTargetMixin):
             sendgrid_delivery = SendGridDelivery(self.config, self.session, self.logger)
             email_messages = sendgrid_delivery.get_to_addrs_sendgrid_messages_map(queue_message)
 
-            if 'smtp_server' in self.config:
-                smtp_delivery = SmtpDelivery(config=self.config,
-                                             session=self.session,
-                                             logger=self.logger)
+            if "smtp_server" in self.config:
+                smtp_delivery = SmtpDelivery(
+                    config=self.config, session=self.session, logger=self.logger
+                )
                 for to_addrs, message in email_messages.items():
                     self.logger.info(
-                        'Sending message to SMTP server, {}.'.format(self.config['smtp_server']))
+                        "Sending message to SMTP server, {}.".format(self.config["smtp_server"])
+                    )
                     smtp_delivery.send_message(message=message, to_addrs=list(to_addrs))
             else:
-                self.logger.info('Sending message to Sendgrid.')
+                self.logger.info("Sending message to Sendgrid.")
                 return sendgrid_delivery.sendgrid_handler(queue_message, email_messages)
         except Exception as error:
             self.logger.exception(error)

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/deploy.py
@@ -22,22 +22,30 @@ except ImportError:
 
 
 def cache_path():
-    return os.path.join(os.path.dirname(__file__), 'cache')
+    return os.path.join(os.path.dirname(__file__), "cache")
 
 
 def get_mailer_requirements():
-    deps = ['azure-identity', 'azure-mgmt-managementgroups', 'azure-mgmt-web',
-            'azure-graphrbac', 'azure-keyvault', 'azure-storage-queue',
-            'azure-storage-blob', 'netaddr', 'sendgrid', 'pyyaml'] + list(CORE_DEPS)
+    deps = [
+        "azure-identity",
+        "azure-mgmt-managementgroups",
+        "azure-mgmt-web",
+        "azure-graphrbac",
+        "azure-keyvault",
+        "azure-storage-queue",
+        "azure-storage-blob",
+        "netaddr",
+        "sendgrid",
+        "pyyaml",
+    ] + list(CORE_DEPS)
     requirements = generate_requirements(
-        deps, ignore=['boto3', 'botocore', 'pywin32'],
-        exclude=['pkg_resources'],
-        include_self=True)
+        deps, ignore=["boto3", "botocore", "pywin32"], exclude=["pkg_resources"], include_self=True
+    )
     return requirements
 
 
 def build_function_package(config, function_name, sub_id):
-    schedule = config.get('function_schedule', '0 */10 * * * *')
+    schedule = config.get("function_schedule", "0 */10 * * * *")
 
     cache_override_path = cache_path()
 
@@ -46,91 +54,98 @@ def build_function_package(config, function_name, sub_id):
     # Build package
     package = FunctionPackage(
         function_name,
-        os.path.join(os.path.dirname(__file__), 'function.py'),
+        os.path.join(os.path.dirname(__file__), "function.py"),
         target_sub_ids=[sub_id],
-        cache_override_path=cache_override_path)
+        cache_override_path=cache_override_path,
+    )
 
-    identity = jmespath_search('function_properties.identity', config)
-    package.build(None,
-                  modules=['c7n', 'c7n_azure', 'c7n_mailer'],
-                  requirements=get_mailer_requirements(),
-                  identity=identity)
+    identity = jmespath_search("function_properties.identity", config)
+    package.build(
+        None,
+        modules=["c7n", "c7n_azure", "c7n_mailer"],
+        requirements=get_mailer_requirements(),
+        identity=identity,
+    )
 
     package.pkg.add_contents(
-        function_path + '/function.json',
-        contents=package.get_function_config({'mode':
-                                              {'type': 'azure-periodic',
-                                               'schedule': schedule}}))
+        function_path + "/function.json",
+        contents=package.get_function_config(
+            {"mode": {"type": "azure-periodic", "schedule": schedule}}
+        ),
+    )
 
     # Add mail templates
-    for d in set(config['templates_folders']):
+    for d in set(config["templates_folders"]):
         if not os.path.exists(d):
             continue
-        for t in [f for f in os.listdir(d) if os.path.splitext(f)[1] == '.j2']:
+        for t in [f for f in os.listdir(d) if os.path.splitext(f)[1] == ".j2"]:
             with open(os.path.join(d, t)) as fh:
-                package.pkg.add_contents(function_path + '/msg-templates/%s' % t, fh.read())
+                package.pkg.add_contents(function_path + "/msg-templates/%s" % t, fh.read())
 
     function_config = copy.deepcopy(config)
 
-    functions_full_template_path = '/home/site/wwwroot/' + function_path + '/msg-templates/'
-    function_config['templates_folders'] = [functions_full_template_path]
+    functions_full_template_path = "/home/site/wwwroot/" + function_path + "/msg-templates/"
+    function_config["templates_folders"] = [functions_full_template_path]
 
-    package.pkg.add_contents(
-        function_path + '/config.json',
-        contents=json.dumps(function_config))
+    package.pkg.add_contents(function_path + "/config.json", contents=json.dumps(function_config))
 
     package.close()
     return package
 
 
 def provision(config):
-    log = logging.getLogger('c7n_mailer.azure.deploy')
+    log = logging.getLogger("c7n_mailer.azure.deploy")
 
-    function_name = config.get('function_name', 'mailer')
-    function_properties = config.get('function_properties', {})
+    function_name = config.get("function_name", "mailer")
+    function_properties = config.get("function_properties", {})
 
     # service plan is parse first, because its location might be shared with storage & insights
-    service_plan = AzureFunctionMode.extract_properties(function_properties,
-                                                'servicePlan',
-                                                {
-                                                    'name': 'cloud-custodian',
-                                                    'location': 'eastus',
-                                                    'resource_group_name': 'cloud-custodian',
-                                                    'sku_tier': 'Dynamic',  # consumption plan
-                                                    'sku_name': 'Y1'
-                                                })
+    service_plan = AzureFunctionMode.extract_properties(
+        function_properties,
+        "servicePlan",
+        {
+            "name": "cloud-custodian",
+            "location": "eastus",
+            "resource_group_name": "cloud-custodian",
+            "sku_tier": "Dynamic",  # consumption plan
+            "sku_name": "Y1",
+        },
+    )
 
-    location = service_plan.get('location', 'eastus')
-    rg_name = service_plan['resource_group_name']
+    location = service_plan.get("location", "eastus")
+    rg_name = service_plan["resource_group_name"]
 
     sub_id = local_session(Session).get_subscription_id()
     suffix = StringUtils.naming_hash(rg_name + sub_id)
 
-    storage_account = AzureFunctionMode.extract_properties(function_properties,
-                                                    'storageAccount',
-                                                    {'name': 'mailerstorage' + suffix,
-                                                     'location': location,
-                                                     'resource_group_name': rg_name})
+    storage_account = AzureFunctionMode.extract_properties(
+        function_properties,
+        "storageAccount",
+        {"name": "mailerstorage" + suffix, "location": location, "resource_group_name": rg_name},
+    )
 
-    app_insights = AzureFunctionMode.extract_properties(function_properties,
-                                                    'appInsights',
-                                                    {'name': service_plan['name'],
-                                                     'location': location,
-                                                     'resource_group_name': rg_name})
+    app_insights = AzureFunctionMode.extract_properties(
+        function_properties,
+        "appInsights",
+        {"name": service_plan["name"], "location": location, "resource_group_name": rg_name},
+    )
 
     function_app_name = FunctionAppUtilities.get_function_name(
-        '-'.join([service_plan['name'], function_name]), suffix)
+        "-".join([service_plan["name"], function_name]), suffix
+    )
     FunctionAppUtilities.validate_function_name(function_app_name)
-    identity = jmespath_search('function_properties.identity', config) or {
-        'type': AUTH_TYPE_EMBED}
+    identity = jmespath_search("function_properties.identity", config) or {"type": AUTH_TYPE_EMBED}
 
     params = FunctionAppUtilities.FunctionAppInfrastructureParameters(
         app_insights=app_insights,
         service_plan=service_plan,
         storage_account=storage_account,
-        function_app={'resource_group_name': service_plan['resource_group_name'],
-                      'identity': identity,
-                      'name': function_app_name})
+        function_app={
+            "resource_group_name": service_plan["resource_group_name"],
+            "identity": identity,
+            "name": function_app_name,
+        },
+    )
 
     FunctionAppUtilities.deploy_function_app(params)
 

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/function.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/function.py
@@ -10,11 +10,13 @@ sys.path.append(dirname(dirname(__file__)))
 
 from c7n_mailer.azure_mailer import handle
 
+
 def main(input):
-    logger = logging.getLogger('custodian.mailer')
-    config_file = join(dirname(__file__), 'config.json')
+    logger = logging.getLogger("custodian.mailer")
+    config_file = join(dirname(__file__), "config.json")
     with open(config_file) as fh:
         config = json.load(fh)
-    return handle.start_c7n_mailer(logger, config, join(dirname(__file__), 'auth.json'))
+    return handle.start_c7n_mailer(logger, config, join(dirname(__file__), "auth.json"))
+
 
 # flake8: noqa

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/handle.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/handle.py
@@ -10,10 +10,10 @@ from c7n_mailer.azure_mailer.azure_queue_processor import MailerAzureQueueProces
 
 def start_c7n_mailer(logger, config, auth_file):
     try:
-        logger.info('c7n_mailer starting...')
+        logger.info("c7n_mailer starting...")
         session = Session(
-            authorization_file=auth_file,
-            resource_endpoint_type=STORAGE_AUTH_ENDPOINT)
+            authorization_file=auth_file, resource_endpoint_type=STORAGE_AUTH_ENDPOINT
+        )
         mailer_azure_queue_processor = MailerAzureQueueProcessor(config, logger, session=session)
         mailer_azure_queue_processor.run()
     except Exception as e:

--- a/tools/c7n_mailer/c7n_mailer/azure_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_mailer/utils.py
@@ -7,9 +7,10 @@ from azure.keyvault.secrets import SecretProperties
 def azure_decrypt(config, logger, session, encrypted_field):
     data = config[encrypted_field]  # type: str
     if type(data) is dict:
-        secret_id = SecretProperties(attributes=None, vault_id=data['secret'])
-        kv_client = session.client('azure.keyvault.secrets.SecretClient',
-                                   vault_url=secret_id.vault_url)
+        secret_id = SecretProperties(attributes=None, vault_id=data["secret"])
+        kv_client = session.client(
+            "azure.keyvault.secrets.SecretClient", vault_url=secret_id.vault_url
+        )
         return kv_client.get_secret(secret_id.name, secret_id.version).value
 
     return data

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -9,190 +9,176 @@ import jsonschema
 import yaml
 from c7n_mailer import deploy, utils
 from c7n_mailer.azure_mailer import deploy as azure_deploy
+
 # from c7n_mailer.gcp_mailer import deploy as gcp_deploy
 from c7n_mailer.utils import session_factory, get_processor, get_provider, Providers
 
 AZURE_KV_SECRET_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        'type': {'enum': ['azure.keyvault']},
-        'secret': {'type': 'string'}
-    },
-    'required': ['type', 'secret'],
-    'additionalProperties': False
+    "type": "object",
+    "properties": {"type": {"enum": ["azure.keyvault"]}, "secret": {"type": "string"}},
+    "required": ["type", "secret"],
+    "additionalProperties": False,
 }
 
 GCP_SECRET_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        'type': {'enum': ['gcp.secretmanager']},
-        'secret': {'type': 'string'}
-    },
-    'required': ['type', 'secret'],
-    'additionalProperties': False
+    "type": "object",
+    "properties": {"type": {"enum": ["gcp.secretmanager"]}, "secret": {"type": "string"}},
+    "required": ["type", "secret"],
+    "additionalProperties": False,
 }
 
-SECURED_STRING_SCHEMA = {
-    'oneOf': [
-        {'type': 'string'},
-        AZURE_KV_SECRET_SCHEMA,
-        GCP_SECRET_SCHEMA
-    ]
-}
+SECURED_STRING_SCHEMA = {"oneOf": [{"type": "string"}, AZURE_KV_SECRET_SCHEMA, GCP_SECRET_SCHEMA]}
 
 CONFIG_SCHEMA = {
-    '$schema': 'http://json-schema.org/draft-07/schema',
-    'id': 'https://schema.cloudcustodian.io/v0/mailer.json',
-    'type': 'object',
-    'additionalProperties': False,
-    'required': ['queue_url'],
-    'properties': {
-        'queue_url': {'type': 'string'},
-        'endpoint_url': {'type': 'string'},
-        'from_address': {'type': 'string'},
-        'additional_email_headers': {
-            'type': 'object',
-            'patternProperties': {
-                '': {'type': 'string'},
-            }
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.cloudcustodian.io/v0/mailer.json",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["queue_url"],
+    "properties": {
+        "queue_url": {"type": "string"},
+        "endpoint_url": {"type": "string"},
+        "from_address": {"type": "string"},
+        "additional_email_headers": {
+            "type": "object",
+            "patternProperties": {
+                "": {"type": "string"},
+            },
         },
-        'contact_tags': {'type': 'array', 'items': {'type': 'string'}},
-        'org_domain': {'type': 'string'},
-
+        "contact_tags": {"type": "array", "items": {"type": "string"}},
+        "org_domain": {"type": "string"},
         # Standard Lambda Function Config
-        'region': {'type': 'string'},
-        'role': {'type': 'string'},
-        'runtime': {'type': 'string'},
-        'memory': {'type': 'integer'},
-        'timeout': {'type': 'integer'},
-        'subnets': {'type': 'array', 'items': {'type': 'string'}},
-        'security_groups': {'type': 'array', 'items': {'type': 'string'}},
-        'dead_letter_config': {'type': 'object'},
-        'lambda_name': {'type': 'string'},
-        'lambda_description': {'type': 'string'},
-        'lambda_tags': {'type': 'object'},
-        'lambda_schedule': {'type': 'string'},
-
+        "region": {"type": "string"},
+        "role": {"type": "string"},
+        "runtime": {"type": "string"},
+        "memory": {"type": "integer"},
+        "timeout": {"type": "integer"},
+        "subnets": {"type": "array", "items": {"type": "string"}},
+        "security_groups": {"type": "array", "items": {"type": "string"}},
+        "dead_letter_config": {"type": "object"},
+        "lambda_name": {"type": "string"},
+        "lambda_description": {"type": "string"},
+        "lambda_tags": {"type": "object"},
+        "lambda_schedule": {"type": "string"},
         # Azure Function Config
-        'function_properties': {
-            'type': 'object',
-            'identity': {
-                'type': 'object',
-                'additionalProperties': False,
-                'properties': {
-                    'type': {'enum': [
-                        "Embedded", "SystemAssigned", "UserAssigned"]},
-                    'client_id': {'type': 'string'},
-                    'id': {'type': 'string'},
+        "function_properties": {
+            "type": "object",
+            "identity": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "type": {"enum": ["Embedded", "SystemAssigned", "UserAssigned"]},
+                    "client_id": {"type": "string"},
+                    "id": {"type": "string"},
                 },
             },
-            'appInsights': {
-                'type': 'object',
-                'oneOf': [
-                    {'type': 'string'},
-                    {'type': 'object',
-                        'properties': {
-                            'name': 'string',
-                            'location': 'string',
-                            'resourceGroupName': 'string'}
-                     }
-                ]
+            "appInsights": {
+                "type": "object",
+                "oneOf": [
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": "string",
+                            "location": "string",
+                            "resourceGroupName": "string",
+                        },
+                    },
+                ],
             },
-            'storageAccount': {
-                'type': 'object',
-                'oneOf': [
-                    {'type': 'string'},
-                    {'type': 'object',
-                        'properties': {
-                            'name': 'string',
-                            'location': 'string',
-                            'resourceGroupName': 'string'}
-                     }
-                ]
+            "storageAccount": {
+                "type": "object",
+                "oneOf": [
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": "string",
+                            "location": "string",
+                            "resourceGroupName": "string",
+                        },
+                    },
+                ],
             },
-            'servicePlan': {
-                'type': 'object',
-                'oneOf': [
-                    {'type': 'string'},
-                    {'type': 'object',
-                        'properties': {
-                            'name': 'string',
-                            'location': 'string',
-                            'resourceGroupName': 'string',
-                            'skuTier': 'string',
-                            'skuName': 'string'}
-                     }
-                ]
+            "servicePlan": {
+                "type": "object",
+                "oneOf": [
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": "string",
+                            "location": "string",
+                            "resourceGroupName": "string",
+                            "skuTier": "string",
+                            "skuName": "string",
+                        },
+                    },
+                ],
             },
         },
         # GCP Cloud Function Config # TODO:
         # 'function_schedule': {'type': 'string'},
         # 'function_skuCode': {'type': 'string'},
         # 'function_sku': {'type': 'string'},
-        'email_base_url': {'type': 'string'},
-
+        "email_base_url": {"type": "string"},
         # Mailer Infrastructure Config
-        'cache_engine': {'type': 'string'},
-        'smtp_server': {'type': 'string'},
-        'smtp_port': {'type': 'integer'},
-        'smtp_ssl': {'type': 'boolean'},
-        'smtp_username': {'type': 'string'},
-        'smtp_password': SECURED_STRING_SCHEMA,
-        'ldap_email_key': {'type': 'string'},
-        'ldap_uid_tags': {'type': 'array', 'items': {'type': 'string'}},
-        'debug': {'type': 'boolean'},
-        'ldap_uid_regex': {'type': 'string'},
-        'ldap_uri': {'type': 'string'},
-        'ldap_bind_dn': {'type': 'string'},
-        'ldap_bind_user': {'type': 'string'},
-        'ldap_uid_attribute': {'type': 'string'},
-        'ldap_manager_attribute': {'type': 'string'},
-        'ldap_email_attribute': {'type': 'string'},
-        'ldap_bind_password_in_kms': {'type': 'boolean'},
-        'ldap_bind_password': SECURED_STRING_SCHEMA,
-        'cross_accounts': {'type': 'object'},
-        'ses_region': {'type': 'string'},
-        'ses_role': {'type': 'string'},
-        'redis_host': {'type': 'string'},
-        'redis_port': {'type': 'integer'},
-        'datadog_api_key': {'type': 'string'},              # TODO: encrypt with KMS?
-        'datadog_application_key': {'type': 'string'},      # TODO: encrypt with KMS?
-        'slack_token': {'type': 'string'},
-        'slack_webhook': {'type': 'string'},
-        'sendgrid_api_key': SECURED_STRING_SCHEMA,
-        'splunk_hec_url': {'type': 'string'},
-        'splunk_hec_token': {'type': 'string'},
-        'splunk_remove_paths': {
-            'type': 'array',
-            'items': {'type': 'string'}
-        },
-        'splunk_actions_list': {'type': 'boolean'},
-        'splunk_max_attempts': {'type': 'integer'},
-        'splunk_hec_max_length': {'type': 'integer'},
-        'splunk_hec_sourcetype': {'type': 'string'},
-
+        "cache_engine": {"type": "string"},
+        "smtp_server": {"type": "string"},
+        "smtp_port": {"type": "integer"},
+        "smtp_ssl": {"type": "boolean"},
+        "smtp_username": {"type": "string"},
+        "smtp_password": SECURED_STRING_SCHEMA,
+        "ldap_email_key": {"type": "string"},
+        "ldap_uid_tags": {"type": "array", "items": {"type": "string"}},
+        "debug": {"type": "boolean"},
+        "ldap_uid_regex": {"type": "string"},
+        "ldap_uri": {"type": "string"},
+        "ldap_bind_dn": {"type": "string"},
+        "ldap_bind_user": {"type": "string"},
+        "ldap_uid_attribute": {"type": "string"},
+        "ldap_manager_attribute": {"type": "string"},
+        "ldap_email_attribute": {"type": "string"},
+        "ldap_bind_password_in_kms": {"type": "boolean"},
+        "ldap_bind_password": SECURED_STRING_SCHEMA,
+        "cross_accounts": {"type": "object"},
+        "ses_region": {"type": "string"},
+        "ses_role": {"type": "string"},
+        "redis_host": {"type": "string"},
+        "redis_port": {"type": "integer"},
+        "datadog_api_key": {"type": "string"},  # TODO: encrypt with KMS?
+        "datadog_application_key": {"type": "string"},  # TODO: encrypt with KMS?
+        "slack_token": {"type": "string"},
+        "slack_webhook": {"type": "string"},
+        "sendgrid_api_key": SECURED_STRING_SCHEMA,
+        "splunk_hec_url": {"type": "string"},
+        "splunk_hec_token": {"type": "string"},
+        "splunk_remove_paths": {"type": "array", "items": {"type": "string"}},
+        "splunk_actions_list": {"type": "boolean"},
+        "splunk_max_attempts": {"type": "integer"},
+        "splunk_hec_max_length": {"type": "integer"},
+        "splunk_hec_sourcetype": {"type": "string"},
         # SDK Config
-        'profile': {'type': 'string'},
-        'http_proxy': {'type': 'string'},
-        'https_proxy': {'type': 'string'},
-
+        "profile": {"type": "string"},
+        "http_proxy": {"type": "string"},
+        "https_proxy": {"type": "string"},
         # Mapping account / emails
-        'account_emails': {'type': 'object'}
-    }
+        "account_emails": {"type": "object"},
+    },
 }
 
 
 def get_logger(debug=False):
-    log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     logging.basicConfig(level=logging.INFO, format=log_format)
-    logging.getLogger('botocore').setLevel(logging.WARNING)
+    logging.getLogger("botocore").setLevel(logging.WARNING)
     if debug:
-        logging.getLogger('botocore').setLevel(logging.DEBUG)
-        debug_logger = logging.getLogger('custodian-mailer')
+        logging.getLogger("botocore").setLevel(logging.DEBUG)
+        debug_logger = logging.getLogger("custodian-mailer")
         debug_logger.setLevel(logging.DEBUG)
         return debug_logger
     else:
-        return logging.getLogger('custodian-mailer')
+        return logging.getLogger("custodian-mailer")
 
 
 def get_and_validate_mailer_config(args):
@@ -205,18 +191,18 @@ def get_and_validate_mailer_config(args):
 
 def get_c7n_mailer_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--config', required=True, help='mailer.yml config file')
-    debug_help_msg = 'sets c7n_mailer logger to debug, for maximum output (the default is INFO)'
-    parser.add_argument('--debug', action='store_true', help=debug_help_msg)
-    max_num_processes_help_msg = 'will run the mailer in parallel, integer of max processes allowed'
-    parser.add_argument('--max-num-processes', type=int, help=max_num_processes_help_msg)
-    templates_folder_help_msg = 'message templates folder location'
-    parser.add_argument('-t', '--templates', help=templates_folder_help_msg)
+    parser.add_argument("-c", "--config", required=True, help="mailer.yml config file")
+    debug_help_msg = "sets c7n_mailer logger to debug, for maximum output (the default is INFO)"
+    parser.add_argument("--debug", action="store_true", help=debug_help_msg)
+    max_num_processes_help_msg = "will run the mailer in parallel, integer of max processes allowed"
+    parser.add_argument("--max-num-processes", type=int, help=max_num_processes_help_msg)
+    templates_folder_help_msg = "message templates folder location"
+    parser.add_argument("-t", "--templates", help=templates_folder_help_msg)
     group = parser.add_mutually_exclusive_group(required=True)
-    update_lambda_help_msg = 'packages your c7n_mailer, uploads the zip to aws lambda as a function'
-    group.add_argument('--update-lambda', action='store_true', help=update_lambda_help_msg)
-    run_help_msg = 'run c7n-mailer locally, process sqs messages and send emails or sns messages'
-    group.add_argument('--run', action='store_true', help=run_help_msg)
+    update_lambda_help_msg = "packages your c7n_mailer, uploads the zip to aws lambda as a function"
+    group.add_argument("--update-lambda", action="store_true", help=update_lambda_help_msg)
+    run_help_msg = "run c7n-mailer locally, process sqs messages and send emails or sns messages"
+    group.add_argument("--run", action="store_true", help=run_help_msg)
     return parser
 
 
@@ -233,26 +219,29 @@ def main():
     args = parser.parse_args()
     mailer_config = get_and_validate_mailer_config(args)
     args_dict = vars(args)
-    logger = get_logger(debug=args_dict.get('debug', False))
+    logger = get_logger(debug=args_dict.get("debug", False))
 
     module_dir = path.dirname(path.abspath(__file__))
-    default_templates = [path.abspath(path.join(module_dir, 'msg-templates')),
-                         path.abspath(path.join(module_dir, '..', 'msg-templates')),
-                         path.abspath('.')]
-    templates = args_dict.get('templates', None)
+    default_templates = [
+        path.abspath(path.join(module_dir, "msg-templates")),
+        path.abspath(path.join(module_dir, "..", "msg-templates")),
+        path.abspath("."),
+    ]
+    templates = args_dict.get("templates", None)
     if templates:
         default_templates.append(path.abspath(path.expanduser(path.expandvars(templates))))
 
-    mailer_config['templates_folders'] = default_templates
+    mailer_config["templates_folders"] = default_templates
 
     provider = get_provider(mailer_config)
-    if args_dict.get('update_lambda'):
-        if args_dict.get('debug'):
-            print('\n** --debug is only supported with --run, not --update-lambda **\n')
+    if args_dict.get("update_lambda"):
+        if args_dict.get("debug"):
+            print("\n** --debug is only supported with --run, not --update-lambda **\n")
             return
-        if args_dict.get('max_num_processes'):
-            print('\n** --max-num-processes is only supported '
-                  'with --run, not --update-lambda **\n')
+        if args_dict.get("max_num_processes"):
+            print(
+                "\n** --max-num-processes is only supported " "with --run, not --update-lambda **\n"
+            )
             return
 
         if provider == Providers.Azure:
@@ -262,8 +251,8 @@ def main():
         elif provider == Providers.AWS:
             deploy.provision(mailer_config, functools.partial(session_factory, mailer_config))
 
-    if args_dict.get('run'):
-        max_num_processes = args_dict.get('max_num_processes')
+    if args_dict.get("run"):
+        max_num_processes = args_dict.get("max_num_processes")
 
         # Select correct processor
         processor = get_processor(mailer_config, logger)
@@ -275,5 +264,5 @@ def main():
             processor.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/c7n_mailer/c7n_mailer/datadog_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/datadog_delivery.py
@@ -9,8 +9,8 @@ from urllib.parse import urlparse, parse_qsl
 
 
 class DataDogDelivery:
-    DATADOG_API_KEY = 'datadog_api_key'
-    DATADOG_APPLICATION_KEY = 'datadog_application_key'
+    DATADOG_API_KEY = "datadog_api_key"
+    DATADOG_APPLICATION_KEY = "datadog_application_key"
 
     def __init__(self, config, session, logger):
         self.config = config
@@ -22,9 +22,8 @@ class DataDogDelivery:
         # Initialize datadog
         if self.datadog_api_key and self.datadog_application_key:
             options = {
-                'api_key': self.datadog_api_key,
-                'app_key': self.datadog_application_key,
-
+                "api_key": self.datadog_api_key,
+                "app_key": self.datadog_application_key,
             }
             initialize(**options)
 
@@ -36,29 +35,41 @@ class DataDogDelivery:
         if not metric_config_map:
             return datadog_rendered_messages
 
-        if sqs_message and sqs_message.get('resources', False):
-            for resource in sqs_message['resources']:
+        if sqs_message and sqs_message.get("resources", False):
+            for resource in sqs_message["resources"]:
                 tags = [
-                    'event:{}'.format(sqs_message['event']),
-                    'account_id:{}'.format(sqs_message['account_id']),
-                    'account:{}'.format(sqs_message['account']),
-                    'region:{}'.format(sqs_message['region'])
+                    "event:{}".format(sqs_message["event"]),
+                    "account_id:{}".format(sqs_message["account_id"]),
+                    "account:{}".format(sqs_message["account"]),
+                    "region:{}".format(sqs_message["region"]),
                 ]
 
-                tags.extend(['{key}:{value}'.format(
-                    key=key, value=resource[key]) for key in resource.keys()
-                    if key != 'Tags'])
-                if resource.get('Tags', False):
-                    tags.extend(['{key}:{value}'.format(
-                        key=tag['Key'], value=tag['Value']) for tag in resource['Tags']])
+                tags.extend(
+                    [
+                        "{key}:{value}".format(key=key, value=resource[key])
+                        for key in resource.keys()
+                        if key != "Tags"
+                    ]
+                )
+                if resource.get("Tags", False):
+                    tags.extend(
+                        [
+                            "{key}:{value}".format(key=tag["Key"], value=tag["Value"])
+                            for tag in resource["Tags"]
+                        ]
+                    )
 
                 for metric_config in metric_config_map:
-                    datadog_rendered_messages.append({
-                        "metric": metric_config['metric_name'],
-                        "points": (date_time, self._get_metric_value(
-                            metric_config=metric_config, tags=tags)),
-                        "tags": tags
-                    })
+                    datadog_rendered_messages.append(
+                        {
+                            "metric": metric_config["metric_name"],
+                            "points": (
+                                date_time,
+                                self._get_metric_value(metric_config=metric_config, tags=tags),
+                            ),
+                            "tags": tags,
+                        }
+                    )
 
         # eg: [{'metric': 'metric_name', 'points': (date_time, value),
         # 'tags': ['tag1':'value', 'tag2':'value']}, ...]
@@ -67,32 +78,37 @@ class DataDogDelivery:
     def deliver_datadog_messages(self, datadog_message_packages, sqs_message):
         if len(datadog_message_packages) > 0:
             self.logger.info(
-                "Sending account:{account} policy:{policy} {resource}:{quantity} to DataDog".
-                format(account=sqs_message.get('account', ''),
-                       policy=sqs_message['policy']['name'],
-                       resource=sqs_message['policy']['resource'],
-                       quantity=len(sqs_message['resources'])))
+                "Sending account:{account} policy:{policy} {resource}:{quantity} to DataDog".format(
+                    account=sqs_message.get("account", ""),
+                    policy=sqs_message["policy"]["name"],
+                    resource=sqs_message["policy"]["resource"],
+                    quantity=len(sqs_message["resources"]),
+                )
+            )
 
             api.Metric.send(datadog_message_packages)
 
     @staticmethod
     def _get_metric_value(metric_config, tags):
         metric_value = 1
-        metric_value_tag = metric_config.get('metric_value_tag', 'default')
-        if metric_value_tag != 'default':
+        metric_value_tag = metric_config.get("metric_value_tag", "default")
+        if metric_value_tag != "default":
             for tag in tags:
                 if metric_value_tag in tag:
-                    metric_value = float(tag[tag.find(":") + 1:])
+                    metric_value = float(tag[tag.find(":") + 1 :])
 
         return metric_value
 
     @staticmethod
     def _get_metrics_config_to_resources_map(sqs_message):
         metric_config_map = []
-        if sqs_message and sqs_message.get(
-                'action', False) and sqs_message['action'].get('to', False):
-            for to in sqs_message['action'].get('to', []):
-                if to.startswith('datadog://'):
+        if (
+            sqs_message
+            and sqs_message.get("action", False)
+            and sqs_message["action"].get("to", False)
+        ):
+            for to in sqs_message["action"].get("to", []):
+                if to.startswith("datadog://"):
                     parsed = urlparse(to)
                     metric_config_map.append(dict(parse_qsl(parsed.query)))
         return metric_config_map

--- a/tools/c7n_mailer/c7n_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/deploy.py
@@ -5,14 +5,10 @@ import logging
 import json
 import os
 
-from c7n.mu import (
-    CloudWatchEventSource,
-    LambdaFunction,
-    LambdaManager,
-    PythonPackageArchive)
+from c7n.mu import CloudWatchEventSource, LambdaFunction, LambdaManager, PythonPackageArchive
 
 
-log = logging.getLogger('custodian-mailer')
+log = logging.getLogger("custodian-mailer")
 
 entry_source = """\
 import logging
@@ -30,34 +26,49 @@ def dispatch(event, context):
 
 CORE_DEPS = [
     # core deps
-    'jinja2', 'markupsafe', 'yaml', 'ldap3', 'pyasn1', 'redis', 'jmespath',
+    "jinja2",
+    "markupsafe",
+    "yaml",
+    "ldap3",
+    "pyasn1",
+    "redis",
+    "jmespath",
     # for other dependencies
-    'pkg_resources',
+    "pkg_resources",
     # transport datadog - recursive deps
-    'datadog', 'decorator',
+    "datadog",
+    "decorator",
     # requests (recursive deps), needed by datadog, slackclient, splunk
-    'requests', 'urllib3', 'idna', 'charset_normalizer', 'certifi',
+    "requests",
+    "urllib3",
+    "idna",
+    "charset_normalizer",
+    "certifi",
     # used by splunk mailer transport
-    'jsonpointer', 'jsonpatch',
+    "jsonpointer",
+    "jsonpatch",
     # sendgrid dependencies
-    'sendgrid', 'python_http_client', 'ellipticcurve']
+    "sendgrid",
+    "python_http_client",
+    "ellipticcurve",
+]
 
 
 def get_archive(config):
-    deps = ['c7n_mailer'] + list(CORE_DEPS)
+    deps = ["c7n_mailer"] + list(CORE_DEPS)
     archive = PythonPackageArchive(modules=deps)
 
-    for d in set(config['templates_folders']):
+    for d in set(config["templates_folders"]):
         if not os.path.exists(d):
             continue
-        for t in [f for f in os.listdir(d) if os.path.splitext(f)[1] == '.j2']:
+        for t in [f for f in os.listdir(d) if os.path.splitext(f)[1] == ".j2"]:
             with open(os.path.join(d, t)) as fh:
-                archive.add_contents('msg-templates/%s' % t, fh.read())
+                archive.add_contents("msg-templates/%s" % t, fh.read())
 
     function_config = copy.deepcopy(config)
-    function_config['templates_folders'] = ['msg-templates/']
-    archive.add_contents('config.json', json.dumps(function_config))
-    archive.add_contents('periodic.py', entry_source)
+    function_config["templates_folders"] = ["msg-templates/"]
+    archive.add_contents("config.json", json.dumps(function_config))
+    archive.add_contents("periodic.py", entry_source)
 
     archive.close()
     return archive
@@ -65,23 +76,24 @@ def get_archive(config):
 
 def provision(config, session_factory):
     func_config = dict(
-        name=config.get('lambda_name', 'cloud-custodian-mailer'),
-        description=config.get('lambda_description', 'Cloud Custodian Mailer'),
-        tags=config.get('lambda_tags', {}),
-        handler='periodic.dispatch',
-        runtime=config['runtime'],
-        memory_size=config['memory'],
-        timeout=config['timeout'],
-        role=config['role'],
-        subnets=config['subnets'],
-        security_groups=config['security_groups'],
-        dead_letter_config=config.get('dead_letter_config', {}),
+        name=config.get("lambda_name", "cloud-custodian-mailer"),
+        description=config.get("lambda_description", "Cloud Custodian Mailer"),
+        tags=config.get("lambda_tags", {}),
+        handler="periodic.dispatch",
+        runtime=config["runtime"],
+        memory_size=config["memory"],
+        timeout=config["timeout"],
+        role=config["role"],
+        subnets=config["subnets"],
+        security_groups=config["security_groups"],
+        dead_letter_config=config.get("dead_letter_config", {}),
         events=[
             CloudWatchEventSource(
-                {'type': 'periodic',
-                 'schedule': config.get('lambda_schedule', 'rate(5 minutes)')},
-                session_factory)
-        ])
+                {"type": "periodic", "schedule": config.get("lambda_schedule", "rate(5 minutes)")},
+                session_factory,
+            )
+        ],
+    )
 
     archive = get_archive(config)
     func = LambdaFunction(func_config, archive)

--- a/tools/c7n_mailer/c7n_mailer/gcp_mailer/gcp_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/gcp_mailer/gcp_queue_processor.py
@@ -36,7 +36,7 @@ class MailerGcpQueueProcessor(MessageTargetMixin):
         # Get first set of messages to process
         messages = self.receive_messages()
 
-        while messages and len(messages['receivedMessages']) > 0:
+        while messages and len(messages["receivedMessages"]) > 0:
             # Discard_date is the timestamp of the last published message in the messages list
             # and will be the date we need to seek to when we ack_messages
             discard_date = messages["receivedMessages"][-1]["message"]["publishTime"]

--- a/tools/c7n_mailer/c7n_mailer/handle.py
+++ b/tools/c7n_mailer/c7n_mailer/handle.py
@@ -11,15 +11,15 @@ from .sqs_queue_processor import MailerSqsQueueProcessor
 
 
 def config_setup(config=None):
-    task_dir = os.environ.get('LAMBDA_TASK_ROOT')
-    os.environ['PYTHONPATH'] = "%s:%s" % (task_dir, os.environ.get('PYTHONPATH', ''))
+    task_dir = os.environ.get("LAMBDA_TASK_ROOT")
+    os.environ["PYTHONPATH"] = "%s:%s" % (task_dir, os.environ.get("PYTHONPATH", ""))
     if not config:
-        with open(os.path.join(task_dir, 'config.json')) as fh:
+        with open(os.path.join(task_dir, "config.json")) as fh:
             config = json.load(fh)
-    if 'http_proxy' in config:
-        os.environ['http_proxy'] = config['http_proxy']
-    if 'https_proxy' in config:
-        os.environ['https_proxy'] = config['https_proxy']
+    if "http_proxy" in config:
+        os.environ["http_proxy"] = config["http_proxy"]
+    if "https_proxy" in config:
+        os.environ["https_proxy"] = config["https_proxy"]
     return config
 
 
@@ -28,7 +28,7 @@ def start_c7n_mailer(logger, config=None, parallel=False):
         session = boto3.Session()
         if not config:
             config = config_setup()
-        logger.info('c7n_mailer starting...')
+        logger.info("c7n_mailer starting...")
         mailer_sqs_queue_processor = MailerSqsQueueProcessor(config, session, logger)
         mailer_sqs_queue_processor.run(parallel)
     except Exception as e:

--- a/tools/c7n_mailer/c7n_mailer/ldap_lookup.py
+++ b/tools/c7n_mailer/c7n_mailer/ldap_lookup.py
@@ -16,33 +16,33 @@ from ldap3.core.exceptions import LDAPSocketOpenError
 
 
 class LdapLookup:
-
     def __init__(self, config, logger):
         self.log = logger
         self.connection = self.get_connection(
-            config.get('ldap_uri'),
-            config.get('ldap_bind_user', None),
-            config.get('ldap_bind_password', None)
+            config.get("ldap_uri"),
+            config.get("ldap_bind_user", None),
+            config.get("ldap_bind_password", None),
         )
-        self.base_dn = config.get('ldap_bind_dn')
-        self.email_key = config.get('ldap_email_key', 'mail')
-        self.manager_attr = config.get('ldap_manager_attribute', 'manager')
-        self.uid_key = config.get('ldap_uid_attribute', 'sAMAccountName')
-        self.attributes = ['displayName', self.uid_key, self.email_key, self.manager_attr]
-        self.uid_regex = config.get('ldap_uid_regex', None)
-        self.cache_engine = config.get('cache_engine', None)
-        if self.cache_engine == 'redis':
-            redis_host = config.get('redis_host')
-            redis_port = int(config.get('redis_port', 6379))
+        self.base_dn = config.get("ldap_bind_dn")
+        self.email_key = config.get("ldap_email_key", "mail")
+        self.manager_attr = config.get("ldap_manager_attribute", "manager")
+        self.uid_key = config.get("ldap_uid_attribute", "sAMAccountName")
+        self.attributes = ["displayName", self.uid_key, self.email_key, self.manager_attr]
+        self.uid_regex = config.get("ldap_uid_regex", None)
+        self.cache_engine = config.get("cache_engine", None)
+        if self.cache_engine == "redis":
+            redis_host = config.get("redis_host")
+            redis_port = int(config.get("redis_port", 6379))
             self.caching = self.get_redis_connection(redis_host, redis_port)
-        elif self.cache_engine == 'sqlite':  # nosec
+        elif self.cache_engine == "sqlite":  # nosec
             if not have_sqlite:
-                raise RuntimeError('No sqlite available: stackoverflow.com/q/44058239')
+                raise RuntimeError("No sqlite available: stackoverflow.com/q/44058239")
             # re nosec, this is running in serverless compute
             # environments, where /tmp is the only writeable space and
             # is effectively isolated to this process.
             self.caching = LocalSqlite(
-                config.get('ldap_cache_file', '/var/tmp/ldap.cache'), logger)  # nosec
+                config.get("ldap_cache_file", "/var/tmp/ldap.cache"), logger
+            )  # nosec
 
     def get_redis_connection(self, redis_host, redis_port):
         return Redis(redis_host=redis_host, redis_port=redis_port, db=0)
@@ -52,15 +52,17 @@ class LdapLookup:
         # an anonymous bind will be attempted.
         try:
             return Connection(
-                ldap_uri, user=ldap_bind_user, password=ldap_bind_password,
+                ldap_uri,
+                user=ldap_bind_user,
+                password=ldap_bind_password,
                 auto_bind=True,
                 receive_timeout=30,
                 auto_referrals=False,
             )
         except LDAPSocketOpenError:
-            self.log.error('Not able to establish a connection with LDAP.')
+            self.log.error("Not able to establish a connection with LDAP.")
         except Exception as e:
-            self.log.warning(f'Error occurred getting LDAP connection: {e}')
+            self.log.warning(f"Error occurred getting LDAP connection: {e}")
 
     def search_ldap(self, base_dn, ldap_filter, attributes):
         self.connection.search(base_dn, ldap_filter, attributes=self.attributes)
@@ -83,7 +85,7 @@ class LdapLookup:
             uid_manager_email = None
             if uid_manager_dn:
                 uid_manager = self.get_metadata_from_dn(uid_manager_dn)
-                uid_manager_email = uid_manager.get('mail')
+                uid_manager_email = uid_manager.get("mail")
             if uid_manager_email:
                 to_addrs.append(uid_manager_email)
         return to_addrs
@@ -93,10 +95,10 @@ class LdapLookup:
         if self.cache_engine:
             cache_result = self.caching.get(user_dn)
             if cache_result:
-                cache_msg = 'Got ldap metadata from local cache for: %s' % user_dn
+                cache_msg = "Got ldap metadata from local cache for: %s" % user_dn
                 self.log.debug(cache_msg)
                 return cache_result
-        ldap_filter = '(%s=*)' % self.uid_key
+        ldap_filter = "(%s=*)" % self.uid_key
         ldap_results = self.search_ldap(user_dn, ldap_filter, attributes=self.attributes)
         if ldap_results:
             ldap_user_metadata = self.get_dict_from_ldap_object(self.connection.entries[0])
@@ -104,14 +106,14 @@ class LdapLookup:
             self.caching.set(user_dn, {})
             return {}
         if self.cache_engine:
-            self.log.debug('Writing user: %s metadata to cache engine.' % user_dn)
+            self.log.debug("Writing user: %s metadata to cache engine." % user_dn)
             self.caching.set(user_dn, ldap_user_metadata)
             self.caching.set(ldap_user_metadata[self.uid_key], ldap_user_metadata)
         return ldap_user_metadata
 
     def get_dict_from_ldap_object(self, ldap_user_object):
         ldap_user_metadata = {attr.key: attr.value for attr in ldap_user_object}
-        ldap_user_metadata['dn'] = ldap_user_object.entry_dn
+        ldap_user_metadata["dn"] = ldap_user_object.entry_dn
 
         email_key = ldap_user_metadata.get(self.email_key, None)
         uid_key = ldap_user_metadata.get(self.uid_key, None)
@@ -119,8 +121,8 @@ class LdapLookup:
         if not email_key or not uid_key:
             return {}
         else:
-            ldap_user_metadata['self.email_key'] = email_key.lower()
-            ldap_user_metadata['self.uid_key'] = uid_key.lower()
+            ldap_user_metadata["self.email_key"] = email_key.lower()
+            ldap_user_metadata["self.uid_key"] = uid_key.lower()
 
         return ldap_user_metadata
 
@@ -134,23 +136,23 @@ class LdapLookup:
             # Out[41]: <_sre.SRE_Match at 0x1109ab440>
             # re.search("^[0-9]{6}$", "1234567") returns None, or "12345a' also returns None
             if not re.search(self.uid_regex, uid):
-                regex_msg = 'uid does not match regex: %s %s' % (self.uid_regex, uid)
+                regex_msg = "uid does not match regex: %s %s" % (self.uid_regex, uid)
                 self.log.debug(regex_msg)
                 return {}
         if self.cache_engine:
             cache_result = self.caching.get(uid)
             if cache_result or cache_result == {}:
-                cache_msg = 'Got ldap metadata from local cache for: %s' % uid
+                cache_msg = "Got ldap metadata from local cache for: %s" % uid
                 self.log.debug(cache_msg)
                 return cache_result
-        ldap_filter = '(%s=%s)' % (self.uid_key, uid)
+        ldap_filter = "(%s=%s)" % (self.uid_key, uid)
         ldap_results = self.search_ldap(self.base_dn, ldap_filter, attributes=self.attributes)
         if ldap_results:
             ldap_user_metadata = self.get_dict_from_ldap_object(self.connection.entries[0])
             if self.cache_engine:
-                self.log.debug('Writing user: %s metadata to cache engine.' % uid)
-                if ldap_user_metadata.get('dn'):
-                    self.caching.set(ldap_user_metadata['dn'], ldap_user_metadata)
+                self.log.debug("Writing user: %s metadata to cache engine." % uid)
+                if ldap_user_metadata.get("dn"):
+                    self.caching.set(ldap_user_metadata["dn"], ldap_user_metadata)
                     self.caching.set(uid, ldap_user_metadata)
                 else:
                     self.caching.set(uid, {})
@@ -169,13 +171,13 @@ class LocalSqlite:
     def __init__(self, local_filename, logger):
         self.log = logger
         self.sqlite = sqlite3.connect(local_filename)
-        self.sqlite.execute('''CREATE TABLE IF NOT EXISTS ldap_cache(key text, value text)''')
+        self.sqlite.execute("""CREATE TABLE IF NOT EXISTS ldap_cache(key text, value text)""")
 
     def get(self, key):
         sqlite_result = self.sqlite.execute("select * FROM ldap_cache WHERE key=?", (key,))
         result = sqlite_result.fetchall()
         if len(result) != 1:
-            error_msg = 'Did not get 1 result from sqlite, something went wrong with key: %s' % key
+            error_msg = "Did not get 1 result from sqlite, something went wrong with key: %s" % key
             self.log.error(error_msg)
             return None
         return json.loads(result[0][1])

--- a/tools/c7n_mailer/c7n_mailer/replay.py
+++ b/tools/c7n_mailer/c7n_mailer/replay.py
@@ -31,27 +31,26 @@ logger = logging.getLogger(__name__)
 
 
 class MailerTester:
-
     def __init__(self, config, raw=None, msg_file=None, msg_plain=False, json_dump_file=None):
         if msg_file:
             if not os.path.exists(msg_file):
                 raise RuntimeError("File does not exist: %s" % msg_file)
-            logger.debug('Reading message from: %s', msg_file)
-            with open(msg_file, 'r') as fh:
+            logger.debug("Reading message from: %s", msg_file)
+            with open(msg_file, "r") as fh:
                 raw = fh.read()
-            logger.debug('Read %d byte message', len(raw))
+            logger.debug("Read %d byte message", len(raw))
             if msg_plain:
                 raw = raw.strip()
             else:
-                logger.debug('base64-decoding and zlib decompressing message')
+                logger.debug("base64-decoding and zlib decompressing message")
                 raw = zlib.decompress(base64.b64decode(raw))
                 if json_dump_file is not None:
-                    with open(json_dump_file, 'wb') as fh:  # pragma: no cover
+                    with open(json_dump_file, "wb") as fh:  # pragma: no cover
                         fh.write(raw)
             self.data = json.loads(raw)
         else:
             self.data = raw
-        logger.debug('Loaded message JSON')
+        logger.debug("Loaded message JSON")
         self.config = config
         self.session = boto3.Session()
 
@@ -60,88 +59,110 @@ class MailerTester:
         if is_slack:
             sd = SlackDelivery(self.config, self.session, logger)
             addrs_to_msgs = sd.get_to_addrs_slack_messages_map(self.data)
-            logger.info('Would send to: %s', addrs_to_msgs.keys())
+            logger.info("Would send to: %s", addrs_to_msgs.keys())
 
             if print_only:
                 print(list(addrs_to_msgs.values())[0])
                 return
             if dry_run:
                 for to_addrs, body in addrs_to_msgs.items():
-                    print('-> SEND MESSAGE TO: %s' % to_addrs)
+                    print("-> SEND MESSAGE TO: %s" % to_addrs)
                     print(body)
                 return
             for to_addrs, body in addrs_to_msgs.items():
-                logger.info('Actually sending to: %s', to_addrs)
+                logger.info("Actually sending to: %s", to_addrs)
                 sd.send_slack_msg(to_addrs, body)
         else:
             emd = EmailDelivery(self.config, self.session, logger)
             addrs_to_msgs = emd.get_to_addrs_email_messages_map(self.data)
-            logger.info('Would send to: %s', addrs_to_msgs.keys())
+            logger.info("Would send to: %s", addrs_to_msgs.keys())
 
             if print_only:
                 mime = get_mimetext_message(
-                    self.config,
-                    logger,
-                    self.data,
-                    self.data['resources'],
-                    ['foo@example.com']
+                    self.config, logger, self.data, self.data["resources"], ["foo@example.com"]
                 )
-                logger.info('Send mail with subject: "%s"', mime['Subject'])
-                print(mime.get_payload(None, True).decode('utf-8'))
+                logger.info('Send mail with subject: "%s"', mime["Subject"])
+                print(mime.get_payload(None, True).decode("utf-8"))
                 return
             if dry_run:
                 for to_addrs, mimetext_msg in addrs_to_msgs.items():
-                    print('-> SEND MESSAGE TO: %s' % '; '.join(to_addrs))
-                    print(mimetext_msg.get_payload(None, True).decode('utf-8'))
+                    print("-> SEND MESSAGE TO: %s" % "; ".join(to_addrs))
+                    print(mimetext_msg.get_payload(None, True).decode("utf-8"))
                 return
             # else actually send the message...
             for to_addrs, mimetext_msg in addrs_to_msgs.items():
-                logger.info('Actually sending to: %s', to_addrs)
+                logger.info("Actually sending to: %s", to_addrs)
                 emd.send_c7n_email(self.data, list(to_addrs), mimetext_msg)
 
 
 def setup_parser():
-    parser = argparse.ArgumentParser('Test c7n-mailer templates and mail')
-    parser.add_argument('-c', '--config', required=True)
-    parser.add_argument('-d', '--dryrun', '--dry-run', dest='dry_run', action='store_true',
-                        default=False,
-                        help='Log messages that would be sent, but do not send')
-    parser.add_argument('-T', '--template-print', dest='print_only',
-                        action='store_true', default=False,
-                        help='Just print rendered templates')
-    parser.add_argument('-t', '--templates', default=None, type=str,
-                        help='message templates folder location')
-    parser.add_argument('-p', '--plain', dest='plain', action='store_true',
-                        default=False,
-                        help='Expect MESSAGE_FILE to be a plain string, '
-                             'rather than the base64-encoded, gzipped SQS '
-                             'message format')
-    parser.add_argument('-j', '--json-dump-file', dest='json_dump_file',
-                        type=str, action='store', default=None,
-                        help='If dump JSON of MESSAGE_FILE to this path; '
-                             'useful to base64-decode and gunzip a message')
-    parser.add_argument('MESSAGE_FILE', type=str, nargs="?",
-                        help='Path to SQS message dump/content file')
-    parser.add_argument('-f', '--policy-file', type=str,
-                        help='Policy file to mimic MESSAGE_FILE')
+    parser = argparse.ArgumentParser("Test c7n-mailer templates and mail")
+    parser.add_argument("-c", "--config", required=True)
     parser.add_argument(
-        '--policy-name', type=str,
-        help='Policy name if multiple policies to mimic MESSAGE_FILE. Defaults to the first.'
+        "-d",
+        "--dryrun",
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=False,
+        help="Log messages that would be sent, but do not send",
     )
-    parser.add_argument('-s', '--output-dir', type=str,
-                        help='Directory for policy output to mimic MESSAGE_FILE')
     parser.add_argument(
-        '-n', '--notify-index', type=int, default=0,
-        help='Index of notify action if multiple notifies exist to mimic MESSAGE_FILE. '
-             'Defaults to 0.'
+        "-T",
+        "--template-print",
+        dest="print_only",
+        action="store_true",
+        default=False,
+        help="Just print rendered templates",
+    )
+    parser.add_argument(
+        "-t", "--templates", default=None, type=str, help="message templates folder location"
+    )
+    parser.add_argument(
+        "-p",
+        "--plain",
+        dest="plain",
+        action="store_true",
+        default=False,
+        help="Expect MESSAGE_FILE to be a plain string, "
+        "rather than the base64-encoded, gzipped SQS "
+        "message format",
+    )
+    parser.add_argument(
+        "-j",
+        "--json-dump-file",
+        dest="json_dump_file",
+        type=str,
+        action="store",
+        default=None,
+        help="If dump JSON of MESSAGE_FILE to this path; "
+        "useful to base64-decode and gunzip a message",
+    )
+    parser.add_argument(
+        "MESSAGE_FILE", type=str, nargs="?", help="Path to SQS message dump/content file"
+    )
+    parser.add_argument("-f", "--policy-file", type=str, help="Policy file to mimic MESSAGE_FILE")
+    parser.add_argument(
+        "--policy-name",
+        type=str,
+        help="Policy name if multiple policies to mimic MESSAGE_FILE. Defaults to the first.",
+    )
+    parser.add_argument(
+        "-s", "--output-dir", type=str, help="Directory for policy output to mimic MESSAGE_FILE"
+    )
+    parser.add_argument(
+        "-n",
+        "--notify-index",
+        type=int,
+        default=0,
+        help="Index of notify action if multiple notifies exist to mimic MESSAGE_FILE. "
+        "Defaults to 0.",
     )
     return parser
 
 
 def session_factory(config):
-    return boto3.Session(
-        region_name=config['region'],
-        profile_name=config.get('profile'))
+    return boto3.Session(region_name=config["region"], profile_name=config.get("profile"))
 
 
 def mimic_sqs(region, policy_file, policy_name, notify_index, output_dir):
@@ -156,43 +177,40 @@ def mimic_sqs(region, policy_file, policy_name, notify_index, output_dir):
 
     with open(policy_file, "r") as f:
         data = yaml.safe_load(f.read())
-    policies = data['policies']
+    policies = data["policies"]
 
     # if there is only one policy, select it
     # otherwise choose the one using the name as the unique identifier
     policy = None
-    if len(data['policies']) == 1 or policy_name is None:
-        policy = data['policies'][0]
-        policy_name = policy['name']
+    if len(data["policies"]) == 1 or policy_name is None:
+        policy = data["policies"][0]
+        policy_name = policy["name"]
     else:
         assert policy_name, "For multiple policies we need a policy name"
         for pol in policies:
-            if pol['name'] == policy_name:
+            if pol["name"] == policy_name:
                 policy = pol
                 break
     assert policy
 
-    template['policy'] = policy
+    template["policy"] = policy
 
     action = None
     notify_idx = 0
-    for act in policy['actions']:
-        if act['type'] == 'notify':
+    for act in policy["actions"]:
+        if act["type"] == "notify":
             if notify_index == notify_idx:
                 action = act
                 break
             notify_idx += 1
 
-    template['action'] = action
+    template["action"] = action
 
-    resources_path = '{}/{}/resources.json'.format(
-        output_dir,
-        policy_name
-    )
+    resources_path = "{}/{}/resources.json".format(output_dir, policy_name)
     with open(resources_path, "r") as f:
         resources = json.loads(f.read())
 
-    template['resources'] = resources
+    template["resources"] = resources
 
     return template
 
@@ -203,26 +221,24 @@ def main():
 
     module_dir = os.path.dirname(os.path.abspath(__file__))
     default_templates = [
-        os.path.abspath(os.path.join(module_dir, 'msg-templates')),
-        os.path.abspath(os.path.join(module_dir, '..', 'msg-templates')),
-        os.path.abspath('.')
+        os.path.abspath(os.path.join(module_dir, "msg-templates")),
+        os.path.abspath(os.path.join(module_dir, "..", "msg-templates")),
+        os.path.abspath("."),
     ]
     templates = options.templates
     if templates:
-        default_templates.append(
-            os.path.abspath(os.path.expanduser(os.path.expandvars(templates)))
-        )
+        default_templates.append(os.path.abspath(os.path.expanduser(os.path.expandvars(templates))))
 
-    log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     logging.basicConfig(level=logging.DEBUG, format=log_format)
-    logging.getLogger('botocore').setLevel(logging.WARNING)
+    logging.getLogger("botocore").setLevel(logging.WARNING)
 
     with open(options.config) as fh:
         config = yaml.load(fh.read(), Loader=yaml.SafeLoader)
 
     jsonschema.validate(config, CONFIG_SCHEMA)
     setup_defaults(config)
-    config['templates_folders'] = default_templates
+    config["templates_folders"] = default_templates
 
     if options.MESSAGE_FILE:
         msg_file = options.MESSAGE_FILE
@@ -230,28 +246,26 @@ def main():
             config,
             msg_file=msg_file,
             msg_plain=options.plain,
-            json_dump_file=options.json_dump_file
+            json_dump_file=options.json_dump_file,
         )
     else:
         try:
-            region = config['region']
+            region = config["region"]
         except KeyError:
-            region = os.environ['AWS_REGION']
+            region = os.environ["AWS_REGION"]
         except KeyError:
-            region = 'us-east-1'
+            region = "us-east-1"
         raw = mimic_sqs(
             region,
             options.policy_file,
             options.policy_name,
             options.notify_index,
-            options.output_dir
+            options.output_dir,
         )
-        tester = MailerTester(
-            config, raw
-        )
+        tester = MailerTester(config, raw)
 
     tester.run(options.dry_run, options.print_only)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -10,32 +10,34 @@ from c7n_mailer.utils_email import is_email
 
 
 class SlackDelivery:
-
     def __init__(self, config, logger, email_handler):
-        self.caching = self.cache_factory(config, config.get('cache_engine', None))
+        self.caching = self.cache_factory(config, config.get("cache_engine", None))
         self.config = config
         self.logger = logger
         self.email_handler = email_handler
 
     def cache_factory(self, config, type):
-        if type == 'redis':
-            return Redis(redis_host=config.get('redis_host'),
-                         redis_port=int(config.get('redis_port', 6379)), db=0)
+        if type == "redis":
+            return Redis(
+                redis_host=config.get("redis_host"),
+                redis_port=int(config.get("redis_port", 6379)),
+                db=0,
+            )
         else:
             return None
 
     def get_to_addrs_slack_messages_map(self, sqs_message):
-        resource_list = copy.deepcopy(sqs_message['resources'])
+        resource_list = copy.deepcopy(sqs_message["resources"])
 
         slack_messages = {}
 
         # Check for Slack targets in 'to' action and render appropriate template.
-        for target in sqs_message.get('action', ()).get('to', []):
-            if target == 'slack://owners':
-                to_addrs_to_resources_map = \
-                    self.email_handler.get_email_to_addrs_to_resources_map(sqs_message)
+        for target in sqs_message.get("action", ()).get("to", []):
+            if target == "slack://owners":
+                to_addrs_to_resources_map = self.email_handler.get_email_to_addrs_to_resources_map(
+                    sqs_message
+                )
                 for to_addrs, resources in to_addrs_to_resources_map.items():
-
                     resolved_addrs = self.retrieve_user_im(list(to_addrs))
 
                     if not resolved_addrs:
@@ -43,50 +45,75 @@ class SlackDelivery:
 
                     for address, slack_target in resolved_addrs.items():
                         slack_messages[address] = get_rendered_jinja(
-                            slack_target, sqs_message, resources,
-                            self.logger, 'slack_template', 'slack_default',
-                            self.config['templates_folders'])
+                            slack_target,
+                            sqs_message,
+                            resources,
+                            self.logger,
+                            "slack_template",
+                            "slack_default",
+                            self.config["templates_folders"],
+                        )
                 self.logger.debug(
-                    "Generating messages for recipient list produced by resource owner resolution.")
-            elif target.startswith('https://hooks.slack.com/'):
+                    "Generating messages for recipient list produced by resource owner resolution."
+                )
+            elif target.startswith("https://hooks.slack.com/"):
                 slack_messages[target] = get_rendered_jinja(
-                    target, sqs_message,
+                    target,
+                    sqs_message,
                     resource_list,
-                    self.logger, 'slack_template', 'slack_default',
-                    self.config['templates_folders'])
-            elif target.startswith('slack://webhook/#') and self.config.get('slack_webhook'):
-                webhook_target = self.config.get('slack_webhook')
+                    self.logger,
+                    "slack_template",
+                    "slack_default",
+                    self.config["templates_folders"],
+                )
+            elif target.startswith("slack://webhook/#") and self.config.get("slack_webhook"):
+                webhook_target = self.config.get("slack_webhook")
                 slack_messages[webhook_target] = get_rendered_jinja(
-                    target.split('slack://webhook/#', 1)[1], sqs_message,
+                    target.split("slack://webhook/#", 1)[1],
+                    sqs_message,
                     resource_list,
-                    self.logger, 'slack_template', 'slack_default',
-                    self.config['templates_folders'])
+                    self.logger,
+                    "slack_template",
+                    "slack_default",
+                    self.config["templates_folders"],
+                )
                 self.logger.debug(
-                    "Generating message for webhook %s." % self.config.get('slack_webhook'))
-            elif target.startswith('slack://') and is_email(target.split('slack://', 1)[1]):
-                resolved_addrs = self.retrieve_user_im([target.split('slack://', 1)[1]])
+                    "Generating message for webhook %s." % self.config.get("slack_webhook")
+                )
+            elif target.startswith("slack://") and is_email(target.split("slack://", 1)[1]):
+                resolved_addrs = self.retrieve_user_im([target.split("slack://", 1)[1]])
                 for address, slack_target in resolved_addrs.items():
                     slack_messages[address] = get_rendered_jinja(
-                        slack_target, sqs_message, resource_list,
-                        self.logger, 'slack_template', 'slack_default',
-                        self.config['templates_folders'])
-            elif target.startswith('slack://#'):
-                resolved_addrs = target.split('slack://#', 1)[1]
+                        slack_target,
+                        sqs_message,
+                        resource_list,
+                        self.logger,
+                        "slack_template",
+                        "slack_default",
+                        self.config["templates_folders"],
+                    )
+            elif target.startswith("slack://#"):
+                resolved_addrs = target.split("slack://#", 1)[1]
                 slack_messages[resolved_addrs] = get_rendered_jinja(
-                    resolved_addrs, sqs_message,
+                    resolved_addrs,
+                    sqs_message,
                     resource_list,
-                    self.logger, 'slack_template', 'slack_default',
-                    self.config['templates_folders'])
-            elif target.startswith('slack://tag/') and 'Tags' in resource_list[0]:
-                tag_name = target.split('tag/', 1)[1]
-                result = next((item for item in resource_list[0].get('Tags', [])
-                               if item["Key"] == tag_name), None)
+                    self.logger,
+                    "slack_template",
+                    "slack_default",
+                    self.config["templates_folders"],
+                )
+            elif target.startswith("slack://tag/") and "Tags" in resource_list[0]:
+                tag_name = target.split("tag/", 1)[1]
+                result = next(
+                    (item for item in resource_list[0].get("Tags", []) if item["Key"] == tag_name),
+                    None,
+                )
                 if not result:
-                    self.logger.debug(
-                        "No %s tag found in resource." % tag_name)
+                    self.logger.debug("No %s tag found in resource." % tag_name)
                     continue
 
-                resolved_addr = slack_target = result['Value']
+                resolved_addr = slack_target = result["Value"]
 
                 if is_email(resolved_addr):
                     ims = self.retrieve_user_im([resolved_addr])
@@ -96,52 +123,62 @@ class SlackDelivery:
                     slack_target = resolved_addr
 
                 slack_messages[resolved_addr] = get_rendered_jinja(
-                    slack_target, sqs_message, resource_list,
-                    self.logger, 'slack_template', 'slack_default',
-                    self.config['templates_folders']
+                    slack_target,
+                    sqs_message,
+                    resource_list,
+                    self.logger,
+                    "slack_template",
+                    "slack_default",
+                    self.config["templates_folders"],
                 )
                 self.logger.debug("Generating message for specified Slack channel.")
         return slack_messages
 
     def slack_handler(self, sqs_message, slack_messages):
         for key, payload in slack_messages.items():
-            self.logger.info("Sending account:%s policy:%s %s:%s slack:%s to %s" % (
-                sqs_message.get('account', ''),
-                sqs_message['policy']['name'],
-                sqs_message['policy']['resource'],
-                str(len(sqs_message['resources'])),
-                sqs_message['action'].get('slack_template', 'slack_default'),
-                key)
+            self.logger.info(
+                "Sending account:%s policy:%s %s:%s slack:%s to %s"
+                % (
+                    sqs_message.get("account", ""),
+                    sqs_message["policy"]["name"],
+                    sqs_message["policy"]["resource"],
+                    str(len(sqs_message["resources"])),
+                    sqs_message["action"].get("slack_template", "slack_default"),
+                    key,
+                )
             )
 
-            self.send_slack_msg(key, payload.encode('utf-8'))
+            self.send_slack_msg(key, payload.encode("utf-8"))
 
     def retrieve_user_im(self, email_addresses):
         list = {}
 
-        if not self.config['slack_token']:
+        if not self.config["slack_token"]:
             self.logger.info("No Slack token found.")
 
         for address in email_addresses:
             if self.caching and self.caching.get(address):
-                self.logger.debug('Got Slack metadata from cache for: %s' % address)
+                self.logger.debug("Got Slack metadata from cache for: %s" % address)
                 list[address] = self.caching.get(address)
                 continue
 
             response = requests.post(
-                url='https://slack.com/api/users.lookupByEmail',
-                data={'email': address},
-                headers={'Content-Type': 'application/x-www-form-urlencoded',
-                         'Authorization': 'Bearer %s' % self.config.get('slack_token')},
-                timeout=60
+                url="https://slack.com/api/users.lookupByEmail",
+                data={"email": address},
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Authorization": "Bearer %s" % self.config.get("slack_token"),
+                },
+                timeout=60,
             ).json()
 
             if not response["ok"]:
                 if "headers" in response.keys() and "Retry-After" in response["headers"]:
                     self.logger.info(
                         "Slack API rate limiting. Waiting %d seconds",
-                        int(response.headers['retry-after']))
-                    time.sleep(int(response.headers['Retry-After']))
+                        int(response.headers["retry-after"]),
+                    )
+                    time.sleep(int(response.headers["Retry-After"]))
                     continue
                 elif response["error"] == "invalid_auth":
                     raise Exception("Invalid Slack token.")
@@ -153,13 +190,12 @@ class SlackDelivery:
                 else:
                     self.logger.warning("Slack Response: {}".format(response))
             else:
-                slack_user_id = response['user']['id']
-                if 'enterprise_user' in response['user'].keys():
-                    slack_user_id = response['user']['enterprise_user']['id']
-                self.logger.debug(
-                    "Slack account %s found for user %s", slack_user_id, address)
+                slack_user_id = response["user"]["id"]
+                if "enterprise_user" in response["user"].keys():
+                    slack_user_id = response["user"]["enterprise_user"]["id"]
+                self.logger.debug("Slack account %s found for user %s", slack_user_id, address)
                 if self.caching:
-                    self.logger.debug('Writing user: %s metadata to cache.', address)
+                    self.logger.debug("Writing user: %s metadata to cache.", address)
                     self.caching.set(address, slack_user_id)
 
                 list[address] = slack_user_id
@@ -167,45 +203,54 @@ class SlackDelivery:
         return list
 
     def send_slack_msg(self, key, message_payload):
-
-        if key.startswith('https://hooks.slack.com/'):
+        if key.startswith("https://hooks.slack.com/"):
             response = requests.post(
                 url=key,
                 data=message_payload,
-                headers={'Content-Type': 'application/json;charset=utf-8'},
-                timeout=60
+                headers={"Content-Type": "application/json;charset=utf-8"},
+                timeout=60,
             )
         else:
             response = requests.post(
-                url='https://slack.com/api/chat.postMessage',
+                url="https://slack.com/api/chat.postMessage",
                 data=message_payload,
-                headers={'Content-Type': 'application/json;charset=utf-8',
-                         'Authorization': 'Bearer %s' % self.config.get('slack_token')},
-                timeout=60
+                headers={
+                    "Content-Type": "application/json;charset=utf-8",
+                    "Authorization": "Bearer %s" % self.config.get("slack_token"),
+                },
+                timeout=60,
             )
 
         if response.status_code == 429 and "Retry-After" in response.headers:
             self.logger.info(
-                "Slack API rate limiting. Waiting %d seconds",
-                int(response.headers['Retry-After']))
-            time.sleep(int(response.headers['Retry-After']))
+                "Slack API rate limiting. Waiting %d seconds", int(response.headers["Retry-After"])
+            )
+            time.sleep(int(response.headers["Retry-After"]))
             return
 
         elif response.status_code != 200:
             self.logger.info(
                 "Error in sending Slack message status:%s response: %s",
-                response.status_code, response.text)
+                response.status_code,
+                response.text,
+            )
             return
 
-        if 'text/html' in response.headers['content-type']:
-            if response.text != 'ok':
-                self.logger.info("Error in sending Slack message. Status:%s, response:%s",
-                                response.status_code, response.text)
+        if "text/html" in response.headers["content-type"]:
+            if response.text != "ok":
+                self.logger.info(
+                    "Error in sending Slack message. Status:%s, response:%s",
+                    response.status_code,
+                    response.text,
+                )
                 return
 
         else:
             response_json = response.json()
-            if not response_json['ok']:
-                self.logger.info("Error in sending Slack message. Status:%s, response:%s",
-                                response.status_code, response_json['error'])
+            if not response_json["ok"]:
+                self.logger.info(
+                    "Error in sending Slack message. Status:%s, response:%s",
+                    response.status_code,
+                    response_json["error"],
+                )
                 return

--- a/tools/c7n_mailer/c7n_mailer/smtp_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/smtp_delivery.py
@@ -7,13 +7,12 @@ import c7n_mailer.utils as utils
 
 
 class SmtpDelivery:
-
     def __init__(self, config, session, logger):
-        smtp_server = config['smtp_server']
-        smtp_port = int(config.get('smtp_port', 25))
-        smtp_ssl = bool(config.get('smtp_ssl', True))
-        smtp_username = config.get('smtp_username')
-        smtp_password = utils.decrypt(config, logger, session, 'smtp_password')
+        smtp_server = config["smtp_server"]
+        smtp_port = int(config.get("smtp_port", 25))
+        smtp_ssl = bool(config.get("smtp_ssl", True))
+        smtp_username = config.get("smtp_username")
+        smtp_password = utils.decrypt(config, logger, session, "smtp_password")
 
         smtp_connection = smtplib.SMTP(smtp_server, smtp_port)
         if smtp_ssl:
@@ -32,4 +31,4 @@ class SmtpDelivery:
             pass
 
     def send_message(self, message, to_addrs):
-        self._smtp_connection.sendmail(message['From'], to_addrs, message.as_string())
+        self._smtp_connection.sendmail(message["From"], to_addrs, message.as_string())

--- a/tools/c7n_mailer/c7n_mailer/sns_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/sns_delivery.py
@@ -3,23 +3,21 @@
 
 from boto3 import Session
 
-from .utils import (
-    get_message_subject, get_resource_tag_targets, get_rendered_jinja)
+from .utils import get_message_subject, get_resource_tag_targets, get_rendered_jinja
 
 
 class SnsDelivery:
-
     def __init__(self, config, session, logger):
         self.config = config
         self.logger = logger
-        self.aws_sts = session.client('sts')
+        self.aws_sts = session.client("sts")
         self.sns_cache = {}
 
     def deliver_sns_messages(self, packaged_sns_messages, sqs_message):
         for packaged_sns_message in packaged_sns_messages:
-            topic = packaged_sns_message['topic']
-            subject = packaged_sns_message['subject']
-            sns_message = packaged_sns_message['sns_message']
+            topic = packaged_sns_message["topic"]
+            subject = packaged_sns_message["subject"]
+            sns_message = packaged_sns_message["sns_message"]
             self.deliver_sns_message(topic, subject, sns_message, sqs_message)
 
     def get_valid_sns_from_list(self, possible_sns_values):
@@ -35,15 +33,11 @@ class SnsDelivery:
             sqs_message,
             resources,
             self.logger,
-            'template',
-            'default',
-            self.config['templates_folders']
+            "template",
+            "default",
+            self.config["templates_folders"],
         )
-        return {
-            'topic': policy_sns_address,
-            'subject': subject,
-            'sns_message': rendered_jinja_body
-        }
+        return {"topic": policy_sns_address, "subject": subject, "sns_message": rendered_jinja_body}
 
     def get_sns_message_packages(self, sqs_message):
         sns_to_resources_map = self.get_sns_addrs_to_resources_map(sqs_message)
@@ -53,31 +47,23 @@ class SnsDelivery:
         # to sns_addrs_to_rendered_jinja_messages as an sns_message package
         for sns_topic, resources in sns_to_resources_map.items():
             sns_addrs_to_rendered_jinja_messages.append(
-                self.get_sns_message_package(
-                    sqs_message,
-                    sns_topic,
-                    subject,
-                    resources
-                )
+                self.get_sns_message_package(sqs_message, sns_topic, subject, resources)
             )
 
         if sns_addrs_to_rendered_jinja_messages == []:
-            self.logger.debug('Found no sns addresses, delivering no messages.')
+            self.logger.debug("Found no sns addresses, delivering no messages.")
         return sns_addrs_to_rendered_jinja_messages
 
     def get_sns_addrs_to_resources_map(self, sqs_message):
-        policy_to_sns_addresses = self.get_valid_sns_from_list(sqs_message['action'].get('to', []))
+        policy_to_sns_addresses = self.get_valid_sns_from_list(sqs_message["action"].get("to", []))
         sns_addrs_to_resources_map = {}
         # go over all sns_addresses from the to field
         for policy_sns_address in policy_to_sns_addresses:
-            sns_addrs_to_resources_map[policy_sns_address] = sqs_message['resources']
+            sns_addrs_to_resources_map[policy_sns_address] = sqs_message["resources"]
         # get sns topics / messages inside resource-owners tags
-        for resource in sqs_message['resources']:
-            resource_owner_tag_keys = self.config.get('contact_tags', [])
-            possible_sns_tag_values = get_resource_tag_targets(
-                resource,
-                resource_owner_tag_keys
-            )
+        for resource in sqs_message["resources"]:
+            resource_owner_tag_keys = self.config.get("contact_tags", [])
+            possible_sns_tag_values = get_resource_tag_targets(resource, resource_owner_tag_keys)
             sns_tag_values = self.get_valid_sns_from_list(possible_sns_tag_values)
             # for each resource, get any valid sns topics, and add them to the map
             for sns_tag_value in sns_tag_values:
@@ -88,39 +74,46 @@ class SnsDelivery:
         return sns_addrs_to_resources_map
 
     def target_is_sns(self, target):
-        if target.startswith('arn:aws:sns'):
+        if target.startswith("arn:aws:sns"):
             return True
         return False
 
     def deliver_sns_message(self, topic, subject, rendered_jinja_body, sqs_message):
         # Max length of subject in sns is 100 chars
         if len(subject) > 100:
-            subject = subject[:97] + '..'
+            subject = subject[:97] + ".."
         try:
-            account = topic.split(':')[4]
+            account = topic.split(":")[4]
             if account in self.sns_cache:
                 sns = self.sns_cache[account]
             else:
                 # if cross_accounts isn't set, we'll try using the current credentials
-                if account not in self.config.get('cross_accounts', []):
+                if account not in self.config.get("cross_accounts", []):
                     session = Session()
                 else:
                     creds = self.aws_sts.assume_role(
-                        RoleArn=self.config['cross_accounts'][account],
-                        RoleSessionName="CustodianNotification")['Credentials']
+                        RoleArn=self.config["cross_accounts"][account],
+                        RoleSessionName="CustodianNotification",
+                    )["Credentials"]
                     session = Session(
-                        aws_access_key_id=creds['AccessKeyId'],
-                        aws_secret_access_key=creds['SecretAccessKey'],
-                        aws_session_token=creds['SessionToken'])
-                self.sns_cache[account] = sns = session.client('sns')
+                        aws_access_key_id=creds["AccessKeyId"],
+                        aws_secret_access_key=creds["SecretAccessKey"],
+                        aws_session_token=creds["SessionToken"],
+                    )
+                self.sns_cache[account] = sns = session.client("sns")
 
-            self.logger.info("Sending account:%s policy:%s sns:%s to %s" % (
-                sqs_message.get('account', ''),
-                sqs_message['policy']['name'],
-                sqs_message['action'].get('template', 'default'),
-                topic))
+            self.logger.info(
+                "Sending account:%s policy:%s sns:%s to %s"
+                % (
+                    sqs_message.get("account", ""),
+                    sqs_message["policy"]["name"],
+                    sqs_message["action"].get("template", "default"),
+                    topic,
+                )
+            )
             sns.publish(TopicArn=topic, Subject=subject, Message=rendered_jinja_body)
         except Exception as e:
             self.logger.warning(
-                "Error policy:%s account:%s sending sns to %s \n %s" % (
-                    sqs_message['policy'], sqs_message.get('account', 'na'), topic, e))
+                "Error policy:%s account:%s sending sns to %s \n %s"
+                % (sqs_message["policy"], sqs_message.get("account", "na"), topic, e)
+            )

--- a/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
@@ -17,7 +17,7 @@ DATA_MESSAGE = "maidmsg/1.0"
 
 class MailerSqsQueueIterator:
     # Copied from custodian to avoid runtime library dependency
-    msg_attributes = ['sequence_id', 'op', 'ser']
+    msg_attributes = ["sequence_id", "op", "ser"]
 
     def __init__(self, aws_sqs, queue_url, logger, limit=0, timeout=10):
         self.aws_sqs = aws_sqs
@@ -39,11 +39,11 @@ class MailerSqsQueueIterator:
             WaitTimeSeconds=self.timeout,
             MaxNumberOfMessages=3,
             MessageAttributeNames=self.msg_attributes,
-            AttributeNames=['SentTimestamp']
+            AttributeNames=["SentTimestamp"],
         )
 
-        msgs = response.get('Messages', [])
-        self.logger.debug('Messages received %d', len(msgs))
+        msgs = response.get("Messages", [])
+        self.logger.debug("Messages received %d", len(msgs))
         for m in msgs:
             self.messages.append(m)
         if self.messages:
@@ -53,22 +53,19 @@ class MailerSqsQueueIterator:
     next = __next__  # python2.7
 
     def ack(self, m):
-        self.aws_sqs.delete_message(
-            QueueUrl=self.queue_url,
-            ReceiptHandle=m['ReceiptHandle'])
+        self.aws_sqs.delete_message(QueueUrl=self.queue_url, ReceiptHandle=m["ReceiptHandle"])
 
 
 class MailerSqsQueueProcessor(MessageTargetMixin):
-
     def __init__(self, config, session, logger, max_num_processes=16):
         self.config = config
         self.logger = logger
         self.session = session
         self.max_num_processes = max_num_processes
-        self.receive_queue = self.config['queue_url']
-        self.endpoint_url = self.config.get('endpoint_url', None)
-        if self.config.get('debug', False):
-            self.logger.debug('debug logging is turned on from mailer config file.')
+        self.receive_queue = self.config["queue_url"]
+        self.endpoint_url = self.config.get("endpoint_url", None)
+        if self.config.get("debug", False):
+            self.logger.debug("debug logging is turned on from mailer config file.")
             logger.setLevel(logging.DEBUG)
 
     """
@@ -87,37 +84,40 @@ class MailerSqsQueueProcessor(MessageTargetMixin):
     - resource-owners has a list of tags, SnSTopic, we'll deliver an sns message for
         any resources with SnSTopic set with a value that is a valid sns topic.
     """
+
     def run(self, parallel=False):
         self.logger.info("Downloading messages from the SQS queue.")
-        aws_sqs = self.session.client('sqs', endpoint_url=self.endpoint_url)
+        aws_sqs = self.session.client("sqs", endpoint_url=self.endpoint_url)
         sqs_messages = MailerSqsQueueIterator(aws_sqs, self.receive_queue, self.logger)
 
-        sqs_messages.msg_attributes = ['mtype', 'recipient']
+        sqs_messages.msg_attributes = ["mtype", "recipient"]
         # lambda doesn't support multiprocessing, so we don't instantiate any mp stuff
         # unless it's being run from CLI on a normal system with SHM
         if parallel:
             import multiprocessing
+
             process_pool = multiprocessing.Pool(processes=self.max_num_processes)
         for sqs_message in sqs_messages:
             self.logger.debug(
-                "Message id: %s received %s" % (
-                    sqs_message['MessageId'], sqs_message.get('MessageAttributes', '')))
-            msg_kind = sqs_message.get('MessageAttributes', {}).get('mtype')
+                "Message id: %s received %s"
+                % (sqs_message["MessageId"], sqs_message.get("MessageAttributes", ""))
+            )
+            msg_kind = sqs_message.get("MessageAttributes", {}).get("mtype")
             if msg_kind:
-                msg_kind = msg_kind['StringValue']
+                msg_kind = msg_kind["StringValue"]
             if not msg_kind == DATA_MESSAGE:
-                warning_msg = 'Unknown sqs_message or sns format %s' % (sqs_message['Body'][:50])
+                warning_msg = "Unknown sqs_message or sns format %s" % (sqs_message["Body"][:50])
                 self.logger.warning(warning_msg)
             if parallel:
                 process_pool.apply_async(self.process_sqs_message, args=sqs_message)
             else:
                 self.process_sqs_message(sqs_message)
-            self.logger.debug('Processed sqs_message')
+            self.logger.debug("Processed sqs_message")
             sqs_messages.ack(sqs_message)
         if parallel:
             process_pool.close()
             process_pool.join()
-        self.logger.info('No sqs_messages left on the queue, exiting c7n_mailer.')
+        self.logger.info("No sqs_messages left on the queue, exiting c7n_mailer.")
         return
 
     # This function when processing sqs messages will only deliver messages over email or sns
@@ -125,24 +125,28 @@ class MailerSqsQueueProcessor(MessageTargetMixin):
     # in the ldap_uid_tags section of your mailer.yml, we'll do a lookup of those emails
     # (and their manager if that option is on) and also send emails there.
     def process_sqs_message(self, encoded_sqs_message):
-        body = encoded_sqs_message['Body']
+        body = encoded_sqs_message["Body"]
         try:
-            body = json.dumps(json.loads(body)['Message'])
+            body = json.dumps(json.loads(body)["Message"])
         except ValueError:
             pass
         sqs_message = json.loads(zlib.decompress(base64.b64decode(body)))
 
-        self.logger.debug("Got account:%s message:%s %s:%d policy:%s recipients:%s" % (
-            sqs_message.get('account', 'na'),
-            encoded_sqs_message['MessageId'],
-            sqs_message['policy']['resource'],
-            len(sqs_message['resources']),
-            sqs_message['policy']['name'],
-            ', '.join(sqs_message['action'].get('to', []))))
+        self.logger.debug(
+            "Got account:%s message:%s %s:%d policy:%s recipients:%s"
+            % (
+                sqs_message.get("account", "na"),
+                encoded_sqs_message["MessageId"],
+                sqs_message["policy"]["resource"],
+                len(sqs_message["resources"]),
+                sqs_message["policy"]["name"],
+                ", ".join(sqs_message["action"].get("to", [])),
+            )
+        )
 
         self.handle_targets(
             sqs_message,
             encoded_sqs_message["Attributes"]["SentTimestamp"],
             email_delivery=True,
-            sns_delivery=True
+            sns_delivery=True,
         )

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -28,9 +28,10 @@ class Providers:
 
 def session_factory(mailer_config):
     import boto3
+
     return boto3.Session(
-        region_name=mailer_config['region'],
-        profile_name=mailer_config.get('profile', None))
+        region_name=mailer_config["region"], profile_name=mailer_config.get("profile", None)
+    )
 
 
 def get_processor(mailer_config, logger):
@@ -44,12 +45,15 @@ def get_processor(mailer_config, logger):
 
     if provider == Providers.Azure:
         from c7n_mailer.azure_mailer.azure_queue_processor import MailerAzureQueueProcessor
+
         processor = MailerAzureQueueProcessor(mailer_config, logger)
     elif provider == Providers.GCP:
         from c7n_mailer.gcp_mailer.gcp_queue_processor import MailerGcpQueueProcessor
+
         processor = MailerGcpQueueProcessor(mailer_config, logger)
     elif provider == Providers.AWS:
         from c7n_mailer.sqs_queue_processor import MailerSqsQueueProcessor
+
         aws_session = session_factory(mailer_config)
         processor = MailerSqsQueueProcessor(mailer_config, aws_session, logger)
 
@@ -58,27 +62,27 @@ def get_processor(mailer_config, logger):
 
 def get_jinja_env(template_folders):
     env = jinja2.Environment(trim_blocks=True, autoescape=False)  # nosec nosemgrep
-    env.filters['yaml_safe'] = functools.partial(yaml.safe_dump, default_flow_style=False)
-    env.filters['date_time_format'] = date_time_format
-    env.filters['get_date_time_delta'] = get_date_time_delta
-    env.filters['from_json'] = json.loads
-    env.filters['get_date_age'] = get_date_age
-    env.globals['format_resource'] = resource_format
-    env.globals['format_struct'] = format_struct
-    env.globals['resource_tag'] = get_resource_tag_value
-    env.globals['get_resource_tag_value'] = get_resource_tag_value
-    env.globals['search'] = jmespath.search
+    env.filters["yaml_safe"] = functools.partial(yaml.safe_dump, default_flow_style=False)
+    env.filters["date_time_format"] = date_time_format
+    env.filters["get_date_time_delta"] = get_date_time_delta
+    env.filters["from_json"] = json.loads
+    env.filters["get_date_age"] = get_date_age
+    env.globals["format_resource"] = resource_format
+    env.globals["format_struct"] = format_struct
+    env.globals["resource_tag"] = get_resource_tag_value
+    env.globals["get_resource_tag_value"] = get_resource_tag_value
+    env.globals["search"] = jmespath.search
     env.loader = jinja2.FileSystemLoader(template_folders)
     return env
 
 
 def get_rendered_jinja(
-        target, sqs_message, resources, logger,
-        specified_template, default_template, template_folders):
+    target, sqs_message, resources, logger, specified_template, default_template, template_folders
+):
     env = get_jinja_env(template_folders)
-    mail_template = sqs_message['action'].get(specified_template, default_template)
+    mail_template = sqs_message["action"].get(specified_template, default_template)
     if not os.path.isabs(mail_template):
-        mail_template = '%s.j2' % mail_template
+        mail_template = "%s.j2" % mail_template
     try:
         template = env.get_template(mail_template)
     except Exception as error_msg:
@@ -88,7 +92,7 @@ def get_rendered_jinja(
     # recast seconds since epoch as utc iso datestring, template
     # authors can use date_time_format helper func to convert local
     # tz. if no execution start time was passed use current time.
-    execution_start = sqs_message.get('execution_start')
+    execution_start = sqs_message.get("execution_start")
     if not execution_start:
         execution_start = time.mktime(datetime.utcnow().timetuple())
     execution_start = datetime.utcfromtimestamp(execution_start).isoformat()
@@ -96,14 +100,15 @@ def get_rendered_jinja(
     rendered_jinja = template.render(
         recipient=target,
         resources=resources,
-        account=sqs_message.get('account', ''),
-        account_id=sqs_message.get('account_id', ''),
-        partition=sqs_message.get('partition', ''),
-        event=sqs_message.get('event', None),
-        action=sqs_message['action'],
-        policy=sqs_message['policy'],
+        account=sqs_message.get("account", ""),
+        account_id=sqs_message.get("account_id", ""),
+        partition=sqs_message.get("partition", ""),
+        event=sqs_message.get("event", None),
+        action=sqs_message["action"],
+        policy=sqs_message["policy"],
         execution_start=execution_start,
-        region=sqs_message.get('region', ''))
+        region=sqs_message.get("region", ""),
+    )
     return rendered_jinja
 
 
@@ -111,11 +116,11 @@ def get_rendered_jinja(
 # and this function would go through the resource and look for any tag keys
 # that match Owners or SupportTeam, and return those values as targets
 def get_resource_tag_targets(resource, target_tag_keys):
-    if 'Tags' not in resource and 'labels' not in resource:
+    if "Tags" not in resource and "labels" not in resource:
         return []
-    tags = resource.get('Tags', []) or resource.get('labels', [])
+    tags = resource.get("Tags", []) or resource.get("labels", [])
     if isinstance(tags, list):
-        tags = {tag['Key']: tag['Value'] for tag in tags}
+        tags = {tag["Key"]: tag["Value"] for tag in tags}
     targets = []
     for target_tag_key in target_tag_keys:
         if target_tag_key in tags:
@@ -124,46 +129,46 @@ def get_resource_tag_targets(resource, target_tag_keys):
 
 
 def get_message_subject(sqs_message):
-    default_subject = 'Custodian notification - %s' % (sqs_message['policy']['name'])
-    subject = sqs_message['action'].get('subject', default_subject)
+    default_subject = "Custodian notification - %s" % (sqs_message["policy"]["name"])
+    subject = sqs_message["action"].get("subject", default_subject)
     jinja_template = jinja2.Template(subject)
     subject = jinja_template.render(
-        account=sqs_message.get('account', ''),
-        account_id=sqs_message.get('account_id', ''),
-        partition=sqs_message.get('partition', ''),
-        event=sqs_message.get('event', None),
-        action=sqs_message['action'],
-        policy=sqs_message['policy'],
-        region=sqs_message.get('region', '')
+        account=sqs_message.get("account", ""),
+        account_id=sqs_message.get("account_id", ""),
+        partition=sqs_message.get("partition", ""),
+        event=sqs_message.get("event", None),
+        action=sqs_message["action"],
+        policy=sqs_message["policy"],
+        region=sqs_message.get("region", ""),
     )
     return subject
 
 
 def setup_defaults(config):
-    config.setdefault('region', 'us-east-1')
-    config.setdefault('ses_region', config.get('region'))
-    config.setdefault('memory', 1024)
-    config.setdefault('runtime', 'python3.7')
-    config.setdefault('timeout', 300)
-    config.setdefault('subnets', None)
-    config.setdefault('security_groups', None)
-    config.setdefault('contact_tags', [])
-    config.setdefault('ldap_uri', None)
-    config.setdefault('ldap_bind_dn', None)
-    config.setdefault('ldap_bind_user', None)
-    config.setdefault('ldap_bind_password', None)
-    config.setdefault('endpoint_url', None)
-    config.setdefault('datadog_api_key', None)
-    config.setdefault('slack_token', None)
-    config.setdefault('slack_webhook', None)
+    config.setdefault("region", "us-east-1")
+    config.setdefault("ses_region", config.get("region"))
+    config.setdefault("memory", 1024)
+    config.setdefault("runtime", "python3.7")
+    config.setdefault("timeout", 300)
+    config.setdefault("subnets", None)
+    config.setdefault("security_groups", None)
+    config.setdefault("contact_tags", [])
+    config.setdefault("ldap_uri", None)
+    config.setdefault("ldap_bind_dn", None)
+    config.setdefault("ldap_bind_user", None)
+    config.setdefault("ldap_bind_password", None)
+    config.setdefault("endpoint_url", None)
+    config.setdefault("datadog_api_key", None)
+    config.setdefault("slack_token", None)
+    config.setdefault("slack_webhook", None)
 
 
-def date_time_format(utc_str, tz_str='US/Eastern', format='%Y %b %d %H:%M %Z'):
+def date_time_format(utc_str, tz_str="US/Eastern", format="%Y %b %d %H:%M %Z"):
     return parser.parse(utc_str).astimezone(gettz(tz_str)).strftime(format)
 
 
 def get_date_time_delta(delta):
-    return str(datetime.now().replace(tzinfo=gettz('UTC')) + timedelta(delta))
+    return str(datetime.now().replace(tzinfo=gettz("UTC")) + timedelta(delta))
 
 
 def get_date_age(date, unit="days"):
@@ -178,236 +183,222 @@ def format_struct(evt):
 
 
 def get_resource_tag_value(resource, k):
-    for t in resource.get('Tags', []):
-        if t['Key'] == k:
-            return t['Value']
-    return ''
+    for t in resource.get("Tags", []):
+        if t["Key"] == k:
+            return t["Value"]
+    return ""
 
 
 def strip_prefix(value, prefix):
     if value.startswith(prefix):
-        return value[len(prefix):]
+        return value[len(prefix) :]
     return value
 
 
 def resource_format(resource, resource_type):
-    if resource_type.startswith('aws.'):
-        resource_type = strip_prefix(resource_type, 'aws.')
-    if resource_type == 'ec2':
-        tag_map = {t['Key']: t['Value'] for t in resource.get('Tags', ())}
+    if resource_type.startswith("aws."):
+        resource_type = strip_prefix(resource_type, "aws.")
+    if resource_type == "ec2":
+        tag_map = {t["Key"]: t["Value"] for t in resource.get("Tags", ())}
         return "%s %s %s %s %s %s" % (
-            resource['InstanceId'],
-            resource.get('VpcId', 'NO VPC!'),
-            resource['InstanceType'],
-            resource.get('LaunchTime'),
-            tag_map.get('Name', ''),
-            resource.get('PrivateIpAddress'))
-    elif resource_type == 'ami':
-        return "%s %s %s" % (
-            resource.get('Name'), resource['ImageId'], resource['CreationDate'])
-    elif resource_type == 'sagemaker-notebook':
-        return "%s" % (resource['NotebookInstanceName'])
-    elif resource_type == 's3':
-        return "%s" % (resource['Name'])
-    elif resource_type == 'ebs':
+            resource["InstanceId"],
+            resource.get("VpcId", "NO VPC!"),
+            resource["InstanceType"],
+            resource.get("LaunchTime"),
+            tag_map.get("Name", ""),
+            resource.get("PrivateIpAddress"),
+        )
+    elif resource_type == "ami":
+        return "%s %s %s" % (resource.get("Name"), resource["ImageId"], resource["CreationDate"])
+    elif resource_type == "sagemaker-notebook":
+        return "%s" % (resource["NotebookInstanceName"])
+    elif resource_type == "s3":
+        return "%s" % (resource["Name"])
+    elif resource_type == "ebs":
         return "%s %s %s %s" % (
-            resource['VolumeId'],
-            resource['Size'],
-            resource['State'],
-            resource['CreateTime'])
-    elif resource_type == 'rds':
+            resource["VolumeId"],
+            resource["Size"],
+            resource["State"],
+            resource["CreateTime"],
+        )
+    elif resource_type == "rds":
         return "%s %s %s %s" % (
-            resource['DBInstanceIdentifier'],
-            "%s-%s" % (
-                resource['Engine'], resource['EngineVersion']),
-            resource['DBInstanceClass'],
-            resource['AllocatedStorage'])
-    elif resource_type == 'rds-cluster':
+            resource["DBInstanceIdentifier"],
+            "%s-%s" % (resource["Engine"], resource["EngineVersion"]),
+            resource["DBInstanceClass"],
+            resource["AllocatedStorage"],
+        )
+    elif resource_type == "rds-cluster":
         return "%s %s %s" % (
-            resource['DBClusterIdentifier'],
-            "%s-%s" % (
-                resource['Engine'], resource['EngineVersion']),
-            resource['AllocatedStorage'])
-    elif resource_type == 'asg':
-        tag_map = {t['Key']: t['Value'] for t in resource.get('Tags', ())}
+            resource["DBClusterIdentifier"],
+            "%s-%s" % (resource["Engine"], resource["EngineVersion"]),
+            resource["AllocatedStorage"],
+        )
+    elif resource_type == "asg":
+        tag_map = {t["Key"]: t["Value"] for t in resource.get("Tags", ())}
         return "%s %s %s" % (
-            resource['AutoScalingGroupName'],
-            tag_map.get('Name', ''),
-            "instances: %d" % (len(resource.get('Instances', []))))
-    elif resource_type == 'elb':
-        tag_map = {t['Key']: t['Value'] for t in resource.get('Tags', ())}
-        if 'ProhibitedPolicies' in resource:
+            resource["AutoScalingGroupName"],
+            tag_map.get("Name", ""),
+            "instances: %d" % (len(resource.get("Instances", []))),
+        )
+    elif resource_type == "elb":
+        tag_map = {t["Key"]: t["Value"] for t in resource.get("Tags", ())}
+        if "ProhibitedPolicies" in resource:
             return "%s %s %s %s" % (
-                resource['LoadBalancerName'],
-                "instances: %d" % len(resource['Instances']),
-                "zones: %d" % len(resource['AvailabilityZones']),
-                "prohibited_policies: %s" % ','.join(
-                    resource['ProhibitedPolicies']))
+                resource["LoadBalancerName"],
+                "instances: %d" % len(resource["Instances"]),
+                "zones: %d" % len(resource["AvailabilityZones"]),
+                "prohibited_policies: %s" % ",".join(resource["ProhibitedPolicies"]),
+            )
         return "%s %s %s" % (
-            resource['LoadBalancerName'],
-            "instances: %d" % len(resource['Instances']),
-            "zones: %d" % len(resource['AvailabilityZones']))
-    elif resource_type == 'redshift':
+            resource["LoadBalancerName"],
+            "instances: %d" % len(resource["Instances"]),
+            "zones: %d" % len(resource["AvailabilityZones"]),
+        )
+    elif resource_type == "redshift":
         return "%s %s %s" % (
-            resource['ClusterIdentifier'],
-            'nodes:%d' % len(resource['ClusterNodes']),
-            'encrypted:%s' % resource['Encrypted'])
-    elif resource_type == 'emr':
-        return "%s status:%s" % (
-            resource['Id'],
-            resource['Status']['State'])
-    elif resource_type == 'cfn':
-        return "%s" % (
-            resource['StackName'])
-    elif resource_type == 'launch-config':
-        return "%s" % (
-            resource['LaunchConfigurationName'])
-    elif resource_type == 'security-group':
-        name = resource.get('GroupName', '')
-        for t in resource.get('Tags', ()):
-            if t['Key'] == 'Name':
-                name = t['Value']
+            resource["ClusterIdentifier"],
+            "nodes:%d" % len(resource["ClusterNodes"]),
+            "encrypted:%s" % resource["Encrypted"],
+        )
+    elif resource_type == "emr":
+        return "%s status:%s" % (resource["Id"], resource["Status"]["State"])
+    elif resource_type == "cfn":
+        return "%s" % (resource["StackName"])
+    elif resource_type == "launch-config":
+        return "%s" % (resource["LaunchConfigurationName"])
+    elif resource_type == "security-group":
+        name = resource.get("GroupName", "")
+        for t in resource.get("Tags", ()):
+            if t["Key"] == "Name":
+                name = t["Value"]
         return "%s %s %s inrules: %d outrules: %d" % (
             name,
-            resource['GroupId'],
-            resource.get('VpcId', 'na'),
-            len(resource.get('IpPermissions', ())),
-            len(resource.get('IpPermissionsEgress', ())))
-    elif resource_type == 'log-group':
-        if 'lastWrite' in resource:
-            return "name: %s last_write: %s" % (
-                resource['logGroupName'],
-                resource['lastWrite'])
-        return "name: %s" % (resource['logGroupName'])
-    elif resource_type == 'cache-cluster':
+            resource["GroupId"],
+            resource.get("VpcId", "na"),
+            len(resource.get("IpPermissions", ())),
+            len(resource.get("IpPermissionsEgress", ())),
+        )
+    elif resource_type == "log-group":
+        if "lastWrite" in resource:
+            return "name: %s last_write: %s" % (resource["logGroupName"], resource["lastWrite"])
+        return "name: %s" % (resource["logGroupName"])
+    elif resource_type == "cache-cluster":
         return "name: %s created: %s status: %s" % (
-            resource['CacheClusterId'],
-            resource['CacheClusterCreateTime'],
-            resource['CacheClusterStatus'])
-    elif resource_type == 'cache-snapshot':
-        cid = resource.get('CacheClusterId')
+            resource["CacheClusterId"],
+            resource["CacheClusterCreateTime"],
+            resource["CacheClusterStatus"],
+        )
+    elif resource_type == "cache-snapshot":
+        cid = resource.get("CacheClusterId")
         if cid is None:
-            cid = ', '.join([
-                ns['CacheClusterId'] for ns in resource['NodeSnapshots']])
+            cid = ", ".join([ns["CacheClusterId"] for ns in resource["NodeSnapshots"]])
         return "name: %s cluster: %s source: %s" % (
-            resource['SnapshotName'],
+            resource["SnapshotName"],
             cid,
-            resource['SnapshotSource'])
-    elif resource_type == 'redshift-snapshot':
-        return "name: %s db: %s" % (
-            resource['SnapshotIdentifier'],
-            resource['DBName'])
-    elif resource_type == 'ebs-snapshot':
-        return "name: %s date: %s" % (
-            resource['SnapshotId'],
-            resource['StartTime'])
-    elif resource_type == 'subnet':
+            resource["SnapshotSource"],
+        )
+    elif resource_type == "redshift-snapshot":
+        return "name: %s db: %s" % (resource["SnapshotIdentifier"], resource["DBName"])
+    elif resource_type == "ebs-snapshot":
+        return "name: %s date: %s" % (resource["SnapshotId"], resource["StartTime"])
+    elif resource_type == "subnet":
         return "%s %s %s %s %s %s" % (
-            resource['SubnetId'],
-            resource['VpcId'],
-            resource['AvailabilityZone'],
-            resource['State'],
-            resource['CidrBlock'],
-            resource['AvailableIpAddressCount'])
-    elif resource_type == 'account':
-        return " %s %s" % (
-            resource['account_id'],
-            resource['account_name'])
-    elif resource_type == 'cloudtrail':
-        return "%s" % (
-            resource['Name'])
-    elif resource_type == 'vpc':
-        return "%s " % (
-            resource['VpcId'])
-    elif resource_type == 'iam-group':
+            resource["SubnetId"],
+            resource["VpcId"],
+            resource["AvailabilityZone"],
+            resource["State"],
+            resource["CidrBlock"],
+            resource["AvailableIpAddressCount"],
+        )
+    elif resource_type == "account":
+        return " %s %s" % (resource["account_id"], resource["account_name"])
+    elif resource_type == "cloudtrail":
+        return "%s" % (resource["Name"])
+    elif resource_type == "vpc":
+        return "%s " % (resource["VpcId"])
+    elif resource_type == "iam-group":
+        return " %s %s %s" % (resource["GroupName"], resource["Arn"], resource["CreateDate"])
+    elif resource_type == "rds-snapshot":
         return " %s %s %s" % (
-            resource['GroupName'],
-            resource['Arn'],
-            resource['CreateDate'])
-    elif resource_type == 'rds-snapshot':
-        return " %s %s %s" % (
-            resource['DBSnapshotIdentifier'],
-            resource['DBInstanceIdentifier'],
-            resource['SnapshotCreateTime'])
-    elif resource_type == 'iam-user':
-        return " %s " % (
-            resource['UserName'])
-    elif resource_type == 'iam-role':
-        return " %s %s " % (
-            resource['RoleName'],
-            resource['CreateDate'])
-    elif resource_type == 'iam-policy':
-        return " %s " % (
-            resource['PolicyName'])
-    elif resource_type == 'iam-profile':
-        return " %s " % (
-            resource['InstanceProfileId'])
-    elif resource_type == 'dynamodb-table':
+            resource["DBSnapshotIdentifier"],
+            resource["DBInstanceIdentifier"],
+            resource["SnapshotCreateTime"],
+        )
+    elif resource_type == "iam-user":
+        return " %s " % (resource["UserName"])
+    elif resource_type == "iam-role":
+        return " %s %s " % (resource["RoleName"], resource["CreateDate"])
+    elif resource_type == "iam-policy":
+        return " %s " % (resource["PolicyName"])
+    elif resource_type == "iam-profile":
+        return " %s " % (resource["InstanceProfileId"])
+    elif resource_type == "dynamodb-table":
         return "name: %s created: %s status: %s" % (
-            resource['TableName'],
-            resource['CreationDateTime'],
-            resource['TableStatus'])
+            resource["TableName"],
+            resource["CreationDateTime"],
+            resource["TableStatus"],
+        )
     elif resource_type == "sqs":
-        return "QueueURL: %s QueueArn: %s " % (
-            resource['QueueUrl'],
-            resource['QueueArn'])
+        return "QueueURL: %s QueueArn: %s " % (resource["QueueUrl"], resource["QueueArn"])
     elif resource_type == "efs":
         return "name: %s  id: %s  state: %s" % (
-            resource.get('Name', ''),
-            resource['FileSystemId'],
-            resource['LifeCycleState']
+            resource.get("Name", ""),
+            resource["FileSystemId"],
+            resource["LifeCycleState"],
         )
     elif resource_type == "network-addr":
         return "ip: %s  id: %s  scope: %s" % (
-            resource['PublicIp'],
-            resource['AllocationId'],
-            resource['Domain']
+            resource["PublicIp"],
+            resource["AllocationId"],
+            resource["Domain"],
         )
     elif resource_type == "route-table":
-        return "id: %s  vpc: %s" % (
-            resource['RouteTableId'],
-            resource['VpcId']
-        )
+        return "id: %s  vpc: %s" % (resource["RouteTableId"], resource["VpcId"])
     elif resource_type == "app-elb":
         return "arn: %s  zones: %s  scheme: %s" % (
-            resource['LoadBalancerArn'],
-            len(resource['AvailabilityZones']),
-            resource['Scheme'])
+            resource["LoadBalancerArn"],
+            len(resource["AvailabilityZones"]),
+            resource["Scheme"],
+        )
     elif resource_type == "nat-gateway":
         return "id: %s  state: %s  vpc: %s" % (
-            resource['NatGatewayId'],
-            resource['State'],
-            resource['VpcId'])
+            resource["NatGatewayId"],
+            resource["State"],
+            resource["VpcId"],
+        )
     elif resource_type == "internet-gateway":
         return "id: %s  attachments: %s" % (
-            resource['InternetGatewayId'],
-            len(resource['Attachments']))
-    elif resource_type == 'lambda':
+            resource["InternetGatewayId"],
+            len(resource["Attachments"]),
+        )
+    elif resource_type == "lambda":
         return "Name: %s  Package Type: %s  Runtime: %s  \n" % (
-            resource['FunctionName'],
-            resource['PackageType'],
-            resource.get('Runtime', 'N/A'))
-    elif resource_type == 'service-quota':
+            resource["FunctionName"],
+            resource["PackageType"],
+            resource.get("Runtime", "N/A"),
+        )
+    elif resource_type == "service-quota":
         try:
             return "ServiceName: %s QuotaName: %s Quota: %i Usage: %i\n" % (
-                resource['ServiceName'],
-                resource['QuotaName'],
-                resource['c7n:UsageMetric']['quota'],
-                resource['c7n:UsageMetric']['metric']
+                resource["ServiceName"],
+                resource["QuotaName"],
+                resource["c7n:UsageMetric"]["quota"],
+                resource["c7n:UsageMetric"]["metric"],
             )
         except KeyError:
             return "ServiceName: %s QuotaName: %s\n" % (
-                resource['ServiceName'],
-                resource['QuotaName'],
+                resource["ServiceName"],
+                resource["QuotaName"],
             )
     else:
         return "%s" % format_struct(resource)
 
 
 def get_provider(mailer_config):
-    if mailer_config.get('queue_url', '').startswith('asq://'):
+    if mailer_config.get("queue_url", "").startswith("asq://"):
         return Providers.Azure
-    if mailer_config.get('queue_url', '').startswith('projects'):
+    if mailer_config.get("queue_url", "").startswith("projects"):
         return Providers.GCP
     return Providers.AWS
 
@@ -415,20 +406,22 @@ def get_provider(mailer_config):
 def kms_decrypt(config, logger, session, encrypted_field):
     if config.get(encrypted_field):
         try:
-            kms = session.client('kms')
-            return kms.decrypt(
-                CiphertextBlob=base64.b64decode(config[encrypted_field]))[
-                    'Plaintext'].decode('utf8')
+            kms = session.client("kms")
+            return kms.decrypt(CiphertextBlob=base64.b64decode(config[encrypted_field]))[
+                "Plaintext"
+            ].decode("utf8")
         except (TypeError, base64.binascii.Error) as e:
             logger.warning(
-                "Error: %s Unable to base64 decode %s, will assume plaintext." %
-                (e, encrypted_field))
+                "Error: %s Unable to base64 decode %s, will assume plaintext."
+                % (e, encrypted_field)
+            )
         except ClientError as e:
-            if e.response['Error']['Code'] != 'InvalidCiphertextException':
+            if e.response["Error"]["Code"] != "InvalidCiphertextException":
                 raise
             logger.warning(
-                "Error: %s Unable to decrypt %s with kms, will assume plaintext." %
-                (e, encrypted_field))
+                "Error: %s Unable to decrypt %s with kms, will assume plaintext."
+                % (e, encrypted_field)
+            )
         return config[encrypted_field]
     else:
         logger.debug("No encrypted value to decrypt.")
@@ -440,9 +433,11 @@ def decrypt(config, logger, session, encrypted_field):
         provider = get_provider(config)
         if provider == Providers.Azure:
             from c7n_mailer.azure_mailer.utils import azure_decrypt
+
             return azure_decrypt(config, logger, session, encrypted_field)
         elif provider == Providers.GCP:
             from c7n_mailer.gcp_mailer.utils import gcp_decrypt
+
             return gcp_decrypt(config, logger, encrypted_field)
         elif provider == Providers.AWS:
             return kms_decrypt(config, logger, session, encrypted_field)
@@ -457,36 +452,33 @@ def decrypt(config, logger, session, encrypted_field):
 def get_aws_username_from_event(logger, event):
     if event is None:
         return None
-    identity = event.get('detail', {}).get('userIdentity', {})
+    identity = event.get("detail", {}).get("userIdentity", {})
     if not identity:
-        logger.warning("Could not get recipient from event \n %s" % (
-            format_struct(event)))
+        logger.warning("Could not get recipient from event \n %s" % (format_struct(event)))
         return None
-    if identity['type'] == 'AssumedRole':
+    if identity["type"] == "AssumedRole":
         logger.debug(
-            'In some cases there is no ldap uid is associated with AssumedRole: %s',
-            identity['arn'])
-        logger.debug(
-            'We will try to assume that identity is in the AssumedRoleSessionName')
-        user = identity['arn'].rsplit('/', 1)[-1]
-        if user is None or user.startswith('i-') or user.startswith('awslambda'):
+            "In some cases there is no ldap uid is associated with AssumedRole: %s", identity["arn"]
+        )
+        logger.debug("We will try to assume that identity is in the AssumedRoleSessionName")
+        user = identity["arn"].rsplit("/", 1)[-1]
+        if user is None or user.startswith("i-") or user.startswith("awslambda"):
             return None
-        if ':' in user:
-            user = user.split(':', 1)[-1]
+        if ":" in user:
+            user = user.split(":", 1)[-1]
         return user
-    if identity['type'] == 'IAMUser' or identity['type'] == 'WebIdentityUser':
-        return identity['userName']
-    if identity['type'] == 'Root':
+    if identity["type"] == "IAMUser" or identity["type"] == "WebIdentityUser":
+        return identity["userName"]
+    if identity["type"] == "Root":
         return None
     # this conditional is left here as a last resort, it should
     # be better documented with an example UserIdentity json
-    if ':' in identity['principalId']:
-        user_id = identity['principalId'].split(':', 1)[-1]
+    if ":" in identity["principalId"]:
+        user_id = identity["principalId"].split(":", 1)[-1]
     else:
-        user_id = identity['principalId']
+        user_id = identity["principalId"]
     return user_id
 
 
 def unique(seq):
     return list({k: None for k in seq})
-   

--- a/tools/c7n_mailer/c7n_mailer/utils_email.py
+++ b/tools/c7n_mailer/c7n_mailer/utils_email.py
@@ -4,10 +4,9 @@ import logging
 from email.mime.text import MIMEText
 from email.utils import parseaddr
 
-from .utils import (
-    get_message_subject, get_rendered_jinja)
+from .utils import get_message_subject, get_rendered_jinja
 
-logger = logging.getLogger('c7n_mailer.utils.email')
+logger = logging.getLogger("c7n_mailer.utils.email")
 
 
 # Those headers are defined as follows:
@@ -23,46 +22,46 @@ logger = logging.getLogger('c7n_mailer.utils.email')
 #  'Importance': "low" / "normal" / "high"
 #              Cf https://tools.ietf.org/html/rfc2156#section-5.3.4
 PRIORITIES = {
-    '1': {
-        'X-Priority': '1 (Highest)',
-        'X-MSMail-Priority': 'High',
-        'Priority': 'urgent',
-        'Importance': 'high',
+    "1": {
+        "X-Priority": "1 (Highest)",
+        "X-MSMail-Priority": "High",
+        "Priority": "urgent",
+        "Importance": "high",
     },
-    '2': {
-        'X-Priority': '2 (High)',
-        'X-MSMail-Priority': 'High',
-        'Priority': 'urgent',
-        'Importance': 'high',
+    "2": {
+        "X-Priority": "2 (High)",
+        "X-MSMail-Priority": "High",
+        "Priority": "urgent",
+        "Importance": "high",
     },
-    '3': {
-        'X-Priority': '3 (Normal)',
-        'X-MSMail-Priority': 'Normal',
-        'Priority': 'normal',
-        'Importance': 'normal',
+    "3": {
+        "X-Priority": "3 (Normal)",
+        "X-MSMail-Priority": "Normal",
+        "Priority": "normal",
+        "Importance": "normal",
     },
-    '4': {
-        'X-Priority': '4 (Low)',
-        'X-MSMail-Priority': 'Low',
-        'Priority': 'non-urgent',
-        'Importance': 'low',
+    "4": {
+        "X-Priority": "4 (Low)",
+        "X-MSMail-Priority": "Low",
+        "Priority": "non-urgent",
+        "Importance": "low",
     },
-    '5': {
-        'X-Priority': '5 (Lowest)',
-        'X-MSMail-Priority': 'Low',
-        'Priority': 'non-urgent',
-        'Importance': 'low',
-    }
+    "5": {
+        "X-Priority": "5 (Lowest)",
+        "X-MSMail-Priority": "Low",
+        "Priority": "non-urgent",
+        "Importance": "low",
+    },
 }
 
 
 def is_email(target):
     if target is None:
         return False
-    if target.startswith('slack://'):
+    if target.startswith("slack://"):
         logger.debug("Slack payload, not an email.")
         return False
-    if parseaddr(target)[1] and '@' in target and '.' in target:
+    if parseaddr(target)[1] and "@" in target and "." in target:
         return True
     else:
         return False
@@ -76,23 +75,22 @@ def priority_header_is_valid(priority_header, logger):
     if priority_header_int and 0 < int(priority_header_int) < 6:
         return True
     else:
-        logger.warning('mailer priority_header is not a valid string from 1 to 5')
+        logger.warning("mailer priority_header is not a valid string from 1 to 5")
         return False
 
 
 def set_mimetext_headers(
-    message, subject, from_addr, to_addrs, cc_addrs, additional_headers,
-    priority, logger
+    message, subject, from_addr, to_addrs, cc_addrs, additional_headers, priority, logger
 ):
     """Sets headers on Mimetext message"""
 
-    message['Subject'] = subject
-    message['From'] = from_addr
-    message['To'] = ', '.join(to_addrs)
+    message["Subject"] = subject
+    message["From"] = from_addr
+    message["To"] = ", ".join(to_addrs)
     if cc_addrs:
         # NOTE filter out unenhanced cc_addrs added by self.get_mimetext_message
         cc_addrs = [cc for cc in cc_addrs if is_email(cc)]
-        message['Cc'] = ', '.join(cc_addrs)
+        message["Cc"] = ", ".join(cc_addrs)
     if additional_headers:
         for k, v in additional_headers.items():
             message[k] = v
@@ -107,22 +105,23 @@ def set_mimetext_headers(
 
 def get_mimetext_message(config, logger, message, resources, to_addrs):
     body = get_rendered_jinja(
-        to_addrs, message, resources, logger,
-        'template', 'default', config['templates_folders'])
+        to_addrs, message, resources, logger, "template", "default", config["templates_folders"]
+    )
 
-    email_format = message['action'].get('template_format', None)
+    email_format = message["action"].get("template_format", None)
     if not email_format:
-        email_format = message['action'].get(
-            'template', 'default').endswith('html') and 'html' or 'plain'
+        email_format = (
+            message["action"].get("template", "default").endswith("html") and "html" or "plain"
+        )
 
     return set_mimetext_headers(
-        message=MIMEText(body, email_format, 'utf-8'),
+        message=MIMEText(body, email_format, "utf-8"),
         subject=get_message_subject(message),
-        from_addr=message['action'].get('from', config['from_address']),
+        from_addr=message["action"].get("from", config["from_address"]),
         to_addrs=to_addrs,
         # FIXME cc has been processed and enhanced in get_email_to_addrs_to_resources_map
-        cc_addrs=message['action'].get('cc', []),
-        additional_headers=config.get('additional_email_headers', {}),
-        priority=message['action'].get('priority_header', None),
-        logger=logger
+        cc_addrs=message["action"].get("cc", []),
+        additional_headers=config.get("additional_email_headers", {}),
+        priority=message["action"].get("priority_header", None),
+        logger=logger,
     )

--- a/tools/c7n_mailer/tests/common.py
+++ b/tools/c7n_mailer/tests/common.py
@@ -46,11 +46,7 @@ MAILER_CONFIG = {
     "cache_engine": "sqlite",
     "role": "arn:aws:iam::xxxx:role/cloudcustodian-mailer",
     "ldap_uid_tags": ["CreatorName", "Owner"],
-    "templates_folders": [
-        os.path.abspath(os.path.dirname(__file__)),
-        os.path.abspath("/"),
-        ""
-    ],
+    "templates_folders": [os.path.abspath(os.path.dirname(__file__)), os.path.abspath("/"), ""],
 }
 MAILER_CONFIG_AZURE = {
     "queue_url": "asq://storageaccount.queue.core.windows.net/queuename",
@@ -60,7 +56,7 @@ MAILER_CONFIG_AZURE = {
         os.path.abspath(os.path.dirname(__file__)),
         os.path.abspath("/"),
         os.path.abspath(os.path.join(os.path.dirname(__file__), "test-templates")),
-        ""
+        "",
     ],
 }
 
@@ -72,11 +68,7 @@ MAILER_CONFIG_GCP = {
     "from_address": "devops@initech.com",
     "queue_url": "projects/c7n-dev/subscriptions/getnotify",
     "smtp_server": "smtp.inittech.com",
-    "templates_folders": [
-        os.path.abspath(os.path.dirname(__file__)),
-        os.path.abspath("/"),
-        ""
-    ],
+    "templates_folders": [os.path.abspath(os.path.dirname(__file__)), os.path.abspath("/"), ""],
 }
 
 RESOURCE_1 = {
@@ -157,13 +149,9 @@ SQS_MESSAGE_1 = {
 }
 
 SQS_MESSAGE_1_ENCODED = {
-    "Body": base64.b64encode(
-        zlib.compress(json.dumps(SQS_MESSAGE_1).encode("utf8"))
-    ),
+    "Body": base64.b64encode(zlib.compress(json.dumps(SQS_MESSAGE_1).encode("utf8"))),
     "MessageId": "1",
-    "Attributes": {
-        "SentTimestamp": "2023-01-01T12:00:00"
-    }
+    "Attributes": {"SentTimestamp": "2023-01-01T12:00:00"},
 }
 
 SQS_MESSAGE_2 = {
@@ -733,7 +721,6 @@ def get_ldap_lookup(cache_engine=None, uid_regex=None):
 
 
 class MockLdapLookup(LdapLookup):
-
     # allows us to instantiate this object and not need a redis daemon
     def get_redis_connection(self, redis_host, redis_port):
         return MockRedisLookup()

--- a/tools/c7n_mailer/tests/test_azure.py
+++ b/tools/c7n_mailer/tests/test_azure.py
@@ -47,7 +47,8 @@ class AzureTest(unittest.TestCase):
         # Run the process messages method
         azure_processor = MailerAzureQueueProcessor(MAILER_CONFIG_AZURE, logger)
         self.assertTrue(
-            azure_processor.process_azure_queue_message(self.compressed_message, "timestamp"))
+            azure_processor.process_azure_queue_message(self.compressed_message, "timestamp")
+        )
 
         # Verify mock calls were correct
         mock_get_addr.assert_called_with(self.loaded_message)
@@ -65,7 +66,8 @@ class AzureTest(unittest.TestCase):
         # Run the process messages method
         azure_processor = MailerAzureQueueProcessor(MAILER_CONFIG_AZURE, logger)
         self.assertFalse(
-            azure_processor.process_azure_queue_message(self.compressed_message, "timestamp"))
+            azure_processor.process_azure_queue_message(self.compressed_message, "timestamp")
+        )
 
         # Verify mock calls were correct
         mock_get_addr.assert_called_with(self.loaded_message)
@@ -262,7 +264,8 @@ class AzureTest(unittest.TestCase):
         ):
             azure_processor = MailerAzureQueueProcessor(smtp_mailer_config, logger)
             self.assertTrue(
-                azure_processor.process_azure_queue_message(self.compressed_message, "timestamp"))
+                azure_processor.process_azure_queue_message(self.compressed_message, "timestamp")
+            )
             mock_smtp.assert_has_calls(
                 [call().send_message(message=self.loaded_message, to_addrs=["mock@test.com"])]
             )
@@ -287,7 +290,8 @@ class AzureTest(unittest.TestCase):
         azure_processor = MailerAzureQueueProcessor(slack_mailer_config, logger)
 
         self.assertTrue(
-            azure_processor.process_azure_queue_message(slack_compressed_message, "timestamp"))
+            azure_processor.process_azure_queue_message(slack_compressed_message, "timestamp")
+        )
         mock_slack.assert_has_calls(
             [call().slack_handler(slack_loaded_message, "mock_slack_message_map")]
         )
@@ -313,7 +317,8 @@ class AzureTest(unittest.TestCase):
         azure_processor = MailerAzureQueueProcessor(datadog_mailer_config, logger)
 
         self.assertTrue(
-            azure_processor.process_azure_queue_message(datadog_compressed_message, "timestamp"))
+            azure_processor.process_azure_queue_message(datadog_compressed_message, "timestamp")
+        )
         mock_datadog.assert_has_calls(
             [call().deliver_datadog_messages("mock_datadog_message_map", datadog_loaded_message)]
         )

--- a/tools/c7n_mailer/tests/test_email.py
+++ b/tools/c7n_mailer/tests/test_email.py
@@ -249,8 +249,8 @@ class EmailTest(unittest.TestCase):
 
     def test_no_mapping_if_no_valid_emails(self):
         SQS_MESSAGE = copy.deepcopy(SQS_MESSAGE_1)
-        SQS_MESSAGE['action'].get('to', []).remove('ldap_uid_tags')
-        SQS_MESSAGE['resources'][0].pop('Tags', None)
+        SQS_MESSAGE["action"].get("to", []).remove("ldap_uid_tags")
+        SQS_MESSAGE["resources"][0].pop("Tags", None)
         emails_to_resources_map = self.email_delivery.get_email_to_addrs_to_resources_map(
             SQS_MESSAGE
         )
@@ -356,19 +356,15 @@ class EmailTest(unittest.TestCase):
     def test_get_ldap_connection(self):
         with patch("c7n_mailer.email_delivery.decrypt") as patched:
             patched.return_value = "a password"
-            delivery = EmailDelivery(
-                {"ldap_uri": "foo"},
-                self.aws_session,
-                MagicMock()
-            )
+            delivery = EmailDelivery({"ldap_uri": "foo"}, self.aws_session, MagicMock())
             patched.assert_called()
-            self.assertEqual(delivery.config['ldap_bind_password'], "a password")
+            self.assertEqual(delivery.config["ldap_bind_password"], "a password")
 
     def test_get_valid_emails_from_list_gcp(self):
         delivery = EmailDelivery(
-            {'ldap_uri': 'foo', 'email_base_url': 'example.com'},
-            self.aws_session, MagicMock())
-        result = delivery.get_valid_emails_from_list(['resource-owner', 'foo:bar'])
+            {"ldap_uri": "foo", "email_base_url": "example.com"}, self.aws_session, MagicMock()
+        )
+        result = delivery.get_valid_emails_from_list(["resource-owner", "foo:bar"])
         self.assertEqual(len(result), 2)
-        self.assertTrue('foo@example.com' in result)
-        self.assertTrue('bar@example.com' in result)
+        self.assertTrue("foo@example.com" in result)
+        self.assertTrue("bar@example.com" in result)

--- a/tools/c7n_mailer/tests/test_gcp.py
+++ b/tools/c7n_mailer/tests/test_gcp.py
@@ -30,10 +30,10 @@ class GcpTest(unittest.TestCase):
                 "attributes": {},
                 "messageId": "",
                 "orderingKey": "",
-                "publishTime": "a time"
+                "publishTime": "a time",
             },
             "ackId": "",
-            "deliveryAttempt": ""
+            "deliveryAttempt": "",
         }
         result = []
         for i in range(count):
@@ -47,7 +47,7 @@ class GcpTest(unittest.TestCase):
         self.assertTrue(
             processor.process_message(
                 GCP_MESSAGES["receivedMessages"][0],
-                GCP_MESSAGES['receivedMessages'][0]['message']['publishTime']
+                GCP_MESSAGES["receivedMessages"][0]["message"]["publishTime"],
             )
         )
         mock_email.assert_called()
@@ -58,13 +58,13 @@ class GcpTest(unittest.TestCase):
         processor = MailerGcpQueueProcessor(MAILER_CONFIG_GCP, logger)
         processor.client = patched_client
         messages = processor.receive_messages()
-        self.assertEqual(len(messages['receivedMessages']), 1)
+        self.assertEqual(len(messages["receivedMessages"]), 1)
         patched_client.execute_command.assert_called_with(
             "pull",
             {
                 "subscription": "projects/c7n-dev/subscriptions/getnotify",
-                "body": {"returnImmediately": True, "max_messages": 1000}
-            }
+                "body": {"returnImmediately": True, "max_messages": 1000},
+            },
         )
 
     def test_ack_message(self):
@@ -77,8 +77,8 @@ class GcpTest(unittest.TestCase):
             "seek",
             {
                 "subscription": "projects/c7n-dev/subscriptions/getnotify",
-                "body": {"time": "2019-05-13T18:31:17.926Z"}
-            }
+                "body": {"time": "2019-05-13T18:31:17.926Z"},
+            },
         )
 
     @patch.object(MailerGcpQueueProcessor, "receive_messages")

--- a/tools/c7n_mailer/tests/test_gcp_mailer_utils.py
+++ b/tools/c7n_mailer/tests/test_gcp_mailer_utils.py
@@ -17,22 +17,13 @@ class GcpUtilsTest(unittest.TestCase):
         mocked_response.payload.data = b"secret value"
         mock_client.access_secret_version.return_value = mocked_response
         self.assertEqual(
-            gcp_decrypt(
-                {"test": {"secret": "foo"}},
-                MagicMock(),
-                "test",
-                mock_client
-            ),
-            "secret value")
+            gcp_decrypt({"test": {"secret": "foo"}}, MagicMock(), "test", mock_client),
+            "secret value",
+        )
         mock_client.access_secret_version.assert_called_with(name="foo/versions/latest")
         self.assertTrue("foo/versions/latest" in CACHE)
         # the value should be cached and we should only see one access secret version call
-        value = gcp_decrypt(
-            {"test": {"secret": "foo"}},
-            MagicMock(),
-            "test",
-            mock_client
-        )
+        value = gcp_decrypt({"test": {"secret": "foo"}}, MagicMock(), "test", mock_client)
         mock_client.access_secret_version.assert_called_once()
 
         # of course, the value of the secret should not have changed

--- a/tools/c7n_mailer/tests/test_sns.py
+++ b/tools/c7n_mailer/tests/test_sns.py
@@ -26,6 +26,6 @@ class SnsTest(unittest.TestCase):
 
     def test_get_sns_to_resources_map(self):
         SQS_MESSAGE = copy.deepcopy(SQS_MESSAGE_1)
-        SQS_MESSAGE['action'].get('to', []).append(self.sns_topic_example)
+        SQS_MESSAGE["action"].get("to", []).append(self.sns_topic_example)
         sns_to_resources = self.sns_delivery.get_sns_addrs_to_resources_map(SQS_MESSAGE)
         self.assertEqual(sns_to_resources, {self.sns_topic_example: [RESOURCE_1]})

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -280,10 +280,7 @@ class ProviderSelector(unittest.TestCase):
             (self.gcp_config, MailerGcpQueueProcessor),
         ]
         for mailer_config, processor in params:
-            self.assertIsInstance(
-                utils.get_processor(mailer_config, logger),
-                processor
-            )
+            self.assertIsInstance(utils.get_processor(mailer_config, logger), processor)
 
     def test_missing_deps_guidance(self):
         """Make sure we catch failed imports and provide guidance around installing
@@ -291,14 +288,14 @@ class ProviderSelector(unittest.TestCase):
         _real_import = builtins.__import__
 
         def fake_import_missing_deps(name, *args, **kwargs):
-            if name.startswith('c7n_gcp') or name.startswith('c7n_azure'):
+            if name.startswith("c7n_gcp") or name.startswith("c7n_azure"):
                 raise ImportError()
             return _real_import(name, *args, **kwargs)
 
-        with patch.object(builtins, '__import__', side_effect=fake_import_missing_deps):
-            with self.assertRaisesRegex(ImportError, r'pip install c7n-mailer\[azure\]'):
+        with patch.object(builtins, "__import__", side_effect=fake_import_missing_deps):
+            with self.assertRaisesRegex(ImportError, r"pip install c7n-mailer\[azure\]"):
                 reload(c7n_mailer.azure_mailer.azure_queue_processor)
-            with self.assertRaisesRegex(ImportError, r'pip install c7n-mailer\[gcp\]'):
+            with self.assertRaisesRegex(ImportError, r"pip install c7n-mailer\[gcp\]"):
                 reload(c7n_mailer.gcp_mailer.gcp_queue_processor)
 
 


### PR DESCRIPTION
This PR only contains changes made by "black tools/c7n_mailer -l 100".
_30 files reformatted, 11 files left unchanged._

I wanted to format c7n_mailer and refactor the email_delivery code (pls see next paragraph, and maybe a few others) before incorporating MS Graph for email sending, as well as integrating MS Teams and Jira. This way, the formatting changes will not interfere with the feature additions. Currently, I haven't seen any recent pull requests related to c7n_mailer, except for the relang (black formatting) one. So, it seems like a good time to make these changes. Please advise.

**Refactor**:
To avoid sending duplicated emails, the SendGrid implementation should be moved out of the send_c7n_email() function. For instance, when to_addrs_to_email_messages_map is {("email-1"): resource-1, ("email-2"): resource-2}, duplicated emails are sent because the to_addrs_to_email_messages_map is looped through twice: once in line 18 and again in line 77.


https://github.com/cloud-custodian/cloud-custodian/blob/9322aa9e6b5a805f17ffdbbbcb6ac2c1e9517c91/tools/c7n_mailer/c7n_mailer/target.py#L17-L19

https://github.com/cloud-custodian/cloud-custodian/blob/9322aa9e6b5a805f17ffdbbbcb6ac2c1e9517c91/tools/c7n_mailer/c7n_mailer/email_delivery.py#L236-L243

https://github.com/cloud-custodian/cloud-custodian/blob/9322aa9e6b5a805f17ffdbbbcb6ac2c1e9517c91/tools/c7n_mailer/c7n_mailer/azure_mailer/sendgrid_delivery.py#L68-L81
