### PR TITLE
c7n-left - support --var-file parameter, update tfparse

### DIFF
--- a/tools/c7n_left/README.md
+++ b/tools/c7n_left/README.md
@@ -38,7 +38,6 @@ cosign verify $IMAGE \
 
 ```shell
 ❯ c7n-left run --help
-
 Usage: c7n-left run [OPTIONS]
 
   evaluate policies against IaC sources.
@@ -49,13 +48,16 @@ Usage: c7n-left run [OPTIONS]
 
 Options:
   --format TEXT
-  --filters TEXT                  filter policies or resources as k=v pairs
+  --filters TEXT                  Filter policies or resources as k=v pairs
                                   with globbing
-  -p, --policy-dir PATH
-  -d, --directory PATH
-  -o, --output [cli|github|json]
-  --output-file FILENAME
-  --output-query TEXT
+  -p, --policy-dir PATH           Directory with policies
+  -d, --directory PATH            IaC directory to evaluate
+  -o, --output [cli|github|json]  Output format (default cli)
+  --output-file FILENAME          Output file (default stdout)
+  --var-file FILE                 Load variables from the given file, can be
+                                  used more than once
+  --output-query TEXT             Use a jmespath expression to filter json
+                                  output
   --summary [policy|resource]
   --help                          Show this message and exit.
 ```

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -35,7 +35,9 @@ def cli():
 @click.option("--var-file", type=click.File("w"), default="-")
 @click.option("--output-query", default=None)
 @click.option("--summary", default="policy", type=click.Choice(summary_options.keys()))
-def run(format, policy_dir, directory, output, output_file, var_file, output_query, summary, filters):
+def run(
+    format, policy_dir, directory, output, output_file, var_file, output_query, summary, filters
+):
     """evaluate policies against IaC sources.
 
     c7n-left -p policy_dir -d terraform_root --filters "severity=HIGH"
@@ -77,7 +79,7 @@ def test(policy_dir, filters):
         policy_dir=policy_dir,
         output_file=sys.stdout,
         filters=filters,
-        var_file=None
+        var_file=None,
     )
 
     reporter = TestReporter(None, config)

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -50,11 +50,12 @@ def run(
         policy_dir=Path(policy_dir),
         output=output,
         output_file=output_file,
-        var_file=var_file,
+        var_files=var_file,
         output_query=output_query,
         summary=summary,
         filters=filters,
     )
+
     exec_filter = ExecutionFilter.parse(config)
     config["exec_filter"] = exec_filter
     policies = exec_filter.filter_policies(load_policies(policy_dir, config))
@@ -79,7 +80,7 @@ def test(policy_dir, filters):
         policy_dir=policy_dir,
         output_file=sys.stdout,
         filters=filters,
-        var_file=(),
+        var_files=(),
     )
 
     reporter = TestReporter(None, config)

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -32,9 +32,10 @@ def cli():
 @click.option("-d", "--directory", type=click.Path())
 @click.option("-o", "--output", default="cli", type=click.Choice(report_outputs.keys()))
 @click.option("--output-file", type=click.File("w"), default="-")
+@click.option("--var-file", type=click.File("w"), default="-")
 @click.option("--output-query", default=None)
 @click.option("--summary", default="policy", type=click.Choice(summary_options.keys()))
-def run(format, policy_dir, directory, output, output_file, output_query, summary, filters):
+def run(format, policy_dir, directory, output, output_file, var_file, output_query, summary, filters):
     """evaluate policies against IaC sources.
 
     c7n-left -p policy_dir -d terraform_root --filters "severity=HIGH"
@@ -47,6 +48,7 @@ def run(format, policy_dir, directory, output, output_file, output_query, summar
         policy_dir=Path(policy_dir),
         output=output,
         output_file=output_file,
+        var_file=var_file,
         output_query=output_query,
         summary=summary,
         filters=filters,
@@ -75,6 +77,7 @@ def test(policy_dir, filters):
         policy_dir=policy_dir,
         output_file=sys.stdout,
         filters=filters,
+        var_file=None
     )
 
     reporter = TestReporter(None, config)

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -32,7 +32,7 @@ def cli():
 @click.option("-d", "--directory", type=click.Path())
 @click.option("-o", "--output", default="cli", type=click.Choice(report_outputs.keys()))
 @click.option("--output-file", type=click.File("w"), default="-")
