### PR TITLE
c7n-left - fix handling of relative source dir

### DIFF
--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -96,6 +96,7 @@ class RichCli(Output):
 
     def on_vars_discovered(self, var_type, var_map, var_path=None):
         if var_type != "uninitialized" and var_map:
+            var_path = var_path or ""
             self.console.print(f"Loaded {len(var_map)} vars from {var_type} {var_path}")
 
     def on_results(self, policy, results):

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -95,7 +95,7 @@ class RichCli(Output):
         )
 
     def on_vars_discovered(self, var_type, var_map, var_path=None):
-        if var_type != "uninitialized":
+        if var_type != "uninitialized" and var_map:
             self.console.print(f"Loaded {len(var_map)} vars from {var_type} {var_path}")
 
     def on_results(self, policy, results):

--- a/tools/c7n_left/c7n_left/output.py
+++ b/tools/c7n_left/c7n_left/output.py
@@ -72,6 +72,8 @@ class JsonGraph(Output):
         data = {}
         data["input_vars"] = self.input_vars
         data["graph"] = dict(self.graph.resource_data)
+        if self.config.output_query:
+            data = jmespath_search(self.config.output_query, data)
         self.config.output_file.write(json.dumps(data, cls=JSONEncoder, indent=2))
 
 

--- a/tools/c7n_left/c7n_left/providers/terraform/variables.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/variables.py
@@ -125,7 +125,7 @@ class VariableResolver:
         return [
             Path(
                 self._write_file_content(json.dumps(uninitialized_vars), ".tfvars.json").name
-            ).relative_to(self.source_dir)
+            ).relative_to(self.source_dir.absolute())
         ]
 
     def get_env_variables(self):

--- a/tools/c7n_left/c7n_left/providers/terraform/variables.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/variables.py
@@ -162,5 +162,5 @@ class VariableResolver:
             else:
                 suffix = str(v).endswith(".tfvars.json") and ".tfvars.json" or ".tfvars"
                 vfr = self._write_file_content(v.read_text(), suffix)
-                resolved_files.append(Path(vfr.name).relative_to(self.source_dir))
+                resolved_files.append(Path(vfr.name).relative_to(self.source_dir.absolute()))
         return resolved_files

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "c7n_left"
-version = "0.3.3"
+version = "0.3.4"
 description = "Custodian policies for IAAC definitions"
 authors = ["Cloud Custodian Project"]
 license = "Apache-2"

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -831,6 +831,8 @@ def test_cli_dump(policy_env, test, debug_cli_runner):
             str(policy_env.policy_dir),
             "--var-file",
             policy_env.policy_dir / "vars.tfvars",
+            "--output-query",
+            "input_vars",
             # "--var-file",
             # policy_env.policy_dir / "vars2.tfvars",
             "--output-file",
@@ -839,8 +841,7 @@ def test_cli_dump(policy_env, test, debug_cli_runner):
     )
     assert result.exit_code == 0
     data = json.loads((policy_env.policy_dir / "output.json").read_text())
-    assert data["graph"]["aws_cloudwatch_log_group"][0]["name"] == "riddle--logs"
-    assert data["input_vars"] == {
+    assert data == {
         "environment": {"repo": "cloud-custodian/cloud-custodian"},
         "uninitialized": {"env": ""},
         "user:vars.tfvars": {"app": "riddle"},

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -481,6 +481,29 @@ resource "aws_cloudwatch_log_stream" "foo" {
     assert results[0].resource["name"] == "Yada"
 
 
+def test_graph_merge_unknown_variable_relative_path(policy_env, monkeypatch):
+    policy_env.write_tf(
+        """
+        variable component {
+           type = string
+        }
+        resource "aws_cloudwatch_log_group" "yada" {
+           name = "Yada"
+           tags = merge(
+              {"Env" = "Public"},
+              {"Component" = var.component}
+           )
+        }
+        """
+    )
+
+    monkeypatch.chdir(policy_env.policy_dir)
+    graph = policy_env.get_graph(Path("."))
+    resource_types = list(graph.get_resources_by_type("aws_cloudwatch_log_group"))
+    log_group = resource_types.pop()[-1][0]
+    assert log_group["tags"] == {"Env": "Public", "Component": ""}
+
+
 def test_graph_merge_unknown_variable(policy_env):
     policy_env.write_tf(
         """

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -739,6 +739,22 @@ resource "aws_alb" "positive1" {
 #    assert resources[0][1][0]['load_balancer_type'] == 'network'
 
 
+def test_graph_var_file_abs_rel_source(tmp_path, monkeypatch, var_tf_setup):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "vars.tfvars").write_text('balancer_type = "network"')
+    graph = TerraformProvider().parse(Path("tf"), (tmp_path / "vars.tfvars",))
+    resources = list(graph.get_resources_by_type("aws_alb"))
+    assert resources[0][1][0]["load_balancer_type"] == "network"
+
+
+def test_graph_var_file_rel_abs_source(tmp_path, monkeypatch, var_tf_setup):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "vars.tfvars").write_text('balancer_type = "network"')
+    graph = TerraformProvider().parse(tmp_path / "tf", ("vars.tfvars",))
+    resources = list(graph.get_resources_by_type("aws_alb"))
+    assert resources[0][1][0]["load_balancer_type"] == "network"
+
+
 def test_graph_non_root_var_file(tmp_path, var_tf_setup):
     (tmp_path / "vars.tfvars").write_text('balancer_type = "network"')
     graph = TerraformProvider().parse(tmp_path / "tf", (tmp_path / "vars.tfvars",))


### PR DESCRIPTION
if we're given a relative path, when we go to create 
an unitialized vars file, we get an absolute path,
which can't be made relative to the source dir, resulting
in the following traceback.

todo 
- [x]  an additional test for a relative source dir and an absolute var path as well.

addresses a few other paper cuts
 - dump command had a --output-query flag that wasn't wired in
 - variable load messages were printing even for no variables loaded and env vars would print a `None` path.


```
 File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/c7n_left/cli.py", line 136, in run
    sys.exit(int(runner.run()))
                 ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/c7n_left/core.py", line 238, in run
    graph = self.provider.parse(self.options.source_dir, self.options.var_files)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/c7n_left/providers/terraform/provider.py", line 88, in parse
    with resolver.get_variables() as var_files:
  File "/usr/local/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/c7n_left/providers/terraform/variables.py", line 80, in get_variables
    self.resolved_files["uninitialized"] = self.get_uninitialized_var_files()
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/c7n_left/providers/terraform/variables.py", line 128, in 
get_uninitialized_var_files
    ).relative_to(self.source_dir)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/pathlib.py", line 730, in relative_to
    raise ValueError("{!r} is not in the subpath of {!r}"
```
