### PR TITLE
aws - asg rename-tag - don't propagate tags when there are no instances

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1404,15 +1404,15 @@ class RenameTag(Action):
              'Key': destination_tag,
              'Value': source['Value']}])
         if propagate and asg['Instances']:
-            self.propagate_instance_tag(source, destination_tag, asg['Instances'])
+            self.propagate_instance_tag(source, destination_tag, asg)
 
-    def propagate_instance_tag(self, source, destination_tag, instances):
+    def propagate_instance_tag(self, source, destination_tag, asg):
         client = local_session(self.manager.session_factory).client('ec2')
         client.delete_tags(
-            Resources=instances,
+            Resources=[i['InstanceId'] for i in asg['Instances']],
             Tags=[{"Key": source['Key']}])
         client.create_tags(
-            Resources=instances,
+            Resources=[i['InstanceId'] for i in asg['Instances']],
             Tags=[{'Key': destination_tag, 'Value': source['Value']}])
 
 


### PR DESCRIPTION
Only try to propagate tags during `rename-tag` if there instances to tag. This avoids a `MissingParameter` error when propagating tags for an asg with no active instances.

Closes #8761