### PR TITLE
Fix list index error in aws arn parsing

### DIFF
--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -299,6 +299,8 @@ class Arn(namedtuple('_Arn', (
         if isinstance(arn, Arn):
             return arn
         parts = arn.split(':', 5)
+        if len(parts) < 3:
+            raise ValueError("Invalid Arn")
         # a few resources use qualifiers without specifying type
         if parts[2] in ('s3', 'apigateway', 'execute-api', 'emr-serverless'):
             parts.append(None)

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -208,6 +208,12 @@ class ArnTest(BaseTest):
             'arn:aws:s3:::my_corporate_bucket/exampleobject.png')
         self.assertEqual(arn.resource, 'my_corporate_bucket/exampleobject.png')
 
+    def test_invalid_arn(self):
+        try:
+            aws.Arn.parse('arn:aws')
+        except ValueError:
+            pass
+
 
 class UtilTest(BaseTest):
 


### PR DESCRIPTION
This fixes an IndexError caused by a list index out of range in c7n/resources/aws.py.

The parse function of the Arn class takes in an arn object or an arn string and parses it. If the input is an arn string, the function will split the string to a maximum of 6 portions with the ":" separator. If the provided arn string has 1 or less ":" separator, the resulting list parts will only contain 1 or 2 items. This makes the parts[2] in the following conditional check raise an IndexError because parts[2] do not exist.

This PR adds a conditional check to ensure the length of parts must be larger than 3 before accessing parts[2].

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated cloud-custodian (https://github.com/google/oss-fuzz/pull/11111).