### PR TITLE
c7n-left - gitlab sast output

### DIFF
--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -74,7 +74,7 @@ class PolicyMetadata:
 
     @property
     def severity(self):
-        value = self.policy.data.get("metadata", {}).get("severity", "")
+        value = self.policy.data.get("metadata", {}).get("severity", "unknown")
         if isinstance(value, str):
             return value.lower()
         return ""

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -60,6 +60,10 @@ class PolicyMetadata:
         return " ".join(self.categories)
 
     @property
+    def url(self):
+        return self.policy.data.get("metadata", {}).get("url")
+
+    @property
     def categories(self):
         categories = self.policy.data.get("metadata", {}).get("category", [])
         if isinstance(categories, str):

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -3,8 +3,11 @@
 #
 import json
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
+from importlib.metadata import version as pkg_version
 import time
+import uuid
 
 from rich.console import Console
 from rich.syntax import Syntax
@@ -14,7 +17,7 @@ from rich.text import Text
 from .core import CollectionRunner, PolicyMetadata
 from .utils import SEVERITY_LEVELS
 from c7n.output import OutputRegistry
-from c7n.utils import jmespath_search
+from c7n.utils import jmespath_search, filter_empty
 
 
 report_outputs = OutputRegistry("left")
@@ -372,3 +375,72 @@ class Json(Output):
         formatted = result.as_dict()
         formatted["code_block"] = line_pairs
         return formatted
+
+
+@report_outputs.register("gitlab_sast")
+class GitlabSAST(Output):
+    SCHEMA_FILE = "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v15.0.6/dist/sast-report-format.json"  # noqa
+
+    def __init__(self, ctx, config):
+        super().__init__(ctx, config)
+        self.results = []
+        self.start_time = None
+
+    def on_results(self, results):
+        self.results.extend(results)
+
+    def on_execution_started(self, *args):
+        self.start_time = datetime.utcnow()
+
+    def get_scanner(self):
+        info = self.get_analyzer()
+        info["url"] = "https://cloudcustodian.io"
+        return info
+
+    def get_analyzer(self):
+        return {
+            "id": "c7n-left",
+            "name": "c7n-left",
+            "version": pkg_version("c7n-left"),
+            "vendor": "Cloud Custodian",
+        }
+
+    def on_execution_ended(self):
+        formatted_results = [self.format_result(r) for r in self.results]
+        self.config.output_file.write(
+            json.dumps(
+                {
+                    "schema": self.SCHEMA_FILE,
+                    "version": "15.0.6",
+                    "scan": {
+                        "type": "sast",
+                        "status": "success",
+                        "start_time": self.start_time.isoformat(),
+                        "end_time": datetime.utcnow().isoformat(),
+                        "analyzer": self.get_analyzer(),
+                        "scanner": self.get_scanner(),
+                    },
+                    "vulnerabilities": formatted_results,
+                },
+                cls=JSONEncoder,
+                indent=2,
+            )
+        )
+
+    def format_result(self, result):
+        md = PolicyMetadata(result.policy)
+        info = result.as_dict()
+        return dict(
+            id=str(uuid.uuid4()),
+            name=md.name,
+            description=md.description,
+            severity=md.severity,
+            identifiers=[
+                filter_empty(dict(name=md.name, type="sinistral", value=md.name, url=md.url))
+            ],
+            location={
+                "file": info["file_path"],
+                "start": info["file_line_start"],
+                "end": info["file_line_end"],
+            },
+        )

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -390,23 +390,11 @@ class GitlabSAST(Output):
         self.results.extend(results)
 
     def on_execution_started(self, *args):
-        self.start_time = datetime.utcnow()
-
-    def get_scanner(self):
-        info = self.get_analyzer()
-        info["url"] = "https://cloudcustodian.io"
-        return info
-
-    def get_analyzer(self):
-        return {
-            "id": "c7n-left",
-            "name": "c7n-left",
-            "version": pkg_version("c7n-left"),
-            "vendor": "Cloud Custodian",
-        }
+        self.start_time = datetime.utcnow().replace(microsecond=0)
 
     def on_execution_ended(self):
         formatted_results = [self.format_result(r) for r in self.results]
