### PR TITLE
fix: get SG IDs from all interfaces on an EC2 instance in 'security-group' filter

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -420,8 +420,8 @@ class LambdaMode(ServerlessExecutionMode):
                 "Custodian Lambda policies have a max length with prefix of %s"
                 " policy:%s prefix:%s" % (
                     MAX_LAMBDA_FUNCTION_NAME_LENGTH,
-                    prefix,
-                    self.policy.name
+                    self.policy.name,
+                    prefix
                 )
             )
         MAX_LAMBDA_FUNCTION_DESCRIPTION_LENGTH = 256

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -161,7 +161,7 @@ class EC2(query.QueryResourceManager):
 @filters.register('security-group')
 class SecurityGroupFilter(net_filters.SecurityGroupFilter):
 
-    RelatedIdsExpression = "SecurityGroups[].GroupId"
+    RelatedIdsExpression = "NetworkInterfaces[].Groups[].GroupId"
 
 
 @filters.register('subnet')

--- a/tests/data/placebo/ec2_security_group_filter_multi_enis/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/ec2_security_group_filter_multi_enis/ec2.DescribeInstances_1.json
@@ -1,0 +1,581 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d239dc99a14a05ff",
+                        "InstanceId": "i-03b80590af6c5000d",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2023,
+                            "month": 10,
+                            "day": 31,
+                            "hour": 10,
+                            "minute": 35,
+                            "second": 7,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-2-87.ec2.internal",
+                        "PrivateIpAddress": "10.0.2.87",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-08d70664677d2d011",
+                        "VpcId": "vpc-0e6611fce3ecb0f0f",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2023,
+                                        "month": 10,
+                                        "day": 31,
+                                        "hour": 10,
+                                        "minute": 35,
+                                        "second": 8,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0f75b51fa925c8b5f"
+                                }
+                            }
+                        ],
+                        "ClientToken": "terraform-20231031103505957500000006",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2023,
+                                        "month": 10,
+                                        "day": 31,
+                                        "hour": 10,
+                                        "minute": 35,
+                                        "second": 7,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-07f882ae40d6683aa",
+                                    "DeleteOnTermination": false,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "private-sg-example",
+                                        "GroupId": "sg-09dd9760660103a06"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:ae:3d:5b:fc:79",
+                                "NetworkInterfaceId": "eni-0391de1df1dd96901",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.2.87",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.2.87"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-08d70664677d2d011",
+                                "VpcId": "vpc-0e6611fce3ecb0f0f",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "private-sg-example",
+                                "GroupId": "sg-09dd9760660103a06"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2023,
+                            "month": 10,
+                            "day": 31,
+                            "hour": 10,
+                            "minute": 35,
+                            "second": 7,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        },
+                        "CurrentInstanceBootMode": "legacy-bios"
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-0a39fde1505eb71bd"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d239dc99a14a05ff",
+                        "InstanceId": "i-0a3bdbed1708220a1",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2023,
+                            "month": 10,
+                            "day": 31,
+                            "hour": 10,
+                            "minute": 35,
+                            "second": 8,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-2-155.ec2.internal",
+                        "PrivateIpAddress": "10.0.2.155",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-08d70664677d2d011",
+                        "VpcId": "vpc-0e6611fce3ecb0f0f",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2023,
+                                        "month": 10,
+                                        "day": 31,
+                                        "hour": 10,
+                                        "minute": 35,
+                                        "second": 9,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-009c6aed4793667ff"
+                                }
+                            }
+                        ],
+                        "ClientToken": "terraform-20231031103506077500000007",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2023,
+                                        "month": 10,
+                                        "day": 31,
+                                        "hour": 10,
+                                        "minute": 35,
+                                        "second": 8,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-0994d61c5324cd851",
+                                    "DeleteOnTermination": false,
+                                    "DeviceIndex": 1,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "private-sg-example",
+                                        "GroupId": "sg-09dd9760660103a06"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:ab:39:85:61:73",
+                                "NetworkInterfaceId": "eni-00c2433e49682f0c3",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.115",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.115"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-0afcfaf701c6a1c4c",
+                                "VpcId": "vpc-0e6611fce3ecb0f0f",
+                                "InterfaceType": "interface"
+                            },
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2023,
+                                        "month": 10,
+                                        "day": 31,
+                                        "hour": 10,
+                                        "minute": 35,
+                                        "second": 8,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-0a887dd6686b09be5",
+                                    "DeleteOnTermination": false,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "public-sg-example",
+                                        "GroupId": "sg-08866faa10e9a51ef"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:c5:d1:f7:12:17",
+                                "NetworkInterfaceId": "eni-085f554b90f031062",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.2.155",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.2.155"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-08d70664677d2d011",
+                                "VpcId": "vpc-0e6611fce3ecb0f0f",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "public-sg-example",
+                                "GroupId": "sg-08866faa10e9a51ef"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2023,
+                            "month": 10,
+                            "day": 31,
+                            "hour": 10,
+                            "minute": 35,
+                            "second": 8,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        },
+                        "CurrentInstanceBootMode": "legacy-bios"
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-05c32d9999b0f331a"
+            },
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-0d239dc99a14a05ff",
+                        "InstanceId": "i-0e424ef402485a38f",
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2023,
+                            "month": 10,
+                            "day": 31,
+                            "hour": 10,
+                            "minute": 35,
+                            "second": 8,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-91.ec2.internal",
+                        "PrivateIpAddress": "10.0.1.91",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-0afcfaf701c6a1c4c",
+                        "VpcId": "vpc-0e6611fce3ecb0f0f",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2023,
+                                        "month": 10,
+                                        "day": 31,
+                                        "hour": 10,
+                                        "minute": 35,
+                                        "second": 9,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0f9529f834657f744"
+                                }
+                            }
+                        ],
+                        "ClientToken": "terraform-20231031103506219400000008",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2023,
+                                        "month": 10,
+                                        "day": 31,
+                                        "hour": 10,
+                                        "minute": 35,
+                                        "second": 8,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-092c68bc7ffd3379d",
+                                    "DeleteOnTermination": false,
+                                    "DeviceIndex": 1,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "public-sg-example",
+                                        "GroupId": "sg-08866faa10e9a51ef"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:e4:df:83:de:4f",
+                                "NetworkInterfaceId": "eni-07f51a84e9c0dcde0",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.2.20",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.2.20"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-08d70664677d2d011",
+                                "VpcId": "vpc-0e6611fce3ecb0f0f",
+                                "InterfaceType": "interface"
+                            },
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2023,
+                                        "month": 10,
+                                        "day": 31,
+                                        "hour": 10,
+                                        "minute": 35,
+                                        "second": 8,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-02ce97b9882256892",
+                                    "DeleteOnTermination": false,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "private-sg-example",
+                                        "GroupId": "sg-09dd9760660103a06"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:42:2d:9c:37:13",
+                                "NetworkInterfaceId": "eni-053b2040041f15ec2",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.91",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.91"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-0afcfaf701c6a1c4c",
+                                "VpcId": "vpc-0e6611fce3ecb0f0f",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "private-sg-example",
+                                "GroupId": "sg-09dd9760660103a06"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2023,
+                            "month": 10,
+                            "day": 31,
+                            "hour": 10,
+                            "minute": 35,
+                            "second": 8,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default"
+                        },
+                        "CurrentInstanceBootMode": "legacy-bios"
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ReservationId": "r-02151a15858a300c7"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_security_group_filter_multi_enis/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/ec2_security_group_filter_multi_enis/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,52 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "Description": "Managed by Terraform",
+                "GroupName": "private-sg-example",
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "10.0.0.0/16",
+                                "Description": "private"
+                            }
+                        ],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": []
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "GroupId": "sg-09dd9760660103a06",
+                "IpPermissionsEgress": [],
+                "VpcId": "vpc-0e6611fce3ecb0f0f"
+            },
+            {
+                "Description": "Managed by Terraform",
+                "GroupName": "public-sg-example",
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0",
+                                "Description": "public"
+                            }
+                        ],
+                        "Ipv6Ranges": [],
+                        "PrefixListIds": [],
+                        "UserIdGroupPairs": []
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "GroupId": "sg-08866faa10e9a51ef",
+                "IpPermissionsEgress": [],
+                "VpcId": "vpc-0e6611fce3ecb0f0f"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/ec2_security_group_filter_multi_enis/ec2.DescribeTags_1.json
+++ b/tests/data/placebo/ec2_security_group_filter_multi_enis/ec2.DescribeTags_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/ec2_security_group_filter_multi_enis/datasources.tf
+++ b/tests/terraform/ec2_security_group_filter_multi_enis/datasources.tf
@@ -1,0 +1,12 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = [
+      "amzn-ami-hvm-*-x86_64-gp2",
+    ]
+  }
+}

