### PR TITLE
Disk availability

### DIFF
--- a/tools/c7n_gcp/tests/data/flights/disk-snapshot-availability/get-compute-v1-projects-cloud-custodian-global-snapshots_1.json
+++ b/tools/c7n_gcp/tests/data/flights/disk-snapshot-availability/get-compute-v1-projects-cloud-custodian-global-snapshots_1.json
@@ -1,0 +1,50 @@
+{
+  "headers": {
+    "etag": "tnYvLGexnzkNujk3st-dhKTEivw=/rbULw3dKAUY9Jv0ETaCWC9Iin70=",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 09 Nov 2021 15:29:59 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1142",
+    "-content-encoding": "gzip",
+    "content-location": "https://compute.googleapis.com/compute/v1/projects/cloud-custodian/global/snapshots?alt=json"
+  },
+  "body": {
+    "id": "projects/cloud-custodian/global/snapshots",
+    "items": [
+      {
+        "id": "3556917585031721471",
+        "creationTimestamp": "2021-11-09T02:36:01.316-08:00",
+        "name": "test-snapshot",
+        "status": "READY",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/disks/docker-tikovka-instance",
+        "sourceDiskId": "8897739022805456677",
+        "diskSizeGb": "10",
+        "storageBytes": "1751071296",
+        "storageBytesStatus": "UP_TO_DATE",
+        "licenses": [
+          "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/licenses/debian-10-buster"
+        ],
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/snapshots/test-snapshot",
+        "labelFingerprint": "42WmSpB8rSM=",
+        "licenseCodes": [
+          "5543610867827062957"
+        ],
+        "storageLocations": [
+          "us-central1"
+        ],
+        "downloadBytes": "1751116280",
+        "kind": "compute#snapshot"
+      }
+    ],
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/snapshots",
+    "kind": "compute#snapshotList"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/disk-snapshot-availability/get-compute-v1-projects-cloud-custodian-zones-us-central1-a-disks-docker-tikovka-instance_1.json
+++ b/tools/c7n_gcp/tests/data/flights/disk-snapshot-availability/get-compute-v1-projects-cloud-custodian-zones-us-central1-a-disks-docker-tikovka-instance_1.json
@@ -1,0 +1,52 @@
+{
+  "headers": {
+    "etag": "aRXHMpI8M-Czzxu-S_7SXAWdWSE=/uSIAdTM6zwGBIH-iZFbfHKAVhGM=",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 09 Nov 2021 15:29:59 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1275",
+    "-content-encoding": "gzip",
+    "content-location": "https://compute.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/disks/docker-tikovka-instance?alt=json"
+  },
+  "body": {
+    "id": "8897739022805456677",
+    "creationTimestamp": "2021-07-02T03:26:18.632-07:00",
+    "name": "docker-tikovka-instance",
+    "sizeGb": "10",
+    "zone": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a",
+    "status": "READY",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/disks/docker-tikovka-instance",
+    "sourceImage": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/images/debian-10-buster-v20210701",
+    "sourceImageId": "3744104277097859331",
+    "type": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/diskTypes/pd-balanced",
+    "licenses": [
+      "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/licenses/debian-10-buster"
+    ],
+    "guestOsFeatures": [
+      {
+        "type": "UEFI_COMPATIBLE"
+      },
+      {
+        "type": "VIRTIO_SCSI_MULTIQUEUE"
+      }
+    ],
+    "lastAttachTimestamp": "2021-07-02T03:26:18.632-07:00",
+    "users": [
+      "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/instances/docker-tikovka-instance"
+    ],
+    "labelFingerprint": "42WmSpB8rSM=",
+    "licenseCodes": [
+      "5543610867827062957"
+    ],
+    "physicalBlockSizeBytes": "4096",
+    "kind": "compute#disk"
+  }
+}

--- a/tools/c7n_gcp/tests/test_compute.py
+++ b/tools/c7n_gcp/tests/test_compute.py
@@ -310,6 +310,21 @@ class DiskTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
+    def test_disk_snapshot_availability(self):
+        factory = self.replay_flight_data(
+            'disk-snapshot-availability', project_id='cloud-custodian')
+        p = self.load_policy(
+            {'name': 'test-disk-snapshot-availability',
+             'resource': 'gcp.snapshot',
+             'filters': [
+                 {'type': 'disk-availability'}]},
+            session_factory=factory)
+
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'test-snapshot')
+
     def test_disk_snapshot_add_date(self):
         factory = self.replay_flight_data('disk-snapshot', project_id='cloud-custodian')
         p = self.load_policy(


### PR DESCRIPTION
Use case:

`
policies:
  - name: compute_engine_old_disk_snapshot
    description: |
      There are volumes that have not had a backup or snapshot in the past 14 days
    resource: gcp.snapshot
    filters:
      - type: reduce
        sort-by: "creationTimestamp"
        order: desc
        group-by: "sourceDiskId"
        limit: 1
      - type: value
        key: creationTimestamp
        op: gt
        value_type: age
        value: 14
      - type: disk-availability
`