### PR TITLE
oci - report generation support for Bucket resource

### DIFF
--- a/tools/c7n_oci/c7n_oci/resources/object_storage.py
+++ b/tools/c7n_oci/c7n_oci/resources/object_storage.py
@@ -40,8 +40,7 @@ class Bucket(QueryResourceManager):
         enum_spec = ("list_buckets", "items[]", {"fields": ["tags"]})
         extra_params = {"compartment_id", "namespace_name"}
         resource_type = "OCI.ObjectStorage/Bucket"
-        id = "id"
-        name = "name"
+        id = name = "name"
         search_resource_type = "bucket"
 
     def _get_extra_params(self):


### PR DESCRIPTION
Mapped the id metadata field to name attribute of the bucket resource - Fix for the customer issue - closes  https://github.com/cloud-custodian/cloud-custodian/issues/8756