### PR TITLE
aws - waf and vpc - fix deprecated field validation

### DIFF
--- a/c7n/filters/waf.py
+++ b/c7n/filters/waf.py
@@ -100,9 +100,10 @@ class WafClassicRegionalFilterBase(ValueFilter, metaclass=ABCMeta):
         return resource_arns
 
     def get_deprecations(self):
+        filter_name = self.data["type"]
         return [
-            DeprecatedField(f"{k} is deprecated", "Use the value filter attributes instead")
-            for k in ['web-acl', 'state']
+            DeprecatedField(f"{filter_name}.{k}", "Use the value filter attributes instead")
+            for k in {'web-acl', 'state'}.intersection(self.data)
         ]
 
     def get_web_acl_from_associations(self, resource_type, resource_arn):
@@ -266,9 +267,10 @@ class WafV2FilterBase(ValueFilter, metaclass=ABCMeta):
         return resource[self.cache_key]
 
     def get_deprecations(self):
+        filter_name = self.data["type"]
         return [
-            DeprecatedField(f"{k} is deprecated", "Use the value filter attributes instead")
-            for k in ['web-acl', 'state']
+            DeprecatedField(f"{filter_name}.{k}", "Use the value filter attributes instead")
+            for k in {'web-acl', 'state'}.intersection(self.data)
         ]
 
     # only needed for REGIONAL resources so no scope used as regional is default

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -206,9 +206,10 @@ class FlowLogv2Filter(ListItemFilter):
     flow_log_map = None
 
     def get_deprecations(self):
+        filter_name = self.data["type"]
         return [
-            DeprecatedField(f"{k} is deprecated", "use list-item style attrs and set operators")
-            for k in self.legacy_schema
+            DeprecatedField(f"{filter_name}.{k}", "use list-item style attrs and set operators")
+            for k in set(self.legacy_schema).intersection(self.data)
         ]
 
     def validate(self):
@@ -2824,9 +2825,10 @@ class SetFlowLogs(BaseAction):
     }
 
     def get_deprecations(self):
+        filter_name = self.data["type"]
         return [
-            DeprecatedField(f"{k} is deprecated", f"set {k} under attrs: block")
-            for k in self.legacy_schema
+            DeprecatedField(f"{filter_name}.{k}", f"set {k} under attrs: block")
+            for k in set(self.legacy_schema).intersection(self.data)
         ]
 
     def validate(self):


### PR DESCRIPTION
Reduce noise in strict validation output, and only report deprecated fields if they're used in a policy.

Given the following policy:

```yaml
policies:
  - name: alb-waf-legacy-syntax
    resource: aws.app-elb
    filters:
      - type: waf-enabled
        state: false
      - type: wafv2-enabled
        state: false

  - name: vpc-flow-log-legacy-syntax
    resource: aws.vpc
    filters:
      - type: flow-logs
        enabled: true
    actions:
      - type: set-flow-log
        state: true
        LogGroupName: /custodian/vpc/flow-logs
```

This is the `custodian validate --strict` output _before_ this change:

```console
2023-09-06 09:30:17,871: custodian.commands:WARNING deprecated usage found in policy
policy 'alb-waf-legacy-syntax' (deprecation-test.yml:2)
  filters:
    field 'web-acl is deprecated' has been deprecated (replaced by Use the value filter attributes instead)
    field 'state is deprecated' has been deprecated (replaced by Use the value filter attributes instead)
    field 'web-acl is deprecated' has been deprecated (replaced by Use the value filter attributes instead)
    field 'state is deprecated' has been deprecated (replaced by Use the value filter attributes instead)
2023-09-06 09:30:17,932: custodian.commands:WARNING deprecated usage found in policy
policy 'vpc-flow-log-legacy-syntax' (deprecation-test.yml:10)
  filters:
    field 'enabled is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'op is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'set-op is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'status is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'deliver-status is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'destination is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'destination-type is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'traffic-type is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'log-format is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
    field 'log-group is deprecated' has been deprecated (replaced by use list-item style attrs and set operators)
  actions:
    field 'DeliverLogsPermissionArn is deprecated' has been deprecated (replaced by set DeliverLogsPermissionArn under attrs: block)
    field 'LogGroupName is deprecated' has been deprecated (replaced by set LogGroupName under attrs: block)
    field 'LogDestination is deprecated' has been deprecated (replaced by set LogDestination under attrs: block)
    field 'LogFormat is deprecated' has been deprecated (replaced by set LogFormat under attrs: block)
    field 'MaxAggregationInterval is deprecated' has been deprecated (replaced by set MaxAggregationInterval under attrs: block)
    field 'LogDestinationType is deprecated' has been deprecated (replaced by set LogDestinationType under attrs: block)
    field 'TrafficType is deprecated' has been deprecated (replaced by set TrafficType under attrs: block)
2023-09-06 09:30:17,932: custodian.commands:INFO Configuration valid: deprecation-test.yml
```

And here is the output _after_ this change:

```console
2023-09-06 10:01:49,029: custodian.commands:WARNING deprecated usage found in policy
policy 'alb-waf-legacy-syntax' (deprecation-test.yml:2)
  filters:
    field 'waf-enabled.state' has been deprecated (replaced by Use the value filter attributes instead)
    field 'wafv2-enabled.state' has been deprecated (replaced by Use the value filter attributes instead)
2023-09-06 10:01:49,156: custodian.commands:WARNING deprecated usage found in policy
policy 'vpc-flow-log-legacy-syntax' (deprecation-test.yml:10)
  filters:
    field 'flow-logs.enabled' has been deprecated (replaced by use list-item style attrs and set operators)
  actions:
    field 'set-flow-log.LogGroupName' has been deprecated (replaced by set LogGroupName under attrs: block)
2023-09-06 10:01:49,156: custodian.commands:INFO Configuration valid: deprecation-test.yml
```

Closes #8918 