### PR TITLE
Enhance iam-policy Filter to Support gcp.organization and gcp.folder Resources

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/filters/iampolicy.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/iampolicy.py
@@ -147,7 +147,8 @@ class IamPolicyUserRolePairFilter(ValueFilter):
         client = self.get_client(session, model)
 
         for r in resources:
-            iam_policy = client.execute_command('getIamPolicy', {"resource": r["projectId"]})
+            resource_key = 'projectId' if 'projectId' in r else 'name'
+            iam_policy = client.execute_command('getIamPolicy', {"resource": r[resource_key]})
             r["c7n:iamPolicyUserRolePair"] = {}
             userToRolesMap = {}
 

--- a/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resourcemanager.py
@@ -485,3 +485,29 @@ class AccessApprovalFilter(ValueFilter):
                 raise ex
 
         return access_approval
+
+
+@Organization.filter_registry.register('iam-policy')
+class OrganizationIamPolicyFilter(IamPolicyFilter):
+    """
+    Overrides the base implementation to process Organization resources correctly.
+    """
+    permissions = ('resourcemanager.organizations.getIamPolicy',)
+
+    def _verb_arguments(self, resource):
+        verb_arguments = SetIamPolicy._verb_arguments(self, resource)
+        verb_arguments['body'] = {}
+        return verb_arguments
+
+
+@Folder.filter_registry.register('iam-policy')
+class FolderIamPolicyFilter(IamPolicyFilter):
+    """
+    Overrides the base implementation to process Folder resources correctly.
+    """
+    permissions = ('resourcemanager.folders.getIamPolicy',)
+
+    def _verb_arguments(self, resource):
+        verb_arguments = SetIamPolicy._verb_arguments(self, resource)
+        verb_arguments['body'] = {}
+        return verb_arguments

