### PR TITLE
aws - value filter - support float value_type besides int

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -106,7 +106,7 @@ OPERATORS = {
 VALUE_TYPES = [
     'age', 'integer', 'expiration', 'normalize', 'size',
     'cidr', 'cidr_size', 'swap', 'resource_count', 'expr',
-    'unique_size', 'date', 'version']
+    'unique_size', 'date', 'version', 'float']
 
 
 class FilterRegistry(PluginRegistry):
@@ -684,6 +684,11 @@ class ValueFilter(BaseValueFilter):
                 value = int(str(value).strip())
             except ValueError:
                 value = 0
+        elif self.vtype == 'float':
+            try:
+                value = float(str(value).strip())
+            except ValueError:
+                value = 0.0
         elif self.vtype == 'size':
             try:
                 return sentinel, len(value)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -405,6 +405,28 @@ class TestValueTypes(BaseFilterTest):
         fdata["op"] = "equal"
         self.assertFilter(fdata, i("abc"), True)
 
+    def test_float(self):
+        fdata = {
+            "type": "value",
+            "key": "tag:Cost",
+            "op": "greater-than",
+            "value_type": "float",
+            "value": 10.0,
+        }
+
+        def i(d):
+            return instance(Tags=[{"Key": "Cost", "Value": d}])
+
+        self.assertFilter(fdata, i("9.9"), False)
+        self.assertFilter(fdata, i("42.1"), True)
+        self.assertFilter(fdata, i("42"), True)
+        self.assertFilter(fdata, i("abc"), False)
+
+        # set default value to 0.0 if the given value is not float
+        fdata["op"] = "equal"
+        fdata["value"] = 0.0
+        self.assertFilter(fdata, i("abc"), True)
+
     def test_integer_with_value_regex(self):
         fdata = {
             "type": "value",


### PR DESCRIPTION
Since some tag value could be float, supporting float value type in the value filter can open up some useful use case. For example, attach estimated cost as a tag to each EC2 instance, then filter them if cost > $50.0.