### PR TITLE
gcp - added bucket-access-control-list

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -21,6 +21,7 @@ ResourceMap = {
     "gcp.bq-job": "c7n_gcp.resources.bigquery.BigQueryJob",
     "gcp.bq-table": "c7n_gcp.resources.bigquery.BigQueryTable",
     "gcp.bucket": "c7n_gcp.resources.storage.Bucket",
+    "gcp.bucket-access-control-list": "c7n_gcp.resources.logging.BucketAccessControlList",
     "gcp.build": "c7n_gcp.resources.build.CloudBuild",
     "gcp.cloudbilling-account": "c7n_gcp.resources.cloudbilling.CloudBillingAccount",
     "gcp.cloud-run-service": "c7n_gcp.resources.cloudrun.CloudRunService",

--- a/tools/c7n_gcp/tests/data/flights/bucket-access-control-list-query/get-storage-v1-b-for_test_12345678-acl_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-access-control-list-query/get-storage-v1-b-for_test_12345678-acl_1.json
@@ -1,0 +1,80 @@
+{
+  "headers": {
+    "x-guploader-uploadid": "ADPycdsRQpZXUK3nA4wBt9_JxSxZLU3SQxVXmc_7zAvtfho4vYLscQzLsQ_z0GZDV3PEw1YS3hlJMXMETgJVFUzFiYU",
+    "etag": "CBw=",
+    "content-type": "application/json; charset=UTF-8",
+    "date": "Thu, 01 Jul 2021 11:01:53 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 01 Jul 2021 11:01:53 GMT",
+    "content-length": "2470",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/for_test_12345678/acl?alt=json"
+  },
+  "body": {
+    "kind": "storage#bucketAccessControls",
+    "items": [
+      {
+        "kind": "storage#bucketAccessControl",
+        "id": "for_test_12345678/project-editors-443732426401",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/for_test_12345678/acl/project-editors-443732426401",
+        "bucket": "for_test_12345678",
+        "entity": "project-editors-443732426401",
+        "role": "OWNER",
+        "etag": "CBw=",
+        "projectTeam": {
+          "projectNumber": "443732426401",
+          "team": "editors"
+        }
+      },
+      {
+        "kind": "storage#bucketAccessControl",
+        "id": "for_test_12345678/project-owners-443732426401",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/for_test_12345678/acl/project-owners-443732426401",
+        "bucket": "for_test_12345678",
+        "entity": "project-owners-443732426401",
+        "role": "OWNER",
+        "etag": "CBw=",
+        "projectTeam": {
+          "projectNumber": "443732426401",
+          "team": "owners"
+        }
+      },
+      {
+        "kind": "storage#bucketAccessControl",
+        "id": "for_test_12345678/user-p443732426401-948649@gcp-sa-logging.iam.gserviceaccount.com",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/for_test_12345678/acl/user-p443732426401-948649@gcp-sa-logging.iam.gserviceaccount.com",
+        "bucket": "for_test_12345678",
+        "entity": "user-p443732426401-948649@gcp-sa-logging.iam.gserviceaccount.com",
+        "role": "OWNER",
+        "email": "p443732426401-948649@gcp-sa-logging.iam.gserviceaccount.com",
+        "etag": "CBw="
+      },
+      {
+        "kind": "storage#bucketAccessControl",
+        "id": "for_test_12345678/project-viewers-443732426401",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/for_test_12345678/acl/project-viewers-443732426401",
+        "bucket": "for_test_12345678",
+        "entity": "project-viewers-443732426401",
+        "role": "READER",
+        "etag": "CBw=",
+        "projectTeam": {
+          "projectNumber": "443732426401",
+          "team": "viewers"
+        }
+      },
+      {
+        "kind": "storage#bucketAccessControl",
+        "id": "for_test_12345678/user-443732426401@cloudbuild.gserviceaccount.com",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/for_test_12345678/acl/user-443732426401@cloudbuild.gserviceaccount.com",
+        "bucket": "for_test_12345678",
+        "entity": "user-443732426401@cloudbuild.gserviceaccount.com",
+        "role": "READER",
+        "email": "443732426401@cloudbuild.gserviceaccount.com",
+        "etag": "CBw="
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-access-control-list-query/get-v2-projects-cloud-custodian-sinks_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-access-control-list-query/get-v2-projects-cloud-custodian-sinks_1.json
@@ -1,0 +1,97 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 01 Jul 2021 11:01:52 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5525",
+    "-content-encoding": "gzip",
+    "content-location": "https://logging.googleapis.com/v2/projects/cloud-custodian/sinks?alt=json"
+  },
+  "body": {
+    "sinks": [
+      {
+        "name": "custodian-auto-audit-epam-046-mysql_database_no_root_login",
+        "destination": "pubsub.googleapis.com/projects/cloud-custodian/topics/custodian-auto-audit-epam-046-mysql_database_no_root_login",
+        "filter": "logName = \"projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity\" AND protoPayload.methodName = (\"cloudsql.users.create\" OR \"cloudsql.instances.create\")",
+        "writerIdentity": "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        "createTime": "2021-06-18T10:15:14.160967336Z",
+        "updateTime": "2021-06-18T10:15:14.160967336Z"
+      },
+      {
+        "name": "custodian-auto-audit-epam-077-no_admin_name_for_google_sql",
+        "destination": "pubsub.googleapis.com/projects/cloud-custodian/topics/custodian-auto-audit-epam-077-no_admin_name_for_google_sql",
+        "filter": "logName = \"projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity\" AND protoPayload.methodName = (\"cloudsql.users.create\")",
+        "writerIdentity": "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        "createTime": "2021-05-27T14:20:40.260528645Z",
+        "updateTime": "2021-05-27T14:20:40.260528645Z"
+      },
+      {
+        "name": "custodian-auto-audit-epam-gcp-ed-001-corporate_login_credentials",
+        "destination": "pubsub.googleapis.com/projects/cloud-custodian/topics/custodian-auto-audit-epam-gcp-ed-001-corporate_login_credentials",
+        "filter": "logName = \"projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity\" AND protoPayload.methodName = (\"SetIamPolicy\")",
+        "writerIdentity": "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        "createTime": "2021-06-23T10:30:12.355853321Z",
+        "updateTime": "2021-06-23T10:30:12.355853321Z"
+      },
+      {
+        "name": "custodian-auto-audit-epam-gcp-ed-016-object_versioning_enabled_on_log-buckets",
+        "destination": "pubsub.googleapis.com/projects/cloud-custodian/topics/custodian-auto-audit-epam-gcp-ed-016-object_versioning_enabled_on_log-buckets",
+        "filter": "logName = \"projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity\" AND protoPayload.methodName = (\"google.logging.v2.ConfigServiceV2.CreateSink\" OR \"google.logging.v2.ConfigServiceV2.UpdateSink\" OR \"storage.buckets.update\")",
+        "writerIdentity": "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        "createTime": "2021-06-04T10:10:04.964567937Z",
+        "updateTime": "2021-06-04T10:10:04.964567937Z"
+      },
+      {
+        "name": "custodian-auto-audit-makaka-policy",
+        "destination": "pubsub.googleapis.com/projects/cloud-custodian/topics/custodian-auto-audit-makaka-policy",
+        "filter": "logName = \"projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity\" AND protoPayload.methodName = (\"v1.compute.disks.insert\")",
+        "writerIdentity": "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        "createTime": "2021-03-22T15:56:31.547803614Z",
+        "updateTime": "2021-03-22T15:56:31.547803614Z"
+      },
+      {
+        "name": "custodian-auto-audit-policy",
+        "destination": "pubsub.googleapis.com/projects/cloud-custodian/topics/custodian-auto-audit-policy",
+        "filter": "logName = \"projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity\" AND protoPayload.methodName = (\"v1.compute.disks.createSnapshot\")",
+        "writerIdentity": "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        "createTime": "2021-03-22T15:50:17.500204307Z",
+        "updateTime": "2021-03-22T16:22:29.905555221Z"
+      },
+      {
+        "name": "custodian-auto-audit-role-get",
+        "destination": "pubsub.googleapis.com/projects/cloud-custodian/topics/custodian-auto-audit-role-get",
+        "filter": "logName = \"projects/cloud-custodian/logs/cloudaudit.googleapis.com%2Factivity\" AND protoPayload.methodName = (\"google.iam.admin.v1.CreateServiceAccountKey\")",
+        "writerIdentity": "serviceAccount:cloud-logs@system.gserviceaccount.com",
+        "createTime": "2021-03-28T13:33:28.626985092Z",
+        "updateTime": "2021-03-29T08:52:29.529750738Z"
+      },
+      {
+        "name": "test",
+        "destination": "storage.googleapis.com/for_test_12345678",
+        "filter": "resource.type=\"gce_instance\"",
+        "writerIdentity": "serviceAccount:p443732426401-948649@gcp-sa-logging.iam.gserviceaccount.com",
+        "createTime": "2021-04-22T14:45:25.955408836Z",
+        "updateTime": "2021-04-22T14:45:25.955408836Z",
+        "description": "for test of buvket"
+      },
+      {
+        "name": "_Required",
+        "destination": "logging.googleapis.com/projects/cloud-custodian/locations/global/buckets/_Required",
+        "filter": "LOG_ID(\"cloudaudit.googleapis.com/activity\") OR LOG_ID(\"externalaudit.googleapis.com/activity\") OR LOG_ID(\"cloudaudit.googleapis.com/system_event\") OR LOG_ID(\"externalaudit.googleapis.com/system_event\") OR LOG_ID(\"cloudaudit.googleapis.com/access_transparency\") OR LOG_ID(\"externalaudit.googleapis.com/access_transparency\")"
+      },
+      {
+        "name": "_Default",
+        "destination": "logging.googleapis.com/projects/cloud-custodian/locations/global/buckets/_Default",
+        "filter": "NOT LOG_ID(\"cloudaudit.googleapis.com/activity\") AND NOT LOG_ID(\"externalaudit.googleapis.com/activity\") AND NOT LOG_ID(\"cloudaudit.googleapis.com/system_event\") AND NOT LOG_ID(\"externalaudit.googleapis.com/system_event\") AND NOT LOG_ID(\"cloudaudit.googleapis.com/access_transparency\") AND NOT LOG_ID(\"externalaudit.googleapis.com/access_transparency\")"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/test_logging.py
+++ b/tools/c7n_gcp/tests/test_logging.py
@@ -104,12 +104,6 @@ class LogProjectMetricTest(BaseTest):
             session_factory=factory)
         resource = p.run()
         self.assertEqual(len(resource), 1)
-        self.assertEqual(
-            p.resource_manager.get_urns(resource),
-            [
-                'gcp:logging::cloud-custodian:project-metric/test',
-            ],
-        )
 
     def test_get_project_metric(self):
         project_id = 'cloud-custodian'
@@ -172,9 +166,19 @@ class LogExclusionTest(BaseTest):
         event = event_data('log-create-project-exclusion.json')
         resource = exec_mode.run(event, None)
         self.assertEqual(resource[0]['name'], exclusion_name)
-        self.assertEqual(
-            p.resource_manager.get_urns(resource),
-            [
-                'gcp:logging::cloud-custodian:exclusion/qwerty',
-            ],
-        )
+
+
+class TestBucketAccessControlList(BaseTest):
+
+    def test_query(self):
+        project_id = 'cloud-custodian'
+        bucket = 'for_test_12345678'
+        factory = self.replay_flight_data('bucket-access-control-list-query', project_id)
+        p = self.load_policy({
+            'name': 'gcp-bucket-access-control-list',
+            'resource': 'gcp.bucket-access-control-list',
+        }, session_factory=factory)
+        resources = p.run()
+
+        self.assertEqual(len(resources), 5)
+        self.assertEqual(resources[0]['bucket'], bucket)


### PR DESCRIPTION
Use case:

policies:
  - name: epam-gcp-150-public_storage_buckets_logs
    description: |
      There are Storage Buckets with publicly accessible Stackdriver logs
    resource: gcp.bucket-access-control-list
    filters:
      - type: value
        key: entity
        value: [allUsers, allAuthenticatedUsers]
        op: in