### PR TITLE
aws - metrics filter - fix get_dimensions method

### DIFF
--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -3,7 +3,7 @@
 import json
 
 from c7n.actions import RemovePolicyBase, ModifyPolicyBase, BaseAction
-from c7n.filters import CrossAccountAccessFilter, PolicyChecker, ValueFilter
+from c7n.filters import CrossAccountAccessFilter, PolicyChecker, ValueFilter, MetricsFilter
 from c7n.filters.kms import KmsRelatedFilter
 import c7n.filters.policystatement as polstmt_filter
 from c7n.manager import resources
@@ -54,6 +54,7 @@ class SNS(QueryResourceManager):
 
 
 SNS.filter_registry.register('marked-for-op', TagActionFilter)
+
 
 
 @SNS.action_registry.register('post-finding')
@@ -447,6 +448,12 @@ class DeleteTopic(BaseAction):
             except client.exceptions.NotFoundException:
                 continue
 
+@SNS.filter_registry.register('metrics')
+class Metrics(MetricsFilter):
+
+    def get_dimensions(self, resource):
+        return [{'Name': self.model.dimension,
+                 'Value': resource['TopicArn'].rsplit(':', 1)[-1]}]
 
 @resources.register('sns-subscription')
 class SNSSubscription(QueryResourceManager):

--- a/tests/data/placebo/test_sns_metrics/monitoring.GetMetricStatistics_1.json
+++ b/tests/data/placebo/test_sns_metrics/monitoring.GetMetricStatistics_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "NumberOfMessagesPublished",
+        "Datapoints": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sns_metrics/sns.GetTopicAttributes_1.json
+++ b/tests/data/placebo/test_sns_metrics/sns.GetTopicAttributes_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:Publish\",\"SNS:RemovePermission\",\"SNS:SetTopicAttributes\",\"SNS:DeleteTopic\",\"SNS:ListSubscriptionsByTopic\",\"SNS:GetTopicAttributes\",\"SNS:AddPermission\",\"SNS:Subscribe\"],\"Resource\":\"arn:aws:sns:us-east-1:111111111111:test\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"111111111111\"}}}]}",
+            "Owner": "111111111111",
+            "SubscriptionsPending": "0",
+            "TopicArn": "arn:aws:sns:us-east-1:111111111111:test",
+            "TracingConfig": "PassThrough",
+            "EffectiveDeliveryPolicy": "{\"http\":{\"defaultHealthyRetryPolicy\":{\"minDelayTarget\":20,\"maxDelayTarget\":20,\"numRetries\":3,\"numMaxDelayRetries\":0,\"numNoDelayRetries\":0,\"numMinDelayRetries\":0,\"backoffFunction\":\"linear\"},\"disableSubscriptionOverrides\":false,\"defaultRequestPolicy\":{\"headerContentType\":\"text/plain; charset=UTF-8\"}}}",
+            "SubscriptionsConfirmed": "0",
+            "DisplayName": "test",
+            "SubscriptionsDeleted": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sns_metrics/sns.ListTopics_1.json
+++ b/tests/data/placebo/test_sns_metrics/sns.ListTopics_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "Topics": [
+            {
+                "TopicArn": "arn:aws:sns:us-east-1:111111111111:test"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sns_metrics/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_sns_metrics/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -886,6 +886,32 @@ class TestSNS(BaseTest):
         self.assertEqual(resources[0]["TopicArn"],
         "arn:aws:sns:ap-northeast-2:644160558196:sns-test-has-statement")
 
+    def test_sns_metrics(self):
+        session_factory = self.replay_flight_data(
+            "test_sns_metrics"
+        )
+        p = self.load_policy(
+            {
+                "name": "test_sns_metrics",
+                "resource": "sns",
+                "filters": [
+                    {
+                        "type": "metrics",
+                        "name": "NumberOfMessagesPublished",
+                        "statistics": "Sum",
+                        "missing-value": 0,
+                        "days": 30,
+                        "value": 0,
+                        "op": "eq",
+                        "period": 2592000
+                    }
+                ],
+            },
+            session_factory=session_factory,
+            config={'region': 'us-east-1'}
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
 
 class TestSubscription(BaseTest):
 


### PR DESCRIPTION
The `metrics` filter isn't working for AWS SNS topics, because in dimensions for key '_TopicName_' as a value is the field with the same name from a resource object. But, the resource doesn't have '_TopicName_', it has only '_TopicArn_' ([docs](https://docs.aws.amazon.com/sns/latest/api/API_GetTopicAttributes.html#API_GetTopicAttributes_ResponseElements)).  

https://github.com/cloud-custodian/cloud-custodian/blob/da2e736649e01235b84ec5e976dc3d857622d363/c7n/filters/metrics.py#L211-L213

There was the following warning:
`2023-09-19 11:19:33,866: custodian.filters:WARNING CW Retrieval error: 'TopicName'
2023-09-19 11:19:33,866: custodian.policy:INFO policy:ecc-aws-560-unused_sns_topic resource:aws.sns region:us-east-1 count:0 time:2.20`

