### PR TITLE
aws - iam-oidc-provider - adds delete action

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -2984,6 +2984,42 @@ class OpenIdProvider(QueryResourceManager):
     source_mapping = {'describe': OpenIdDescribe}
 
 
+@OpenIdProvider.action_registry.register('delete')
+class OpenIdProviderDelete(BaseAction):
+    """Delete an OpenID Connect IAM Identity Provider
+
+    For example, if you want to automatically delete an OIDC IdP for example.com
+
+    :example:
+
+      .. code-block:: yaml
+
+        - name: aws-iam-oidc-provider-delete-expired
+          resource: iam-oidc-provider
+          filters:
+            - type: value
+              key: Url
+              value: example.com
+          actions:
+            - type: delete
+
+    """
+    schema = type_schema('delete')
+    permissions = ('iam:DeleteOpenIDConnectProvider',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('iam')
+        for provider in resources:
+            self.manager.retry(
+                client.delete_open_id_connect_provider,
+                OpenIDConnectProviderArn=provider['Arn'],
+                ignore_err_codes=(
+                    'NoSuchEntityException',
+                    'DeleteConflictException',
+                ),
+            )
+
+
 @InstanceProfile.filter_registry.register('has-specific-managed-policy')
 class SpecificIamProfileManagedPolicy(ValueFilter):
     """Filter an IAM instance profile that contains an IAM role that has a specific managed IAM

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -2994,7 +2994,7 @@ class OpenIdProviderDelete(BaseAction):
 
       .. code-block:: yaml
 
-        - name: aws-iam-oidc-provider-delete-expired
+        - name: aws-iam-oidc-provider-delete
           resource: iam-oidc-provider
           filters:
             - type: value

--- a/tests/data/placebo/iam_delete_provider_oidc/iam.DeleteOpenIDConnectProvider_1.json
+++ b/tests/data/placebo/iam_delete_provider_oidc/iam.DeleteOpenIDConnectProvider_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/iam_delete_provider_oidc/iam.GetOpenIDConnectProvider_1.json
+++ b/tests/data/placebo/iam_delete_provider_oidc/iam.GetOpenIDConnectProvider_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200,
+    "data": {
+        "Url": "accounts.google.com",
+        "ClientIDList": [
+            "644160558196-342342xasdasdasda-apps.googleusercontent.com"
+        ],
+        "ThumbprintList": [
+            "cf23df2207d99a74fbe169e3eba035e633b65d94"
+        ],
+        "CreateDate": {
+            "__class__": "datetime",
+            "year": 2023,
+            "month": 10,
+            "day": 14,
+            "hour": 3,
+            "minute": 51,
+            "second": 58,
+            "microsecond": 790000
+        },
+        "Tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/iam_delete_provider_oidc/iam.GetOpenIDConnectProvider_2.json
+++ b/tests/data/placebo/iam_delete_provider_oidc/iam.GetOpenIDConnectProvider_2.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Type": "Sender",
+            "Code": "NoSuchEntity",
+            "Message": "OpenIDConnect Provider not found for arn arn:aws:iam::644160558196:oidc-provider/accounts.google.com"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/iam_delete_provider_oidc/iam.ListOpenIDConnectProviders_1.json
+++ b/tests/data/placebo/iam_delete_provider_oidc/iam.ListOpenIDConnectProviders_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "OpenIDConnectProviderList": [
+            {
+                "Arn": "arn:aws:iam::644160558196:oidc-provider/accounts.google.com"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/iam_delete_provider_oidc/oidc_provider.tf
+++ b/tests/terraform/iam_delete_provider_oidc/oidc_provider.tf
@@ -1,0 +1,16 @@
+# Example lifted from
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_iam_openid_connect_provider" "test_oidc_provider" {
+  url = "https://accounts.google.com"
+
+  client_id_list = [
+    "266362248691-342342xasdasdasda-apps.googleusercontent.com",
+  ]
+
+  thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94"]
+}

--- a/tests/terraform/iam_delete_provider_oidc/tf_resources.json
+++ b/tests/terraform/iam_delete_provider_oidc/tf_resources.json
@@ -1,0 +1,21 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_iam_openid_connect_provider": {
+            "test_oidc_provider": {
+                "arn": "arn:aws:iam::644160558196:oidc-provider/accounts.google.com",
+                "client_id_list": [
+                    "644160558196-342342xasdasdasda-apps.googleusercontent.com"
+                ],
+                "id": "arn:aws:iam::644160558196:oidc-provider/accounts.google.com",
+                "tags": null,
+                "tags_all": {},
+                "thumbprint_list": [
+                    "cf23df2207d99a74fbe169e3eba035e633b65d94"
+                ],
+                "url": "accounts.google.com"
+            }
+        }
+    }
+}

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1387,8 +1387,8 @@ def test_iam_delete_provider_oidc_action(test, iam_delete_provider_oidc):
     # The 'iam_delete_provider_oidc' argument allows us to access the
     # data in the 'tf_resources.json' file inside the
     # 'tests/terraform/iam_delete_provider_oidc' directory.  Here's how
-    # we access the provider's arn using a 'dotted' notation:
-    iam_provider_arn = iam_delete_provider_oidc['aws_iam_openid_connect_provider.test_oidc_provider.arn']
+    # we access the IAM provider's arn using a 'dotted' notation:
+    arn = iam_delete_provider_oidc['aws_iam_openid_connect_provider.test_oidc_provider.arn']
 
     # Uncomment to following line when you're recording the first time:
     # session_factory = test.record_flight_data('iam_delete_provider_oidc')
@@ -1425,12 +1425,12 @@ def test_iam_delete_provider_oidc_action(test, iam_delete_provider_oidc):
     # Here's the number of resources that the policy resolved,
     # i.e. the resources that passed the filters:
     assert len(resources) == 1
-    assert resources[0]['Arn'] == iam_provider_arn
+    assert resources[0]['Arn'] == arn
 
     # We're testing that our delete action worked because the iam
     # provider now no longer exists:
     with pytest.raises(client.exceptions.NoSuchEntityException):
-        client.get_open_id_connect_provider(OpenIDConnectProviderArn=iam_provider_arn)
+        client.get_open_id_connect_provider(OpenIDConnectProviderArn=arn)
 
 # The terraform fixture sets up resources, which happens before we
 # actually enter the test:

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1380,6 +1380,57 @@ def test_iam_group_delete(test, iam_user_group):
     with pytest.raises(client.exceptions.NoSuchEntityException):
         client.get_group(GroupName=resources[0]['GroupName'])
 
+# The terraform fixture sets up resources, which happens before we
+# actually enter the test:
+@terraform('iam_delete_provider_oidc', teardown=terraform.TEARDOWN_IGNORE)
+def test_iam_delete_provider_oidc_action(test, iam_delete_provider_oidc):
+    # The 'iam_delete_provider_oidc' argument allows us to access the
+    # data in the 'tf_resources.json' file inside the
+    # 'tests/terraform/iam_delete_provider_oidc' directory.  Here's how
+    # we access the provider's arn using a 'dotted' notation:
+    iam_provider_arn = iam_delete_provider_oidc['aws_iam_openid_connect_provider.test_oidc_provider.arn']
+
+    # Uncomment to following line when you're recording the first time:
+    # session_factory = test.record_flight_data('iam_delete_provider_oidc')
+
+    # If you already recorded the interaction with AWS for this test,
+    # you can just replay it.  In which case, the files containing the
+    # responses from AWS are gonna be found inside the
+    # 'tests/data/placebo/iam_delete_provider_oidc' directory:
+    session_factory = test.replay_flight_data('iam_delete_provider_oidc')
+
+    # Set up an 'iam' boto client for the test:
+    client = session_factory().client('iam')
+
+    # Execute the 'delete' action that we want to test:
+    pdata = {
+        'name': 'delete',
+        'resource': 'iam-oidc-provider',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'Url',
+                'value': 'accounts.google.com',
+            },
+        ],
+        'actions': [
+            {
+                'type': 'delete',
+            },
+        ],
+    }
+    policy = test.load_policy(pdata, session_factory=session_factory)
+    resources = policy.run()
+
+    # Here's the number of resources that the policy resolved,
+    # i.e. the resources that passed the filters:
+    assert len(resources) == 1
+    assert resources[0]['Arn'] == iam_provider_arn
+
+    # We're testing that our delete action worked because the iam
+    # provider now no longer exists:
+    with pytest.raises(client.exceptions.NoSuchEntityException):
+        client.get_open_id_connect_provider(OpenIDConnectProviderArn=iam_provider_arn)
 
 # The terraform fixture sets up resources, which happens before we
 # actually enter the test:


### PR DESCRIPTION
Adds a delete action for IAM OpenID Connect Identity Provider.