--- a/tests/terraform/ec2_security_group_filter_multi_enis/main.tf
+++ b/tests/terraform/ec2_security_group_filter_multi_enis/main.tf
@@ -1,0 +1,69 @@
+resource "aws_instance" "primary_interface" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+
+  network_interface {
+    delete_on_termination = false
+    device_index          = 0
+    network_interface_id  = aws_network_interface.primary_interface_public.id
+  }
+
+  network_interface {
+    delete_on_termination = false
+    device_index          = 1
+    network_interface_id  = aws_network_interface.primary_interface_private.id
+  }
+}
+
+resource "aws_network_interface" "primary_interface_public" {
+  subnet_id       = aws_subnet.public.id
+  security_groups = [aws_security_group.public.id, ]
+}
+
+resource "aws_network_interface" "primary_interface_private" {
+  subnet_id       = aws_subnet.private.id
+  security_groups = [aws_security_group.private.id, ]
+}
+
+resource "aws_instance" "secondary_interface" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+
+  network_interface {
+    delete_on_termination = false
+    device_index          = 0
+    network_interface_id  = aws_network_interface.secondary_interface_private.id
+  }
+
+  network_interface {
+    delete_on_termination = false
+    device_index          = 1
+    network_interface_id  = aws_network_interface.secondary_interface_public.id
+  }
+}
+
+resource "aws_network_interface" "secondary_interface_public" {
+  subnet_id       = aws_subnet.public.id
+  security_groups = [aws_security_group.public.id, ]
+}
+
+resource "aws_network_interface" "secondary_interface_private" {
+  subnet_id       = aws_subnet.private.id
+  security_groups = [aws_security_group.private.id, ]
+}
+
+resource "aws_instance" "private_only_interface" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+
+  network_interface {
+    delete_on_termination = false
+    device_index          = 0
+    network_interface_id  = aws_network_interface.private_only_interface.id
+  }
+}
+
+resource "aws_network_interface" "private_only_interface" {
+  subnet_id       = aws_subnet.public.id
+  security_groups = [aws_security_group.private.id, ]
+}

