### PR TITLE
Small fix for empty recommender results

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/filters/recommender.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/recommender.py
@@ -100,7 +100,8 @@ class RecommenderFilter(Filter):
                 f"projects/{project}/locations/{r}/recommenders/{self.rec_info['id']}"
             )
             for page in client.execute_paged_query("list", {"parent": parent}):
-                recommends.extend(page['recommendations'])
+                if (len(page) > 0):
+                    recommends.extend(page['recommendations'])
         return recommends
 
     def match_resources(self, recommends, resources):

--- a/tools/c7n_gcp/c7n_gcp/filters/recommender.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/recommender.py
@@ -100,8 +100,7 @@ class RecommenderFilter(Filter):
                 f"projects/{project}/locations/{r}/recommenders/{self.rec_info['id']}"
             )
             for page in client.execute_paged_query("list", {"parent": parent}):
-                if (len(page) > 0):
-                    recommends.extend(page['recommendations'])
+                recommends.extend(page.get('recommendations', []))
         return recommends
 
     def match_resources(self, recommends, resources):


### PR DESCRIPTION
If the Recommender API returns a blank/empty result, custodian fails with `KeyError: 'recommendations'` for the policy.  This will allow the policy to continue if there are no recommender results. 