### PR TITLE
metrics - add ignore_zero and specify metrics name in query params

### DIFF
--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -38,7 +38,7 @@ class SessionFactory:
 
     policy_name = property(None, _set_policy_name)
 
-    def __call__(self, assume=True, region=None):
+    def __call__(self, assume=True, region=None, profile=None):
         if self.assume_role and assume:
             session = Session(profile_name=self.profile)
             session = assumed_session(
@@ -46,7 +46,7 @@ class SessionFactory:
                 region or self.region, self.external_id)
         else:
             session = Session(
-                region_name=region or self.region, profile_name=self.profile)
+                region_name=region or self.region, profile_name=profile or self.profile)
 
         return self.update(session)
 

--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -38,7 +38,7 @@ class SessionFactory:
 
     policy_name = property(None, _set_policy_name)
 
-    def __call__(self, assume=True, region=None, profile=None):
+    def __call__(self, assume=True, region=None):
         if self.assume_role and assume:
             session = Session(profile_name=self.profile)
             session = assumed_session(
@@ -46,7 +46,7 @@ class SessionFactory:
                 region or self.region, self.external_id)
         else:
             session = Session(
-                region_name=region or self.region, profile_name=profile or self.profile)
+                region_name=region or self.region, profile_name=self.profile)
 
         return self.update(session)
 

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -382,7 +382,8 @@ class MetricsOutput(Metrics):
         self.namespace = self.config.get('namespace', DEFAULT_NAMESPACE)
         self.region = self.config.get('region')
         self.ignore_zero = self.config.get('ignore_zero')
-        self.metrics = self.config.get('metrics') and self.config.get('metrics').split(',')
+        am = self.config.get('active_metrics')
+        self.active_metrics = am and am.split(',')
         self.destination = (
             self.config.scheme == 'aws' and
             self.config.get('netloc') == 'master') and 'master' or None
@@ -421,8 +422,8 @@ class MetricsOutput(Metrics):
         if self.ignore_zero in ['1', 'true', 'True']:
             metrics = [m for m in metrics if m.get("Value") != 0]
         # NOTE filter metrics data by the metric name configured
