### PR TITLE
releng: vendor selections of distutils

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = c7n/vendored/*

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ test:
 
 test-coverage:
 	. $(PWD)/test.env && poetry run pytest -n auto \
+            --cov-config .coveragerc \
             --cov-report $(COVERAGE_TYPE) \
             --cov c7n \
             --cov tools/c7n_azure/c7n_azure \

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -14,7 +14,7 @@ import re
 
 from dateutil.tz import tzutc
 from dateutil.parser import parse
-from distutils import version
+from c7n.vendored.distutils import version
 from random import sample
 
 from c7n.element import Element

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -42,7 +42,7 @@ from datetime import timedelta
 
 from decimal import Decimal as D, ROUND_HALF_UP
 
-from distutils.version import LooseVersion
+from c7n.vendored.distutils.version import LooseVersion
 from botocore.exceptions import ClientError
 from concurrent.futures import as_completed
 

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -16,7 +16,7 @@ from unittest import mock
 import pytest
 import yaml
 
-from distutils.util import strtobool
+from c7n.vendored.distutils.util import strtobool
 
 from c7n import deprecated, policy
 from c7n.exceptions import DeprecationError

--- a/c7n/vendored/distutils/__init__.py
+++ b/c7n/vendored/distutils/__init__.py
@@ -1,0 +1,6 @@
+"""distutils
+
+Vendored from Python 3.11:
+
+https://github.com/python/cpython/tree/3.11/Lib/distutils
+"""

--- a/c7n/vendored/distutils/util.py
+++ b/c7n/vendored/distutils/util.py
@@ -1,0 +1,22 @@
+"""distutils.util
+
+Miscellaneous utility functions -- anything that doesn't fit into
+one of the other *util.py modules.
+
+Source: https://github.com/python/cpython/blob/6fea61a9e02260648fbec204e9caac6d5176cc7b/Lib/distutils/util.py
+"""
+
+def strtobool (val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/c7n/vendored/distutils/version.py
+++ b/c7n/vendored/distutils/version.py
@@ -1,0 +1,230 @@
+# distutils/version.py
+#
+# Vendored from:
+# https://github.com/python/cpython/blob/6fea61a9e02260648fbec204e9caac6d5176cc7b/Lib/distutils/version.py
+
+"""Provides classes to represent module version numbers (one class for
+each style of version numbering).  There are currently two such classes
+implemented: StrictVersion and LooseVersion.
+
+Every version number class implements the following interface:
+  * the 'parse' method takes a string and parses it to some internal
+    representation; if the string is an invalid version number,
+    'parse' raises a ValueError exception
+  * the class constructor takes an optional string argument which,
+    if supplied, is passed to 'parse'
+  * __str__ reconstructs the string that was passed to 'parse' (or
+    an equivalent string -- ie. one that will generate an equivalent
+    version number instance)
+  * __repr__ generates Python code to recreate the version number instance
+  * _cmp compares the current instance with either another instance
+    of the same class or a string (which will be parsed to an instance
+    of the same class, thus must follow the same rules)
+"""
+
+import re
+
+class Version:
+    """Abstract base class for version numbering classes.  Just provides
+    constructor (__init__) and reproducer (__repr__), because those
+    seem to be the same for all version numbering classes; and route
+    rich comparisons to _cmp.
+    """
+
+    def __init__ (self, vstring=None):
+        if vstring:
+            self.parse(vstring)
+
+    def __repr__ (self):
+        return "%s ('%s')" % (self.__class__.__name__, str(self))
+
+    def __eq__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c == 0
+
+    def __lt__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c < 0
+
+    def __le__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c <= 0
+
+    def __gt__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c > 0
+
+    def __ge__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c >= 0
+
+
+# Interface for version-number classes -- must be implemented
+# by the following classes (the concrete ones -- Version should
+# be treated as an abstract class).
+#    __init__ (string) - create and take same action as 'parse'
+#                        (string parameter is optional)
+#    parse (string)    - convert a string representation to whatever
+#                        internal representation is appropriate for
+#                        this style of version numbering
+#    __str__ (self)    - convert back to a string; should be very similar
+#                        (if not identical to) the string supplied to parse
+#    __repr__ (self)   - generate Python code to recreate
+#                        the instance
+#    _cmp (self, other) - compare two version numbers ('other' may
+#                        be an unparsed version string, or another
+#                        instance of your version class)
+
+# The rules according to Greg Stein:
+# 1) a version number has 1 or more numbers separated by a period or by
+#    sequences of letters. If only periods, then these are compared
+#    left-to-right to determine an ordering.
+# 2) sequences of letters are part of the tuple for comparison and are
+#    compared lexicographically
+# 3) recognize the numeric components may have leading zeroes
+#
+# The LooseVersion class below implements these rules: a version number
+# string is split up into a tuple of integer and string components, and
+# comparison is a simple tuple comparison.  This means that version
+# numbers behave in a predictable and obvious way, but a way that might
+# not necessarily be how people *want* version numbers to behave.  There
+# wouldn't be a problem if people could stick to purely numeric version
+# numbers: just split on period and compare the numbers as tuples.
+# However, people insist on putting letters into their version numbers;
+# the most common purpose seems to be:
+#   - indicating a "pre-release" version
+#     ('alpha', 'beta', 'a', 'b', 'pre', 'p')
+#   - indicating a post-release patch ('p', 'pl', 'patch')
+# but of course this can't cover all version number schemes, and there's
+# no way to know what a programmer means without asking him.
+#
+# The problem is what to do with letters (and other non-numeric
+# characters) in a version number.  The current implementation does the
+# obvious and predictable thing: keep them as strings and compare
+# lexically within a tuple comparison.  This has the desired effect if
+# an appended letter sequence implies something "post-release":
+# eg. "0.99" < "0.99pl14" < "1.0", and "5.001" < "5.001m" < "5.002".
+#
+# However, if letters in a version number imply a pre-release version,
+# the "obvious" thing isn't correct.  Eg. you would expect that
+# "1.5.1" < "1.5.2a2" < "1.5.2", but under the tuple/lexical comparison
+# implemented here, this just isn't so.
+#
+# Two possible solutions come to mind.  The first is to tie the
+# comparison algorithm to a particular set of semantic rules, as has
+# been done in the StrictVersion class above.  This works great as long
+# as everyone can go along with bondage and discipline.  Hopefully a
+# (large) subset of Python module programmers will agree that the
+# particular flavour of bondage and discipline provided by StrictVersion
+# provides enough benefit to be worth using, and will submit their
+# version numbering scheme to its domination.  The free-thinking
+# anarchists in the lot will never give in, though, and something needs
+# to be done to accommodate them.
+#
+# Perhaps a "moderately strict" version class could be implemented that
+# lets almost anything slide (syntactically), and makes some heuristic
+# assumptions about non-digits in version number strings.  This could
+# sink into special-case-hell, though; if I was as talented and
+# idiosyncratic as Larry Wall, I'd go ahead and implement a class that
+# somehow knows that "1.2.1" < "1.2.2a2" < "1.2.2" < "1.2.2pl3", and is
+# just as happy dealing with things like "2g6" and "1.13++".  I don't
+# think I'm smart enough to do it right though.
+#
+# In any case, I've coded the test suite for this module (see
+# ../test/test_version.py) specifically to fail on things like comparing
+# "1.2a2" and "1.2".  That's not because the *code* is doing anything
+# wrong, it's because the simple, obvious design doesn't match my
+# complicated, hairy expectations for real-world version numbers.  It
+# would be a snap to fix the test suite to say, "Yep, LooseVersion does
+# the Right Thing" (ie. the code matches the conception).  But I'd rather
+# have a conception that matches common notions about version numbers.
+
+class LooseVersion (Version):
+
+    """Version numbering for anarchists and software realists.
+    Implements the standard interface for version number classes as
+    described above.  A version number consists of a series of numbers,
+    separated by either periods or strings of letters.  When comparing
+    version numbers, the numeric components will be compared
+    numerically, and the alphabetic components lexically.  The following
+    are all valid version numbers, in no particular order:
+
+        1.5.1
+        1.5.2b2
+        161
+        3.10a
+        8.02
+        3.4j
+        1996.07.12
+        3.2.pl0
+        3.1.1.6
+        2g6
+        11g
+        0.960923
+        2.2beta29
+        1.13++
+        5.5.kw
+        2.0b1pl0
+
+    In fact, there is no such thing as an invalid version number under
+    this scheme; the rules for comparison are simple and predictable,
+    but may not always give the results you want (for some definition
+    of "want").
+    """
+
+    component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
+
+    def __init__ (self, vstring=None):
+        if vstring:
+            self.parse(vstring)
+
+
+    def parse (self, vstring):
+        # I've given up on thinking I can reconstruct the version string
+        # from the parsed tuple -- so I just store the string here for
+        # use by __str__
+        self.vstring = vstring
+        components = [x for x in self.component_re.split(vstring)
+                              if x and x != '.']
+        for i, obj in enumerate(components):
+            try:
+                components[i] = int(obj)
+            except ValueError:
+                pass
+
+        self.version = components
+
+
+    def __str__ (self):
+        return self.vstring
+
+
+    def __repr__ (self):
+        return "LooseVersion ('%s')" % str(self)
+
+
+    def _cmp (self, other):
+        if isinstance(other, str):
+            other = LooseVersion(other)
+        elif not isinstance(other, LooseVersion):
+            return NotImplemented
+
+        if self.version == other.version:
+            return 0
+        if self.version < other.version:
+            return -1
+        if self.version > other.version:
+            return 1
+
+
+# end class LooseVersion

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 import re
 import pytest
 
-from distutils.util import strtobool
+from c7n.vendored.distutils.util import strtobool
 from .constants import ACCOUNT_ID
 
 try:

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -8,7 +8,7 @@ import shutil
 import zipfile
 import re
 from datetime import datetime, timedelta, tzinfo
-from distutils.util import strtobool
+from c7n.vendored.distutils.util import strtobool
 
 import boto3
 import placebo

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -6,7 +6,7 @@ import logging
 import os
 import time
 
-import distutils.util
+from c7n.vendored.distutils.util import strtobool
 import requests
 from c7n_azure.constants import (
     AUTH_TYPE_MSI,
@@ -47,7 +47,7 @@ class FunctionPackage:
         self.function_path = function_path or os.path.join(
             os.path.dirname(os.path.realpath(__file__)), 'function.py')
         self.cache_override_path = cache_override_path
-        self.enable_ssl_cert = not distutils.util.strtobool(
+        self.enable_ssl_cert = not strtobool(
             os.environ.get(ENV_CUSTODIAN_DISABLE_SSL_CERT_VERIFICATION, 'no'))
 
         if target_sub_ids is not None:

--- a/tools/c7n_azure/tests_azure/azure_common.py
+++ b/tools/c7n_azure/tests_azure/azure_common.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import re
-from distutils.util import strtobool
+from c7n.vendored.distutils.util import strtobool
 from functools import wraps
 from time import sleep
 

--- a/tools/c7n_oci/tests/conftest.py
+++ b/tools/c7n_oci/tests/conftest.py
@@ -1,7 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import os
-from distutils.util import strtobool
+from c7n.vendored.distutils.util import strtobool
 
 import pytest
 from oci_common import replace_email, replace_namespace, replace_ocid

--- a/tools/dev/changelog.py
+++ b/tools/dev/changelog.py
@@ -6,7 +6,7 @@ import docker
 import json
 
 from collections import defaultdict
-from distutils import version
+from c7n.vendored.distutils import version
 from datetime import datetime, timedelta
 from dateutil.tz import tzoffset, tzutc
 from dateutil.parser import parse as parse_date

--- a/tools/ops/azure/functionslc.py
+++ b/tools/ops/azure/functionslc.py
@@ -7,7 +7,7 @@ import time
 import click
 import requests
 from c7n_azure.policy import AzureFunctionMode
-from distutils.util import strtobool
+from c7n.vendored.distutils.util import strtobool
 from enum import Enum
 
 from c7n.config import Config


### PR DESCRIPTION
Our distutils usage was limited to distutils.version.LooseVersion and distutils.util.strtobool. Vendor those selections from Python 3.11.

Worth noting that while we carry distutils references, c7n won't be usable on Python 3.12.
 
Closes #8394