### PR TITLE
docs - fix event filter example to use `op: contains`

### DIFF
--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -453,9 +453,13 @@ describe resource call as is the case in the ValueFilter
          events:
              - RunInstances
        filters:
-         - type: event                                                                           ─┐ The key is a JMESPath Query of
-           key: "detail.requestParameters.networkInterfaceSet.items[].associatePublicIpAddress"   ├▶the event JSON from CloudWatch
-           value: true                                                                           ─┘
+         - type: event
+           # The key is a JMESPath Query of the event JSON from CloudWatch.
+           key: "detail.requestParameters.networkInterfaceSet.items[].associatePublicIpAddress"
+           # The key expression returns a list. Combining "op: contains" with "value: true"
+           # allows this filter to match if any network interface has a public IP address.
+           op: contains
+           value: true
        actions:
          - type: terminate
            force: true


### PR DESCRIPTION
Also move explanations to in-policy comments rather than side notes off to the right (to avoid losing them off-screen or having to scroll right).

Closes #8947 