--- a/tools/c7n_gcp/tests/data/flights/folder-iam-policy/get-v2-folders_1.json
+++ b/tools/c7n_gcp/tests/data/flights/folder-iam-policy/get-v2-folders_1.json
@@ -1,0 +1,43 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 02 Oct 2023 21:09:44 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=279",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1563",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v2/folders?parent=organizations%2F111111111111&alt=json"
+  },
+  "body": {
+    "folders": [
+      {
+        "name": "folders/222222222222",
+        "parent": "organizations/870080179722",
+        "displayName": "Foo",
+        "lifecycleState": "ACTIVE",
+        "createTime": "2023-05-23T12:22:07.777Z"
+      },
+      {
+        "name": "folders/333333333333",
+        "parent": "organizations/870080179722",
+        "displayName": "Bar",
+        "lifecycleState": "ACTIVE",
+        "createTime": "2023-03-31T19:17:36.833Z"
+      },
+      {
+        "name": "folders/444444444444",
+        "parent": "organizations/870080179722",
+        "displayName": "Baz",
+        "lifecycleState": "ACTIVE",
+        "createTime": "2023-05-10T16:53:57.896Z"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-222222222222-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-222222222222-getIamPolicy_1.json
@@ -1,0 +1,36 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 02 Oct 2023 21:09:45 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=180",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "364",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwYGvF9al7g=",
+    "bindings": [
+      {
+        "role": "roles/resourcemanager.folderAdmin",
+        "members": [
+          "user:abc@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/admin",
+        "members": [
+          "user:hijklm@gmail.com",
+          "zzzzz"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-222222222222-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-222222222222-getIamPolicy_1.json
@@ -27,8 +27,9 @@
       {
         "role": "roles/admin",
         "members": [
-          "user:hijklm@gmail.com",
-          "zzzzz"
+          "serviceAccount:abc@testproject.iam.gserviceaccount.com",
+          "user:abc@gmail.com",
+          "abcdefg"
         ]
       }
     ]

--- a/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-333333333333-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-333333333333-getIamPolicy_1.json
@@ -27,8 +27,9 @@
       {
         "role": "roles/admin",
         "members": [
-          "user:hijklm@gmail.com",
-          "zzzzz"
+          "serviceAccount:abc@testproject.iam.gserviceaccount.com",
+          "user:abc@gmail.com",
+          "abcdefg"
         ]
       }
     ]

--- a/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-333333333333-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-333333333333-getIamPolicy_1.json
@@ -1,0 +1,36 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 02 Oct 2023 21:09:45 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=171",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "364",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwYCgz1pUZ4=",
+    "bindings": [
+      {
+        "role": "roles/resourcemanager.folderAdmin",
+        "members": [
+          "user:abc@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/admin",
+        "members": [
+          "user:hijklm@gmail.com",
+          "zzzzz"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-444444444444-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-444444444444-getIamPolicy_1.json
@@ -1,0 +1,36 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 02 Oct 2023 21:09:44 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=181",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1511",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwYDhvAWOho=",
+    "bindings": [
+      {
+        "role": "roles/resourcemanager.folderAdmin",
+        "members": [
+          "user:abc@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/admin",
+        "members": [
+          "user:hijklm@gmail.com",
+          "zzzzz"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-444444444444-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/folder-iam-policy/post-v2-folders-444444444444-getIamPolicy_1.json
@@ -27,8 +27,9 @@
       {
         "role": "roles/admin",
         "members": [
-          "user:hijklm@gmail.com",
-          "zzzzz"
+          "serviceAccount:abc@testproject.iam.gserviceaccount.com",
+          "user:abc@gmail.com",
+          "abcdefg"
         ]
       }
     ]

--- a/tools/c7n_gcp/tests/data/flights/organization-iam-policy/post-v1-organizations-111111111111-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/organization-iam-policy/post-v1-organizations-111111111111-getIamPolicy_1.json
@@ -1,0 +1,83 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 02 Oct 2023 20:25:34 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=236",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "14708",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwYGazsSkKc=",
+    "bindings": [
+      {
+        "role": "roles/owner",
+        "members": [
+          "serviceAccount:abc@testproject.iam.gserviceaccount.com",
+          "user:abc@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:def@testproject.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "user:abc@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/admin",
+        "members": [
+          "group:dummyGroup1",
+          "user:abc@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/editor",
+        "members": [
+          "allUsers",
+          "user:zzz@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "user:abc@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/admin",
+        "members": [
+          "serviceAccount:abc@testproject.iam.gserviceaccount.com",
+          "user:abc@gmail.com",
+          "abcdefg"
+        ]
+      },
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:def@testproject.iam.gserviceaccount.com",
+          "user:zzz@gmail.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "user:abc@gmail.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/organization-iam-policy/post-v1-organizations-search_1.json
+++ b/tools/c7n_gcp/tests/data/flights/organization-iam-policy/post-v1-organizations-search_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 02 Oct 2023 20:52:25 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=142",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "287",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "organizations": [
+      {
+        "displayName": "foo.bar",
+        "owner": {
+          "directoryCustomerId": "F36eaat1i"
+        },
+        "creationTime": "2021-11-23T17:36:36.820Z",
+        "lifecycleState": "ACTIVE",
+        "name": "organizations/111111111111"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -237,8 +237,8 @@ class FolderTest(BaseTest):
             'filters': [{
                 'type': 'iam-policy',
                 'user-role':
-                    {'user': "zzzzz",
-                    'has': False,
+                    {'user': "abcdefg",
+                    'has': True,
                     'role': 'roles/admin'}
             }]},
             session_factory=factory)

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -8,7 +8,10 @@ from unittest import mock
 
 import pytest
 
-from c7n_gcp.resources.resourcemanager import FolderIamPolicyFilter, HierarchyAction, OrganizationIamPolicyFilter
+from c7n_gcp.resources.resourcemanager import (
+    FolderIamPolicyFilter, HierarchyAction, OrganizationIamPolicyFilter
+)
+
 from gcp_common import BaseTest
 
 
@@ -176,16 +179,16 @@ class OrganizationTest(BaseTest):
     @mock.patch("c7n_gcp.resources.resourcemanager.SetIamPolicy._verb_arguments")
     def test_organization_iam_policy_filter_verb_arguments(self, mock_base_verb_arguments):
         organization = {'id': 'example_organization_id'}
-        
+
         mock_manager = mock.Mock()
         mock_manager.resource_type = 'organization'
-        
+
         mock_base_verb_arguments.return_value = {'body': {}}
-        
+
         policy_filter = OrganizationIamPolicyFilter(data={}, manager=mock_manager)
-        
+
         params = policy_filter._verb_arguments(organization)
-        
+
         assert 'body' in params
         assert params['body'] == {}
 
@@ -270,18 +273,19 @@ class FolderTest(BaseTest):
     @mock.patch("c7n_gcp.resources.resourcemanager.SetIamPolicy._verb_arguments")
     def test_folder_iam_policy_filter_verb_arguments(self, mock_base_verb_arguments):
         folder = {'id': 'example_folder_id'}
-        
+
         mock_manager = mock.Mock()
         mock_manager.resource_type = 'folder'
-        
+
         mock_base_verb_arguments.return_value = {'body': {}}
-        
+
         policy_filter = FolderIamPolicyFilter(data={}, manager=mock_manager)
-        
+
         params = policy_filter._verb_arguments(folder)
-        
+
         assert 'body' in params
         assert params['body'] == {}
+
 
 class ProjectTest(BaseTest):
 
@@ -640,7 +644,6 @@ class TestAccessApprovalFilter(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-
 
 
 class TestEssentialContactsFilter(BaseTest):

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -126,6 +126,53 @@ class OrganizationTest(BaseTest):
         expected_bindings[0]['members'].insert(2, 'user:mediapills@gmail.com')
         self.assertEqual(actual_bindings['bindings'], expected_bindings)
 
+    def test_organization_iam_policy_value_filter(self):
+        factory = self.replay_flight_data('organization-iam-policy')
+        p = self.load_policy({
+            'name': 'resource',
+            'resource': 'gcp.organization',
+            'filters': [{
+                'type': 'iam-policy',
+                'doc':
+                    {'key': 'bindings[*].members[]',
+                    'op': 'contains',
+                    'value': 'user:abc@gmail.com'}
+            }]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        for resource in resources:
+            self.assertTrue('c7n:iamPolicy' in resource)
+            bindings = resource['c7n:iamPolicy']['bindings']
+            members = set()
+            for binding in bindings:
+                for member in binding['members']:
+                    members.add(member)
+            self.assertTrue('user:abc@gmail.com' in members)
+
+    def test_organization_iam_policy_user_pair_filter(self):
+        factory = self.replay_flight_data('organization-iam-policy')
+        p = self.load_policy({
+            'name': 'resource',
+            'resource': 'gcp.organization',
+            'filters': [{
+                'type': 'iam-policy',
+                'user-role':
+                    {'user': "abcdefg",
+                    'has': True,
+                    'role': 'roles/admin'}
+            }]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        for resource in resources:
+            self.assertTrue('c7n:iamPolicyUserRolePair' in resource)
+            user_role_pair = resource['c7n:iamPolicyUserRolePair']
+            self.assertTrue("abcdefg" in user_role_pair)
+            self.assertTrue('roles/admin' in user_role_pair["abcdefg"])
+
 
 class FolderTest(BaseTest):
 
@@ -150,6 +197,59 @@ class FolderTest(BaseTest):
                 "gcp:cloudresourcemanager:::folder/112838955399",
             ],
         )
+
+    def test_folder_iam_policy_value_filter(self):
+        factory = self.replay_flight_data('folder-iam-policy')
+        p = self.load_policy({
+            'name': 'resource',
+            'resource': 'gcp.folder',
+            'query': [{
+                'parent': 'organizations/111111111111'
+            }],
+            'filters': [{
+                'type': 'iam-policy',
+                'doc':
+                    {'key': 'bindings[*].members[]',
+                    'op': 'contains',
+                    'value': 'user:abc@gmail.com'}
+            }]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 3)
+
+        for resource in resources:
+            self.assertTrue('c7n:iamPolicy' in resource)
+            bindings = resource['c7n:iamPolicy']['bindings']
+            members = set()
+            for binding in bindings:
+                for member in binding['members']:
+                    members.add(member)
+            self.assertTrue('user:abc@gmail.com' in members)
+
+    def test_folder_iam_policy_user_pair_filter(self):
+        factory = self.replay_flight_data('folder-iam-policy')
+        p = self.load_policy({
+            'name': 'resource',
+            'resource': 'gcp.folder',
+            'query': [{
+                'parent': 'organizations/111111111111'
+            }],
+            'filters': [{
+                'type': 'iam-policy',
+                'user-role':
+                    {'user': "zzzzz",
+                    'has': False,
+                    'role': 'roles/admin'}
+            }]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 3)
+
+        for resource in resources:
+            self.assertTrue('c7n:iamPolicyUserRolePair' in resource)
+            user_role_pair = resource['c7n:iamPolicyUserRolePair']
+            self.assertTrue("abcdefg" in user_role_pair)
+            self.assertTrue('roles/admin' in user_role_pair["abcdefg"])
 
 
 class ProjectTest(BaseTest):

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-from c7n_gcp.resources.resourcemanager import HierarchyAction
+from c7n_gcp.resources.resourcemanager import FolderIamPolicyFilter, HierarchyAction, OrganizationIamPolicyFilter
 from gcp_common import BaseTest
 
 
@@ -173,6 +173,22 @@ class OrganizationTest(BaseTest):
             self.assertTrue("abcdefg" in user_role_pair)
             self.assertTrue('roles/admin' in user_role_pair["abcdefg"])
 
+    @mock.patch("c7n_gcp.resources.resourcemanager.SetIamPolicy._verb_arguments")
+    def test_organization_iam_policy_filter_verb_arguments(self, mock_base_verb_arguments):
+        organization = {'id': 'example_organization_id'}
+        
+        mock_manager = mock.Mock()
+        mock_manager.resource_type = 'organization'
+        
+        mock_base_verb_arguments.return_value = {'body': {}}
+        
+        policy_filter = OrganizationIamPolicyFilter(data={}, manager=mock_manager)
+        
+        params = policy_filter._verb_arguments(organization)
+        
+        assert 'body' in params
+        assert params['body'] == {}
+
 
 class FolderTest(BaseTest):
 
@@ -251,6 +267,21 @@ class FolderTest(BaseTest):
             self.assertTrue("abcdefg" in user_role_pair)
             self.assertTrue('roles/admin' in user_role_pair["abcdefg"])
 
+    @mock.patch("c7n_gcp.resources.resourcemanager.SetIamPolicy._verb_arguments")
+    def test_folder_iam_policy_filter_verb_arguments(self, mock_base_verb_arguments):
+        folder = {'id': 'example_folder_id'}
+        
+        mock_manager = mock.Mock()
+        mock_manager.resource_type = 'folder'
+        
+        mock_base_verb_arguments.return_value = {'body': {}}
+        
+        policy_filter = FolderIamPolicyFilter(data={}, manager=mock_manager)
+        
+        params = policy_filter._verb_arguments(folder)
+        
+        assert 'body' in params
+        assert params['body'] == {}
 
 class ProjectTest(BaseTest):
 


### PR DESCRIPTION
Extends the capability of the `iam-policy` filter type to support `gcp.organization` and `gcp.folder` resources. Previously, this filter type was only available for the `gcp.project` resource. With this enhancement, users can analyze IAM Policy information across all three GCP resource hierarchy levels: Organization, Folder, and Project, enabling more comprehensive policy evaluations and management.