-@click.option("--var-file", type=click.Path(), default=None)
+@click.option("--var-file", type=click.Path(), default=(), multiple=True)
 @click.option("--output-query", default=None)
 @click.option("--summary", default="policy", type=click.Choice(summary_options.keys()))
 def run(
@@ -79,7 +79,7 @@ def test(policy_dir, filters):
         policy_dir=policy_dir,
         output_file=sys.stdout,
         filters=filters,
-        var_file=None,
+        var_file=(),
     )
 
     reporter = TestReporter(None, config)

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -27,13 +27,29 @@ def cli():
 
 @cli.command()
 @click.option("--format", default="terraform")
-@click.option("--filters", help="filter policies or resources as k=v pairs with globbing")
-@click.option("-p", "--policy-dir", type=click.Path())
-@click.option("-d", "--directory", type=click.Path())
-@click.option("-o", "--output", default="cli", type=click.Choice(report_outputs.keys()))
-@click.option("--output-file", type=click.File("w"), default="-")
-@click.option("--var-file", type=click.Path(exists=True, dir_okay=False), default=(), multiple=True)
-@click.option("--output-query", default=None)
+@click.option("--filters", help="Filter policies or resources as k=v pairs with globbing")
+@click.option("-p", "--policy-dir", type=click.Path(), help="Directory with policies")
+@click.option("-d", "--directory", type=click.Path(), help="IaC directory to evaluate")
+@click.option(
+    "-o",
+    "--output",
+    default="cli",
+    help="Output format (default cli)",
+    type=click.Choice(report_outputs.keys()),
+)
+@click.option(
+    "--output-file", help="Output file (default stdout)", type=click.File("w"), default="-"
+)
+@click.option(
+    "--var-file",
+    help="Load variables from the given file, can be used more than once",
+    type=click.Path(exists=True, dir_okay=False),
+    default=(),
+    multiple=True,
+)
+@click.option(
+    "--output-query", default=None, help="Use a jmespath expression to filter json output"
+)
 @click.option("--summary", default="policy", type=click.Choice(summary_options.keys()))
 def run(
     format, policy_dir, directory, output, output_file, var_file, output_query, summary, filters

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -32,7 +32,7 @@ def cli():
 @click.option("-d", "--directory", type=click.Path())
 @click.option("-o", "--output", default="cli", type=click.Choice(report_outputs.keys()))
 @click.option("--output-file", type=click.File("w"), default="-")
-@click.option("--var-file", type=click.Path(), default=(), multiple=True)
+@click.option("--var-file", type=click.Path(exists=True, dir_okay=False), default=(), multiple=True)
 @click.option("--output-query", default=None)
 @click.option("--summary", default="policy", type=click.Choice(summary_options.keys()))
 def run(

--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -32,7 +32,7 @@ def cli():
 @click.option("-d", "--directory", type=click.Path())
 @click.option("-o", "--output", default="cli", type=click.Choice(report_outputs.keys()))
 @click.option("--output-file", type=click.File("w"), default="-")
-@click.option("--var-file", type=click.File("w"), default="-")
+@click.option("--var-file", type=click.Path(), default=None)
 @click.option("--output-query", default=None)
 @click.option("--summary", default="policy", type=click.Choice(summary_options.keys()))
 def run(

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -215,7 +215,7 @@ class CollectionRunner:
             log.warning("no %s source files found" % provider.type)
             return True
 
-        graph = provider.parse(self.options.source_dir)
+        graph = provider.parse(self.options.source_dir, self.options.var_file)
 
         for p in self.policies:
             p.expand_variables(p.get_variables())

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -215,7 +215,7 @@ class CollectionRunner:
             log.warning("no %s source files found" % provider.type)
             return True
 
-        graph = provider.parse(self.options.source_dir, self.options.var_file)
+        graph = provider.parse(self.options.source_dir, self.options.var_files)
 
         for p in self.policies:
             p.expand_variables(p.get_variables())

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -42,9 +42,9 @@ class TerraformProvider(IACSourceProvider):
             p.data["mode"] = {"type": "terraform-source"}
         return policies
 
-    def parse(self, source_dir, var_file=()):
+    def parse(self, source_dir, var_files=()):
         graph = TerraformGraph(
-            load_from_path(source_dir, vars_paths=var_file, allow_downloads=True), source_dir
+            load_from_path(source_dir, vars_paths=var_files, allow_downloads=True), source_dir
         )
         graph.build()
         log.debug("Loaded %d %s resources", len(graph), self.type)

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -42,8 +42,8 @@ class TerraformProvider(IACSourceProvider):
             p.data["mode"] = {"type": "terraform-source"}
         return policies
 
-    def parse(self, source_dir, var_file=None):
-        print(var_file)
+    def parse(self, source_dir, var_file=""):
+        var_file = var_file or ""
         graph = TerraformGraph(
             load_from_path(source_dir, vars_path=var_file, allow_downloads=True), source_dir
         )

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -42,7 +42,7 @@ class TerraformProvider(IACSourceProvider):
             p.data["mode"] = {"type": "terraform-source"}
         return policies
 
-    def parse(self, source_dir):
+    def parse(self, source_dir, var_file=None):
         graph = TerraformGraph(load_from_path(source_dir, allow_downloads=True), source_dir)
         graph.build()
         log.debug("Loaded %d %s resources", len(graph), self.type)

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -42,10 +42,9 @@ class TerraformProvider(IACSourceProvider):
             p.data["mode"] = {"type": "terraform-source"}
         return policies
 
-    def parse(self, source_dir, var_file=""):
-        var_file = var_file or ""
+    def parse(self, source_dir, var_file=()):
         graph = TerraformGraph(
-            load_from_path(source_dir, vars_path=var_file, allow_downloads=True), source_dir
+            load_from_path(source_dir, vars_paths=var_file, allow_downloads=True), source_dir
         )
         graph.build()
         log.debug("Loaded %d %s resources", len(graph), self.type)

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -1,6 +1,9 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #
+import contextlib
+from pathlib import Path
+import tempfile
 
 from tfparse import load_from_path
 
@@ -43,17 +46,74 @@ class TerraformProvider(IACSourceProvider):
         return policies
 
     def parse(self, source_dir, var_files=()):
-        graph = TerraformGraph(
-            load_from_path(source_dir, vars_paths=var_files, allow_downloads=True), source_dir
-        )
-        graph.build()
-        log.debug("Loaded %d %s resources", len(graph), self.type)
-        return graph
+        with self.get_variables(source_dir, var_files) as var_files:
+            graph = TerraformGraph(
+                load_from_path(source_dir, vars_paths=var_files, allow_downloads=True),
+                source_dir,
+            )
+            graph.build()
+            log.debug("Loaded %d %s resources", len(graph), self.type)
+            return graph
 
     def match_dir(self, source_dir):
         files = list(source_dir.glob("*.tf"))
         files += list(source_dir.glob("*.tf.json"))
         return files
+
+    @contextlib.contextmanager
+    def get_variables(self, source_dir, var_files, tf_vars=()):
+        """handle all the ways to pass variables into terraform
+
+        also perform various workarounds on tfparse's scanning to mirror terraform behavior.
+
+        - pickup tf var files not in the root module
+        - pickup auto.tfvars
+
+        note TF_VAR_ environment variables are handled by tfparse.
+        
+        https://developer.hashicorp.com/terraform/language/values/variables#assigning-values-to-root-module-variables
+        precedence
+        https://www.ntweekly.com/2023/03/15/terraform-variables-precedence-and-order/
+        """
+        var_files = [Path(v) for v in var_files]
+        resolved_files = []
+        temp_files = []
+
+        def write_file_content(content):
+            fh = tempfile.NamedTemporaryFile(
+                dir=source_dir, prefix="c7n-left-", suffix=".tfvars", mode="w+"
+            )
+            fh.write(content)
+            fh.flush()
+            temp_files.append(fh)
+            resolved_files.append(Path(fh.name).relative_to(source_dir))
+
+        # auto vars
+        resolved_files.extend([f.relative_to(source_dir) for f in source_dir.rglob("*auto.tfvars")])
+        resolved_files.extend(
+            [f.relative_to(source_dir) for f in source_dir.rglob("*auto.tfvars.json")]
+        )
+
+        # see tf doc link above, these are also auto loaded.
+        if (source_dir / "terraform.tfvars").exists():
+            resolved_files.append(Path("terraform.tfvars"))
+        if (source_dir / "terraform.tfvars.json").exists():
+            resolved_files.append(Path("terraform.tfvars.json"))
+
+        # move any files outside of module root into module as temp files.
+        for v in var_files:
+            if not v.is_absolute() and (source_dir / v).exists():
+                resolved_files.append(v)
+            elif v.is_absolute() and str(v).startswith(str(source_dir)):
+                resolved_files.append(v.relative_to(source_dir))
+            else:
+                write_file_content(v.read_text())
+
+        try:
+            yield resolved_files
+        finally:
+            for fh in temp_files:
+                fh.close()
 
 
 @execution.register("terraform-source")

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -43,7 +43,10 @@ class TerraformProvider(IACSourceProvider):
         return policies
 
     def parse(self, source_dir, var_file=None):
-        graph = TerraformGraph(load_from_path(source_dir, allow_downloads=True), source_dir)
+        print(var_file)
+        graph = TerraformGraph(
+            load_from_path(source_dir, vars_path=var_file, allow_downloads=True), source_dir
+        )
         graph.build()
         log.debug("Loaded %d %s resources", len(graph), self.type)
         return graph

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -70,7 +70,7 @@ class TerraformProvider(IACSourceProvider):
         - pickup auto.tfvars
 
         note TF_VAR_ environment variables are handled by tfparse.
-        
+
         https://developer.hashicorp.com/terraform/language/values/variables#assigning-values-to-root-module-variables
         precedence
         https://www.ntweekly.com/2023/03/15/terraform-variables-precedence-and-order/

--- a/tools/c7n_left/poetry.lock
+++ b/tools/c7n_left/poetry.lock
@@ -776,19 +776,19 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "tfparse"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python HCL/Terraform parser via extension for AquaSecurity defsec"
 optional = false
 python-versions = "*"
 files = [
-    {file = "tfparse-0.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b38f9942bfd84a939dbc8ed9ca455bce8877cebe352dd55b10053aa577fc26d4"},
-    {file = "tfparse-0.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:754ba5bd7a7c7aa75ca9653a3de39c580f7fcf195f7912a26337d2fc9edd96f8"},
-    {file = "tfparse-0.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b46875dc7da35ae2e086343bf573a599e45224f10cbc409dfac422e2c2e2c71d"},
-    {file = "tfparse-0.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80a4f93f95457887a30cab180dc5c0aa3144f29bd1933ea31313c74c8f8b6891"},
-    {file = "tfparse-0.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ca8b92e064739fb9fcbd026bed0cba0150338792dafc49081b1a84596c55d4cb"},
-    {file = "tfparse-0.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f80025ba6b7202f98f4d3f799766b1daa400bc68a7e512f6e66077561ca4fb95"},
-    {file = "tfparse-0.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5ef0a5c1bb5f0bae6e2be4d0715e5a3e62488bc55479c12c2b314b6a0c4f231"},
-    {file = "tfparse-0.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84ae6e466c20190ce8b5ee6198504f247b0ea881f5564bbd9704830fc91f5081"},
+    {file = "tfparse-0.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d0ecf85f9ee0dfc7e5a486c92ac804572aace21180c2f3ffdda53c8664a557cc"},
+    {file = "tfparse-0.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d51eacf2a9437b56bb7ef2914f0f78b0038746de6554cc1ce86abc2c9f4f514f"},
+    {file = "tfparse-0.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1546a1cb5442c9102e276a053da86ff03939a496c49a16f5b4800a6970fca89"},
+    {file = "tfparse-0.6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e300b455a1c66e0ad49dadea5f5a75062d9c34c39a1bfcfcdc20d6fabff488f"},
+    {file = "tfparse-0.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0bc299d86cfc81c2a20eb8cd6f4561859228f7f63de9eea8b4f7904f9f25df40"},
+    {file = "tfparse-0.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9a2ce20d93bd0748b2ba7369c30eeb23dede11a30c2a9ae942fb2f1c5656611a"},
+    {file = "tfparse-0.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76334344523f0fb55198818986c56d81b8ca3cbff623108d3c723b69f56b446a"},
+    {file = "tfparse-0.6.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad4cb44a84e6a4627d72f03a2e1b928ea0134f257d3eada0381071c0743009fd"},
 ]
 
 [package.dependencies]
@@ -850,4 +850,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "22bbd794bf690f985e89663759956a0eb6cd7ae3384c4b0ea3112f8595cf46cb"
+content-hash = "bbff8cad6b896221352b5775e6e69644df77dd67772c7c694d44c9aba3b8619e"

--- a/tools/c7n_left/poetry.lock
+++ b/tools/c7n_left/poetry.lock
@@ -776,19 +776,19 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "tfparse"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python HCL/Terraform parser via extension for AquaSecurity defsec"
 optional = false
 python-versions = "*"
 files = [
-    {file = "tfparse-0.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d0ecf85f9ee0dfc7e5a486c92ac804572aace21180c2f3ffdda53c8664a557cc"},
-    {file = "tfparse-0.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d51eacf2a9437b56bb7ef2914f0f78b0038746de6554cc1ce86abc2c9f4f514f"},
-    {file = "tfparse-0.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1546a1cb5442c9102e276a053da86ff03939a496c49a16f5b4800a6970fca89"},
-    {file = "tfparse-0.6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e300b455a1c66e0ad49dadea5f5a75062d9c34c39a1bfcfcdc20d6fabff488f"},
-    {file = "tfparse-0.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0bc299d86cfc81c2a20eb8cd6f4561859228f7f63de9eea8b4f7904f9f25df40"},
-    {file = "tfparse-0.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9a2ce20d93bd0748b2ba7369c30eeb23dede11a30c2a9ae942fb2f1c5656611a"},
-    {file = "tfparse-0.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76334344523f0fb55198818986c56d81b8ca3cbff623108d3c723b69f56b446a"},
-    {file = "tfparse-0.6.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad4cb44a84e6a4627d72f03a2e1b928ea0134f257d3eada0381071c0743009fd"},
+    {file = "tfparse-0.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9c2a78ba942732570919b97d2535dbe8aded0cd3c399b5ec34a7975203846fce"},
+    {file = "tfparse-0.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7b289de7db814fde9b07050b0ae80f17f4470847878eb92da6360086460b2dcb"},
+    {file = "tfparse-0.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:877d3ef95bb7cbc7ddfced7addd85d6acd326a72cab45157993772bead179600"},
+    {file = "tfparse-0.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6750ae9b64f93e3423a24092cb38608420b7ef8169da5d843e73a03bdb795b1b"},
+    {file = "tfparse-0.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:df1ce46f45d97b8b5207687b008d51defd467424b9a613b5dda93db3433c8534"},
+    {file = "tfparse-0.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:87317b6e786ae3ea2ef6e5ab982f925ae38cd3c84c259378ad127c3b113e2d78"},
+    {file = "tfparse-0.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:330041600327e20ea9678a20491a2ae935a5dfb30501cfc6114f89fef1dd1e32"},
+    {file = "tfparse-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9026d3c7c03d6ea9744b563bc51254ebe12ad16103b7101c88a521fffb77a7d"},
 ]
 
 [package.dependencies]

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -23,7 +23,7 @@ c7n = {path = "../..", develop = true}
 
 click = ">=8.0"
 rich = "^13.1"
-tfparse = "^0.5"
+tfparse = "^0.6"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/tools/c7n_left/tests/conftest.py
+++ b/tools/c7n_left/tests/conftest.py
@@ -1,4 +1,8 @@
+import contextlib
+import io
+
 import pytest
+from click.testing import CliRunner
 
 from c7n.testing import PyTestUtils
 
@@ -7,3 +11,20 @@ from c7n.testing import PyTestUtils
 def test(request):
     test_utils = PyTestUtils(request)
     return test_utils
+
+
+class DebugCliRunner(CliRunner):
+    def invoke(self, cli, args=None, **kwargs):
+        params = kwargs.copy()
+        params['catch_exceptions'] = False
+        return super().invoke(cli, args=args, **params)
+
+    @contextlib.contextmanager
+    def isolation(self, input=None, env=None, color=False):
+        s = io.BytesIO(b"{stdout not captured because --pdb-trace}")
+        yield (s, not self.mix_stderr and s)
+
+
+@pytest.fixture
+def debug_cli_runner():
+    return DebugCliRunner()

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -50,7 +50,7 @@ class ResultsReporter:
 def run_policy(policy, terraform_dir, tmp_path):
     (tmp_path / "policies.json").write_text(json.dumps({"policies": [policy]}, indent=2))
     config = Config.empty(
-        policy_dir=tmp_path, source_dir=terraform_dir, exec_filter=None, var_file=""
+        policy_dir=tmp_path, source_dir=terraform_dir, exec_filter=None, var_file=()
     )
     policies = utils.load_policies(tmp_path, config)
     reporter = ResultsReporter()
@@ -296,7 +296,7 @@ resource "aws_alb" "positive1" {
         )
     )
 
-    graph = TerraformProvider().parse(tmp_path / "tf", "vars.tf")
+    graph = TerraformProvider().parse(tmp_path / "tf", ("vars.tf",))
     resources = list(graph.get_resources_by_type("aws_alb"))
     assert resources[0][1][0]['load_balancer_type'] == 'network'
 

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -259,9 +259,9 @@ def test_provider_parse():
     }
 
 
-def test_var_file_flag_cli(tmp_path):
+def test_var_file(tmp_path):
     (tmp_path / "tf").mkdir()
-    (tmp_path / "vars.tf").write_text(
+    (tmp_path / "tf" / "vars.tf").write_text(
         """
         balancer_type = "network"
         """
@@ -296,27 +296,9 @@ resource "aws_alb" "positive1" {
         )
     )
 
-    # graph = TerraformProvider().parse(tmp_path / "tf", tmp_path / "vars.tf")
-    runner = CliRunner()
-    result = runner.invoke(
-        cli.cli,
-        [
-            "run",
-            "-p",
-            str(tmp_path),
-            "-d",
-            str(tmp_path / "tf"),
-            "--var-file",
-            str(tmp_path / "vars.tf"),
-            "-o",
-            "json",
-            "--output-file",
-            str(tmp_path / "output.json"),
-        ],
-    )
-    assert result.exit_code == 1
-    data = json.loads((tmp_path / "output.json").read_text())
-    assert len(data["results"]) == 1
+    graph = TerraformProvider().parse(tmp_path / "tf", "vars.tf")
+    resources = list(graph.get_resources_by_type("aws_alb"))
+    assert resources[0][1][0]['load_balancer_type'] == 'network'
 
 
 def test_multi_resource_list_policy(tmp_path):

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -49,7 +49,8 @@ class ResultsReporter:
 
 def run_policy(policy, terraform_dir, tmp_path):
     (tmp_path / "policies.json").write_text(json.dumps({"policies": [policy]}, indent=2))
-    config = Config.empty(policy_dir=tmp_path, source_dir=terraform_dir, exec_filter=None)
+    config = Config.empty(
+        policy_dir=tmp_path, source_dir=terraform_dir, exec_filter=None, var_file="")
     policies = utils.load_policies(tmp_path, config)
     reporter = ResultsReporter()
     core.CollectionRunner(policies, config, reporter).run()


### PR DESCRIPTION
support passing --var-file when evaluating terraform.

closes #8210

one behavior oddity, I'm noticing with defsec, it treats the vars file path as relative to the terraform module root. I think we would want to have it resolved separately and out of that directory.

[update] that oddity should be resolved by https://github.com/cloud-custodian/tfparse/pull/135

we'll need a new release of tfparse to pick that up.

[update 2] its still an issue, going to file as a separate ticket rather than block this.