### PR TITLE
Az blob upload fix fixes #8885

### DIFF
--- a/tools/c7n_azure/c7n_azure/storage_utils.py
+++ b/tools/c7n_azure/c7n_azure/storage_utils.py
@@ -13,7 +13,8 @@ class OldBlobServiceClient(BlobServiceClient):
 
     def create_blob_from_path(self, container_name, blob_name, content):
         client = self.get_blob_client(container_name, blob_name)
-        client.upload_blob(content, overwrite=True)
+        with open(path, "rb") as data:
+            client.upload_blob(data, overwrite=True)
 
     def get_blob_to_bytes(self, container_name, blob_name):
         client = self.get_blob_client(container_name, blob_name)

--- a/tools/c7n_azure/c7n_azure/storage_utils.py
+++ b/tools/c7n_azure/c7n_azure/storage_utils.py
@@ -11,7 +11,7 @@ from azure.storage.queue import QueueClient
 
 class OldBlobServiceClient(BlobServiceClient):
 
-    def create_blob_from_path(self, container_name, blob_name, content):
+    def create_blob_from_path(self, container_name, blob_name, path):
         client = self.get_blob_client(container_name, blob_name)
         with open(path, "rb") as data:
             client.upload_blob(data, overwrite=True)


### PR DESCRIPTION
create_blob_from_path() doesn't actually upload the file contents to blob storage, it just uploads the path itself _as_ the content. This PR modifies the function to actually read the source file as content for the blob upload.


closes #8885