### PR TITLE
gcp - added notebook instance

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/notebook.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/notebook.py
@@ -1,0 +1,37 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from c7n_gcp.provider import resources
+from c7n_gcp.query import QueryResourceManager, TypeInfo
+
+
+@resources.register('notebook-instance')
+class NotebookInstance(QueryResourceManager):
+    """ GC resource: https://cloud.google.com/vertex-ai/docs/workbench/reference/rest
+
+    GCP Vertex AI Workbench has public IPs.
+
+    :example: GCP Vertex AI Workbench has public IPs
+
+    .. yaml:
+
+     policies:
+      - name: epam-gcp-304-vertex-ai-workbench-does-not-have-public-ips
+        description: |
+          GCP Vertex AI Workbench has public IPs
+        resource: gcp.notebook-instance
+        filters:
+          - type: value
+            key: noPublicIp
+            op: ne
+            value: true
+    """
+    class resource_type(TypeInfo):
+        service = 'notebooks'
+        version = 'v1'
+        component = 'projects.locations.instances'
+        enum_spec = ('list', 'instances[]', None)
+        scope_key = 'parent'
+        name = id = 'id'
+        scope_template = "projects/{}/locations/-"
+        permissions = ('notebooks.instances.list',)
+        default_report_fields = ['displayName', 'expireTime']

--- a/tools/c7n_gcp/c7n_gcp/resources/notebook.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/notebook.py
@@ -15,7 +15,7 @@ class NotebookInstance(QueryResourceManager):
     .. yaml:
 
      policies:
-      - name: epam-gcp-304-vertex-ai-workbench-does-not-have-public-ips
+      - name: epam-gcp-vertex-ai-workbench-does-not-have-public-ips
         description: |
           GCP Vertex AI Workbench has public IPs
         resource: gcp.notebook-instance

--- a/tools/c7n_gcp/c7n_gcp/resources/notebook.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/notebook.py
@@ -4,7 +4,7 @@ from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo
 
 
-@resources.register('notebook-instance')
+@resources.register('notebook')
 class NotebookInstance(QueryResourceManager):
     """ GC resource: https://cloud.google.com/vertex-ai/docs/workbench/reference/rest
 
@@ -15,14 +15,13 @@ class NotebookInstance(QueryResourceManager):
     .. yaml:
 
      policies:
-      - name: epam-gcp-vertex-ai-workbench-does-not-have-public-ips
+      - name: gcp-vertex-ai-workbench-with-public-ips
         description: |
           GCP Vertex AI Workbench has public IPs
-        resource: gcp.notebook-instance
+        resource: gcp.notebook
         filters:
           - type: value
             key: noPublicIp
-            op: ne
             value: true
     """
     class resource_type(TypeInfo):
@@ -31,7 +30,13 @@ class NotebookInstance(QueryResourceManager):
         component = 'projects.locations.instances'
         enum_spec = ('list', 'instances[]', None)
         scope_key = 'parent'
-        name = id = 'id'
+        name = id = 'name'
         scope_template = "projects/{}/locations/-"
         permissions = ('notebooks.instances.list',)
-        default_report_fields = ['displayName', 'expireTime']
+        default_report_fields = ['name', 'createTime', 'state']
+        urn_id_segments = (-1,)
+        urn_component = "instances"
+
+        @classmethod
+        def _get_location(cls, resource):
+            return resource['name'].split('/')[3]

