### PR TITLE
c7n-left - default provider tags augment, handle empty resource tags

### DIFF
--- a/tools/c7n_left/c7n_left/providers/terraform/provider.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/provider.py
@@ -57,7 +57,7 @@ class TerraformResourceManager(IACResourceManager):
 
         for r in resources:
             rtags = dict(provider_tags)
-            if 'tags' in r:
+            if r.get('tags'):
                 rtags.update(r['tags'])
             r['tags'] = rtags
 

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "c7n_left"
-version = "0.3.0"
+version = "0.3.1"
 description = "Custodian policies for IAAC definitions"
 authors = ["Cloud Custodian Project"]
 license = "Apache-2"


### PR DESCRIPTION


if a resource had an empty tags block augment with provider tags
would fail.

