### PR TITLE
aws - launch-template-version - generate arns that include a version number

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -2231,6 +2231,12 @@ class LaunchTemplate(query.QueryResourceManager):
                         'LaunchTemplateVersions', ()))
         return template_versions
 
+    def get_arns(self, resources):
+        arns = []
+        for r in resources:
+            arns.append(self.generate_arn(f"{r['LaunchTemplateId']}/{r['VersionNumber']}"))
+        return arns
+
     def get_resources(self, rids, cache=True):
         # Launch template versions have a compound primary key
         #

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -2189,6 +2189,10 @@ class TestLaunchTemplate(BaseTest):
         resources = p.resource_manager.get_resources([
             'lt-00b3b2755218e3fdd'])
         self.assertEqual(len(resources), 4)
+        self.assertIn(
+            'arn:aws:ec2:us-east-1:644160558196:launch-template/lt-00b3b2755218e3fdd/4',
+            p.resource_manager.get_arns(resources)
+        )
 
     def test_launch_template_versions(self):
         factory = self.replay_flight_data('test_launch_template_query')

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -203,7 +203,8 @@ class PolicyMetaLint(BaseTest):
         overrides = overrides.difference(
             {'account', 's3', 'hostedzone', 'log-group', 'rest-api', 'redshift-snapshot',
              'rest-stage', 'codedeploy-app', 'codedeploy-group', 'fis-template', 'dlm-policy',
-             'apigwv2', 'apigwv2-stage', 'apigw-domain-name', 'fis-experiment'})
+             'apigwv2', 'apigwv2-stage', 'apigw-domain-name', 'fis-experiment',
+             'launch-template-version'})
         if overrides:
             raise ValueError("unknown arn overrides in %s" % (", ".join(overrides)))
 


### PR DESCRIPTION
The `aws.launch-template-version` resource represents a specific version of a launch template, but under the covers its generated ARN represented the launch template. Switch to a synthetic ARN that includes a version number.

**Note:** Because this resource type uses EC2-style tag actions rather than universal/bulk tagging, its tag actions will continue to work (and tag launch templates rather than launch template _versions_). That feels a bit quirky, but changing it is likely to break existing policies. As far as I can tell changing only the ARN generation _won't_ break existing policies.