-        if self.metrics:
-            metrics = [m for m in metrics if m["MetricName"] in self.metrics]
+        if self.active_metrics:
+            metrics = [m for m in metrics if m["MetricName"] in self.active_metrics]
         if not metrics:
             return
         return self.retry(

--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -381,7 +381,6 @@ class MetricsOutput(Metrics):
         super(MetricsOutput, self).__init__(ctx, config)
         self.namespace = self.config.get('namespace', DEFAULT_NAMESPACE)
         self.region = self.config.get('region')
-        self.profile = self.config.get('profile')
         self.ignore_zero = self.config.get('ignore_zero')
         self.metrics = self.config.get('metrics') and self.config.get('metrics').split(',')
         self.destination = (
@@ -413,7 +412,7 @@ class MetricsOutput(Metrics):
     def _put_metrics(self, ns, metrics):
         if self.destination == 'master':
             watch = self.ctx.session_factory(
-                assume=False, profile=self.profile).client('cloudwatch', region_name=self.region)
+                assume=False).client('cloudwatch', region_name=self.region)
         else:
             watch = utils.local_session(
                 self.ctx.session_factory).client('cloudwatch', region_name=self.region)

--- a/docs/source/aws/usage.rst
+++ b/docs/source/aws/usage.rst
@@ -60,9 +60,9 @@ region, additional account and region dimensions will be included.
 
 Typically, the following 5 metrics are included: PolicyException, ResourceCount, ResourceTime,
 ActionTime, and ApiCalls. Value zero will be recorded as well. To filter the metrics
-and save costs, you can use the ``metrics`` and/or ``ignore_zero`` query parameters::
+and save costs, you can use the ``active_metrics`` and/or ``ignore_zero`` query parameters::
 
-  custodian run -s . --metrics aws://?ignore_zero=true&metrics=ResourceCount,ApiCalls
+  custodian run -s . --metrics aws://?ignore_zero=true&active_metrics=ResourceCount,ApiCalls
 
 
 CloudWatch Logs

--- a/docs/source/aws/usage.rst
+++ b/docs/source/aws/usage.rst
@@ -35,10 +35,11 @@ flag needs to be specified when running Cloud Custodian::
 
 You can also consolidate metrics into a single account by specifying the ``master``
 location in the cli. Note that this is only applicable when using the ``--assume`` option
-in the cli or when using c7n-org. By default, metrics will be sent to the same account
-that is being executed against::
+in the cli or when using c7n-org. You can use ``profile`` query parameter to specify a
+profile for the cli to access the ``master``. By default, metrics will be sent to the
+same account that is being executed against::
 
-  custodian run -s <output_directory> --metrics aws://master
+  custodian run -s <output_directory> --metrics aws://master?profile=my_profile
 
 Additionally, to use a different namespace other than the default ``CloudMaid``, you can
 add the following query parameter to the metrics flag::
@@ -57,6 +58,12 @@ specify a region::
 
 When running the metrics in a centralized account or when centralizing to a specific
 region, additional account and region dimensions will be included.
+
+Typically, the following 4 metrics are included: ResourceCount, ResourceTime,
+ActionTime, and ApiCalls. Value zero will be recorded as well. To filter the metrics
+and save costs, you can use the ``metrics`` and/or ``ignore_zero`` query parameters::
+
+  custodian run -s . --metrics aws://?ignore_zero=true&metrics=ResourceCount,ApiCalls
 
 
 CloudWatch Logs

--- a/docs/source/aws/usage.rst
+++ b/docs/source/aws/usage.rst
@@ -35,11 +35,10 @@ flag needs to be specified when running Cloud Custodian::
 
 You can also consolidate metrics into a single account by specifying the ``master``
 location in the cli. Note that this is only applicable when using the ``--assume`` option
-in the cli or when using c7n-org. You can use ``profile`` query parameter to specify a
-profile for the cli to access the ``master``. By default, metrics will be sent to the
-same account that is being executed against::
+in the cli or when using c7n-org. By default, metrics will be sent to the same account
+that is being executed against::
 
-  custodian run -s <output_directory> --metrics aws://master?profile=my_profile
+  custodian run -s <output_directory> --metrics aws://master
 
 Additionally, to use a different namespace other than the default ``CloudMaid``, you can
 add the following query parameter to the metrics flag::
@@ -59,7 +58,7 @@ specify a region::
 When running the metrics in a centralized account or when centralizing to a specific
 region, additional account and region dimensions will be included.
 
-Typically, the following 4 metrics are included: ResourceCount, ResourceTime,
+Typically, the following 5 metrics are included: PolicyException, ResourceCount, ResourceTime,
 ActionTime, and ApiCalls. Value zero will be recorded as well. To filter the metrics
 and save costs, you can use the ``metrics`` and/or ``ignore_zero`` query parameters::
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -7,7 +7,7 @@ import threading
 import socket
 import sys
 from urllib.error import URLError, HTTPError
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from c7n.config import Bag, Config
 from c7n.exceptions import PolicyValidationError, InvalidOutputConfig
@@ -325,6 +325,28 @@ class OutputMetricsTest(BaseTest):
         self.assertTrue(isinstance(sink, aws.MetricsOutput))
         sink.put_metric('ResourceCount', 101, 'Count')
         sink.flush()
+
+    def test_metrics_query_params(self):
+        # Test metrics filter when 'metrics' and 'ignore_zero' is present in query parameters
+        conf = Bag({'metrics': 'ResourceCount,ApiCalls', 'scheme': 'aws', 'ignore_zero': 'true'})
+        ctx = Bag(session_factory=self.replay_flight_data('output-aws-metrics'),
+                  options=Bag(account_id='123456789012', region='us-east-1'),
+                  policy=Bag(name='test', resource_type='ec2'))
+        moutput = aws.MetricsOutput(ctx, conf)
+
+        with patch("botocore.client.BaseClient._make_api_call") as aws_api:
+            moutput.put_metric('ResourceCount', 0, 'Count', Scope='Policy', Food='Pizza')
+            moutput.flush()
+            assert aws_api.call_count == 0
+
+            moutput.put_metric('Calories', 400, 'Count', Scope='Policy', Food='Pizza')
+            moutput.flush()
+            assert aws_api.call_count == 0
+
+            moutput._put_metrics("ns", [{'MetricName': 'Calls'}, {'MetricName': 'ResourceCount'}])
+            assert aws_api.call_args[0][0] == "PutMetricData"
+            assert aws_api.call_args[0][1]["MetricData"] == [{'MetricName': 'ResourceCount'}]
+            assert aws_api.call_count == 1
 
 
 class OutputLogsTest(BaseTest):

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -328,7 +328,8 @@ class OutputMetricsTest(BaseTest):
 
     def test_metrics_query_params(self):
         # Test metrics filter when 'metrics' and 'ignore_zero' is present in query parameters
-        conf = Bag({'metrics': 'ResourceCount,ApiCalls', 'scheme': 'aws', 'ignore_zero': 'true'})
+        conf = Bag(
+            {'active_metrics': 'ResourceCount,ApiCalls', 'scheme': 'aws', 'ignore_zero': 'true'})
         ctx = Bag(session_factory=self.replay_flight_data('output-aws-metrics'),
                   options=Bag(account_id='123456789012', region='us-east-1'),
                   policy=Bag(name='test', resource_type='ec2'))


### PR DESCRIPTION
**Change 1:**
Added a `profile` query param to support authentication via aws profile.

**Change 2 (related to #8667):** 
Typically, when a policy is executed, it puts the following four metrics: ResourceCount, ResourceTime, ActionTime, and ApiCalls. For a small/medium-sized cloud environment, this could result in 200 policies * 100 accounts * 4 metrics = 80,000 metrics.

```
Tiered price for: 80000 metrics
10000 metrics x 0.3000000000 USD = 3000.00 USD
70000 metrics x 0.1000000000 USD = 7000.00 USD
Total tier cost: 3000.00 USD + 7000.00 USD = 10000.00 USD (Metrics cost (includes custom metrics))
CloudWatch Metrics cost (monthly): 10,000.00 USD
```
Of course, if the policies are executed only twice a day, the cost should be cut down to **$800**. Although this amount may not be significant, it would still be beneficial to provide users with the option to choose which metrics to include, allowing them to reduce costs to some extent, eg, $200 a month for recording ResourceCount only.

```sh
# for example
c7n-org run -s . -c accounts.yml -u policy.yml --metrics-uri 'aws://master?profile=my_profile&region=ap-southeast-2&ignore_zero=true&metrics=ResourceCount'
```