### PR TITLE
fix: use correct regex patterns in ami shares

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -432,8 +432,14 @@ class SetPermissions(BaseAction):
         remove = []
         add = []
         account_regex = re.compile('\\d{12}')
-        org_regex = re.compile('arn:[a-zA-Z-]+:organizations:\\d{12}:organization/o-.*')
-        ou_regex = re.compile('arn:[a-zA-Z-]+:organizations:\\d{12}:ou/o-.*/ou-.*')
+        # https://docs.aws.amazon.com/organizations/latest/APIReference/API_Organization.html
+        org_regex = re.compile(
+            r'arn:aws:organizations::\d{12}:organization\/o-[a-z0-9]{10,32}'
+        )
+        # https://docs.aws.amazon.com/organizations/latest/APIReference/API_OrganizationalUnit.html
+        ou_regex = re.compile(
+            r'arn:aws:organizations::\d{12}:ou\/o-[a-z0-9]{10,32}\/ou-[0-9a-z]{4,32}-[0-9a-z]{8,32}'
+        )
         if to_remove:
             if 'all' in to_remove:
                 remove.append({'Group': 'all'})

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -434,11 +434,11 @@ class SetPermissions(BaseAction):
         account_regex = re.compile('\\d{12}')
         # https://docs.aws.amazon.com/organizations/latest/APIReference/API_Organization.html
         org_regex = re.compile(
-            r'arn:aws:organizations::\d{12}:organization\/o-[a-z0-9]{10,32}'
+            r'arn:[a-zA-Z-]+:organizations::\d{12}:organization\/o-[a-z0-9]{10,32}'
         )
         # https://docs.aws.amazon.com/organizations/latest/APIReference/API_OrganizationalUnit.html
         ou_regex = re.compile(
-            r'arn:aws:organizations::\d{12}:ou\/o-[a-z0-9]{10,32}\/ou-[0-9a-z]{4,32}-[0-9a-z]{8,32}'
+            r'arn:[a-zA-Z-]+:organizations::\d{12}:ou\/o-[a-z0-9]{10,32}\/ou-[0-9a-z]{4,32}-[0-9a-z]{8,32}'
         )
         if to_remove:
             if 'all' in to_remove:


### PR DESCRIPTION
This PR provides a fix to use correct/official regex patterns in AMI-Resource when you need to filter or act on AMIs shared with certain ORGs and/or OUs. Before this PR, the regex patterns weren't able to identify such shares => Current version for ORGs i.e. causes pattern error: https://regex101.com/r/soUzXk/1 But even if fixed, the current pattern is incorrect: https://regex101.com/r/4ALvll/1