### PR TITLE
add a case-insensitive option in 'Type' filter

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -667,12 +667,9 @@ class ValueFilter(BaseValueFilter):
             return True
         elif self.op:
             op = OPERATORS[self.op]
-            if case_insensitive_filter:
-                try:
-                    return op(r.lower(), [x.lower() for x in v])
-                except TypeError:
-                    return False
             try:
+                if case_insensitive_filter and isinstance(r, str):
+                    return op(r.lower(), [x.lower() for x in v])
                 return op(r, v)
             except TypeError:
                 return False
@@ -680,7 +677,6 @@ class ValueFilter(BaseValueFilter):
             return r.lower() == v.lower()
         elif not case_insensitive_filter:
             return r == v
-
         return False
 
     def process_value_type(self, sentinel, value, resource):

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -646,7 +646,7 @@ class ValueFilter(BaseValueFilter):
         if 'case-insensitive' in self.data:
             case_insensitive_filter = self.data['case-insensitive']
 
-        r = self.get_resource_value(self.k, i) # ikraemer
+        r = self.get_resource_value(self.k, i)
         if self.op in ('in', 'not-in') and r is None:
             r = ()
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -232,16 +232,30 @@ class TestValueFilter(unittest.TestCase):
         self.assertTrue(vf.match(resource))
 
     def test_value_case_insensitive_true(self):
-        resource = {"a": 1, "id":"Test"}
-        vf = filters.factory({"type": "value", "value": "test", "key": "id", "case-insensitive":True})
+        resource = {"a": 1, "id": "Test"}
+        vf = filters.factory(
+            {
+                "type": "value",
+                "value": "test",
+                "key": "id",
+                "case-insensitive": True
+            }
+        )
 
         res = vf.match(resource)
 
         self.assertTrue(res)
 
     def test_value_case_insensitive_false(self):
-        resource = {"a": 1, "id":"Test"}
-        vf = filters.factory({"type": "value", "value": "test", "key": "id", "case-insensitive":False})
+        resource = {"a": 1, "id": "Test"}
+        vf = filters.factory(
+            {
+                "type": "value",
+                "value": "test",
+                "key": "id",
+                "case-insensitive": False
+            }
+        )
 
         res = vf.match(resource)
 
@@ -1039,6 +1053,7 @@ class TestInList(unittest.TestCase):
                 "case-insensitive": True
             }
         )
+        self.assertEqual(f(instance(Thing="Foo")), True)
         self.assertEqual(f(instance(Thing="foo")), True)
         self.assertEqual(f(instance(Thing="Baz")), False)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -315,6 +315,15 @@ class TestValueFilter(unittest.TestCase):
             "key": "ingress"})
         self.assertRaises(TypeError, vf.match(resource))
 
+        resource = {"id": 1}
+        vf = filters.factory({
+            "type": "value",
+            "value": ["abc"],
+            "op": "in",
+            "key": "id",
+            "case-insensitive": True})
+        self.assertRaises(TypeError, vf.match(resource))
+
     def test_value_path(self):
         resource = {'list':[{'a':['one','two'],'b':'one'},{'a':['one'],'b':'two'}]}
         vf = filters.factory({

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -231,6 +231,22 @@ class TestValueFilter(unittest.TestCase):
             "key": "a"})
         self.assertTrue(vf.match(resource))
 
+    def test_value_case_insensitive_true(self):
+        resource = {"a": 1, "id":"Test"}
+        vf = filters.factory({"type": "value", "value": "test", "key": "id", "case-insensitive":True})
+
+        res = vf.match(resource)
+
+        self.assertTrue(res)
+
+    def test_value_case_insensitive_false(self):
+        resource = {"a": 1, "id":"Test"}
+        vf = filters.factory({"type": "value", "value": "test", "key": "id", "case-insensitive":False})
+
+        res = vf.match(resource)
+
+        self.assertFalse(res)
+
     def test_value_match(self):
         resource = {"a": 1, "Tags": [{"Key": "xtra", "Value": "hello"}]}
         vf = filters.factory({"type": "value", "value": None, "key": "tag:xtra"})
@@ -1010,8 +1026,21 @@ class TestInList(unittest.TestCase):
             }
         )
         self.assertEqual(f(instance(Thing="Foo")), True)
+        self.assertEqual(f(instance(Thing="foo")), False)
         self.assertEqual(f(instance(Thing="Baz")), False)
 
+    def test_in_case_insensitive(self):
+        f = filters.factory(
+            {
+                "type": "value",
+                "key": "Thing",
+                "value": ["Foo", "Bar", "Quux"],
+                "op": "in",
+                "case-insensitive": True
+            }
+        )
+        self.assertEqual(f(instance(Thing="foo")), True)
+        self.assertEqual(f(instance(Thing="Baz")), False)
 
 class TestNotInList(unittest.TestCase):
 


### PR DESCRIPTION
This Pr is meant to solve issue https://github.com/cloud-custodian/cloud-custodian/issues/9089. That way, filtering can be done on case-insensitive values. Default behaviour stays the same, which makes this change backward-compatible.