### PR TITLE
resolver - support decompression when using value_from with s3

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -60,7 +60,9 @@ class URIResolver:
         client = self.session_factory().client('s3', region_name=region)
         result = client.get_object(**params)
         body = result['Body'].read()
-        if isinstance(body, str):
+        if params['Key'].endswith(('.gz', '.zip', '.gzip')):
+            return zlib.decompress(body, ZIP_OR_GZIP_HEADER_DETECT).decode('utf-8')
+        elif isinstance(body, str):
             return body
         else:
             return body.decode('utf-8')

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -60,7 +60,7 @@ class URIResolver:
         client = self.session_factory().client('s3', region_name=region)
         result = client.get_object(**params)
         body = result['Body'].read()
-        if params['Key'].endswith(('.gz', '.zip', '.gzip')):
+        if params['Key'].lower().endswith(('.gz', '.zip', '.gzip')):
             return zlib.decompress(body, ZIP_OR_GZIP_HEADER_DETECT).decode('utf-8')
         elif isinstance(body, str):
             return body


### PR DESCRIPTION
Add support for value decompression with `value_from` parameter of a filter when the `url` is an S3 URI that ends with .gz, .zip, or .gzip

This feature bridges the gap between Custodian output to S3 which is gzip compressed by default where the `value_from` doesn't support gzip decompression.

`value_from` already supports decompression for non-s3 URLs. This change handles decompression for S3 URLs as well.

The following policy will be valid after this change:

```yaml
policies:
  - name: list-in-use-images-master
    resource: ami
    filters:
      - type: value
        key: "ImageId"
        op: not-in
        value_from:
          format: json
          expr: "[].ImageId"
          url: s3://custodian-integrations/reports/<aws-account>/us-east-2/list-in-use-images/2023/08/18/19/resources.json.gz
```