### PR TITLE
azure - event-grid-domain

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/event_grid_domain.py
+++ b/tools/c7n_azure/c7n_azure/resources/event_grid_domain.py
@@ -1,0 +1,26 @@
+from c7n_azure.provider import resources
+from c7n_azure.query import QueryResourceManager
+
+
+@resources.register('event-grid-domain')
+class EventGridDomain(QueryResourceManager):
+    """Event Grid Domain Resource
+
+    :example:
+
+    Finds all Event Grid Domains in the subscription
+
+    .. code-block:: yaml
+
+        policies:
+            - name: find-all-event-grid-domains
+              resource: azure.event-grid-domain
+
+    """
+
+    class resource_type(QueryResourceManager.resource_type):
+        doc_groups = ['Events']
+
+        service = 'azure.mgmt.eventgrid'
+        client = 'EventGridManagementClient'
+        enum_spec = ('domains', 'list_by_subscription', None)

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -31,6 +31,7 @@ ResourceMap = {
     "azure.defender-setting": "c7n_azure.resources.defender.DefenderSetting",
     "azure.disk": "c7n_azure.resources.disk.Disk",
     "azure.dnszone": "c7n_azure.resources.dns_zone.DnsZone",
+    "azure.event-grid-domain": "c7n_azure.resources.event_grid_domain.EventGridDomain",
     "azure.eventhub": "c7n_azure.resources.event_hub.EventHub",
     "azure.eventsubscription": "c7n_azure.resources.event_subscription.EventSubscription",
     "azure.front-door": "c7n_azure.resources.front_door.FrontDoor",

--- a/tools/c7n_azure/tests_azure/cassettes/AzureEventGridDomainTest.test_event_grid_domain_policy_run.json
+++ b/tools/c7n_azure/tests_azure/cassettes/AzureEventGridDomainTest.test_event_grid_domain_policy_run.json
@@ -1,0 +1,74 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.EventGrid/domains?api-version=2020-06-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Wed, 01 Sep 2021 09:42:31 GMT"
+                    ],
+                    "content-length": [
+                        "1149"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "properties": {
+                                    "privateEndpointConnections": [
+                                        {
+                                            "properties": {
+                                                "privateEndpoint": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Network/privateEndpoints/testegendp"
+                                                },
+                                                "groupIds": [
+                                                    "domain"
+                                                ],
+                                                "privateLinkServiceConnectionState": {
+                                                    "status": "Approved",
+                                                    "description": "Auto-approved",
+                                                    "actionsRequired": "None"
+                                                },
+                                                "provisioningState": "Succeeded"
+                                            },
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.EventGrid/domains/testegvv/privateEndpointConnections/testegendp.b4364cac-af59-4ba1-a716-f579cfd2b92c",
+                                            "name": "testegendp.b4364cac-af59-4ba1-a716-f579cfd2b92c",
+                                            "type": "Microsoft.EventGrid/domains/privateEndpointConnections"
+                                        }
+                                    ],
+                                    "provisioningState": "Succeeded",
+                                    "endpoint": "https://testegvv.eastus-1.eventgrid.azure.net/api/events",
+                                    "inputSchema": "EventGridSchema",
+                                    "metricResourceId": "193a20c8-e7db-48f6-8dd3-fbbc8689bcd3",
+                                    "publicNetworkAccess": "Enabled"
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.EventGrid/domains/testegvv",
+                                "name": "testegvv",
+                                "type": "Microsoft.EventGrid/domains"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_event_grid_domain.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_event_grid_domain.py
@@ -1,0 +1,28 @@
+from ..azure_common import BaseTest
+
+
+class AzureEventGridDomainTest(BaseTest):
+
+    def test_event_grid_domain_schema_validate(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'find-all-event-grid-domains',
+                'resource': 'azure.event-grid-domain'
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_event_grid_domain_policy_run(self):
+        p = self.load_policy({
+            'name': 'find-all-event-grid-domains',
+            'resource': 'azure.event-grid-domain',
+            'filters': [{
+                'type': 'value',
+                'key': 'properties.privateEndpointConnections[].properties'
+                       '.privateLinkServiceConnectionState.status',
+                'value': 'Approved',
+                'op': 'contains'
+            }],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('testegvv', resources[0]['name'])


### PR DESCRIPTION
Use case:
`
policies:
  - name: asb_eg_domains_private_link
    description: Event Grid Domains service without Private Endpoint connection configured
    resource: azure.event-grid-domain
    filters:
      - not:
          - type: value
            key: properties.privateEndpointConnections[].properties.privateLinkServiceConnectionState.status
            value: Approved
            op: contains
`