--- a/tests/terraform/ec2_security_group_filter_multi_enis/network.tf
+++ b/tests/terraform/ec2_security_group_filter_multi_enis/network.tf
@@ -1,0 +1,78 @@
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "private"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "public"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "public"
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  route = []
+
+  tags = {
+    Name = "private"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  subnet_id      = aws_subnet.private.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_security_group" "public" {
+  name   = "public-sg-example"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    description      = "public"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "all"
+    cidr_blocks      = [_block]
+  }
+}
+
+resource "aws_security_group" "private" {
+  name   = "private-sg-example"
+  vpc_id = aws_vpc.this.id
+}

--- a/tests/terraform/ec2_security_group_filter_multi_enis/network.tf
+++ b/tests/terraform/ec2_security_group_filter_multi_enis/network.tf
@@ -64,11 +64,11 @@ resource "aws_security_group" "public" {
   vpc_id = aws_vpc.this.id
 
   ingress {
-    description      = "public"
-    from_port        = 0
-    to_port          = 0
-    protocol         = "all"
-    cidr_blocks      = [_block]
+    description = "public"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "all"
+    cidr_blocks = [_block]
   }
 }
 

--- a/tests/terraform/ec2_security_group_filter_multi_enis/tf_resources.json
+++ b/tests/terraform/ec2_security_group_filter_multi_enis/tf_resources.json
@@ -1,0 +1,850 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_ami": {
+            "amazon_linux": {
+                "architecture": "x86_64",
+                "arn": "arn:aws:ec2:us-east-1::image/ami-0d239dc99a14a05ff",
+                "block_device_mappings": [
+                    {
+                        "device_name": "/dev/xvda",
+                        "ebs": {
+                            "delete_on_termination": "true",
+                            "encrypted": "false",
+                            "iops": "0",
+                            "snapshot_id": "snap-0622a97495175951f",
+                            "throughput": "0",
+                            "volume_size": "8",
+                            "volume_type": "gp2"
+                        },
+                        "no_device": "",
+                        "virtual_name": ""
+                    }
+                ],
+                "boot_mode": "",
+                "creation_date": "2023-10-24T17:42:18.000Z",
+                "deprecation_time": "2024-01-01T00:00:00.000Z",
+                "description": "Amazon Linux AMI 2018.03.0.20231024.0 x86_64 HVM gp2",
+                "ena_support": true,
+                "executable_users": null,
+                "filter": [
+                    {
+                        "name": "name",
+                        "values": [
+                            "amzn-ami-hvm-*-x86_64-gp2"
+                        ]
+                    }
+                ],
+                "hypervisor": "xen",
+                "id": "ami-0d239dc99a14a05ff",
+                "image_id": "ami-0d239dc99a14a05ff",
+                "image_location": "amazon/amzn-ami-hvm-2018.03.0.20231024.0-x86_64-gp2",
+                "image_owner_alias": "amazon",
+                "image_type": "machine",
+                "imds_support": "",
+                "include_deprecated": false,
+                "kernel_id": "",
+                "most_recent": true,
+                "name": "amzn-ami-hvm-2018.03.0.20231024.0-x86_64-gp2",
+                "name_regex": null,
+                "owner_id": "644160558196",
+                "owners": [
+                    "amazon"
+                ],
+                "platform": "",
+                "platform_details": "Linux/UNIX",
+                "product_codes": [],
+                "public": true,
+                "ramdisk_id": "",
+                "root_device_name": "/dev/xvda",
+                "root_device_type": "ebs",
+                "root_snapshot_id": "snap-0622a97495175951f",
+                "sriov_net_support": "simple",
+                "state": "available",
+                "state_reason": {
+                    "code": "UNSET",
+                    "message": "UNSET"
+                },
+                "tags": {},
+                "timeouts": null,
+                "tpm_support": "",
+                "usage_operation": "RunInstances",
+                "virtualization_type": "hvm"
+            }
+        },
+        "aws_instance": {
+            "primary_interface": {
+                "ami": "ami-0d239dc99a14a05ff",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0a3bdbed1708220a1",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1a",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_options": [
+                    {
+                        "amd_sev_snp": "",
+                        "core_count": 1,
+                        "threads_per_core": 1
+                    }
+                ],
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": "",
+                "host_resource_group_arn": null,
+                "iam_instance_profile": "",
+                "id": "i-0a3bdbed1708220a1",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_lifecycle": "",
+                "instance_market_options": [],
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_protocol_ipv6": "disabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [
+                    {
+                        "delete_on_termination": false,
+                        "device_index": 0,
+                        "network_card_index": 0,
+                        "network_interface_id": "eni-085f554b90f031062"
+                    },
+                    {
+                        "delete_on_termination": false,
+                        "device_index": 1,
+                        "network_card_index": 0,
+                        "network_interface_id": "eni-00c2433e49682f0c3"
+                    }
+                ],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": 0,
+                "primary_network_interface_id": "eni-085f554b90f031062",
+                "private_dns": "ip-10-0-2-155.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.2.155",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-009c6aed4793667ff",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "spot_instance_request_id": "",
+                "subnet_id": "subnet-08d70664677d2d011",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-08866faa10e9a51ef"
+                ]
+            },
+            "private_only_interface": {
+                "ami": "ami-0d239dc99a14a05ff",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-03b80590af6c5000d",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1a",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_options": [
+                    {
+                        "amd_sev_snp": "",
+                        "core_count": 1,
+                        "threads_per_core": 1
+                    }
+                ],
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": "",
+                "host_resource_group_arn": null,
+                "iam_instance_profile": "",
+                "id": "i-03b80590af6c5000d",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_lifecycle": "",
+                "instance_market_options": [],
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_protocol_ipv6": "disabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [
+                    {
+                        "delete_on_termination": false,
+                        "device_index": 0,
+                        "network_card_index": 0,
+                        "network_interface_id": "eni-0391de1df1dd96901"
+                    }
+                ],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": 0,
+                "primary_network_interface_id": "eni-0391de1df1dd96901",
+                "private_dns": "ip-10-0-2-87.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.2.87",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0f75b51fa925c8b5f",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "spot_instance_request_id": "",
+                "subnet_id": "subnet-08d70664677d2d011",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-09dd9760660103a06"
+                ]
+            },
+            "secondary_interface": {
+                "ami": "ami-0d239dc99a14a05ff",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0e424ef402485a38f",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1a",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_core_count": 1,
+                "cpu_options": [
+                    {
+                        "amd_sev_snp": "",
+                        "core_count": 1,
+                        "threads_per_core": 1
+                    }
+                ],
+                "cpu_threads_per_core": 1,
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": "",
+                "host_resource_group_arn": null,
+                "iam_instance_profile": "",
+                "id": "i-0e424ef402485a38f",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_lifecycle": "",
+                "instance_market_options": [],
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_protocol_ipv6": "disabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [
+                    {
+                        "delete_on_termination": false,
+                        "device_index": 0,
+                        "network_card_index": 0,
+                        "network_interface_id": "eni-053b2040041f15ec2"
+                    },
+                    {
+                        "delete_on_termination": false,
+                        "device_index": 1,
+                        "network_card_index": 0,
+                        "network_interface_id": "eni-07f51a84e9c0dcde0"
+                    }
+                ],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": 0,
+                "primary_network_interface_id": "eni-053b2040041f15ec2",
+                "private_dns": "ip-10-0-1-91.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.91",
+                "public_dns": "",
+                "public_ip": "",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": false,
+                        "iops": 100,
+                        "kms_key_id": "",
+                        "tags": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0f9529f834657f744",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "spot_instance_request_id": "",
+                "subnet_id": "subnet-0afcfaf701c6a1c4c",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-09dd9760660103a06"
+                ]
+            }
+        },
+        "aws_internet_gateway": {
+            "this": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:internet-gateway/igw-03f8dafc19dbe07ad",
+                "id": "igw-03f8dafc19dbe07ad",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-0e6611fce3ecb0f0f"
+            }
+        },
+        "aws_network_interface": {
+            "primary_interface_private": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:network-interface/eni-00c2433e49682f0c3",
+                "attachment": [],
+                "description": "",
+                "id": "eni-00c2433e49682f0c3",
+                "interface_type": "interface",
+                "ipv4_prefix_count": 0,
+                "ipv4_prefixes": [],
+                "ipv6_address_count": 0,
+                "ipv6_address_list": [],
+                "ipv6_address_list_enabled": false,
+                "ipv6_addresses": [],
+                "ipv6_prefix_count": 0,
+                "ipv6_prefixes": [],
+                "mac_address": "12:ab:39:85:61:73",
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_name": "",
+                "private_ip": "10.0.1.115",
+                "private_ip_list": [
+                    "10.0.1.115"
+                ],
+                "private_ip_list_enabled": false,
+                "private_ips": [
+                    "10.0.1.115"
+                ],
+                "private_ips_count": 0,
+                "security_groups": [
+                    "sg-09dd9760660103a06"
+                ],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0afcfaf701c6a1c4c",
+                "tags": null,
+                "tags_all": {}
+            },
+            "primary_interface_public": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:network-interface/eni-085f554b90f031062",
+                "attachment": [],
+                "description": "",
+                "id": "eni-085f554b90f031062",
+                "interface_type": "interface",
+                "ipv4_prefix_count": 0,
+                "ipv4_prefixes": [],
+                "ipv6_address_count": 0,
+                "ipv6_address_list": [],
+                "ipv6_address_list_enabled": false,
+                "ipv6_addresses": [],
+                "ipv6_prefix_count": 0,
+                "ipv6_prefixes": [],
+                "mac_address": "12:c5:d1:f7:12:17",
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_name": "",
+                "private_ip": "10.0.2.155",
+                "private_ip_list": [
+                    "10.0.2.155"
+                ],
+                "private_ip_list_enabled": false,
+                "private_ips": [
+                    "10.0.2.155"
+                ],
+                "private_ips_count": 0,
+                "security_groups": [
+                    "sg-08866faa10e9a51ef"
+                ],
+                "source_dest_check": true,
+                "subnet_id": "subnet-08d70664677d2d011",
+                "tags": null,
+                "tags_all": {}
+            },
+            "private_only_interface": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:network-interface/eni-0391de1df1dd96901",
+                "attachment": [],
+                "description": "",
+                "id": "eni-0391de1df1dd96901",
+                "interface_type": "interface",
+                "ipv4_prefix_count": 0,
+                "ipv4_prefixes": [],
+                "ipv6_address_count": 0,
+                "ipv6_address_list": [],
+                "ipv6_address_list_enabled": false,
+                "ipv6_addresses": [],
+                "ipv6_prefix_count": 0,
+                "ipv6_prefixes": [],
+                "mac_address": "12:ae:3d:5b:fc:79",
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_name": "",
+                "private_ip": "10.0.2.87",
+                "private_ip_list": [
+                    "10.0.2.87"
+                ],
+                "private_ip_list_enabled": false,
+                "private_ips": [
+                    "10.0.2.87"
+                ],
+                "private_ips_count": 0,
+                "security_groups": [
+                    "sg-09dd9760660103a06"
+                ],
+                "source_dest_check": true,
+                "subnet_id": "subnet-08d70664677d2d011",
+                "tags": null,
+                "tags_all": {}
+            },
+            "secondary_interface_private": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:network-interface/eni-053b2040041f15ec2",
+                "attachment": [],
+                "description": "",
+                "id": "eni-053b2040041f15ec2",
+                "interface_type": "interface",
+                "ipv4_prefix_count": 0,
+                "ipv4_prefixes": [],
+                "ipv6_address_count": 0,
+                "ipv6_address_list": [],
+                "ipv6_address_list_enabled": false,
+                "ipv6_addresses": [],
+                "ipv6_prefix_count": 0,
+                "ipv6_prefixes": [],
+                "mac_address": "12:42:2d:9c:37:13",
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_name": "",
+                "private_ip": "10.0.1.91",
+                "private_ip_list": [
+                    "10.0.1.91"
+                ],
+                "private_ip_list_enabled": false,
+                "private_ips": [
+                    "10.0.1.91"
+                ],
+                "private_ips_count": 0,
+                "security_groups": [
+                    "sg-09dd9760660103a06"
+                ],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0afcfaf701c6a1c4c",
+                "tags": null,
+                "tags_all": {}
+            },
+            "secondary_interface_public": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:network-interface/eni-07f51a84e9c0dcde0",
+                "attachment": [],
+                "description": "",
+                "id": "eni-07f51a84e9c0dcde0",
+                "interface_type": "interface",
+                "ipv4_prefix_count": 0,
+                "ipv4_prefixes": [],
+                "ipv6_address_count": 0,
+                "ipv6_address_list": [],
+                "ipv6_address_list_enabled": false,
+                "ipv6_addresses": [],
+                "ipv6_prefix_count": 0,
+                "ipv6_prefixes": [],
+                "mac_address": "12:e4:df:83:de:4f",
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_name": "",
+                "private_ip": "10.0.2.20",
+                "private_ip_list": [
+                    "10.0.2.20"
+                ],
+                "private_ip_list_enabled": false,
+                "private_ips": [
+                    "10.0.2.20"
+                ],
+                "private_ips_count": 0,
+                "security_groups": [
+                    "sg-08866faa10e9a51ef"
+                ],
+                "source_dest_check": true,
+                "subnet_id": "subnet-08d70664677d2d011",
+                "tags": null,
+                "tags_all": {}
+            }
+        },
+        "aws_route_table": {
+            "private": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:route-table/rtb-05647570652472b03",
+                "id": "rtb-05647570652472b03",
+                "owner_id": "644160558196",
+                "propagating_vgws": [],
+                "route": [],
+                "tags": {
+                    "Name": "private"
+                },
+                "tags_all": {
+                    "Name": "private"
+                },
+                "timeouts": null,
+                "vpc_id": "vpc-0e6611fce3ecb0f0f"
+            },
+            "public": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:route-table/rtb-0b6de5dc5519434de",
+                "id": "rtb-0b6de5dc5519434de",
+                "owner_id": "644160558196",
+                "propagating_vgws": [],
+                "route": [
+                    {
+                        "carrier_gateway_id": "",
+                        "cidr_block": "0.0.0.0/0",
+                        "core_network_arn": "",
+                        "destination_prefix_list_id": "",
+                        "egress_only_gateway_id": "",
+                        "gateway_id": "igw-03f8dafc19dbe07ad",
+                        "ipv6_cidr_block": "",
+                        "local_gateway_id": "",
+                        "nat_gateway_id": "",
+                        "network_interface_id": "",
+                        "transit_gateway_id": "",
+                        "vpc_endpoint_id": "",
+                        "vpc_peering_connection_id": ""
+                    }
+                ],
+                "tags": {
+                    "Name": "public"
+                },
+                "tags_all": {
+                    "Name": "public"
+                },
+                "timeouts": null,
+                "vpc_id": "vpc-0e6611fce3ecb0f0f"
+            }
+        },
+        "aws_route_table_association": {
+            "private": {
+                "gateway_id": "",
+                "id": "rtbassoc-0cbbabd97bd9666f7",
+                "route_table_id": "rtb-05647570652472b03",
+                "subnet_id": "subnet-0afcfaf701c6a1c4c",
+                "timeouts": null
+            },
+            "public": {
+                "gateway_id": "",
+                "id": "rtbassoc-0ad827ae6f4b3f137",
+                "route_table_id": "rtb-0b6de5dc5519434de",
+                "subnet_id": "subnet-08d70664677d2d011",
+                "timeouts": null
+            }
+        },
+        "aws_security_group": {
+            "private": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:security-group/sg-09dd9760660103a06",
+                "description": "Managed by Terraform",
+                "egress": [],
+                "id": "sg-09dd9760660103a06",
+                "ingress": [
+                    {
+                        "cidr_blocks": [
+                            "10.0.0.0/16"
+                        ],
+                        "description": "private",
+                        "from_port": 0,
+                        "ipv6_cidr_blocks": [],
+                        "prefix_list_ids": [],
+                        "protocol": "-1",
+                        "security_groups": [],
+                        "self": false,
+                        "to_port": 0
+                    }
+                ],
+                "name": "private-sg-example",
+                "name_prefix": "",
+                "owner_id": "644160558196",
+                "revoke_rules_on_delete": false,
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-0e6611fce3ecb0f0f"
+            },
+            "public": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:security-group/sg-08866faa10e9a51ef",
+                "description": "Managed by Terraform",
+                "egress": [],
+                "id": "sg-08866faa10e9a51ef",
+                "ingress": [
+                    {
+                        "cidr_blocks": [
+                            "0.0.0.0/0"
+                        ],
+                        "description": "public",
+                        "from_port": 0,
+                        "ipv6_cidr_blocks": [],
+                        "prefix_list_ids": [],
+                        "protocol": "-1",
+                        "security_groups": [],
+                        "self": false,
+                        "to_port": 0
+                    }
+                ],
+                "name": "public-sg-example",
+                "name_prefix": "",
+                "owner_id": "644160558196",
+                "revoke_rules_on_delete": false,
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-0e6611fce3ecb0f0f"
+            }
+        },
+        "aws_subnet": {
+            "private": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:subnet/subnet-0afcfaf701c6a1c4c",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "us-east-1a",
+                "availability_zone_id": "use1-az2",
+                "cidr_block": "10.0.1.0/24",
+                "customer_owned_ipv4_pool": "",
+                "enable_dns64": false,
+                "enable_lni_at_device_index": 0,
+                "enable_resource_name_dns_a_record_on_launch": false,
+                "enable_resource_name_dns_aaaa_record_on_launch": false,
+                "id": "subnet-0afcfaf701c6a1c4c",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "ipv6_native": false,
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": false,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_hostname_type_on_launch": "ip-name",
+                "tags": {
+                    "Name": "private"
+                },
+                "tags_all": {
+                    "Name": "private"
+                },
+                "timeouts": null,
+                "vpc_id": "vpc-0e6611fce3ecb0f0f"
+            },
+            "public": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:subnet/subnet-08d70664677d2d011",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "us-east-1a",
+                "availability_zone_id": "use1-az2",
+                "cidr_block": "10.0.2.0/24",
+                "customer_owned_ipv4_pool": "",
+                "enable_dns64": false,
+                "enable_lni_at_device_index": 0,
+                "enable_resource_name_dns_a_record_on_launch": false,
+                "enable_resource_name_dns_aaaa_record_on_launch": false,
+                "id": "subnet-08d70664677d2d011",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "ipv6_native": false,
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": false,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_hostname_type_on_launch": "ip-name",
+                "tags": {
+                    "Name": "public"
+                },
+                "tags_all": {
+                    "Name": "public"
+                },
+                "timeouts": null,
+                "vpc_id": "vpc-0e6611fce3ecb0f0f"
+            }
+        },
+        "aws_vpc": {
+            "this": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:vpc/vpc-0e6611fce3ecb0f0f",
+                "assign_generated_ipv6_cidr_block": false,
+                "cidr_block": "10.0.0.0/16",
+                "default_network_acl_id": "acl-0cd4fd0883e0f1573",
+                "default_route_table_id": "rtb-0acf63e06399619d2",
+                "default_security_group_id": "sg-0b9ae871dd5d148db",
+                "dhcp_options_id": "dopt-a542cadf",
+                "enable_dns_hostnames": false,
+                "enable_dns_support": true,
+                "enable_network_address_usage_metrics": false,
+                "id": "vpc-0e6611fce3ecb0f0f",
+                "instance_tenancy": "default",
+                "ipv4_ipam_pool_id": null,
+                "ipv4_netmask_length": null,
+                "ipv6_association_id": "",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_network_border_group": "",
+                "ipv6_ipam_pool_id": "",
+                "ipv6_netmask_length": 0,
+                "main_route_table_id": "rtb-0acf63e06399619d2",
+                "owner_id": "644160558196",
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
An EC2 instance may have multiple network interfaces where each interface may have different security groups.

As a result, the EC2 instance have different SGs on multiple interfaces so that we have to check all of them in 'security-group' filter, not only associated with the default interface.