### PR TITLE
aws - backup - adding cross-account and remove-statements

### DIFF
--- a/c7n/resources/backup.py
+++ b/c7n/resources/backup.py
@@ -1,6 +1,12 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+import json
+
+from botocore.exceptions import ClientError
+
+from c7n.actions import RemovePolicyBase
 from c7n.manager import resources
+from c7n.filters import CrossAccountAccessFilter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.query import QueryResourceManager, TypeInfo, DescribeSource, ConfigSource
 from c7n.tags import universal_augment
@@ -97,3 +103,140 @@ class BackupVault(QueryResourceManager):
 class KmsFilter(KmsRelatedFilter):
 
     RelatedIdsExpression = 'EncryptionKeyArn'
+
+
+@BackupVault.filter_registry.register('cross-account')
+class BackupCrossAccountFilter(CrossAccountAccessFilter):
+    """
+    Filter to return all AWS Backup Vaults with cross account access permissions
+
+    :example:
+
+        .. code-block::yaml
+
+            policies:
+              - name: check-backup-vaults-cross-account
+                resource: aws.backup-vault
+                filters:
+                  - type: cross-account
+              - name: check-backup-vaults-cross-account-whitelist
+                resource: aws.backup-vault
+                filters:
+                  - type: cross-account
+                    whitelist:
+                      - allow-account-1
+                      - allow-account-2
+              - name: check-backup-vaults-cross-account-whitelist-orgid
+                resource: aws.backup-vault
+                filters:
+                  - type: cross-account
+                    whitelist_orgids:
+                      - allow-orgid-1
+                      - allow-orgid-2
+              - name: check-backup-vaults-cross-account-blacklist
+                resource: aws.backup-vault
+                filters:
+                  - type: cross-account
+                    blacklist:
+                      - deny-account-1
+                      - deny-account-2
+              - name: check-backup-vaults-cross-account-blacklist-orgid
+                resource: aws.backup-vault
+                filters:
+                  - type: cross-account
+                    blacklist_orgids:
+                      - deny-orgid-1
+                      - deny-orgid-2
+    """
+
+    permissions = ('backup:GetBackupVaultAccessPolicy')
+
+    def process(self, resources, event=None):
+        def _augment(r):
+            client = local_session(self.manager.session_factory).client('backup')
+            try:
+                r['Policy'] = client.get_backup_vault_access_policy(
+                    BackupVaultName=r['BackupVaultName']
+                )['Policy']
+                return r
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                    self.log.warning(
+                        f'Policy not found for {r["BackupVaultName"]}'
+                    )
+
+        with self.executor_factory(max_workers=3) as w:
+            resources = list(
+                filter(None, w.map(_augment, resources))
+            )
+
+        return super(BackupCrossAccountFilter, self).process(resources, event)
+
+
+@BackupVault.action_registry.register('remove-statements')
+class RemovePolicyStatement(RemovePolicyBase):
+    """
+    Action to remove policy statements from AWS Backup Vault access policy
+
+    :example:
+
+        .. code-block::yaml
+
+            policies:
+              - name: check-backup-vaults-cross-account-remove
+                resource: aws.backup-vault
+                filters:
+                  - type: cross-account
+                actions:
+                  - type: remove-statements
+                    statement_ids: matched
+    """
+
+    permissions = ('backup:GetBackupVaultAccessPolicy', 'backup:SetBackupVaultAccessPolicy')
+
+    def process(self, resources):
+        results = []
+        client = local_session(self.manager.session_factory).client('backup')
+        for r in resources:
+            try:
+                results += filter(None, [self.process_resource(client, r)])
+            except Exception:
+                self.log.exception(f'Error processing Backup Vault: {r["BackupVaultName"]}')
+
+    def process_resource(self, client, resource):
+        if 'Policy' not in resource.keys():
+            try:
+                resource['Policy'] = client.get_backup_vault_access_policy(
+                    BackupVaultName=resource['BackupVaultName']
+                )['Policy']
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                    self.log.error(
+                        f'Policy not found for {resource["BackupVaultName"]}'
+                    )
+                    raise e
+
+        if not resource['Policy']:
+            return
+
+        policy = json.loads(resource['Policy'])
+        statements, found = self.process_policy(
+            policy, resource, CrossAccountAccessFilter.annotation_key
+        )
+
+        if not found:
+            return
+
+        if not statements:
+            client.delete_backup_vault_access_policy(BackupVaultName=resource['BackupVaultName'])
+        else:
+            client.set_backup_vault_access_policy(
+                BackupVaultName=resource['BackupVaultName'],
+                policy={'Policy': json.dumps(policy)}
+            )
+
+        return {
+            'Name': resource['BackupVaultName'],
+            'State': 'PolicyRemoved',
+            'Statements': found
+        }

