### PR TITLE
aws - user-pool - include resource details from parent augment

### DIFF
--- a/c7n/resources/cognito.py
+++ b/c7n/resources/cognito.py
@@ -16,6 +16,7 @@ class DescribeIdentityPool(DescribeSource):
 
 class DescribeUserPool(DescribeSource):
     def augment(self, resources):
+        resources = super().augment(resources)
         return universal_augment(self.manager, resources)
 
 

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -15,6 +15,9 @@ class UserPool(BaseTest):
             sorted([n["Name"] for n in resources]),
             ["c7nusers", "origin_userpool_MOBILEHUB_1667653900"],
         )
+        # Confirm that our augment pass has tag information and detail
+        # from describe_user_pool
+        self.assertLessEqual({"Id", "Tags", "SchemaAttributes"}, set(resources[0]))
 
     def test_delete_user_pool(self):
         factory = self.replay_flight_data("test_cognito-user-pool_delete")


### PR DESCRIPTION
Raised [in Slack](https://cloud-custodian.slack.com/archives/CAL4P6YE6/p1687878243298939) and I believe there's an issue incoming also...

Looked like the `universal_augment` that pulls tag data was overriding rather than supplementing the parent class's augment that makes use of `detail_spec`.