### PR TITLE
docs - cover list-item under generic filters

### DIFF
--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -437,6 +437,59 @@ Value Path
   This implementation allows for the comparison of two separate lists of values
   within the same resource.
 
+List Item Filter
+----------------
+
+The ``list-item`` filter makes it easier to evaluate resource properties that contain
+a list of values.
+
+Example 1: AWS ECS Task Definitions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+AWS ECS task definitions include a list of container definitions. This policy matches
+a task definition if any of its container images reference an image from outside a given
+account and region:
+
+  .. code-block:: yaml
+
+    - name: find-task-def-not-using-registry
+      resource: aws.ecs-task-definition
+      filters:
+        - not:
+          - type: list-item
+            key: containerDefinitions
+            attrs:
+              - not:
+                - type: value
+                  key: image
+                  value: "${account_id}.dkr.ecr.us-east-2.amazonaws.com.*"
+                  op: regex
+
+That check is not possible with the ``value`` filter alone, because the ``regex``
+operator cannot operate directly against a list.
+
+Example 2: S3 Lifecycle Rules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+S3 buckets can have lifecycle policies that include multiple rules.
+This policy matches buckets that are missing a rule for cleaning up
+incomplete multipart uploads.
+
+  .. code-block:: yaml
+
+    - name: s3-mpu-cleanup-not-configured
+      resource: aws.s3
+      filters:
+        - not:
+          - type: list-item
+            key: Lifecycle.Rules[]
+            attrs:
+              - Status: Enabled
+              - AbortIncompleteMultipartUpload.DaysAfterInitiation: not-null
+
+Here the ``list-item`` filter ensures that we check a combination of multiple
+properties for each individual lifecycle rule.
+
 Event Filter
 -------------
 


### PR DESCRIPTION
In #9004 @danbunnell made the good point that having the `list-item` filter buried under AWS filters hurts its discoverability a bit. It's a pretty useful filter, so we should probably cover it in the generic section.

This is a first stab stolen from the existing docs under aws common filters and @danbunnell's S3 use case. Tweaks/additions/clarifications welcome.