### PR TITLE
gcp - added patch deployment

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/osconfig.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/osconfig.py
@@ -16,3 +16,4 @@ class PatchDeployment(QueryResourceManager):
         name = id = 'id'
         scope_template = 'projects/{}'
         default_report_fields = ['displayName', 'expireTime']
+        asset_type = 'osconfig.googleapis.com/PatchDeployment'

--- a/tools/c7n_gcp/c7n_gcp/resources/osconfig.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/osconfig.py
@@ -1,0 +1,18 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from c7n_gcp.provider import resources
+from c7n_gcp.query import QueryResourceManager, TypeInfo
+
+
+@resources.register('patch-deployment')
+class PatchDeployment(QueryResourceManager):
+    """ GC resource: https://cloud.google.com/compute/docs/osconfig/rest/v1/projects.patchDeployments"""
+    class resource_type(TypeInfo):
+        service = 'osconfig'
+        version = 'v1'
+        component = 'projects.patchDeployments'
+        enum_spec = ('list', 'patchDeployments[]', None)
+        scope_key = 'parent'
+        name = id = 'id'
+        scope_template = 'projects/{}'
+        default_report_fields = ['displayName', 'expireTime']

--- a/tools/c7n_gcp/c7n_gcp/resources/osconfig.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/osconfig.py
@@ -13,7 +13,12 @@ class PatchDeployment(QueryResourceManager):
         component = 'projects.patchDeployments'
         enum_spec = ('list', 'patchDeployments[]', None)
         scope_key = 'parent'
-        name = id = 'id'
+        name = id = 'name'
         scope_template = 'projects/{}'
-        default_report_fields = ['displayName', 'expireTime']
+        default_report_fields = ['name', 'description', 'createTime', 'state', 'rollout.mode']
         asset_type = 'osconfig.googleapis.com/PatchDeployment'
+        urn_component = "patchDeployment"
+        urn_id_path = "name"
+        urn_id_segments = (-1,)
+
+

--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -83,6 +83,7 @@ ResourceMap = {
     "gcp.ml-model": "c7n_gcp.resources.mlengine.MLModel",
     "gcp.notebook": "c7n_gcp.resources.notebook.NotebookInstance",
     "gcp.organization": "c7n_gcp.resources.resourcemanager.Organization",
+    "gcp.patch-deployment": "c7n_gcp.resources.osconfig.PatchDeployment",
     "gcp.project": "c7n_gcp.resources.resourcemanager.Project",
     "gcp.project-role": "c7n_gcp.resources.iam.ProjectRole",
     "gcp.pubsub-snapshot": "c7n_gcp.resources.pubsub.PubSubSnapshot",

--- a/tools/c7n_gcp/tests/data/flights/gcp-patch-deployment-query/get-v1-projects-cloud-custodian-patchDeployments_1.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-patch-deployment-query/get-v1-projects-cloud-custodian-patchDeployments_1.json
@@ -1,0 +1,60 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 04 Jul 2023 21:48:23 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "950",
+    "-content-encoding": "gzip",
+    "content-location": "https://osconfig.googleapis.com/v1/projects/cloud-custodian/patchDeployments?alt=json"
+  },
+  "body": {
+    "patchDeployments": [
+      {
+        "name": "projects/cloud-custodian/patchDeployments/test",
+        "description": "test",
+        "instanceFilter": {
+          "groupLabels": [
+            {
+              "labels": {
+                "test": ""
+              }
+            }
+          ],
+          "zones": [
+            "asia-east1-a",
+            "us-central1-c"
+          ]
+        },
+        "patchConfig": {
+          "rebootConfig": "DEFAULT",
+          "apt": {},
+          "yum": {},
+          "zypper": {},
+          "windowsUpdate": {}
+        },
+        "duration": "3600s",
+        "oneTimeSchedule": {
+          "executeTime": "2023-07-27T21:00:00Z"
+        },
+        "createTime": "2023-07-04T21:48:09.221518Z",
+        "updateTime": "2023-07-04T21:48:09.221518Z",
+        "rollout": {
+          "mode": "ZONE_BY_ZONE",
+          "disruptionBudget": {
+            "percent": 25
+          }
+        },
+        "state": "ACTIVE"
+      }
+    ],
+    "nextPageToken": "ChVwcm9qZWN0cy80NDM3MzI0MjY0MDESBHRlc3Q="
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/gcp-patch-deployment-query/get-v1-projects-cloud-custodian-patchDeployments_2.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-patch-deployment-query/get-v1-projects-cloud-custodian-patchDeployments_2.json
@@ -1,0 +1,19 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 04 Jul 2023 21:48:23 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "3",
+    "-content-encoding": "gzip",
+    "content-location": "https://osconfig.googleapis.com/v1/projects/cloud-custodian/patchDeployments?alt=json&pageToken=ChVwcm9qZWN0cy80NDM3MzI0MjY0MDESBHRlc3Q%3D"
+  },
+  "body": {}
+}

--- a/tools/c7n_gcp/tests/test_osconfig.py
+++ b/tools/c7n_gcp/tests/test_osconfig.py
@@ -1,0 +1,17 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from gcp_common import BaseTest
+
+
+class PatchDeploymentTest(BaseTest):
+
+    def test_query(self):
+        factory = self.replay_flight_data('gcp-patch-deployment-query')
+        p = self.load_policy({
+            'name': 'gcp-patch-deployment',
+            'resource': 'gcp.patch-deployment'},
+            session_factory=factory)
+        resources = p.run()
+
+        self.assertTrue(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/patchDeployments/test')

--- a/tools/c7n_gcp/tests/test_osconfig.py
+++ b/tools/c7n_gcp/tests/test_osconfig.py
@@ -15,3 +15,8 @@ class PatchDeploymentTest(BaseTest):
 
         self.assertTrue(len(resources), 1)
         self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/patchDeployments/test')
+
+        assert p.resource_manager.get_urns(resources) == [
+            "gcp:osconfig::cloud-custodian:patchDeployment/test"
+        ]
+

--- a/tools/c7n_gcp/tests/test_query.py
+++ b/tools/c7n_gcp/tests/test_query.py
@@ -34,6 +34,7 @@ def test_gcp_resource_metadata_asset_type():
         'ml-job',
         'ml-model',
         'notebook',
+        'patch-deployment',
         'sourcerepo',
         'sql-backup-run',
         'sql-ssl-cert',


### PR DESCRIPTION
Use case:

`policies:
  - name: os-patch-deployment-configured-with-recurring-schedule
    description: |
      OS Patch Deployment is not configured with a recurring schedule
    resource: gcp.patch-deployment
    filters:
      - type: value
        key: recurringSchedule
        value: absent`