### PR TITLE
azure - sql-managed-instance and its filters

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -79,6 +79,8 @@ ResourceMap = {
     "azure.spring-service-instance": "c7n_azure.resources.spring.SpringServiceInstance",
     "azure.sql-database": "c7n_azure.resources.sqldatabase.SqlDatabase",
     "azure.sqldatabase": "c7n_azure.resources.sqldatabase.SqlDatabase",
+    "azure.sql-managed-instance": "c7n_azure.resources.sqlmanagedinstance.SqlManagedInstance",
+    "azure.sqlmanagedinstance": "c7n_azure.resources.sqlmanagedinstance.SqlManagedInstance",
     "azure.sql-server": "c7n_azure.resources.sqlserver.SqlServer",
     "azure.sqlserver": "c7n_azure.resources.sqlserver.SqlServer",
     "azure.storage": "c7n_azure.resources.storage.Storage",

--- a/tools/c7n_azure/c7n_azure/resources/sqlmanagedinstance.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqlmanagedinstance.py
@@ -1,0 +1,219 @@
+import distutils.util
+import logging
+
+from c7n_azure.filters import ValueFilter
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ArmResourceManager
+from c7n.filters import Filter
+from c7n.utils import type_schema
+
+log = logging.getLogger('custodian.azure.sql-managed-instance')
+
+
+@resources.register('sql-managed-instance', aliases=['sqlmanagedinstance'])
+class SqlManagedInstance(ArmResourceManager):
+
+    class resource_type(ArmResourceManager.resource_type):
+        doc_groups = ['Instances']
+
+        service = 'azure.mgmt.sql'
+        client = 'SqlManagementClient'
+        enum_spec = ('managed_instances', 'list', None)
+        resource_type = 'Microsoft.Sql/managedInstances'
+        diagnostic_settings_enabled = False
+
+
+@SqlManagedInstance.filter_registry.register('vulnerability-assessments')
+class SqlManagedInstanceVulnerabilityAssessmentsFilter(Filter):
+    """
+    Filters resources by vulnerability assessments.
+
+    :example:
+
+    .. code-block:: yaml
+
+    policies:
+      - name: azure-sql-managed-instance-vulnerability-assessments
+        resource: azure.sql-managed-instance
+        filters:
+          - type: vulnerability-assessments
+            key: recurring_scans.is_enabled
+            value: true
+    """
+
+    schema = type_schema(
+        'vulnerability-assessments', rinherit=ValueFilter.schema
+    )
+
+    def __call__(self, resource):
+        return resource
+
+    @staticmethod
+    def filter_by_assessments(assessments, filtering_properties, value):
+        add_to_filtered = False
+        for assessment in assessments:
+            assessment = assessment.as_dict()
+            property_value = assessment
+            for filtering_property in filtering_properties:
+                if filtering_property in property_value:
+                    property_value = property_value[filtering_property]
+                else:
+                    property_value = None
+                    break
+            if type(property_value) is bool and type(value) is str:
+                value = distutils.util.strtobool(value)
+            if value == property_value:
+                add_to_filtered = True
+                break
+        return add_to_filtered
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client('azure.mgmt.sql.SqlManagementClient')
+
+        filtered_resources = []
+        key = self.data['key']
+        value = self.data['value']
+        filtering_properties = key.split('.')
+        for resource in resources:
+            assessments = client.managed_instance_vulnerability_assessments.list_by_instance(
+                resource['resourceGroup'],
+                resource['name']
+            )
+            add_to_filtered = self.filter_by_assessments(assessments, filtering_properties, value)
+            if add_to_filtered:
+                filtered_resources.append(resource)
+
+        return super(SqlManagedInstanceVulnerabilityAssessmentsFilter, self).process(
+            filtered_resources, event)
+
+
+@SqlManagedInstance.filter_registry.register('encryption-protector')
+class SqlManagedInstanceEncryptionProtectorsFilter(Filter):
+    """
+    Filters resources by encryption protectors.
+
+    :example:
+
+    .. code-block:: yaml
+
+    policies:
+      - name: azure-sql-managed-instance-service-managed
+        resource: azure.sql-managed-instance
+        filters:
+          - type: encryption-protector
+            key: kind
+            value: servicemanaged
+    """
+
+    schema = type_schema(
+        'encryption-protector', rinherit=ValueFilter.schema
+    )
+
+    def __call__(self, resource):
+        return resource
+
+    @staticmethod
+    def filter_by_encryption_protector(protectors, filtering_properties, value):
+        add_to_filtered = False
+        for protector in protectors:
+            protector = protector.as_dict()
+            property_value = protector
+            for filtering_property in filtering_properties:
+                if filtering_property in property_value:
+                    property_value = property_value[filtering_property]
+                else:
+                    property_value = None
+                    break
+            if type(property_value) is bool and type(value) is str:
+                value = distutils.util.strtobool(value)
+            if value == property_value:
+                add_to_filtered = True
+                break
+        return add_to_filtered
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client('azure.mgmt.sql.SqlManagementClient')
+
+        filtered_resources = []
+        key = self.data['key']
+        value = self.data['value']
+        filtering_properties = key.split('.')
+        for resource in resources:
+            protectors = client.managed_instance_encryption_protectors.list_by_instance(
+                resource['resourceGroup'],
+                resource['name']
+            )
+            add_to_filtered = self.filter_by_encryption_protector(
+                protectors, filtering_properties, value)
+
+            if add_to_filtered:
+                filtered_resources.append(resource)
+
+        return super(SqlManagedInstanceEncryptionProtectorsFilter, self).process(
+            filtered_resources, event)
+
+
+@SqlManagedInstance.filter_registry.register('managed-server-security-alert-policies')
+class SqlManagedInstanceSecurityAlertPoliciesFilter(Filter):
+    """
+    Filters resources by managed server security alert policies'.
+
+    :example:
+
+    .. code-block:: yaml
+
+    policies:
+      - name: azure-sql-managed-server-security-alert-policies
+        resource: azure.sql-managed-instance
+        filters:
+          - type: managed-server-security-alert-policies
+            key: state
+            value: Disabled
+    """
+
+    schema = type_schema(
+        'managed-server-security-alert-policies', rinherit=ValueFilter.schema
+    )
+
+    def __call__(self, resource):
+        return resource
+
+    @staticmethod
+    def filter_by_security_alert_policies(security_alert_policies, filtering_properties, value):
+        add_to_filtered = False
+        for security_alert_policy in security_alert_policies:
+            security_alert_policy = security_alert_policy.as_dict()
+            property_value = security_alert_policy
+            for filtering_property in filtering_properties:
+                if filtering_property in property_value:
+                    property_value = property_value[filtering_property]
+                else:
+                    property_value = None
+                    break
+            if type(property_value) is bool and type(value) is str:
+                value = distutils.util.strtobool(value)
+            if value == property_value:
+                add_to_filtered = True
+                break
+        return add_to_filtered
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client('azure.mgmt.sql.SqlManagementClient')
+
+        filtered_resources = []
+        key = self.data['key']
+        value = self.data['value']
+        filtering_properties = key.split('.')
+        for resource in resources:
+            security_alert_policies = (
+                client.managed_server_security_alert_policies.list_by_instance(
+                    resource['resourceGroup'],
+                    resource['name']))
+            add_to_filtered = self.filter_by_security_alert_policies(
+                security_alert_policies, filtering_properties, value)
+
+            if add_to_filtered:
+                filtered_resources.append(resource)
+
+        return super(SqlManagedInstanceSecurityAlertPoliciesFilter, self).process(
+            filtered_resources, event)

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_filter_encryption_protector.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_filter_encryption_protector.json
@@ -1,0 +1,121 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Fri, 24 Sep 2021 13:43:22 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "1276"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "068ac866-15e5-4bc3-96fa-495482496d96",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "testsqlmi71.71ccd8863ff8.database.windows.net",
+                                    "administratorLogin": "testadm71",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Network/virtualNetworks/vnet-testsqlmi71/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "71ccd8863ff8",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71",
+                                "name": "testsqlmi71",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71/encryptionProtector?api-version=2017-10-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Fri, 24 Sep 2021 13:43:23 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "358"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "kind": "servicemanaged",
+                                "properties": {
+                                    "serverKeyName": "ServiceManaged",
+                                    "serverKeyType": "ServiceManaged"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71/encryptionProtector/current",
+                                "name": "current",
+                                "type": "Microsoft.Sql/managedInstances/encryptionProtector"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_filter_recurring_scans.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_filter_recurring_scans.json
@@ -1,0 +1,126 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Fri, 24 Sep 2021 13:13:07 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "1276"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "068ac866-15e5-4bc3-96fa-495482496d96",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "testsqlmi71.71ccd8863ff8.database.windows.net",
+                                    "administratorLogin": "testadm71",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Network/virtualNetworks/vnet-testsqlmi71/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "71ccd8863ff8",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71",
+                                "name": "testsqlmi71",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71/vulnerabilityAssessments?api-version=2018-06-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Fri, 24 Sep 2021 13:13:17 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "485"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "properties": {
+                                    "storageContainerPath": "https://sqlva43wdauneefhes.blob.core.windows.net/vulnerability-assessment/",
+                                    "recurringScans": {
+                                        "isEnabled": true,
+                                        "emailSubscriptionAdmins": true,
+                                        "emails": [
+                                            "volodymyr_vrydnyk@epam.com"
+                                        ]
+                                    }
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71/vulnerabilityAssessments/Default",
+                                "name": "Default",
+                                "type": "Microsoft.Sql/managedInstances/vulnerabilityAssessments"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_instance.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_instance.json
@@ -1,0 +1,77 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 21 Sep 2021 15:39:04 GMT"
+                    ],
+                    "content-length": [
+                        "1264"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "185f2516-c869-4aae-b485-40cb4190b515",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "vvtestmisql.6fb8019adb20.database.windows.net",
+                                    "administratorLogin": "vvadmin",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Network/virtualNetworks/vnet-vvtestmisql/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "6fb8019adb20",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvtestmisql",
+                                "name": "vvtestmisql",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_instance_security_alert_policies.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_instance_security_alert_policies.json
@@ -1,0 +1,77 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 21 Sep 2021 15:42:15 GMT"
+                    ],
+                    "content-length": [
+                        "1264"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "185f2516-c869-4aae-b485-40cb4190b515",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "vvtestmisql.6fb8019adb20.database.windows.net",
+                                    "administratorLogin": "vvadmin",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Network/virtualNetworks/vnet-vvtestmisql/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "6fb8019adb20",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvtestmisql",
+                                "name": "vvtestmisql",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_server_security_alert_policies.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_server_security_alert_policies.json
@@ -1,0 +1,132 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Wed, 29 Sep 2021 10:21:48 GMT"
+                    ],
+                    "content-length": [
+                        "1261"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "7153dfac-8387-49e3-87fc-0dd44059a248",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "vvsqlmi1.4b120597217c.database.windows.net",
+                                    "administratorLogin": "vvadm",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Network/virtualNetworks/vnet-vvsqlmi1/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "4b120597217c",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {
+                                    "VV": "test"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvsqlmi1",
+                                "name": "vvsqlmi1",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvsqlmi1/securityAlertPolicies?api-version=2017-03-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Wed, 29 Sep 2021 10:21:48 GMT"
+                    ],
+                    "content-length": [
+                        "463"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "properties": {
+                                    "state": "Disabled",
+                                    "disabledAlerts": [
+                                        ""
+                                    ],
+                                    "emailAddresses": [
+                                        ""
+                                    ],
+                                    "emailAccountAdmins": false,
+                                    "storageEndpoint": "",
+                                    "storageAccountAccessKey": "",
+                                    "retentionDays": 0,
+                                    "creationTime": "2021-09-29T10:07:55.11Z"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvsqlmi1/securityAlertPolicies/Default",
+                                "name": "Default",
+                                "type": "Microsoft.Sql/managedInstances/securityAlertPolicies"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqlmanagedinstance.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqlmanagedinstance.py
@@ -1,0 +1,84 @@
+from ..azure_common import BaseTest
+
+
+class SqlManagedInstanceTest(BaseTest):
+
+    def test_sql_managed_instance_schema_validate(self):
+        p = self.load_policy({
+            'name': 'test-policy-assignment',
+            'resource': 'azure.sql-managed-instance'
+        }, validate=True)
+        self.assertTrue(p)
+
+        # test alias for back-compatibility
+        p = self.load_policy({
+            'name': 'test-policy-assignment',
+            'resource': 'azure.sqlmanagedinstance'
+        }, validate=True)
+        self.assertTrue(p)
+
+    def test_sql_managed_instance(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-instance-all',
+            'resource': 'azure.sql-managed-instance',
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('vvtestmisql', resources[0]['name'])
+
+    def test_sql_managed_instance_security_alert_policies(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-instance-filter-security-alert-policy',
+            'resource': 'azure.sql-managed-instance',
+            'filters': [{
+                'type': 'value',
+                'key': 'properties.state',
+                'value': 'Ready'
+            }]
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('vvtestmisql', resources[0]['name'])
+        self.assertEqual('Ready', resources[0]['properties']['state'])
+
+    def test_sql_managed_server_security_alert_policies(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-server-filter-security-alert-policy',
+            'resource': 'azure.sql-managed-instance',
+            'filters': [{
+                'type': 'managed-server-security-alert-policies',
+                'key': 'state',
+                'value': 'Disabled'
+            }]
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('vvsqlmi1', resources[0]['name'])
+
+    def test_filter_recurring_scans(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-instance-recurring-scan-disabled',
+            'resource': 'azure.sql-managed-instance',
+            'filters': [
+                {'type': 'vulnerability-assessments',
+                 'key': 'recurring_scans.is_enabled',
+                 'value': 'True'
+                 }],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('testsqlmi71', resources[0]['name'])
+
+    def test_filter_encryption_protector(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-instance-service-managed',
+            'resource': 'azure.sql-managed-instance',
+            'filters': [
+                {'type': 'encryption-protector',
+                 'key': 'kind',
+                 'value': 'servicemanaged'
+                 }],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('testsqlmi71', resources[0]['name'])


### PR DESCRIPTION
Added `azure.sql-managed-instance` and its filters: 
- `encryption-protector`
- `managed-server-security-alert-policies`
- `vulnerability-assessments`


Use cases:

### vulnerability-assessments
```yaml
policies:
  - name: asb_sqlmi
    resource: azure.sql-managed-instance
    filters:
      - type: vulnerability-assessments
        key: recurring_scans.is_enabled
        value: false
```

### managed-server-security-alert-policies
```yaml
policies:
  - name: asb_sql_managed_instance_atp
    resource: azure.sql-managed-instance
    filters:
      - type: managed-server-security-alert-policies
        key: state
        value: Disabled
```

### encryption-protector
```yaml
policies:
  - name: asb_sql_managed_inst_cmk
    resource: azure.sql-managed-instance
    filters:
      - type: encryption-protector
        key: kind
        value: servicemanaged
```