### PR TITLE
aws - identity-pool - include resource details from parent augment

### DIFF
--- a/c7n/resources/cognito.py
+++ b/c7n/resources/cognito.py
@@ -11,6 +11,7 @@ from c7n.utils import local_session, type_schema
 
 class DescribeIdentityPool(DescribeSource):
     def augment(self, resources):
+        resources = super().augment(resources)
         return universal_augment(self.manager, resources)
 
 

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -51,6 +51,12 @@ class IdentityPool(BaseTest):
             sorted([n["IdentityPoolName"] for n in resources]),
             ["origin_MOBILEHUB_1667653900", "test_delete_id_pool"],
         )
+        # Confirm that our augment pass has tag information and detail
+        # from describe_identity_pool
+        self.assertLessEqual(
+            {"IdentityPoolId", "Tags", "CognitoIdentityProviders"},
+            set(resources[0])
+        )
 
     def test_delete_identity_pool(self):
         factory = self.replay_flight_data("test_cognito-identity-pool_delete")


### PR DESCRIPTION
This works together with #8684 to fix #8691, where we had tag augments overriding rather than combining with the parent class augment. We need the parent's augment because it uses `detail_spec` to fetch more resource detail.