### PR TITLE
Skip ResourceInUseException when ELB has dependency

### DIFF
--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -713,6 +713,8 @@ class AppELBDeleteAction(BaseAction):
                 client.delete_load_balancer, LoadBalancerArn=alb['LoadBalancerArn'])
         except client.exceptions.LoadBalancerNotFoundException:
             pass
+        except client.exceptions.ResourceInUseException:
+            pass
         except client.exceptions.OperationNotPermittedException as e:
             self.log.warning(
                 "Exception trying to delete ALB: %s error: %s",

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -713,11 +713,12 @@ class AppELBDeleteAction(BaseAction):
                 client.delete_load_balancer, LoadBalancerArn=alb['LoadBalancerArn'])
         except client.exceptions.LoadBalancerNotFoundException:
             pass
-        except client.exceptions.ResourceInUseException:
-            pass
-        except client.exceptions.OperationNotPermittedException as e:
+        except (
+            client.exceptions.OperationNotPermittedException,
+            client.exceptions.ResourceInUseException
+        ) as e:
             self.log.warning(
-                "Exception trying to delete ALB: %s error: %s",
+                "Exception trying to delete load balancer: %s error: %s",
                 alb['LoadBalancerArn'], e)
 
 


### PR DESCRIPTION
Skip ResourceInUseException when ELB has dependency and can't be deleted. Allow c7n to skip this resource and deal with other resources.

Users need to deal with the dependency issue follow this article:
https://repost.aws/knowledge-center/elb-fix-nlb-associated-with-service