### PR TITLE
c7n-left - fix default tags with module resources

### DIFF
--- a/tools/c7n_left/c7n_left/providers/terraform/filters.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/filters.py
@@ -28,7 +28,7 @@ class Taggable(Filter):
             return False
         tag_data = cls.get_tag_data()
         r = resources[0]
-        tf_path = r['__tfmeta']['path']
+        tf_path = r['__tfmeta']['label']
         provider = tf_path.split('_', 1)[0]
         if provider not in tag_data:
             return False

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "c7n_left"
-version = "0.2.1"
+version = "0.2.2"
 description = "Custodian policies for IAAC definitions"
 authors = ["Cloud Custodian Project"]
 license = "Apache-2"

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -22,6 +22,7 @@ try:
         extract_mod_stack,
     )
     from c7n_left.providers.terraform.graph import Resolver
+    from c7n_left.providers.terraform.filters import Taggable
 
     LEFT_INSTALLED = True
 except ImportError:
@@ -124,6 +125,22 @@ def test_extract_mod_stack():
         "module.db.module.db_instance",
         "module.db.module.db_instance.aws_db_instance.this[0]",
     ]
+
+
+def test_taggable_module_resource():
+    assert (
+        Taggable.is_taggable(
+            (
+                {
+                    '__tfmeta': {
+                        'label': 'aws_security_group',
+                        'path': 'module.my_module.aws_security_group.this_name_prefix[0]',
+                    }
+                },
+            )
+        )
+        is True
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION


default tags on aws provider doesn't flow to module level resources without this

