### PR TITLE
aws - rds - delete | filter out resources associated with a cluster

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -565,8 +565,7 @@ class Delete(BaseAction):
     def process(self, dbs):
         skip = self.data.get('skip-snapshot', False)
         # Can't delete an instance in an aurora cluster, use a policy on the cluster
-        dbs = self.filter_resources(dbs, "DBClusterIdentifier", [None])
-
+        dbs = [r for r in dbs if not r.get('DBClusterIdentifier')]
         # Concurrency feels like overkill here.
         client = local_session(self.manager.session_factory).client('rds')
         for db in dbs:


### PR DESCRIPTION
Closes #8886 

Bug wrt allowed values join. allowed_value is coming back as 'None'