### PR TITLE
Fix "invalid header value" error for Slack token

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/target.py
+++ b/tools/c7n_mailer/c7n_mailer/target.py
@@ -37,7 +37,7 @@ class MessageTargetMixin(object):
             if self.config.get("slack_token"):
                 self.config["slack_token"] = decrypt(
                     self.config, self.logger, self.session, "slack_token"
-                )
+                ).strip()
 
             slack_delivery = SlackDelivery(self.config, self.logger, email_delivery)
             slack_messages = slack_delivery.get_to_addrs_slack_messages_map(message)


### PR DESCRIPTION
I was getting this error when using an encrypted token.

```
ValueError: Invalid header value b'Bearer xoxb-1234-1234\n'
```

I created the token by following [these instructions](https://github.com/cloud-custodian/cloud-custodian/issues/8566#issuecomment-1549943392).