### PR TITLE
tools/ops - logsetup - remove double sys import

### DIFF
--- a/tools/ops/logsetup.py
+++ b/tools/ops/logsetup.py
@@ -86,7 +86,7 @@ def main():
     try:
         manager.publish(func)
     except Exception:
-        import traceback, pdb, sys
+        import traceback, pdb
         traceback.print_exc()
         pdb.post_mortem(sys.exc_info()[-1])
 


### PR DESCRIPTION
Ruff started throwing `F823 Local variable 'sys' referenced before assignment` in `tools/ops/logsetup.py` because we import sys twice. That _feels_ like an unintentional change but it's also a fair callout, so we may as well remove that second import.