### PR TITLE
Update ebs.py

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1204,11 +1204,7 @@ class EncryptInstanceVolumes(BaseAction):
         return False
 
     def create_encrypted_volume(self, ec2, v, key_id, instance_id):
-        # check if the ebs volume had tags to be copied over
-        if 'Tags' in v:
-            unencrypted_volume_tags = v['Tags']
-        else:
-            unencrypted_volume_tags = []
+        unencrypted_volume_tags = v.get('Tags', [])
         # Create a current snapshot
         results = ec2.create_snapshot(
             VolumeId=v['VolumeId'],

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -1204,7 +1204,11 @@ class EncryptInstanceVolumes(BaseAction):
         return False
 
     def create_encrypted_volume(self, ec2, v, key_id, instance_id):
-        unencrypted_volume_tags = v['Tags']
+        # check if the ebs volume had tags to be copied over
+        if 'Tags' in v:
+            unencrypted_volume_tags = v['Tags']
+        else:
+            unencrypted_volume_tags = []
         # Create a current snapshot
         results = ec2.create_snapshot(
             VolumeId=v['VolumeId'],


### PR DESCRIPTION
ebs.py had a bug in line 1207 that prevented the execution when a policy checked for the presence of tags and ebs volume had no tags attached. Added an if statement that checks if the v['Tags'] is not None and if it is, just passes and empty list.