### PR TITLE
aws - Correct the default value for an empty list of EC2 Tags

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -90,7 +90,7 @@ class DescribeEC2(query.DescribeSource):
 
         m = self.manager.get_model()
         for r in resources:
-            r['Tags'] = resource_tags.get(r[m.id], ())
+            r['Tags'] = resource_tags.get(r[m.id], [])
         return resources
 
 


### PR DESCRIPTION
This PR addresses issue #8953

The empty list literal is `[]`, but in our case it was set to empty tuple literal `()`.
That leads to the following error when we try to use `"length(Tags)"` and the EC2 instance has no tags:

```bash
c7n_org:ERROR Exception running policy:aws-ec2-untagged account:my-account region:us-east-1 error:In function length(), invalid type for value: (), expected one of: ['string', 'array', 'object'], received: "unknown"
```