### PR TITLE
Add missing mailer config to docs + other docs fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,6 +64,9 @@ source_suffix = ['.rst', '.md']
 # The master toctree document.
 master_doc = 'index'
 
+# Generate Markdown header links anchors
+myst_heading_anchors = 3
+
 # General information about the project.
 project = u'Cloud Custodian'
 author = u'Kapil Thangavelu'

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -21,7 +21,7 @@ Discussion is also available on `Gitter <https://gitter.im/cloud-custodian/cloud
 Code of Conduct
 ---------------
 
-This project adheres to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+This project adheres to the `CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>`_
 
 By participating, you are expected to honor this code.
 

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -258,7 +258,7 @@ or Azure Storage accounts::
 Mailer and Notifications Deployment
 -----------------------------------
 
-For instructions on how to deploy the mailer for notifications, see :doc:`/tools/c7n-mailer`
+For instructions on how to deploy the mailer for notifications, see :doc:`/tools/c7n-mailer`.
 
 .. _multi_account_execution:
 

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -3,7 +3,7 @@
 Getting Started
 ===============
 
-See also the readme in the GitHub repository.
+Also see the README in the `GitHub repository <https://github.com/cloud-custodian/cloud-custodian>`_.
 
 * :ref:`install-cc`
 * :ref:`explore-cc`
@@ -40,7 +40,7 @@ specific cloud.
 Linux and Mac OS
 +++++++++++++++++++++++++++
 
-To install Cloud Custodian ::
+To install Cloud Custodian::
 
   python3 -m venv custodian
   source custodian/bin/activate
@@ -62,7 +62,7 @@ To install Cloud Custodian for Oracle Cloud Infrastructure (OCI), you will also 
 Windows (CMD/PowerShell)
 +++++++++++++++++++++++++++
 
-To install Cloud Custodian run::
+To install Cloud Custodian, run::
 
   python3 -m venv custodian
   .\custodian\Scripts\Activate.ps1   # For Powershell users  
@@ -80,12 +80,12 @@ To install Cloud Custodian for GCP, you will also need to run::
 Docker
 ++++++
 
-To install via docker, run::
+To install via Docker, run::
 
   docker pull cloudcustodian/c7n
 
-You'll need to export cloud provider credentials to the container
-when executing. One example, if you're using environment variables for provider
+You'll need to export your cloud provider credentials to the container
+when executing. For example, if you're using environment variables for provider
 credentials::
 
   docker run -it \
@@ -184,7 +184,7 @@ validate it separately:
 
   custodian validate custodian.yml
 
-You can also check which resources are identified by the policy, without
+You can also check which resources are identified by the policy without
 running any actions on the resources:
 
 .. code-block:: bash

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -13,8 +13,8 @@ implementation.
 
 ## Message Relay
 
-Custodian Mailer subscribes to an SQS queue, looks up users, and sends email
-via SES and/or send notification to DataDog. Custodian lambda and instance policies can send to it. SQS queues
+Custodian Mailer subscribes to an SQS queue, looks up users, and sends emails
+via SES, Slack messages, and/or notifications to DataDog or Splunk. Custodian Lambda and instance policies can send messages to the SQS queue. SQS queues
 should be cross-account enabled for sending between accounts.
 
 
@@ -86,7 +86,7 @@ c7n integration with AWS CloudWatch and use the
 to collect CloudWatch metrics. The mailer/messenger integration is only
 for the case you don't want or you can't use AWS CloudWatch, e.g. in Azure or GCP.
 
-Note this integration requires the additional dependency of datadog python bindings:
+Note this integration requires the additional dependency of Datadog Python bindings:
 ```
 pip install datadog
 ```
@@ -102,7 +102,7 @@ datadog_application_key: YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
 
 (Also set `region` if you are in a region other than `us-east-1`.)
 
-Now let's make a Custodian policy to populate your mailer queue. Create a
+Now, let's make a Custodian policy to populate your mailer queue. Create a
 `test-policy.yml`:
 
 ```yaml
@@ -120,13 +120,14 @@ policies:
           queue: https://sqs.us-east-1.amazonaws.com/1234567890/c7n-mailer-test
 ```
 
