### PR TITLE
releng - handle chainguard image change re no version

### DIFF
--- a/docker/c7n-left
+++ b/docker/c7n-left
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:3.11-dev as builder
+FROM cgr.dev/chainguard/python:latest-dev as builder
 
 ARG POETRY_VERSION="1.4.0"
 
@@ -23,7 +23,7 @@ RUN python -m venv "${HOME}/venv" && \
     . "${HOME}/venv/bin/activate" && \
     ~/tools/bin/poetry install --no-dev
 
-FROM cgr.dev/chainguard/python:3.11
+FROM cgr.dev/chainguard/python:latest
 
 LABEL name="c7n-left" \
       repository="http://github.com/cloud-custodian/cloud-custodian"


### PR DESCRIPTION


docker image builds are currently broken due to chain guard image changes where they no longer publish major version tags only
latest.

this addresses #8704 but does not sustainably solve for things (ie breakage when 3.12 comes out), 
moving to ubuntu in #8795 would solve permanently, but leaves us with a bit of cve footprint, so still requires some thinking.





