### PR TITLE
gcp - bq-job - update enum_spec

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/bigquery.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/bigquery.py
@@ -64,7 +64,7 @@ class BigQueryJob(QueryResourceManager):
         service = 'bigquery'
         version = 'v2'
         component = 'jobs'
-        enum_spec = ('list', 'jobs[]', {'allUsers': True})
+        enum_spec = ('list', 'jobs[]', {'allUsers': True, 'projection': 'full'})
         get_requires_event = True
         scope = 'project'
         scope_key = 'projectId'


### PR DESCRIPTION
The resource **gcp.bq-job** returned insufficient fields. By adding the `'projection': 'full'` parameter I was able to see all the resource information.
Method: jobs.list: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/list

**resources.json before:**
```json
[
  {
    "id": "cloud-custodian:US.job_id",
    "kind": "bigquery#job",
    "jobReference": {
      "projectId": "cloud-custodian",
      "jobId": "job_id",
      "location": "US"
    },
    "state": "DONE",
    "errorResult": {
      "reason": "notFound",
      "message": "Not found: Dataset cloud-custodian:dataset_name was not found in location US"
    },
    "statistics": {
      "creationTime": "1695906539628",
      "startTime": "1695906539657",
      "endTime": "1695906539657"
    },
    "status": {
      "errorResult": {
        "reason": "notFound",
        "message": "Not found: Dataset cloud-custodian:dataset_name was not found in location US"
      },
      "state": "DONE"
    }
  }
]
```

**resources.json after:**
```json
[
  {
    "id": "cloud-custodian:US.job_id",
    "kind": "bigquery#job",
    "jobReference": {
      "projectId": "cloud-custodian",
      "jobId": "job_id",
      "location": "US"
    },
    "state": "DONE",
    "errorResult": {
      "reason": "notFound",
      "message": "Not found: Dataset cloud-custodian:dataset_id was not found in location US"
    },
    "statistics": {
      "creationTime": "1695906539628",
      "startTime": "1695906539657",
      "endTime": "1695906539657"
    },
    "configuration": {
      "query": {
        "query": "SELECT /* do nothing */ 1;",
        "destinationTable": {
          "projectId": "cloud-custodian",
          "datasetId": "dataset_id",
          "tableId": "table_id"
        },
        "createDisposition": "CREATE_IF_NEEDED",
        "writeDisposition": "WRITE_EMPTY",
        "priority": "INTERACTIVE",
        "useQueryCache": true,
        "useLegacySql": false
      },
      "jobType": "QUERY"
    },
    "status": {
      "errorResult": {
        "reason": "notFound",
        "message": "Not found: Dataset cloud-custodian:dataset_id was not found in location US"
      },
      "errors": [
        {
          "reason": "notFound",
          "message": "Not found: Dataset cloud-custodian:dataset_id was not found in location US"
        }
      ],
      "state": "DONE"
    },
    "user_email": "test@cloud-custodian.iam.gserviceaccount.com",
    "principal_subject": "serviceAccount:test@cloud-custodian.iam.gserviceaccount.com"
  }
]
```
