### PR TITLE
Update mugc.py

### DIFF
--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -25,7 +25,7 @@ log = logging.getLogger('mugc')
 def load_policies(options, config):
     policies = PolicyCollection([], config)
     for f in options.config_files:
-        policies += policy_load(config, f).filter(options.policy_filter)
+        policies += policy_load(config, f).filter(options.policy_filters)
     return policies
 
 
@@ -163,8 +163,8 @@ def setup_parser():
     parser.add_argument(
         "--policy-regex",
         help="The policy must match the regex")
-    parser.add_argument("-p", "--policies", default=None, dest='policy_filter',
-                        help="Only use named/matched policies")
+    parser.add_argument("-p", "--policies", default=[], dest='policy_filters',
+                        action='append', help="Only use named/matched policies")
     parser.add_argument(
         "--assume", default=None, dest="assume_role",
         help="Role to assume")


### PR DESCRIPTION
--policies argument in mugc.py is passing a string instead of a list.

Results:
% python3 ../tools/ops/mugc.py policies.yaml --policies "s3-cross-account" --policies "ec2-require-non-public-and-encrypted-volumes" --policies "tag-compliance"
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "t" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "a" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "g" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "-" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "c" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "o" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "m" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "p" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "l" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "i" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "a" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "n" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "c" did not match any policies.
2023-06-22 10:37:29,177: c7n.policies:WARNING Policy pattern "e" did not match any policies.