--- a/tests/data/placebo/test_backup_vault_cross_account_filter/backup.GetBackupVaultAccessPolicy_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account_filter/backup.GetBackupVaultAccessPolicy_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BackupVaultName": "c7n-test-backup-vault",
+        "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:c7n-test-backup-vault",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"backup:CopyIntoBackupVault\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"aws:PrincipalOrgID\":\"o-4amkskbcf1\"}}}]}"
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account_filter/backup.ListBackupVaults_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account_filter/backup.ListBackupVaults_1.json
@@ -1,0 +1,97 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BackupVaultList": [
+            {
+                "BackupVaultName": "Default",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:Default",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 8,
+                    "minute": 59,
+                    "second": 50,
+                    "microsecond": 374000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "CreatorRequestId": "Default",
+                "NumberOfRecoveryPoints": 1,
+                "Locked": false
+            },
+            {
+                "BackupVaultName": "aws/efs/automatic-backup-vault",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:aws/efs/automatic-backup-vault",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 11,
+                    "day": 2,
+                    "hour": 15,
+                    "minute": 21,
+                    "second": 7,
+                    "microsecond": 12000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "CreatorRequestId": "aws/efs/automatic-backup-644160558196-us-east-1",
+                "NumberOfRecoveryPoints": 70,
+                "Locked": false
+            },
+            {
+                "BackupVaultName": "c7n-test-backup-vault",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:c7n-test-backup-vault",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 9,
+                    "day": 5,
+                    "hour": 14,
+                    "minute": 0,
+                    "second": 21,
+                    "microsecond": 998000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "CreatorRequestId": "fa836dfa-2184-42ce-80c6-f54e123fae09",
+                "NumberOfRecoveryPoints": 0,
+                "Locked": false
+            },
+            {
+                "BackupVaultName": "myvault",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:myvault",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 2,
+                    "hour": 17,
+                    "minute": 10,
+                    "second": 51,
+                    "microsecond": 600000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/012af1cd-bef1-4ed5-b893-8b8d263ae6a4",
+                "CreatorRequestId": "dee5fec7-b6e7-4dcf-9d3c-e3915ae4286b",
+                "NumberOfRecoveryPoints": 0,
+                "Locked": false
+            },
+            {
+                "BackupVaultName": "test_backup_vault_policy_statement_filter",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:test_backup_vault_policy_statement_filter",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 20,
+                    "hour": 15,
+                    "minute": 45,
+                    "second": 1,
+                    "microsecond": 491000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "NumberOfRecoveryPoints": 0,
+                "Locked": false
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account_filter/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account_filter/tagging.GetResources_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:backup:us-east-1:644160558196:backup-vault:c7n-test-backup-vault",
+                "Tags": []
+            },
+            {
+                "ResourceARN": "arn:aws:backup:us-east-1:644160558196:backup-vault:myvault",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account_filter_remove/backup.DeleteBackupVaultAccessPolicy_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account_filter_remove/backup.DeleteBackupVaultAccessPolicy_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account_filter_remove/backup.GetBackupVaultAccessPolicy_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account_filter_remove/backup.GetBackupVaultAccessPolicy_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BackupVaultName": "c7n-test-backup-vault",
+        "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:c7n-test-backup-vault",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"backup:CopyIntoBackupVault\",\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"aws:PrincipalOrgID\":\"o-4amkskbcf1\"}}}]}"
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account_filter_remove/backup.ListBackupVaults_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account_filter_remove/backup.ListBackupVaults_1.json
@@ -1,0 +1,97 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "BackupVaultList": [
+            {
+                "BackupVaultName": "Default",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:Default",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 17,
+                    "hour": 8,
+                    "minute": 59,
+                    "second": 50,
+                    "microsecond": 374000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "CreatorRequestId": "Default",
+                "NumberOfRecoveryPoints": 1,
+                "Locked": false
+            },
+            {
+                "BackupVaultName": "aws/efs/automatic-backup-vault",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:aws/efs/automatic-backup-vault",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 11,
+                    "day": 2,
+                    "hour": 15,
+                    "minute": 21,
+                    "second": 7,
+                    "microsecond": 12000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "CreatorRequestId": "aws/efs/automatic-backup-644160558196-us-east-1",
+                "NumberOfRecoveryPoints": 70,
+                "Locked": false
+            },
+            {
+                "BackupVaultName": "c7n-test-backup-vault",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:c7n-test-backup-vault",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 9,
+                    "day": 5,
+                    "hour": 14,
+                    "minute": 0,
+                    "second": 21,
+                    "microsecond": 998000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "CreatorRequestId": "fa836dfa-2184-42ce-80c6-f54e123fae09",
+                "NumberOfRecoveryPoints": 0,
+                "Locked": false
+            },
+            {
+                "BackupVaultName": "myvault",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:myvault",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 3,
+                    "day": 2,
+                    "hour": 17,
+                    "minute": 10,
+                    "second": 51,
+                    "microsecond": 600000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/012af1cd-bef1-4ed5-b893-8b8d263ae6a4",
+                "CreatorRequestId": "dee5fec7-b6e7-4dcf-9d3c-e3915ae4286b",
+                "NumberOfRecoveryPoints": 0,
+                "Locked": false
+            },
+            {
+                "BackupVaultName": "test_backup_vault_policy_statement_filter",
+                "BackupVaultArn": "arn:aws:backup:us-east-1:644160558196:backup-vault:test_backup_vault_policy_statement_filter",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 20,
+                    "hour": 15,
+                    "minute": 45,
+                    "second": 1,
+                    "microsecond": 491000
+                },
+                "EncryptionKeyArn": "arn:aws:kms:us-east-1:644160558196:key/5d97ffc0-5842-49ce-9daf-6d0a129bf6c8",
+                "NumberOfRecoveryPoints": 0,
+                "Locked": false
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_backup_vault_cross_account_filter_remove/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_backup_vault_cross_account_filter_remove/tagging.GetResources_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:backup:us-east-1:644160558196:backup-vault:c7n-test-backup-vault",
+                "Tags": []
+            },
+            {
+                "ResourceARN": "arn:aws:backup:us-east-1:644160558196:backup-vault:myvault",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}


### PR DESCRIPTION
This PR will resolve issue https://github.com/cloud-custodian/cloud-custodian/issues/8914, by adding cross-account filter and remove-statements action to the aws.backup-vault resource.