--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -81,6 +81,7 @@ ResourceMap = {
     "gcp.log-project-sink": "c7n_gcp.resources.logging.LogProjectSink",
     "gcp.ml-job": "c7n_gcp.resources.mlengine.MLJob",
     "gcp.ml-model": "c7n_gcp.resources.mlengine.MLModel",
+    "gcp.notebook-instance": "c7n_gcp.resources.notebook.NotebookInstance",
     "gcp.organization": "c7n_gcp.resources.resourcemanager.Organization",
     "gcp.project": "c7n_gcp.resources.resourcemanager.Project",
     "gcp.project-role": "c7n_gcp.resources.iam.ProjectRole",

--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -81,7 +81,7 @@ ResourceMap = {
     "gcp.log-project-sink": "c7n_gcp.resources.logging.LogProjectSink",
     "gcp.ml-job": "c7n_gcp.resources.mlengine.MLJob",
     "gcp.ml-model": "c7n_gcp.resources.mlengine.MLModel",
-    "gcp.notebook-instance": "c7n_gcp.resources.notebook.NotebookInstance",
+    "gcp.notebook": "c7n_gcp.resources.notebook.NotebookInstance",
     "gcp.organization": "c7n_gcp.resources.resourcemanager.Organization",
     "gcp.project": "c7n_gcp.resources.resourcemanager.Project",
     "gcp.project-role": "c7n_gcp.resources.iam.ProjectRole",

--- a/tools/c7n_gcp/tests/data/flights/test_notebook_instance_list_query/get-v1-projects-cloud-custodian-locations---instances_1.json
+++ b/tools/c7n_gcp/tests/data/flights/test_notebook_instance_list_query/get-v1-projects-cloud-custodian-locations---instances_1.json
@@ -1,0 +1,95 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 14 Jul 2022 07:55:19 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "3231",
+    "-content-encoding": "gzip",
+    "content-location": "https://notebooks.googleapis.com/v1/projects/cloud-custodian/locations/-/instances?alt=json"
+  },
+  "body": {
+    "instances": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1-a/instances/instancetest",
+        "proxyUri": "283ed5736dc76283-dot-us-central1.notebooks.googleusercontent.com",
+        "serviceAccount": "443732426401-compute@developer.gserviceaccount.com",
+        "machineType": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/machineTypes/n1-standard-1",
+        "state": "ACTIVE",
+        "network": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/networks/default",
+        "subnet": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/subnetworks/default",
+        "labels": {
+          "goog-caip-notebook": ""
+        },
+        "metadata": {
+          "proxy-mode": "service_account",
+          "shutdown-script": "/opt/deeplearning/bin/shutdown_script.sh",
+          "enable-guest-attributes": "TRUE",
+          "version": "94",
+          "restriction": "",
+          "report-system-health": "true",
+          "framework": "NumPy/SciPy/scikit-learn",
+          "proxy-url": "283ed5736dc76283-dot-us-central1.notebooks.googleusercontent.com",
+          "title": "Base.CPU",
+          "notebooks-api": "PROD"
+        },
+        "createTime": "2022-07-14T07:54:28.028128572Z",
+        "updateTime": "2022-07-14T07:55:16.886988097Z",
+        "disks": [
+          {
+            "autoDelete": true,
+            "boot": true,
+            "deviceName": "boot",
+            "diskSizeGb": "100",
+            "guestOsFeatures": [
+              {
+                "type": "VIRTIO_SCSI_MULTIQUEUE"
+              },
+              {
+                "type": "UEFI_COMPATIBLE"
+              },
+              {
+                "type": "GVNIC"
+              }
+            ],
+            "interface": "SCSI",
+            "kind": "compute#attachedDisk",
+            "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/licenses/c2d-tensorflow",
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/licenses/c2d-dl-platform-gvnic",
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/licenses/c2d-dl-platform-cpu-common",
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/licenses/c2d-dl-platform-debian-10",
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/licenses/c2d-dl-platform-notebooks"
+            ],
+            "mode": "READ_WRITE",
+            "source": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/disks/instancetest-boot",
+            "type": "PERSISTENT"
+          },
+          {
+            "autoDelete": true,
+            "deviceName": "data",
+            "diskSizeGb": "100",
+            "index": "1",
+            "interface": "SCSI",
+            "kind": "compute#attachedDisk",
+            "mode": "READ_WRITE",
+            "source": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/disks/instancetest-data",
+            "type": "PERSISTENT"
+          }
+        ],
+        "shieldedInstanceConfig": {
+          "enableVtpm": true,
+          "enableIntegrityMonitoring": true
+        },
+        "creator": "gcp.lab.cust1@epmcseclab.com"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/test_notebook.py
+++ b/tools/c7n_gcp/tests/test_notebook.py
@@ -1,0 +1,20 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from gcp_common import BaseTest
+
+
+class NotebookInstanceTest(BaseTest):
+
+    def test_notebook_instance_query(self):
+        project_id = 'gcp-lab-custodian'
+        factory = self.replay_flight_data('test_notebook_instance_list_query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'notebook-instance-query',
+             'resource': 'gcp.notebook-instance'},
+            session_factory=factory)
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/'
+                                               'locations/us-central1-a/instances/instancetest')

--- a/tools/c7n_gcp/tests/test_notebook.py
+++ b/tools/c7n_gcp/tests/test_notebook.py
@@ -11,10 +11,13 @@ class NotebookInstanceTest(BaseTest):
                                           project_id=project_id)
         p = self.load_policy(
             {'name': 'notebook-instance-query',
-             'resource': 'gcp.notebook-instance'},
+             'resource': 'gcp.notebook'},
             session_factory=factory)
         resources = p.run()
 
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/'
                                                'locations/us-central1-a/instances/instancetest')
+        assert p.resource_manager.get_urns(resources) == [
+            "gcp:notebooks:us-central1-a:gcp-lab-custodian:instances/instancetest"
+        ]

--- a/tools/c7n_gcp/tests/test_query.py
+++ b/tools/c7n_gcp/tests/test_query.py
@@ -33,6 +33,7 @@ def test_gcp_resource_metadata_asset_type():
         'log-exclusion',
         'ml-job',
         'ml-model',
+        'notebook-instance',
         'sourcerepo',
         'sql-backup-run',
         'sql-ssl-cert',

--- a/tools/c7n_gcp/tests/test_query.py
+++ b/tools/c7n_gcp/tests/test_query.py
@@ -33,7 +33,7 @@ def test_gcp_resource_metadata_asset_type():
         'log-exclusion',
         'ml-job',
         'ml-model',
-        'notebook-instance',
+        'notebook',
         'sourcerepo',
         'sql-backup-run',
         'sql-ssl-cert',


### PR DESCRIPTION
Use case

`
policies:
  - name: epam-gcp-vertex-ai-workbench-does-not-have-public-ips
    description: |
      GCP Vertex AI Workbench has public IPs
    resource: gcp.notebook-instance
    filters:
      - type: value
        key: noPublicIp
        op: ne
        value: true
`