### PR TITLE
releng - docs build sans aws cli install

### DIFF
--- a/.github/composites/docs-publish/action.yaml
+++ b/.github/composites/docs-publish/action.yaml
@@ -18,11 +18,6 @@ runs:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}
 
-    - name: Install Deps
-      shell: bash
-      run: |
-        pip install -U awscli
-
     - name: Publish
       shell: bash
       run: |


### PR DESCRIPTION

aws cli install via pip is currently broken due to dependency stack pyyaml < 6 is running afoul of cython3 if a wheel isn't present
as source compilation is broken.


