### PR TITLE
aws - flow-log filter & action - refactor for kinesis/parquet support

### DIFF
--- a/c7n/cache.py
+++ b/c7n/cache.py
@@ -129,10 +129,11 @@ class SqlKvCache(Cache):
         self.conn = sqlite3.connect(self.cache_path)
         self.conn.execute(self.create_table)
         with self.conn as cursor:
-            log.debug('expiring stale cache entries')
-            cursor.execute(
+            result = cursor.execute(
                 'delete from c7n_cache where create_date < ?',
                 [datetime.utcnow() - timedelta(minutes=self.cache_period)])
+            if result.rowcount:
+                log.debug('expired %d stale cache entries', result.rowcount)
 
     def load(self):
         if not self.conn:

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -1144,6 +1144,14 @@ class ListItemFilter(Filter):
         self._expr = jmespath_compile(self.data['key'])
         return self._expr
 
+    def check_count(self, rcount):
+        if 'count' not in self.data:
+            return False
+        count = self.data['count']
+        op = OPERATORS[self.data.get('count_op', 'eq')]
+        if op(rcount, count):
+            return True
+
     def process(self, resources, event=None):
         result = []
         frm = ListItemResourceManager(
@@ -1151,6 +1159,8 @@ class ListItemFilter(Filter):
         for r in resources:
             list_values = self.get_item_values(r)
             if not list_values:
+                if self.check_count(0):
+                    result.append(r)
                 continue
             if not isinstance(list_values, list):
                 item_type = type(list_values)
@@ -1163,10 +1173,8 @@ class ListItemFilter(Filter):
             matched_indicies = [r['c7n:_id'] for r in list_resources]
             for idx, list_value in enumerate(list_values):
                 list_value.pop('c7n:_id')
-            if self.data.get('count'):
-                count = self.data['count']
-                op = OPERATORS[self.data.get('count_op', 'eq')]
-                if op(len(list_resources), count):
+            if 'count' in self.data:
+                if self.check_count(len(list_resources)):
                     result.append(r)
             elif list_resources:
                 if not self.annotate_items:

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -85,6 +85,7 @@ ResourceMap = {
     "aws.event-bus": "c7n.resources.cw.EventBus",
     "aws.event-rule": "c7n.resources.cw.EventRule",
     "aws.event-rule-target": "c7n.resources.cw.EventRuleTarget",
+    "aws.flow-log": "c7n.resources.vpc.FlowLog",
     "aws.firewall": "c7n.resources.firewall.NetworkFirewall",
     "aws.firehose": "c7n.resources.kinesis.DeliveryStream",
     "aws.fis-template": "c7n.resources.fis.ExperimentTemplate",

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -64,7 +64,7 @@ class FlowLog(query.QueryResourceManager):
         id_prefix = 'fl-'
 
     source_mapping = {
-        'describe': 'DescribeFlow',
+        'describe': DescribeFlow,
         'config': query.ConfigSource
     }
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -220,6 +220,7 @@ class FlowLogv2Filter(ListItemFilter):
         return super().validate()
 
     def convert(self):
+        self.source_data = {}
         # no mixing of legacy and list-item style
         if 'attrs' in self.data:
             return

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -518,7 +518,6 @@ class PolicyMetaLint(BaseTest):
             'AWS::Detective::Graph',
             'AWS::DMS::Certificate',
             'AWS::EC2::EgressOnlyInternetGateway',
-            'AWS::EC2::FlowLog',
             'AWS::EC2::LaunchTemplate',
             'AWS::EC2::RegisteredHAInstance',
             'AWS::EC2::TransitGatewayAttachment',

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -212,7 +212,6 @@ class VpcTest(BaseTest):
         factory = self.replay_flight_data("test_vpc_flow_logs_misconfigured")
 
         vpc_id1 = "vpc-4a9ff72e"
-
         traffic_type = "all"
         log_group = "/aws/lambda/myIOTFunction"
         status = "active"
@@ -228,7 +227,7 @@ class VpcTest(BaseTest):
                                 "type": "flow-logs",
                                 "enabled": True,
                                 "op": "equal",
-                                "set-op": "or",
+                                "set-op": "and",
                                 "status": status,
                                 "traffic-type": traffic_type,
                                 "log-group": log_group,
@@ -241,7 +240,7 @@ class VpcTest(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]["VpcId"], vpc_id1)
+        self.assertEqual(resources[0]['VpcId'], vpc_id1)
 
     def test_eni_vpc_filter(self):
         self.session_factory = self.replay_flight_data("test_eni_vpc_filter")

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -227,7 +227,7 @@ class VpcTest(BaseTest):
                                 "type": "flow-logs",
                                 "enabled": True,
                                 "op": "equal",
-                                "set-op": "and",
+                                "set-op": "or",
                                 "status": status,
                                 "traffic-type": traffic_type,
                                 "log-group": log_group,

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -3288,42 +3288,6 @@ class FlowLogsTest(BaseTest):
         self.assertEqual(resources[0]['c7n:flow-logs'][0]['LogDestination'],
                          'arn:aws:s3:::c7n-vpc-flow-logs')
 
-    def test_vpc_set_flow_logs_validation(self):
-        with self.assertRaises(PolicyValidationError) as e:
-            self.load_policy({
-                'name': 'flow-set-validate-1',
-                'resource': 'vpc',
-                'actions': [{
-                    'type': 'set-flow-log',
-                    'LogDestination': 'arn:aws:s3:::c7n-vpc-flow-logs/test/'
-                }]})
-        self.assertIn(
-            "DeliverLogsPermissionArn missing", str(e.exception))
-        with self.assertRaises(PolicyValidationError) as e:
-            self.load_policy({
-                'name': 'flow-set-validate-2',
-                'resource': 'vpc',
-                'actions': [{
-                    'type': 'set-flow-log',
-                    'DeliverLogsPermissionArn': 'arn:aws:iam',
-                    'LogGroupName': '/cloudwatch/logs',
-                    'LogDestination': 'arn:aws:s3:::c7n-vpc-flow-logs/test/'
-                }]})
-        self.assertIn("Exactly one of", str(e.exception))
-        with self.assertRaises(PolicyValidationError) as e:
-            self.load_policy({
-                'name': 'flow-set-validate-3',
-                'resource': 'vpc',
-                'actions': [{
-                    'type': 'set-flow-log',
-                    'LogDestinationType': 's3',
-                    'DeliverLogsPermissionArn': 'arn:aws:iam',
-                    'LogDestination': 'arn:aws:s3:::c7n-vpc-flow-logs/test/'
-                }]})
-        self.assertIn(
-            "DeliverLogsPermissionArn is prohibited for destination-type:s3",
-            str(e.exception))
-
     def test_vpc_set_flow_logs_s3(self):
         session_factory = self.replay_flight_data("test_vpc_set_flow_logs_s3")
         p = self.load_policy(

--- a/tools/ops/logsetup.py
+++ b/tools/ops/logsetup.py
@@ -86,7 +86,7 @@ def main():
     try:
         manager.publish(func)
     except Exception:
-        import traceback, pdb, sys
+        import traceback, pdb
         traceback.print_exc()
         pdb.post_mortem(sys.exc_info()[-1])
 


### PR DESCRIPTION
refactor flow log support on filter/action to have better pass through on
attributes. flow logs have grown capabilities over the years, which don't
match up to the original filter/action implementation, rather then having
a translation layer, use a pass through. additionally list item filter,
allows for most of the use cases on the filter side w/o translation.

at the moment this is structured as a `-v2` suffixed filter/action, tbd
if we can maintain compatiblity on the original action schema.

[update] was able to implement with full compatibility, so dropped the v2 suffixes.

closes #8723