-There is a special `to` format that specifies datadog delivery, and includes the datadog configuration via url parameters.
-- metric_name: is the name of the metrics send to DataDog
-- metric_value_tag: by default the metric value send to DataDog is `1` but if you want to use one of the tags returned in the policy you can set it with the attribute `metric_value_tag`, for example in the `test-policy.yml` the value used is the size of the EBS volume. The value must be a number and it's transformed to a float value.
+There is a special `to` format that specifies Datadog delivery and it includes the Datadog configuration via URL parameters:
+
+- `metric_name`: is the name of the metrics send to DataDog.
+- `metric_value_tag`: by default the metric value to send to DataDog is `1`, but if you want to use one of the tags returned in the policy, you can set it with the attribute `metric_value_tag`. For example, in the `test-policy.yml` policy, the value used is the size of the EBS volume. The value must be a number and it will be transformed to a float value.
 
 ### Slack:
 
-The Custodian mailer supports Slack messaging as a separate notification mechanism for the SQS transport method. To enable Slack integration, you must specify a Slack token in the `slack_token` field under the `mailer.yml` file.
+The Custodian mailer supports Slack messaging as a separate notification mechanism for the SES transport method. To enable Slack integration, you must specify a Slack token in the `slack_token` field in your `mailer.yml` file. For example:
 
 ```yaml
 queue_url: https://sqs.us-east-1.amazonaws.com/1234567890/c7n-mailer-test
@@ -158,21 +159,21 @@ policies:
           queue: https://sqs.us-east-1.amazonaws.com/1234567890/c7n-mailer-test
 ```
 
-Slack messages support use of a unique template field specified by `slack_template`. This field is unique and usage will not break
+Slack messages support the use of a unique template field specified in `slack_template`. This field is unique and usage will not break
 existing functionality for messages also specifying an email template in the `template` field. This field is optional, however,
 and if not specified, the mailer will use the default value `slack_default`.
 
 The unique template field `slack_msg_color` can be used to specify a color
