### PR TITLE
Fix bug destinationPortRange test

### DIFF
--- a/tools/c7n_azure/c7n_azure/utils.py
+++ b/tools/c7n_azure/c7n_azure/utils.py
@@ -308,7 +308,7 @@ class PortsRangeHelper:
             Returns an array of PortsRange tuples
         """
         properties = rule['properties']
-        if 'destinationPortRange' in properties:
+        if 'destinationPortRange' in properties and properties['destinationPortRange']:
             return [PortsRangeHelper._get_port_range(properties['destinationPortRange'])]
         else:
             return [PortsRangeHelper._get_port_range(r)

--- a/tools/c7n_azure/tests_azure/test_azure_utils.py
+++ b/tools/c7n_azure/tests_azure/test_azure_utils.py
@@ -116,6 +116,8 @@ class UtilsTest(BaseTest):
         self.assertEqual(PortsRangeHelper.get_ports_set_from_rule(rule), {10, 11, 12})
         rule = {'properties': {'destinationPortRanges': ['80', '10-12']}}
         self.assertEqual(PortsRangeHelper.get_ports_set_from_rule(rule), {10, 11, 12, 80})
+        rule = {'properties': {'destinationPortRange': '','destinationPortRanges': ['80', '10-12']}}
+        self.assertEqual(PortsRangeHelper.get_ports_set_from_rule(rule), {10, 11, 12, 80})
 
     def test_validate_ports_string(self):
         self.assertEqual(PortsRangeHelper.validate_ports_string('80'), True)


### PR DESCRIPTION
destinationPortRange field is always present in the actual result set. 
The if statement needs to be is it empty, then use destinationPortRanges. I left the 'destinationPortRange in properties' just so the utils test wouldn't fail.