+
         self.config.output_file.write(
             json.dumps(
                 {
@@ -416,7 +404,7 @@ class GitlabSAST(Output):
                         "type": "sast",
                         "status": "success",
                         "start_time": self.start_time.isoformat(),
-                        "end_time": datetime.utcnow().isoformat(),
+                        "end_time": datetime.utcnow().replace(microsecond=0).isoformat(),
                         "analyzer": self.get_analyzer(),
                         "scanner": self.get_scanner(),
                     },
@@ -434,7 +422,7 @@ class GitlabSAST(Output):
             id=str(uuid.uuid4()),
             name=md.name,
             description=md.description,
-            severity=md.severity,
+            severity=md.severity.title(),
             identifiers=[
                 filter_empty(dict(name=md.name, type="sinistral", value=md.name, url=md.url))
             ],
@@ -444,3 +432,16 @@ class GitlabSAST(Output):
                 "end": info["file_line_end"],
             },
         )
+
+    def get_scanner(self):
+        info = self.get_analyzer()
+        info["url"] = "https://cloudcustodian.io"
+        return info
+
+    def get_analyzer(self):
+        return {
+            "id": "c7n-left",
+            "name": "c7n-left",
+            "version": pkg_version("c7n-left"),
+            "vendor": {"name": "Cloud Custodian"},
+        }

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -4,18 +4,19 @@
 import json
 import os
 import subprocess
-from unittest.mock import ANY
-
-import pytest
 from pathlib import Path
+from unittest.mock import ANY
+from urllib.request import urlopen
 
+import jsonschema
+import pytest
 from click.testing import CliRunner
 
 from c7n.config import Config
 from c7n.resources import load_resources
 
 try:
-    from c7n_left import cli, core, policy as policy_core
+    from c7n_left import cli, core, output, policy as policy_core
     from c7n_left.providers.terraform.provider import (
         TerraformProvider,
         TerraformResourceManager,
@@ -879,6 +880,47 @@ def test_cli_no_policies(tmp_path, caplog):
         ],
     )
     assert caplog.record_tuples == [("c7n.iac", 30, "no policies found")]
+
+
+@pytest.mark.skipif(
+    os.environ.get('GITHUB_ACTIONS') is None,
+    reason="runs in github actions as it requires network access for schema validation",
+)
+def test_cli_gitlab_sast_output(policy_env, tmp_path, debug_cli_runner):
+    policy_env.write_tf(
+        """
+resource "aws_cloudwatch_log_group" "yada" {
+  name = "Bar"
+}
+        """
+    )
+    policy_env.write_policy(
+        {
+            "name": "tag-required",
+            "description": "tags are required on log groups",
+            "metadata": {"url": "https://cloudcustodian.io", "severity": "high"},
+            "resource": "terraform.aws_cloudwatch_log_group",
+            "filters": [{"tags": "absent"}],
+        }
+    )
+    runner = debug_cli_runner  # CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "run",
+            "-p",
+            str(tmp_path),
+            "-d",
+            str(tmp_path),
+            "-o",
+            "gitlab_sast",
+            "--output-file",
+            str(tmp_path / "output.json"),
+        ],
+    )
+    report = json.loads((tmp_path / "output.json").read_text())
+    result = jsonschema.validate(report, json.loads(urlopen(output.GitlabSAST.SCHEMA_FILE).read()))
+    assert not result
 
 
 @pytest.mark.skipif(

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -1054,7 +1054,7 @@ def test_cli_output_github(tmp_path):
     assert result.exit_code == 1
     expected = (
         "::error file=tests/terraform/aws_s3_encryption_audit/main.tf,line=25,lineEnd=28,"
-        "title=terraform.aws_s3_bucket - policy:check-bucket::a description"
+        "title=terraform.aws_s3_bucket - policy:check-bucket severity:unknown::a description"
     )
     assert expected in result.output
 


### PR DESCRIPTION
gitlab sast json output

enables https://docs.gitlab.com/ee/user/application_security/sast/

via outputting https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/tree/master

albeit that seems to be gated, so doing junitxml as a fast followup.
