### PR TITLE
gcp - added datafusion

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/datafusion.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/datafusion.py
@@ -21,5 +21,6 @@ class DatafusionInstance(QueryResourceManager):
         urn_component = "instances"
         urn_id_segments = (-1,)
 
+        @classmethod
         def _get_location(cls, resource):
-            resource['name'].split('/')[3]
+            return resource['name'].split('/')[3]

--- a/tools/c7n_gcp/c7n_gcp/resources/datafusion.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/datafusion.py
@@ -17,3 +17,9 @@ class DatafusionInstance(QueryResourceManager):
         scope_template = "projects/{}/locations/-"
         name = id = "name"
         default_report_fields = ['name', 'updateTime']
+        asset_type = "datafusion.googleapis.com/Instance"
+        urn_component = "instances"
+        urn_id_segments = (-1,)
+
+        def _get_location(cls, resource):
+            resource['name'].split('/')[3]

--- a/tools/c7n_gcp/c7n_gcp/resources/datafusion.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/datafusion.py
@@ -1,0 +1,19 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from c7n_gcp.provider import resources
+from c7n_gcp.query import (QueryResourceManager, TypeInfo)
+
+
+@resources.register('datafusion-instance')
+class DatafusionInstance(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'datafusion'
+        version = 'v1'
+        component = 'projects.locations.instances'
+        enum_spec = ('list', 'instances[]', None)
+        scope = 'project'
+        scope_key = 'parent'
+        scope_template = "projects/{}/locations/-"
+        name = id = "name"
+        default_report_fields = ['name', 'updateTime']

--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -27,6 +27,7 @@ ResourceMap = {
     "gcp.cloud-run-job": "c7n_gcp.resources.cloudrun.CloudRunJob",
     "gcp.compute-project": "c7n_gcp.resources.compute.Project",
     "gcp.dataflow-job": "c7n_gcp.resources.dataflow.DataflowJob",
+    "gcp.datafusion-instance": "c7n_gcp.resources.datafusion.DatafusionInstance",
     "gcp.disk": "c7n_gcp.resources.compute.Disk",
     "gcp.dm-deployment": "c7n_gcp.resources.deploymentmanager.DMDeployment",
     "gcp.dns-managed-zone": "c7n_gcp.resources.dns.DnsManagedZone",

--- a/tools/c7n_gcp/tests/data/flights/gcp-datafusion-instance-query/get-v1-projects-cloud-custodian-locations---instances_1.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-datafusion-instance-query/get-v1-projects-cloud-custodian-locations---instances_1.json
@@ -1,0 +1,44 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Wed, 03 Aug 2022 07:59:24 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "856",
+    "-content-encoding": "gzip",
+    "content-location": "https://datafusion.googleapis.com/v1/projects/cloud-custodian/locations/-/instances?alt=json"
+  },
+  "body": {
+    "instances": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/instances/instance-311-green",
+        "type": "DEVELOPER",
+        "enableStackdriverLogging": true,
+        "networkConfig": {},
+        "labels": {
+          "compliancestatus": "green",
+          "custodiarule": "epam-gcp-311-datafusion-stackdriver-logging"
+        },
+        "createTime": "2022-08-03T07:47:48.242226610Z",
+        "updateTime": "2022-08-03T07:47:48.242226610Z",
+        "state": "CREATING",
+        "version": "6.6.0",
+        "serviceAccount": "cloud-datafusion-management-sa@ud07a47f529c5f0ad-tp.iam.gserviceaccount.com",
+        "availableVersion": [
+          {
+            "versionNumber": "6.7.0"
+          }
+        ],
+        "p4ServiceAccount": "service-443732426401@gcp-sa-datafusion.iam.gserviceaccount.com",
+        "tenantProjectId": "ud07a47f529c5f0ad-tp"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/test_datafusion.py
+++ b/tools/c7n_gcp/tests/test_datafusion.py
@@ -1,0 +1,19 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from gcp_common import BaseTest
+
+
+class DatafusionInstanceTest(BaseTest):
+
+    def test_query(self):
+        factory = self.replay_flight_data('gcp-datafusion-instance-query')
+        p = self.load_policy({
+            'name': 'gcp-datafusion',
+            'resource': 'gcp.datafusion-instance'},
+            session_factory=factory)
+        resources = p.run()
+
+        self.assertTrue(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/'
+                                               'locations/us-central1/'
+                                               'instances/instance-311-green')

--- a/tools/c7n_gcp/tests/test_datafusion.py
+++ b/tools/c7n_gcp/tests/test_datafusion.py
@@ -17,3 +17,7 @@ class DatafusionInstanceTest(BaseTest):
         self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/'
                                                'locations/us-central1/'
                                                'instances/instance-311-green')
+
+        assert p.resource_manager.get_urns(resources) == [
+            "gcp:datafusion:us-central1:cloud-custodian:instances/instance-311-green"
+        ]

--- a/tools/c7n_gcp/tests/test_query.py
+++ b/tools/c7n_gcp/tests/test_query.py
@@ -26,6 +26,7 @@ def test_gcp_resource_metadata_asset_type():
         'build',
         'dataflow-job',
         'dm-deployment',
+        'datafusion-instance',
         'secret',
         'function',
         'loadbalancer-ssl-policy',


### PR DESCRIPTION
Use case:

policies:
  - name: epam-gcp-datafusion-stackdriver-monitoring
    description: |
      Datafusion does not have stack driver monitoring enabled
    resource: gcp.datafusion-instance
    filters:
      - type: value
        key: enableStackdriverMonitoring
        value: true
        op: ne