### PR TITLE
azure - sql-database.filters.data-encryption

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
@@ -694,3 +694,9 @@ class Resize(AzureBaseAction):
             database['name'],
             DatabaseUpdate(sku=sku, max_size_bytes=max_size_bytes)
         )
+
+
+@SqlDatabase.filter_registry.register('data-encryption')
+class SqlDatabaseDataEncryptionFilter(TransparentDataEncryptionFilter):
+
+    schema = type_schema('data-encryption', rinherit=TransparentDataEncryptionFilter.schema)

--- a/tools/c7n_azure/tests_azure/cassettes/SqlDatabaseDataEncryptionFilterTest.data_encryption_filter.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlDatabaseDataEncryptionFilterTest.data_encryption_filter.json
@@ -1,0 +1,311 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/servers?api-version=2015-05-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 09 Mar 2021 14:25:59 GMT"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "478"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "kind": "v12.0",
+                                "properties": {
+                                    "administratorLogin": "custodian",
+                                    "version": "12.0",
+                                    "state": "Ready",
+                                    "fullyQualifiedDomainName": "cctestsqlserverp2fkgne6rt5vw.database.windows.net"
+                                },
+                                "location": "eastus2",
+                                "tags": {
+                                    "CreatorEmail": "yauhen_shaliou@epam.com"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw",
+                                "name": "cctestsqlserverp2fkgne6rt5vw",
+                                "type": "Microsoft.Sql/servers"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases?api-version=2017-10-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 09 Mar 2021 14:25:59 GMT"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "2736"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Standard",
+                                    "tier": "Standard",
+                                    "capacity": 10
+                                },
+                                "kind": "v12.0,user",
+                                "properties": {
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "maxSizeBytes": 268435456000,
+                                    "status": "Online",
+                                    "databaseId": "a3de1cf0-eb1c-4644-8fc9-40887c9b04af",
+                                    "creationDate": "2021-03-09T10:36:46.867Z",
+                                    "currentServiceObjectiveName": "S0",
+                                    "requestedServiceObjectiveName": "S0",
+                                    "defaultSecondaryLocation": "centralus",
+                                    "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "zoneRedundant": false,
+                                    "earliestRestoreDate": "2021-03-09T10:45:19Z",
+                                    "readScale": "Disabled",
+                                    "readReplicaCount": 0,
+                                    "currentSku": {
+                                        "name": "Standard",
+                                        "tier": "Standard",
+                                        "capacity": 10
+                                    }
+                                },
+                                "location": "eastus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/cclongtermretentiondb",
+                                "name": "cclongtermretentiondb",
+                                "type": "Microsoft.Sql/servers/databases"
+                            },
+                            {
+                                "sku": {
+                                    "name": "Standard",
+                                    "tier": "Standard",
+                                    "capacity": 10
+                                },
+                                "kind": "v12.0,user",
+                                "properties": {
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "maxSizeBytes": 2147483648,
+                                    "status": "Online",
+                                    "databaseId": "86780124-b09a-45ea-b2b8-1633fde62317",
+                                    "creationDate": "2021-03-09T10:36:41.337Z",
+                                    "currentServiceObjectiveName": "S0",
+                                    "requestedServiceObjectiveName": "S0",
+                                    "defaultSecondaryLocation": "centralus",
+                                    "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "zoneRedundant": false,
+                                    "earliestRestoreDate": "2021-03-09T10:45:31Z",
+                                    "readScale": "Disabled",
+                                    "readReplicaCount": 0,
+                                    "currentSku": {
+                                        "name": "Standard",
+                                        "tier": "Standard",
+                                        "capacity": 10
+                                    }
+                                },
+                                "location": "eastus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/cctestdb",
+                                "name": "cctestdb",
+                                "type": "Microsoft.Sql/servers/databases"
+                            },
+                            {
+                                "sku": {
+                                    "name": "System",
+                                    "tier": "System",
+                                    "capacity": 0
+                                },
+                                "kind": "v12.0,system",
+                                "managedBy": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw",
+                                "properties": {
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "maxSizeBytes": 32212254720,
+                                    "status": "Online",
+                                    "databaseId": "9958f24e-907d-4b98-8b89-a8ac1d748225",
+                                    "creationDate": "2021-03-09T10:35:36.713Z",
+                                    "currentServiceObjectiveName": "System0",
+                                    "requestedServiceObjectiveName": "System0",
+                                    "defaultSecondaryLocation": "centralus",
+                                    "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "zoneRedundant": false,
+                                    "readScale": "Disabled",
+                                    "readReplicaCount": 0,
+                                    "currentSku": {
+                                        "name": "System",
+                                        "tier": "System",
+                                        "capacity": 0
+                                    }
+                                },
+                                "location": "eastus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/master",
+                                "name": "master",
+                                "type": "Microsoft.Sql/servers/databases"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/cclongtermretentiondb/transparentDataEncryption/current?api-version=2014-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 09 Mar 2021 14:27:09 GMT"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "dataserviceversion": [
+                        "3.0;"
+                    ],
+                    "content-length": [
+                        "358"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "name": "current",
+                        "location": "East US 2",
+                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/cclongtermretentiondb/transparentDataEncryption/current",
+                        "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+                        "properties": {
+                            "status": "Enabled"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/cctestdb/transparentDataEncryption/current?api-version=2014-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 09 Mar 2021 14:27:11 GMT"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "dataserviceversion": [
+                        "3.0;"
+                    ],
+                    "content-length": [
+                        "345"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "name": "current",
+                        "location": "East US 2",
+                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/cctestdb/transparentDataEncryption/current",
+                        "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+                        "properties": {
+                            "status": "Enabled"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/master/transparentDataEncryption/current?api-version=2014-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 09 Mar 2021 14:27:12 GMT"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "dataserviceversion": [
+                        "3.0;"
+                    ],
+                    "content-length": [
+                        "344"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "name": "current",
+                        "location": "East US 2",
+                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_sqlserver/providers/Microsoft.Sql/servers/cctestsqlserverp2fkgne6rt5vw/databases/master/transparentDataEncryption/current",
+                        "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+                        "properties": {
+                            "status": "Disabled"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py
@@ -1,7 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from azure.mgmt.sql.models import DatabaseUpdate, Sku, BackupShortTermRetentionPolicy
-from ..azure_common import BaseTest, arm_template, requires_arm_polling
+from ..azure_common import BaseTest, arm_template, cassette_name, requires_arm_polling
 from c7n_azure.resources.sqldatabase import (
     BackupRetentionPolicyHelper, ShortTermBackupRetentionPolicyAction)
 from c7n_azure.session import Session
@@ -567,3 +567,21 @@ class LongTermBackupRetentionPolicyActionTest(BaseTest):
             *self.retention_policy_context
         )
         self.assertEqual(getattr(current_retention_period, retention_property), period)
+
+
+class SqlDatabaseDataEncryptionFilterTest(BaseTest):
+
+    @cassette_name('data_encryption_filter')
+    @arm_template('sqlserver.json')
+    def test_filter(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-data-encryption',
+            'resource': 'azure.sql-database',
+            'filters': [
+                {'type': 'data-encryption',
+                 'enabled': False}],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('9958f24e-907d-4b98-8b89-a8ac1d748225',
+                         resources[0]['properties']['databaseId'])


### PR DESCRIPTION
Use case:
```yaml
policies:
  - name: cis_db_sql_db_encryption_on
    resource: azure.sql-database
    filters:
      - type: data-encryption
        enabled: false
```
Alias for `transparent-data-encryption` filter