### PR TITLE
aws - rds - delete - handle  InvalidParameterValue exception

### DIFF
--- a/c7n/element.py
+++ b/c7n/element.py
@@ -50,7 +50,7 @@ class Element:
             self.log.warning(
                 "%s implicitly filtered %d of %d resources key:%s on %s",
                 self.type, len(results), resource_count, key_expr,
-                (', '.join(allowed_values)))
+                (', '.join(map(str, allowed_values))))
         return results
 
     def get_deprecations(self):

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -590,6 +590,11 @@ class Delete(BaseAction):
             except ClientError as e:
                 if e.response['Error']['Code'] == "InvalidDBInstanceState":
                     continue
+                if e.response['Error']['Code'] == "InvalidParameterValue":
+                    self.log.warning(
+                        "Delete failed, DBInstance %s has invalid parameter value",
+                        db['DBInstanceIdentifier'])
+                    continue
                 raise
 
         return dbs


### PR DESCRIPTION
When deleting DBInstances, I meet the following error:
An error occurred (InvalidParameterValue) when calling the DeleteDBInstance operation: Deleting cluster instances isn't supported for DB engine postgres.

This error means we can't delete such DBInstance. We need to handle this kind of exception and continue to do delete action for the rest of resources.