### PR TITLE
utils - multiple json encoders during json dump(s) #8860

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -215,7 +215,7 @@ def type_schema(
 
 
 # Based on https://stackoverflow.com/a/76931520
-def multiple_json_encoders_factory(*encoder):
+def multiple_json_encoders_factory(*encoders):
     class MultipleJsonEncoders(json.JSONEncoder):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -94,7 +94,7 @@ def loads(body):
 
 
 def dumps(data, fh=None, indent=0):
-    encoder = multiple_json_encoders_factory(DateTimeEncoder, BytesDumpEncoder)
+    encoder = multiple_json_encoders_factory(DateTimeEncoder, BytesEncoder)
 
     if fh:
         return json.dump(data, fh, cls=encoder, indent=indent)
@@ -231,7 +231,7 @@ def multiple_json_encoders_factory(*encoder):
     
     return MultipleJsonEncoders
 
-class BytesDumpEncoder(json.JSONEncoder):
+class BytesEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, bytes):
             return obj.decode()

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -220,7 +220,7 @@ def multiple_json_encoders_factory(*encoders):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.encoders = [encoder(*args, **kwargs) for encoder in encoders]
-        
+
         def default(self, o):
             for encoder in self.encoders:
                 try:
@@ -228,7 +228,7 @@ def multiple_json_encoders_factory(*encoders):
                 except TypeError:
                     pass
             return super().default(o)
-    
+
     return MultipleJsonEncoders
 
 class BytesEncoder(json.JSONEncoder):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -215,6 +215,13 @@ class UtilTest(BaseTest):
 
         self.assertEqual(utils.local_session(p.session_factory), previous)
 
+    def test_encode_bytes(self):
+        self.assertEqual(
+            json.loads(json.dumps(
+                {"bytes": b"123"}, cls=utils.JsonEncoder)),
+                {'bytes': '123'}
+            )
+
     def test_format_date(self):
         d = parse_date("2018-02-02 12:00")
         self.assertEqual("{}".format(utils.FormatDate(d)), "2018-02-02 12:00:00")
@@ -228,7 +235,7 @@ class UtilTest(BaseTest):
         self.assertEqual("{:+5M%M}".format(utils.FormatDate(d)), "05")
 
         self.assertEqual(json.dumps(utils.FormatDate(d),
-                                    cls=utils.DateTimeEncoder, indent=2),
+                                    cls=utils.JsonEncoder, indent=2),
                          '"2018-02-02T12:00:00"')
         self.assertEqual(str(d), '2018-02-02 12:00:00')
 
@@ -438,7 +445,7 @@ class UtilTest(BaseTest):
         self.assertEqual(json.loads(utils.format_event(event)), json.loads(event_json))
 
     def test_date_time_decoder(self):
-        dtdec = utils.DateTimeEncoder()
+        dtdec = utils.JsonEncoder()
         self.assertRaises(TypeError, dtdec.default, "test")
 
     def test_set_annotation(self):


### PR DESCRIPTION
I detected that some resources like WAFv2 could have bytes as the value in a dictionary, more information on #8860

closes #8860.

I think that would be very useful, the dumps function uses multiple JSON Encoders, for multiple scenarios.
The two scenarios that I see right now are the DateTimeEncoder and the BytesEncoder (for #8860).
Since json.dump and json.dumps do not support natively multiple encoders, it's necessary to create an "encoder" that will aggregate the functionalities of many encoders but in a clean way. 

I created the factory **multiple_json_encoders_factory** to allow extensibility for future scenarios.