### PR TITLE
aws - eip - release - handle InvalidAddress.PtrSet and InvalidAddress.Locked exception

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2434,11 +2434,11 @@ class AddressRelease(BaseAction):
                 # If its already been released, ignore, else raise.
                 if e.response['Error']['Code'] == 'InvalidAddress.PtrSet':
                     self.log.warning(
-                        "EIP %d cannot be released because it has a PTR record set.",
+                        "EIP %s cannot be released because it has a PTR record set.",
                         r['AllocationId'])
                 if e.response['Error']['Code'] == 'InvalidAddress.Locked':
                     self.log.warning(
-                        "EIP %d cannot be released because it is locked to your account.",
+                        "EIP %s cannot be released because it is locked to your account.",
                         r['AllocationId'])
                 if e.response['Error']['Code'] != 'InvalidAllocationID.NotFound':
                     raise

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2435,11 +2435,11 @@ class AddressRelease(BaseAction):
                 if e.response['Error']['Code'] == 'InvalidAddress.PtrSet':
                     self.log.warning(
                         "EIP %d cannot be released because it has a PTR record set.",
-                        AllocationId)
+                        r['AllocationId'])
                 if e.response['Error']['Code'] == 'InvalidAddress.Locked':
                     self.log.warning(
                         "EIP %d cannot be released because it is locked to your account. Please contact AWS Support to unlock it.",
-                        AllocationId)
+                        r['AllocationId'])
                 if e.response['Error']['Code'] != 'InvalidAllocationID.NotFound':
                     raise
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2438,7 +2438,7 @@ class AddressRelease(BaseAction):
                         r['AllocationId'])
                 if e.response['Error']['Code'] == 'InvalidAddress.Locked':
                     self.log.warning(
-                        "EIP %d cannot be released because it is locked to your account. Please contact AWS Support to unlock it.",
+                        "EIP %d cannot be released because it is locked to your account.",
                         r['AllocationId'])
                 if e.response['Error']['Code'] != 'InvalidAllocationID.NotFound':
                     raise

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2432,6 +2432,14 @@ class AddressRelease(BaseAction):
                 client.release_address(AllocationId=r['AllocationId'])
             except ClientError as e:
                 # If its already been released, ignore, else raise.
+                if e.response['Error']['Code'] == 'InvalidAddress.PtrSet':
+                    self.log.warning(
+                        "EIP %d cannot be released because it has a PTR record set.",
+                        AllocationId)
+                if e.response['Error']['Code'] == 'InvalidAddress.Locked':
+                    self.log.warning(
+                        "EIP %d cannot be released because it is locked to your account. Please contact AWS Support to unlock it.",
+                        AllocationId)
                 if e.response['Error']['Code'] != 'InvalidAllocationID.NotFound':
                     raise
 


### PR DESCRIPTION
Handle exception when release EIPs.

I meet the following AWS error when release EIPs, the reason is the EIP has PTR record set or locked by AWS Support:
```
ERROR Exception running policy:awseiprelease account:xxxxregion:cn-northwest-1 error:An error occurred (InvalidAddress.PtrSet) when calling the ReleaseAddress operation: The address with allocation id [eipalloc-xxxx] cannot be released because it has a PTR record set.
ERROR Exception running policy:awseiprelease account:xxxxregion:cn-north-1 error:An error occurred (InvalidAddress.Locked) when calling the ReleaseAddress operation: The address with allocation id [eipalloc-xxxx] cannot be released because it is locked to your account. Please contact AWS Support to unlock it.
```