### PR TITLE
c7n-left - cli output module resource refs

### DIFF
--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -80,6 +80,11 @@ class RichResult:
             yield f"  [red]Reason: {policy.data['description']}[/red]"
         yield f"  [purple]File: {resource.filename}:{resource.line_start}-{resource.line_end}"
 
+        refs = self.policy_resource.resource.get_references()
+        if refs:
+            yield "  [yellow]References:"
+            for r in refs:
+                yield f"   - {r}"
         lines = resource.get_source_lines()
         yield Syntax(
             "\n".join(lines),

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -80,11 +80,6 @@ class RichResult:
             yield f"  [red]Reason: {policy.data['description']}[/red]"
         yield f"  [purple]File: {resource.filename}:{resource.line_start}-{resource.line_end}"
 
-        refs = self.policy_resource.resource.get_references()
-        if refs:
-            yield "  [yellow]References:"
-            for r in refs:
-                yield f"   - {r}"
         lines = resource.get_source_lines()
         yield Syntax(
             "\n".join(lines),
@@ -92,6 +87,11 @@ class RichResult:
             line_numbers=True,
             lexer=resource.format,
         )
+        refs = self.policy_resource.resource.get_references()
+        if refs:
+            yield "  [yellow]References:"
+            for r in refs:
+                yield f"   - {r}"
         yield ""
 
 

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -173,8 +173,7 @@ class TerraformSource(IACSourceMode):
 
         call_stack = extract_mod_stack(mod_resource['__tfmeta']['path'])
         ancestor = mod_map[call_stack[0]]
-        ancestor['__tfmeta'].setdefault('refs', []).append(
-            mod_resource['__tfmeta']['path'])
+        ancestor['__tfmeta'].setdefault('refs', []).append(mod_resource['__tfmeta']['path'])
         return ancestor
 
 

--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -173,7 +173,8 @@ class TerraformSource(IACSourceMode):
 
         call_stack = extract_mod_stack(mod_resource['__tfmeta']['path'])
         ancestor = mod_map[call_stack[0]]
-        ancestor['__tfmeta'].setdefault('call_stack', {})[id(mod_resource)] = call_stack
+        ancestor['__tfmeta'].setdefault('refs', []).append(
+            mod_resource['__tfmeta']['path'])
         return ancestor
 
 

--- a/tools/c7n_left/c7n_left/providers/terraform/resource.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/resource.py
@@ -33,6 +33,9 @@ class TerraformResource(dict):
     def src_dir(self):
         return self.location["src_dir"]
 
+    def get_references(self):
+        return self.location.get('refs', ())
+
     def get_source_lines(self):
         lines = (self.src_dir / self.filename).read_text().split("\n")
         return lines[self.line_start - 1 : self.line_end]  # noqa

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "c7n_left"
-version = "0.2.3"
+version = "0.2.4"
 description = "Custodian policies for IAAC definitions"
 authors = ["Cloud Custodian Project"]
 license = "Apache-2"

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -881,6 +881,10 @@ def test_cli_no_policies(tmp_path, caplog):
     assert caplog.record_tuples == [("c7n.iac", 30, "no policies found")]
 
 
+@pytest.mark.skipif(
+    os.environ.get('GITHUB_ACTIONS') is None,
+    reason="runs in github actions as it requires network access for tf get",
+)
 def test_cli_output_rich_mod_resource_ref(tmp_path, debug_cli_runner):
     (tmp_path / "main.tf").write_text(DB_MODULE_TF)
     (tmp_path / "policy.json").write_text(

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -143,13 +143,7 @@ def test_taggable_module_resource():
     )
 
 
-@pytest.mark.skipif(
-    os.environ.get('GITHUB_ACTIONS') is None,
-    reason="runs in github actions as it requires network access for tf init",
-)
-def test_mod_reference(tmp_path):
-    (tmp_path / "main.tf").write_text(
-        """
+DB_MODULE_TF = """
 module "db" {
   source  = "terraform-aws-modules/rds/aws"
   version = "~> 3.0"
@@ -167,8 +161,15 @@ module "db" {
   username = "user"
   port     = "3306"
 }
-        """
-    )
+"""
+
+
+@pytest.mark.skipif(
+    os.environ.get('GITHUB_ACTIONS') is None,
+    reason="runs in github actions as it requires network access for tf init",
+)
+def test_mod_reference(tmp_path):
+    (tmp_path / "main.tf").write_text(DB_MODULE_TF)
     subprocess.check_call(args="terraform init", shell=True, cwd=tmp_path)
     results = run_policy(
         {
@@ -182,7 +183,9 @@ module "db" {
     assert len(results) == 1
     assert results[0].resource['__tfmeta']['filename'] == 'main.tf'
     assert results[0].resource['__tfmeta']['type'] == 'module'
-    assert results[0].resource['__tfmeta']['refs'] == ['module.db.module.db_instance.aws_db_instance.this[0]']
+    assert results[0].resource['__tfmeta']['refs'] == [
+        'module.db.module.db_instance.aws_db_instance.this[0]'
+    ]
 
 
 def test_graph_resolver():
@@ -876,6 +879,30 @@ def test_cli_no_policies(tmp_path, caplog):
         ],
     )
     assert caplog.record_tuples == [("c7n.iac", 30, "no policies found")]
+
+
+def test_cli_output_rich_mod_resource_ref(tmp_path, debug_cli_runner):
+    (tmp_path / "main.tf").write_text(DB_MODULE_TF)
+    (tmp_path / "policy.json").write_text(
+        json.dumps(
+            {
+                "policies": [
+                    {
+                        "name": "check-backup",
+                        "resource": "terraform.aws_db_instance",
+                        "filters": [{"backup_retention_period": 0}],
+                    }
+                ]
+            }
+        )
+    )
+    subprocess.check_call(args="terraform get", shell=True, cwd=tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["run", "-p", str(tmp_path), "-d", str(tmp_path), "-o", "cli"])
+    assert result.exit_code == 1
+    assert "References:" in result.output
+    assert 'module.db.module.db_instance.aws_db_instance.this[0]' in result.output
 
 
 def test_cli_output_rich(tmp_path):

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -182,6 +182,7 @@ module "db" {
     assert len(results) == 1
     assert results[0].resource['__tfmeta']['filename'] == 'main.tf'
     assert results[0].resource['__tfmeta']['type'] == 'module'
+    assert results[0].resource['__tfmeta']['refs'] == ['module.db.module.db_instance.aws_db_instance.this[0]']
 
 
 def test_graph_resolver():


### PR DESCRIPTION

when outputing a module block, also print the module resource paths that matched.

closes #8913


