### PR TITLE
aws - glue - fix toggle-metrics filter

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -211,7 +211,7 @@ class GlueJobToggleMetrics(BaseAction):
             del params['Timeout']
 
         if self.data.get('enabled'):
-            if not 'DefaultArguments' in params:
+            if 'DefaultArguments' not in params:
                 params['DefaultArguments'] = {}
             params["DefaultArguments"]["--enable-metrics"] = ""
         else:

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -205,10 +205,19 @@ class GlueJobToggleMetrics(BaseAction):
         if 'WorkerType' in params or 'NumberOfWorkers' in params:
             del params['MaxCapacity']
 
+        # Can't specify Timeout when updating Ray jobs.
+        # Removing Timeout preserves default setting.
+        if params['Command']['Name'] == 'glueray':
+            del params['Timeout']
+
         if self.data.get('enabled'):
+            if not 'DefaultArguments' in params:
+                params['DefaultArguments'] = {}
             params["DefaultArguments"]["--enable-metrics"] = ""
         else:
-            del params["DefaultArguments"]["--enable-metrics"]
+            if 'DefaultArguments' in params and \
+                '--enable-metrics' in params['DefaultArguments']:
+                del params["DefaultArguments"]["--enable-metrics"]
 
         return params
 

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.GetJobs_1.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.GetJobs_1.json
@@ -3,147 +3,140 @@
     "data": {
         "Jobs": [
             {
-                "Name": "my-testing-job",
+                "Name": "test-job-1",
                 "Description": "",
-                "Role": "AWSGlueServiceRoleDefault",
+                "Role": "arn:aws:iam::644160558196:role/my-glue-role",
                 "CreatedOn": {
                     "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 14,
-                    "minute": 57,
-                    "second": 39,
-                    "microsecond": 289000
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 12,
+                    "minute": 35,
+                    "second": 18,
+                    "microsecond": 390000
                 },
                 "LastModifiedOn": {
                     "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 20,
-                    "second": 47,
-                    "microsecond": 458000
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 17,
+                    "second": 21,
+                    "microsecond": 111000
                 },
                 "ExecutionProperty": {
                     "MaxConcurrentRuns": 1
                 },
                 "Command": {
-                    "Name": "gluestreaming",
-                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/script",
-                    "PythonVersion": "2"
-                },
-                "DefaultArguments": {
-                    "--class": "GlueApp",
-                    "--job-bookmark-option": "job-bookmark-disable",
-                    "--job-language": "scala"
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/test-job-1.py",
+                    "PythonVersion": "3"
                 },
                 "MaxRetries": 0,
                 "AllocatedCapacity": 10,
+                "Timeout": 2880,
                 "MaxCapacity": 10.0,
-                "GlueVersion": "0.9"
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "4.0",
+                "ExecutionClass": "STANDARD"
             },
             {
-                "Name": "testjob",
+                "Name": "test-job-2",
                 "Description": "",
-                "Role": "arn:aws:iam::644160558196:role/agi-admin-svc-exec-role",
+                "Role": "arn:aws:iam::644160558196:role/my-glue-role",
                 "CreatedOn": {
                     "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 2,
-                    "second": 48,
-                    "microsecond": 768000
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 32,
+                    "second": 5,
+                    "microsecond": 140000
                 },
                 "LastModifiedOn": {
                     "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 15,
-                    "second": 14,
-                    "microsecond": 198000
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 32,
+                    "second": 5,
+                    "microsecond": 140000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueray",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/test-job-2.py",
+                    "PythonVersion": "3.9",
+                    "Runtime": "Ray2.4"
+                },
+                "DefaultArguments": {},
+                "MaxRetries": 0,
+                "AllocatedCapacity": 6,
+                "Timeout": 480,
+                "MaxCapacity": 6.0,
+                "WorkerType": "Z.2X",
+                "NumberOfWorkers": 3,
+                "GlueVersion": "4.0",
+                "ExecutionClass": "STANDARD"
+            },
+            {
+                "Name": "test-job-3",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/my-glue-role",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 20,
+                    "second": 27,
+                    "microsecond": 504000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 30,
+                    "second": 19,
+                    "microsecond": 543000
                 },
                 "ExecutionProperty": {
                     "MaxConcurrentRuns": 1
                 },
                 "Command": {
                     "Name": "glueetl",
-                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/test-job-3.scala",
                     "PythonVersion": "3"
                 },
                 "DefaultArguments": {
-                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
                     "--class": "GlueApp",
-                    "--enable-continuous-cloudwatch-log": "true",
-                    "--enable-glue-datacatalog": "true",
-                    "--enable-job-insights": "true",
                     "--enable-spark-ui": "true",
-                    "--job-bookmark-option": "job-bookmark-enable",
-                    "--job-language": "python",
-                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/",
+                    "--enable-job-insights": "false",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--job-bookmark-option": "job-bookmark-disable",
+                    "--job-language": "scala",
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/"
                 },
-                "MaxRetries": 3,
+                "MaxRetries": 0,
                 "AllocatedCapacity": 10,
                 "Timeout": 2880,
                 "MaxCapacity": 10.0,
                 "WorkerType": "G.1X",
                 "NumberOfWorkers": 10,
-                "GlueVersion": "3.0"
-            },
-            {
-                "Name": "testjob2",
-                "Description": "",
-                "Role": "arn:aws:iam::644160558196:role/AccountProvisioningRoleForPaas",
-                "CreatedOn": {
-                    "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 7,
-                    "second": 57,
-                    "microsecond": 551000
-                },
-                "LastModifiedOn": {
-                    "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 17,
-                    "second": 59,
-                    "microsecond": 699000
-                },
-                "ExecutionProperty": {
-                    "MaxConcurrentRuns": 1
-                },
-                "Command": {
-                    "Name": "glueetl",
-                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
-                    "PythonVersion": "3"
-                },
-                "DefaultArguments": {
-                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
-                    "--class": "GlueApp",
-                    "--enable-continuous-cloudwatch-log": "true",
-                    "--enable-glue-datacatalog": "true",
-                    "--enable-spark-ui": "true",
-                    "--job-bookmark-option": "job-bookmark-enable",
-                    "--job-language": "python",
-                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
-                },
-                "MaxRetries": 3,
-                "AllocatedCapacity": 11,
-                "Timeout": 2880,
-                "MaxCapacity": 11.0,
-                "WorkerType": "G.1X",
-                "NumberOfWorkers": 10,
-                "GlueVersion": "1.0"
+                "GlueVersion": "4.0",
+                "ExecutionClass": "STANDARD"
             }
         ],
         "ResponseMetadata": {}

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.GetJobs_2.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.GetJobs_2.json
@@ -3,150 +3,146 @@
     "data": {
         "Jobs": [
             {
-                "Name": "my-testing-job",
+                "Name": "test-job-1",
                 "Description": "",
-                "Role": "AWSGlueServiceRoleDefault",
+                "Role": "arn:aws:iam::644160558196:role/my-glue-role",
                 "CreatedOn": {
                     "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 14,
-                    "minute": 57,
-                    "second": 39,
-                    "microsecond": 289000
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 12,
+                    "minute": 35,
+                    "second": 18,
+                    "microsecond": 390000
                 },
                 "LastModifiedOn": {
                     "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 22,
-                    "second": 36,
-                    "microsecond": 569000
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 35,
+                    "second": 42,
+                    "microsecond": 874000
                 },
                 "ExecutionProperty": {
                     "MaxConcurrentRuns": 1
                 },
                 "Command": {
-                    "Name": "gluestreaming",
-                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/script",
-                    "PythonVersion": "2"
+                    "Name": "glueetl",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/test-job-1.py",
+                    "PythonVersion": "3"
                 },
                 "DefaultArguments": {
-                    "--class": "GlueApp",
-                    "--enable-metrics": "",
-                    "--job-bookmark-option": "job-bookmark-disable",
-                    "--job-language": "scala"
+                    "--enable-metrics": ""
                 },
                 "MaxRetries": 0,
                 "AllocatedCapacity": 10,
+                "Timeout": 2880,
                 "MaxCapacity": 10.0,
-                "GlueVersion": "0.9"
+                "WorkerType": "G.1X",
+                "NumberOfWorkers": 10,
+                "GlueVersion": "4.0",
+                "ExecutionClass": "STANDARD"
             },
             {
-                "Name": "testjob",
+                "Name": "test-job-2",
                 "Description": "",
-                "Role": "arn:aws:iam::644160558196:role/agi-admin-svc-exec-role",
+                "Role": "arn:aws:iam::644160558196:role/my-glue-role",
                 "CreatedOn": {
                     "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 2,
-                    "second": 48,
-                    "microsecond": 768000
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 32,
+                    "second": 5,
+                    "microsecond": 140000
                 },
                 "LastModifiedOn": {
                     "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 22,
-                    "second": 36,
-                    "microsecond": 772000
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 35,
+                    "second": 43,
+                    "microsecond": 489000
+                },
+                "ExecutionProperty": {
+                    "MaxConcurrentRuns": 1
+                },
+                "Command": {
+                    "Name": "glueray",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/test-job-2.py",
+                    "PythonVersion": "3.9",
+                    "Runtime": "Ray2.4"
+                },
+                "DefaultArguments": {
+                    "--enable-metrics": ""
+                },
+                "MaxRetries": 0,
+                "AllocatedCapacity": 6,
+                "Timeout": 480,
+                "MaxCapacity": 6.0,
+                "WorkerType": "Z.2X",
+                "NumberOfWorkers": 3,
+                "GlueVersion": "4.0",
+                "ExecutionClass": "STANDARD"
+            },
+            {
+                "Name": "test-job-3",
+                "Description": "",
+                "Role": "arn:aws:iam::644160558196:role/my-glue-role",
+                "CreatedOn": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 20,
+                    "second": 27,
+                    "microsecond": 504000
+                },
+                "LastModifiedOn": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 10,
+                    "day": 12,
+                    "hour": 13,
+                    "minute": 35,
+                    "second": 43,
+                    "microsecond": 701000
                 },
                 "ExecutionProperty": {
                     "MaxConcurrentRuns": 1
                 },
                 "Command": {
                     "Name": "glueetl",
-                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
+                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/test-job-3.scala",
                     "PythonVersion": "3"
                 },
                 "DefaultArguments": {
-                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
                     "--class": "GlueApp",
-                    "--enable-continuous-cloudwatch-log": "true",
-                    "--enable-glue-datacatalog": "true",
-                    "--enable-job-insights": "true",
-                    "--enable-metrics": "",
                     "--enable-spark-ui": "true",
-                    "--job-bookmark-option": "job-bookmark-enable",
-                    "--job-language": "python",
-                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
+                    "--enable-metrics": "",
+                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/",
+                    "--enable-job-insights": "false",
+                    "--enable-glue-datacatalog": "true",
+                    "--enable-continuous-cloudwatch-log": "true",
+                    "--job-bookmark-option": "job-bookmark-disable",
+                    "--job-language": "scala",
+                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/"
                 },
-                "MaxRetries": 3,
+                "MaxRetries": 0,
                 "AllocatedCapacity": 10,
                 "Timeout": 2880,
                 "MaxCapacity": 10.0,
                 "WorkerType": "G.1X",
                 "NumberOfWorkers": 10,
-                "GlueVersion": "3.0"
-            },
-            {
-                "Name": "testjob2",
-                "Description": "",
-                "Role": "arn:aws:iam::644160558196:role/AccountProvisioningRoleForPaas",
-                "CreatedOn": {
-                    "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 7,
-                    "second": 57,
-                    "microsecond": 551000
-                },
-                "LastModifiedOn": {
-                    "__class__": "datetime",
-                    "year": 2022,
-                    "month": 3,
-                    "day": 8,
-                    "hour": 15,
-                    "minute": 22,
-                    "second": 36,
-                    "microsecond": 965000
-                },
-                "ExecutionProperty": {
-                    "MaxConcurrentRuns": 1
-                },
-                "Command": {
-                    "Name": "glueetl",
-                    "ScriptLocation": "s3://aws-glue-assets-644160558196-us-east-1/scripts/Untitled job.py",
-                    "PythonVersion": "3"
-                },
-                "DefaultArguments": {
-                    "--TempDir": "s3://aws-glue-assets-644160558196-us-east-1/temporary/",
-                    "--class": "GlueApp",
-                    "--enable-continuous-cloudwatch-log": "true",
-                    "--enable-glue-datacatalog": "true",
-                    "--enable-metrics": "",
-                    "--enable-spark-ui": "true",
-                    "--job-bookmark-option": "job-bookmark-enable",
-                    "--job-language": "python",
-                    "--spark-event-logs-path": "s3://aws-glue-assets-644160558196-us-east-1/sparkHistoryLogs/"
-                },
-                "MaxRetries": 3,
-                "AllocatedCapacity": 11,
-                "Timeout": 2880,
-                "MaxCapacity": 11.0,
-                "WorkerType": "G.1X",
-                "NumberOfWorkers": 10,
-                "GlueVersion": "1.0"
+                "GlueVersion": "4.0",
+                "ExecutionClass": "STANDARD"
             }
         ],
         "ResponseMetadata": {}

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_1.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_1.json
@@ -1,7 +1,7 @@
 {
     "status_code": 200,
     "data": {
-        "JobName": "my-testing-job",
+        "JobName": "test-job-1",
         "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_2.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_2.json
@@ -1,7 +1,7 @@
 {
     "status_code": 200,
     "data": {
-        "JobName": "testjob",
+        "JobName": "test-job-2",
         "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_3.json
+++ b/tests/data/placebo/test_glue_job_enable_metrics/glue.UpdateJob_3.json
@@ -1,7 +1,7 @@
 {
     "status_code": 200,
     "data": {
-        "JobName": "testjob2",
+        "JobName": "test-job-3",
         "ResponseMetadata": {}
     }
 }


### PR DESCRIPTION
Fixes added for AWS glue-job resource filter `toggle-metrics`:

---

1.

It is possible for glue jobs to exist without the `DefaultArguments` parameter. For these types of jobs, you will encounter the following runtime error:

```
Error updating glue job: 'DefaultArguments'
```

Logic has been added to ensure the `DefaultArguments` parameter exists when updating jobs.

---

2.



Another error can occur when working with Ray jobs for Glue when updating a job and including the `Timeout` parameter:

```
Error updating glue job: An error occurred (InvalidInputException) when calling the UpdateJob operation: Timeout not supported for Ray jobs
```

Removing the timeout parameter resolves this error and preserves the default `Timeout` setting, but we encounter another error for a missing attribute:

```
Error updating glue job: An error occurred (InvalidInputException) when calling the UpdateJob operation: Runtime parameter is required for GlueRay command
```

It has been found that this parameter appears to be missing from the `Command` attribute in prior versions of **Boto**, as specifying **botocore** and **boto3** in the `packages` attribute of the policy appears to fix:

```
policies:
  - name: gluejob-enable-metrics
    resource: glue-job
    description: Enables the collection of metrics for glue job run profiling
    mode:
      type: periodic
      schedule: rate(1 day)
      role: arn:aws:iam::{account_id}:role/my-favorite-role
      packages:
        - botocore
        - boto3
    filters:
      - type: value
        key: 'DefaultArguments."--enable-metrics"'
        value: absent
    actions:
      - type: toggle-metrics
        enabled: true
```