-border for the slack message. This accepts the Slack presets of `danger` (red),
-`warning` (yellow) and `good` (green). It can also accept a HTML hex code. See
+border for the Slack message. This accepts the Slack presets of `danger` (red),
+`warning` (yellow) and `good` (green). It can also accept an HTML hex code. See
 the [Slack documentation](https://api.slack.com/reference/messaging/attachments#fields)
 for details.
 
-Note: if you are using a hex color code it will need to be wrapped in quotes
-like so: `slack_msg_color: '#4287f51'`. Otherwise the YAML interpreter will consider it a
+**Note:** if you are using a hex color code, it will need to be wrapped in quotes
+like so: `slack_msg_color: '#4287f51'`. Otherwise, the YAML interpreter will consider it a
 [comment](https://yaml.org/spec/1.2/spec.html#id2780069).
 
-Slack integration for the mailer supports several flavors of messaging, listed below. These are not mutually exclusive and any combination of the types can be used, but the preferred method is [incoming webhooks](https://api.slack.com/incoming-webhooks).
+The Slack integration for c7n-mailer supports several flavors of messaging, listed below. These are not mutually exclusive and any combination of the types can be used, but the preferred method is [incoming webhooks](https://api.slack.com/incoming-webhooks).
 
 | Requires&nbsp;`slack_token` | Key                                                                             | Type   | Notes                                                                                                                                                           |
 |:---------------------------:|:--------------------------------------------------------------------------------|:-------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -183,17 +184,17 @@ Slack integration for the mailer supports several flavors of messaging, listed b
 |             No              | `slack://webhook/#c7n-webhook-test`                                             | string | **(DEPRECATED)** Send to a Slack webhook; appended with the target channel. **IMPORTANT**: *This requires a `slack_webhook` value defined in the `mailer.yml`.* |
 |             Yes             | `slack://tag/resource-tag`                                                      | string | Send to target found in resource tag. Example of value in tag: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX                    |
 
-Slack delivery can also be set via a resource's tag name. For example, using "slack://tag/slack_channel" will look for a tag name of 'slack_channel', and if matched on a resource will deliver the message to the value of that resource's tag:
+Slack delivery can also be set via a resource's tag name. For example, using `slack://tag/slack_channel` will look for a tag name of `slack_channel`, and if matched on a resource will deliver the message to the value of that resource's tag:
 
 `slack_channel:https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
 `slack_channel:custodian-test`
 `owner:foo@bar`
 
-Delivery via tag has been tested with webhooks but should support all delivery methods.
+Delivery via tag has been tested with webhooks, but it should support all delivery methods.
 
 ### Splunk HTTP Event Collector (HEC)
 
-The Custodian mailer supports delivery to the HTTP Event Collector (HEC) endpoint of a Splunk instance as a separate notification mechanism for the SQS transport method. To enable Splunk HEC integration, you must specify the URL to the HEC endpoint as well as a valid username and token:
+The Custodian mailer supports delivery to the HTTP Event Collector (HEC) endpoint of a Splunk instance as a separate notification mechanism for the SES transport method. To enable Splunk HEC integration, you must specify the URL to the HEC endpoint as well as a valid username and token:
 
 ```yaml
 queue_url: https://sqs.us-east-1.amazonaws.com/1234567890/c7n-mailer-test
@@ -252,7 +253,7 @@ Custodian mailer.
 
 Once [installed](#developer-install-os-x-el-capitan) you should have a
 `c7n-mailer` executable on your path:
-aws
+
 ```
 (env) $ c7n-mailer
 usage: c7n-mailer [-h] -c CONFIG
@@ -260,10 +261,10 @@ c7n-mailer: error: argument -c/--config is required
 (env) $
 ```
 
-Fundamentally what `c7n-mailer` does is deploy a Lambda (using
+Fundamentally, what `c7n-mailer` does is it deploys a Lambda function (using
 [Mu](http://cloudcustodian.io/docs/policy/mu.html)) based on
-configuration you specify in a YAML file.  Here is [the
-schema](https://github.com/cloud-custodian/cloud-custodian/blob/18d4247e913d54f36a078ed61386695362a3b10d/tools/c7n_mailer/c7n_mailer/cli.py#L43) to which the file must conform,
+the configuration you specify in a YAML file.  Here is [the
+schema](https://github.com/cloud-custodian/cloud-custodian/blob/18d4247e913d54f36a078ed61386695362a3b10d/tools/c7n_mailer/c7n_mailer/cli.py#L43) to which the file must conform
 and here is a description of the options:
 
 | Required? | Key                       | Type             | Notes                                                             |

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -250,7 +250,7 @@ Custodian mailer.
 
 ## Usage & Configuration
 
-Once [installed](#Developer Install (OS X El Capitan)) you should have a
+Once [installed](#developer-install-os-x-el-capitan) you should have a
 `c7n-mailer` executable on your path:
 aws
 ```
@@ -472,7 +472,7 @@ policies:
 
 So breaking it down, you add an action of type `notify`. You can specify a
 template that's used to format the email; customizing templates is described
-[below](#Writing an email template).
+[below](#writing-an-email-template).
 
 The `to` list specifies the intended recipient for the email. You can specify
 either an email address, an SNS topic, a Datadog Metric, or a special value. The special values

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -127,7 +127,7 @@ There is a special `to` format that specifies Datadog delivery and it includes t
 
 ### Slack:
 
-The Custodian mailer supports Slack messaging as a separate notification mechanism for the SES transport method. To enable Slack integration, you must specify a Slack token in the `slack_token` field in your `mailer.yml` file. For example:
+The Custodian mailer supports Slack messaging as a separate notification mechanism for the SQS transport method. To enable Slack integration, you must specify a Slack token in the `slack_token` field in your `mailer.yml` file. For example:
 
 ```yaml
 queue_url: https://sqs.us-east-1.amazonaws.com/1234567890/c7n-mailer-test

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -23,7 +23,7 @@ should be cross-account enabled for sending between accounts.
 Our goal in starting out with the Custodian mailer is to install the mailer,
 and run a policy that triggers an email to your inbox.
 
-1. [Install](#Developer Install (OS X El Capitan) the mailer on your laptop (if you are not running as a [Docker container](https://hub.docker.com/r/cloudcustodian/mailer)
+1. [Install](#developer-install-os-x-el-capitan) the mailer on your laptop (if you are not running as a [Docker container](https://hub.docker.com/r/cloudcustodian/mailer)
    - or use `pip install c7n-mailer`
 2. In your text editor, create a `mailer.yml` file to hold your mailer config.
 3. In the AWS console, create a new standard SQS queue (quick create is fine).

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -266,27 +266,34 @@ configuration you specify in a YAML file.  Here is [the
 schema](https://github.com/cloud-custodian/cloud-custodian/blob/18d4247e913d54f36a078ed61386695362a3b10d/tools/c7n_mailer/c7n_mailer/cli.py#L43) to which the file must conform,
 and here is a description of the options:
 
-| Required? | Key             | Type             | Notes                                                             |
-|:---------:|:----------------|:-----------------|:------------------------------------------------------------------|
-| &#x2705;  | `queue_url`     | string           | the queue to listen to for messages                               | 
-|           | `from_address`  | string           | default from address                                              |
-|           | `endpoint_url`  | string           | SQS API URL (for use with VPC Endpoints)                          |
-|           | `contact_tags`  | array of strings | tags that we should look at for address information               |
-|           | `email_base_url`| string           | Base URL to construct a valid email address from a resource owner |
+| Required? | Key                       | Type             | Notes                                                             |
+|:---------:|:--------------------------|:-----------------|:------------------------------------------------------------------|
+| &#x2705;  | `queue_url`               | string           | the queue to listen to for messages                               | 
+|           | `from_address`            | string           | default from address                                              |
+|           | `endpoint_url`            | string           | SQS API URL (for use with VPC Endpoints)                          |
+|           | `contact_tags`            | array of strings | tags that we should look at for address information               |
+|           | `email_base_url`          | string           | Base URL to construct a valid email address from a resource owner |
+|           | `additional_email_headers`| object           | Additional email headers. |
+|           | `org_domain`              | string           | Domain to add to AWS usernames to construct email addresses. |
+
 
 
 ### Standard Lambda Function Config
 
 | Required? | Key                  | Type             |
 |:---------:|:---------------------|:-----------------|
+| &#x2705;  | `role`               | string           |
 |           | `dead_letter_config` | object           |
 |           | `memory`             | integer          |
 |           | `region`             | string           |
-| &#x2705;  | `role`               | string           |
 |           | `runtime`            | string           |
 |           | `security_groups`    | array of strings |
 |           | `subnets`            | array of strings |
 |           | `timeout`            | integer          |
+|           | `lambda_name`        | string           |
+|           | `lambda_description` | string           |
+|           | `lambda_tags`        | object           |
+|           | `lambda_schedule`    | string           |
 
 ### Standard Azure Functions Config
 

--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -175,18 +175,18 @@ times, or alternatively with comma separated values.
 
 Groups of accounts can also be selected for execution by specifying
 the `-t` tag filter.  Account tags are specified in the config
-file. ie given the above accounts config file you can specify all prod
-accounts with `-t type:prod`. you can specify the -t flag multiple
+file. Given the above accounts config file, you can specify all prod
+accounts with `-t type:prod`. You can specify the `-t` flag multiple
 times or use a comma separated list.
 
 You can specify which policies to use for execution by either
 specifying `-p` or selecting groups of policies via their tags with
-`-l`, both options support being specified multiple times or using
+`-l`. Both options support being specified multiple times or using
 comma separated values.
 
-By default in aws, c7n-org will execute in parallel across regions,
-the '-r' flag can be specified multiple times, and defaults to
-(us-east-1, us-west-2).  a special value of `all` will execute across
+By default in AWS, c7n-org will execute in parallel across regions.
+The `-r` flag can be specified multiple times and defaults to
+`(us-east-1, us-west-2)`.  A special value of `all` will execute across
 all regions.
 
 
@@ -260,17 +260,17 @@ page](https://cloudcustodian.io/docs/azure/authentication.html).
 
 ## Additional OCI Instructions
 
-The script 'ocitenancies.py' accepts an optional argument '--add-child-tenancies'
-which adds all the child tenancies associated with the 'DEFAULT' profile's tenancy 
+The script `ocitenancies.py` accepts an optional argument `--add-child-tenancies`
+which adds all the child tenancies associated with the `DEFAULT` profile's tenancy 
 in the generated c7n-org configuration file. If the profile for child tenancy is not available in 
 the OCI configuration file, then either user can add the profile for the child tenancy to the
-OCI configuration file and replace <ADD_PROFILE> entry in the c7n-org configuration with the
+OCI configuration file and replace the `<ADD_PROFILE>` entry in the c7n-org configuration with the
 corresponding profile name or the user can delete the child tenancy entry from the
 c7n-org configuration file. For more info about config file, refer to this [page](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm).
 
-If user wants to query for the resources in the specific compartments in c7n-org, then user
-can pass the compartment OCID's to the 'oci_compartments' under 'vars' section like below. If the 
-'oci_comparments' is not passed under vars, then the resources will be fetched from the tenancy level.
+If the user wants to query for the resources in the specific compartments in c7n-org, then the user
+can pass the compartment OCID's to the `oci_compartments` under the `vars` section like below. If the 
+`oci_comparments` is not passed under `vars`, then the resources will be fetched from the tenancy level.
 
 ```yaml
 tenancies:

--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -4,7 +4,7 @@
 % [comment]: # (This file is moved during document generation.)
 % [comment]: # (Only edit the original document at ./tools/c7n_org/README.md)
 
-c7n-org is a tool to run custodian against multiple AWS accounts,
+c7n-org is a tool to run Custodian against multiple AWS accounts,
 Azure subscriptions, GCP projects, or OCI tenancies in parallel.
 
 ## Installation
@@ -97,38 +97,40 @@ tenancies:
 
 ### Config File Generation
 
-We also distribute scripts to generate the necessary config file in the `scripts` folder.
+We also distribute scripts to generate the necessary config file in the [`scripts` folder](https://github.com/cloud-custodian/cloud-custodian/tree/main/tools/c7n_org/scripts).
 
-**Note:** Currently these are distributed only via git, per
-<https://github.com/cloud-custodian/cloud-custodian/issues/2420> we'll
+**Note:** Currently these are distributed only via git. Per
+<https://github.com/cloud-custodian/cloud-custodian/issues/2420>, we'll
 be looking to incorporate them into a new c7n-org subcommand.
 
 - For **AWS**, the script `orgaccounts.py` generates a config file
   from the AWS Organizations API.
+
+```shell
+python orgaccounts.py -f accounts.yml
+```
 
 - For **Azure**, the script `azuresubs.py` generates a config file
   from the Azure Resource Management API.
 
     - Please see the [Additional Azure Instructions](#additional-azure-instructions) for initial setup and other important info.
 
+```shell
+python azuresubs.py -f subscriptions.yml
+```
+
 - For **GCP**, the script `gcpprojects.py` generates a config file from
   the GCP Resource Management API.
+
+```shell
+python gcpprojects.py -f projects.yml
+```
 
 - For **OCI**, the script `ocitenancies.py` generates a config file
   using OCI Configuration file and OCI Organizations API.
   
     - Please refer to the [Additional OCI Instructions](#additional-oci-instructions) for additional information.
 
-
-```shell
-python orgaccounts.py -f accounts.yml
-```
-```shell
-python azuresubs.py -f subscriptions.yml
-```
-```shell
-python gcpprojects.py -f projects.yml
-```
 ```shell
 python ocitenancies.py -f tenancies.yml
 ```
@@ -143,6 +145,7 @@ To run a policy, the following arguments must be passed in:
 -u | policy
 ```
 
+For example:
 
 ```shell
 c7n-org run -c accounts.yml -s output -u test.yml --dryrun
@@ -230,7 +233,7 @@ c7n-org run-script -s . -c my-projects.yml gcp_check_{region}.sh
 c7n-org run-script -s . -c my-projects.yml use_another_policy_result.sh {output_dir}
 ```
 
-**Note** Variable interpolation is sensitive to proper quoting and spacing,
+**Note:** Variable interpolation is sensitive to proper quoting and spacing,
 i.e., `{ charge_code }` would be invalid due to the extra white space. Additionally,
 yaml parsing can transform a value like `{charge_code}` to null, unless it's quoted
 in strings like the above example. Values that do interpolation into other content

--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -99,26 +99,25 @@ tenancies:
 
 We also distribute scripts to generate the necessary config file in the `scripts` folder.
 
-**Note** Currently these are distributed only via git, per
-https://github.com/cloud-custodian/cloud-custodian/issues/2420 we'll
+**Note:** Currently these are distributed only via git, per
+<https://github.com/cloud-custodian/cloud-custodian/issues/2420> we'll
 be looking to incorporate them into a new c7n-org subcommand.
 
 - For **AWS**, the script `orgaccounts.py` generates a config file
-  from the AWS Organizations API
+  from the AWS Organizations API.
 
 - For **Azure**, the script `azuresubs.py` generates a config file
-  from the Azure Resource Management API
+  from the Azure Resource Management API.
 
-    - Please see the [Additional Azure Instructions](#Additional Azure Instructions)
-    - for initial setup and other important info
+    - Please see the [Additional Azure Instructions](#additional-azure-instructions) for initial setup and other important info.
 
 - For **GCP**, the script `gcpprojects.py` generates a config file from
-  the GCP Resource Management API
+  the GCP Resource Management API.
 
 - For **OCI**, the script `ocitenancies.py` generates a config file
-  using OCI Configuration file and OCI Organizations API
+  using OCI Configuration file and OCI Organizations API.
   
-    - Please refer to the 'Additional OCI Instructions' for additional information
+    - Please refer to the [Additional OCI Instructions](#additional-oci-instructions) for additional information.
 
 
 ```shell


### PR DESCRIPTION
Some small documentation fixes. Most notably:

- Fix CNCF link on https://cloudcustodian.io/docs/contribute.html
- Fix "Developer Install (OS X El Capitan)" links on https://cloudcustodian.io/docs/tools/c7n-mailer.html
- Add missing Mailer config values.