### PR TITLE
Allow config-rule to support Periodic mode

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -1723,10 +1723,10 @@ class ConfigRule(AWSEventBase):
             params['Scope']['ComplianceResourceTypes'] = self.data.get(
                 'resource-types', ())
         if self.data.get('schedule'):
-            params['Source']['SourceDetails'] = [{
+            params['Source']['SourceDetails'].append({
                 'EventSource': 'aws.config',
                 'MessageType': 'ScheduledNotification'
-            }]
+            })
             params['MaximumExecutionFrequency'] = self.data['schedule']
         return params
 

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -964,7 +964,14 @@ class ConfigRuleMode(LambdaMode):
     See `AWS Config <https://aws.amazon.com/config/>`_ for more details.
     """
     cfg_event = None
-    schema = utils.type_schema('config-rule', rinherit=LambdaMode.schema)
+    schema = utils.type_schema('config-rule',
+                               schedule={'enum': [
+                                   "One_Hour",
+                                   "Three_Hours",
+                                   "Six_Hours",
+                                   "Twelve_Hours",
+                                   "TwentyFour_Hours"]},
+                               rinherit=LambdaMode.schema)
 
     def validate(self):
         super(ConfigRuleMode, self).validate()


### PR DESCRIPTION
We should allow the config-rule execution mode to support both 'Configuration Change' and 'Periodic' trigger modes.   The reasons are as follows: 1. This is supported by AWS. 2. Using only the 'Configuration Change' trigger mode may miss resource evaluations due to various reasons, and we need a compensatory mechanism.