### PR TITLE
openstack - secret

### DIFF
--- a/tools/c7n_openstack/c7n_openstack/entry.py
+++ b/tools/c7n_openstack/c7n_openstack/entry.py
@@ -7,7 +7,8 @@ from c7n_openstack.resources import (
     flavor,
     server,
     user,
-    security_group
+    security_group,
+    secret
 )
 
 log = logging.getLogger('custodian.openstack')
@@ -17,7 +18,9 @@ ALL = [
     project,
     server,
     user,
-    security_group]
+    security_group,
+    secret
+]
 
 
 def initialize_openstack():

--- a/tools/c7n_openstack/c7n_openstack/query.py
+++ b/tools/c7n_openstack/c7n_openstack/query.py
@@ -27,7 +27,18 @@ class ResourceQuery:
         return self._invoke_client_enum(client, enum_op, params)
 
     def _invoke_client_enum(self, client, enum_op, params):
-        res = getattr(client, enum_op)(**params)
+        if isinstance(enum_op, list):
+            obj = None
+            res = []
+            for op in enum_op:
+                if obj is None:
+                    obj = getattr(client, op)
+                else:
+                    obj = getattr(obj, op)
+            for r in obj(**params):
+                res.append(r.toDict() if not isinstance(enum_op, dict) else r)
+        else:
+            res = getattr(client, enum_op)(**params)
         return res
 
 

--- a/tools/c7n_openstack/c7n_openstack/query.py
+++ b/tools/c7n_openstack/c7n_openstack/query.py
@@ -28,13 +28,10 @@ class ResourceQuery:
 
     def _invoke_client_enum(self, client, enum_op, params):
         if isinstance(enum_op, list):
-            obj = None
+            obj = client
             res = []
             for op in enum_op:
-                if obj is None:
-                    obj = getattr(client, op)
-                else:
-                    obj = getattr(obj, op)
+                obj = getattr(obj, op)
             for r in obj(**params):
                 res.append(r.toDict() if not isinstance(enum_op, dict) else r)
         else:

--- a/tools/c7n_openstack/c7n_openstack/resources/resource_map.py
+++ b/tools/c7n_openstack/c7n_openstack/resources/resource_map.py
@@ -7,4 +7,5 @@ ResourceMap = {
     "openstack.user": "c7n_openstack.resources.user.User",
     "openstack.volume": "c7n_openstack.resources.volume.Volume",
     "openstack.security-group": "c7n_openstack.resources.security_group.SecurityGroup",
+    "openstack.secret": "c7n_openstack.resources.secret.Secret"
 }

--- a/tools/c7n_openstack/c7n_openstack/resources/secret.py
+++ b/tools/c7n_openstack/c7n_openstack/resources/secret.py
@@ -1,0 +1,14 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+from c7n_openstack.query import QueryResourceManager, TypeInfo
+from c7n_openstack.provider import resources
+
+
+@resources.register('secret')
+class Secret(QueryResourceManager):
+    class resource_type(TypeInfo):
+        enum_spec = (['key_manager', 'secrets'], None)
+        id = 'secret_id'
+        name = 'name'
+        default_report_fields = ['id', 'name', 'secret_type', 'algorithm', 'expires_at']

--- a/tools/c7n_openstack/tests/data/flights/test_secret_without_expiration
+++ b/tools/c7n_openstack/tests/data/flights/test_secret_without_expiration
@@ -1,0 +1,135 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Content-Type: [application/json]
+    method: GET
+    uri: http://keystone:5000/
+  response:
+    body: {string: '{"versions": {"values": [{"id": "v3.14", "status": "stable", "updated": "2020-04-07T00:00:00Z", "links": [{"rel": "self", "href": "http://127.0.0.1:5000/v3/"}], "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+j
+son"}]}]}}'}
+    headers:
+      Content-Type: [application/json]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Content-Type: [application/json]
+    method: POST
+    uri: http://keystone:5000/v3/auth/tokens
+  response:
+    body:
+      string: '{"token": {"methods": ["password"], "user": {"domain": {"id": "default",
+        "name": "Default"}, "id": "58e8dcfcbc8a45879bc566b2935ba5e4", "name": "admin",
+        "password_expires_at": null}, "audit_ids": ["cKdBmKRCTDa7lfpNVrdYjg"], "expires_at":
+        "2023-11-10T22:08:44.000000Z", "issued_at": "2023-11-10T21:08:44.000000Z",
+        "project": {"domain": {"id": "default", "name": "Default"}, "id": "314a347c744349479e901e57922b70e5",
+        "name": "demo"}, "is_domain": false, "roles": [{"id": "b7fe104b0d624e2d9629c2e41957c737",
+        "name": "reader"}, {"id": "87dbe14de84d4c62bd46c5629bf47e33", "name": "admin"},
+        {"id": "e5fd977cc1884282b1268968824eaca0", "name": "member"}, {"id": "4674b64a36964ab2abd0e82911afedc1",
+        "name": "manager"}], "catalog": [{"endpoints": [{"id": "87ce6e5381ee4e87bf2015f39ad1de7f",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/image",
+        "region": "RegionOne"}], "id": "0942a9f505fe413d9a51982cccaac5e5", "type":
+        "image", "name": "glance"}, {"endpoints": [{"id": "9be35accc8964ac3a7e3711f906222e9",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/share/v2",
+        "region": "RegionOne"}], "id": "1d6115ca51044e9c999e5cb595098702", "type":
+        "sharev2", "name": "manilav2"}, {"endpoints": [{"id": "7541e5d4bd7c4a54a11597bebc301463",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/volume/v3/314a347c744349479e901e57922b70e5",
+        "region": "RegionOne"}], "id": "22922a8a51e94f3ea7ab0f77c333755a", "type":
+        "volumev3", "name": "cinderv3"}, {"endpoints": [{"id": "ae6f6d86bc4041a39790df1ed62bc437",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/compute/v2.1",
+        "region": "RegionOne"}], "id": "22c861c637db498a82e8ffdaff3c0c1d", "type":
+        "compute", "name": "nova"}, {"endpoints": [{"id": "446817563ed94e24b21b6d1c47ca98ef",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/placement",
+        "region": "RegionOne"}], "id": "3b4e8e62dba74fb4aed61d9aad495129", "type":
+        "placement", "name": "placement"}, {"endpoints": [{"id": "21df59e8389e44fd864ce92eb7cade73",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/share/v2",
+        "region": "RegionOne"}], "id": "833724454f6249ed921520e0566837b0", "type":
+        "shared-file-system", "name": "shared-file-system"}, {"endpoints": [{"id":
+        "2651cfe5ab17461991d74759fe07bf7a", "interface": "public", "region_id": "RegionOne",
+        "url": "http://10.0.2.14/compute/v2/314a347c744349479e901e57922b70e5", "region":
+        "RegionOne"}], "id": "84131e4b6b3b4153a2e1ac34aeb1f093", "type": "compute_legacy",
+        "name": "nova_legacy"}, {"endpoints": [{"id": "c5958a4d002b475d87964400524c2da5",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/volume/v3/314a347c744349479e901e57922b70e5",
+        "region": "RegionOne"}], "id": "9786063907504ddaafdf28f78be1e44c", "type":
+        "block-storage", "name": "cinder"}, {"endpoints": [{"id": "3ec1bb6d2e484d7d8a69cae754a3d93c",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14:9696/networking",
+        "region": "RegionOne"}], "id": "9c959e47acd34590b8a4e905220577a0", "type":
+        "network", "name": "neutron"}, {"endpoints": [{"id": "54454508ac5c483f97ac25806db9d2dc",
+        "interface": "internal", "region_id": "RegionOne", "url": "http://10.0.2.14/key-manager",
+        "region": "RegionOne"}, {"id": "86f464b7eac64877aa357c2838477d86", "interface":
+        "admin", "region_id": "RegionOne", "url": "http://10.0.2.14/key-manager",
+        "region": "RegionOne"}, {"id": "b55d2074f4da41f1ac9f78ebc20c4104", "interface":
+        "public", "region_id": "RegionOne", "url": "http://10.0.2.14/key-manager",
+        "region": "RegionOne"}], "id": "a0a5379ac20644a3b4510b79a5565191", "type":
+        "key-manager", "name": "barbican"}, {"endpoints": [{"id": "235d31f133f84a93a149a9a4de3c29b9",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14:8080/v1/AUTH_314a347c744349479e901e57922b70e5",
+        "region": "RegionOne"}, {"id": "3c5f7fe4807d40b5866cba3347b92462", "interface":
+        "admin", "region_id": "RegionOne", "url": "http://10.0.2.14:8080", "region":
+        "RegionOne"}], "id": "b02de6eed0df4049a19338ec202fe362", "type": "object-store",
+        "name": "swift"}, {"endpoints": [{"id": "1c5ed69b88874920a0c7147569d28aeb",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/share/v2/314a347c744349479e901e57922b70e5",
+        "region": "RegionOne"}], "id": "bd7f0686312b43dbbd7244eb44737c16", "type":
+        "sharev2_legacy", "name": "manilav2_legacy"}, {"endpoints": [{"id": "072699a432754d749bea52570c98fd7e",
+        "interface": "internal", "region_id": "RegionOne", "url": "http://10.0.2.14/metric",
+        "region": "RegionOne"}, {"id": "3a6e589efb274b64aff38efa9d0440f3", "interface":
+        "public", "region_id": "RegionOne", "url": "http://10.0.2.14/metric", "region":
+        "RegionOne"}, {"id": "59078e49f2fb4ac5859385ed621c4ebd", "interface": "admin",
+        "region_id": "RegionOne", "url": "http://10.0.2.14/metric", "region": "RegionOne"}],
+        "id": "d29c4b57fac94546909b58394babf3c4", "type": "metric", "name": "gnocchi"},
+        {"endpoints": [{"id": "757ce9015b1c41dc936675685ec07fb2", "interface": "public",
+        "region_id": "RegionOne", "url": "http://10.0.2.14/share/v1/314a347c744349479e901e57922b70e5",
+        "region": "RegionOne"}], "id": "f210feb330f742c4a22524fcb1174411", "type":
+        "share", "name": "manila"}, {"endpoints": [{"id": "63ee54348ddf441b9d3c0ef12c2b2dae",
+        "interface": "public", "region_id": "RegionOne", "url": "http://10.0.2.14/identity",
+        "region": "RegionOne"}], "id": "fc0b9142361f42b988d426a988f06b64", "type":
+        "identity", "name": "keystone"}]}}'
+    headers:
+      X-Subject-Token: "test-token"
+      Content-Type: [application/json]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Content-Type: [application/json]
+    method: GET
+    uri: http://10.0.2.14/key-manager
+  response:
+    body:
+      string: '{"versions": {"values": [{"id": "v1", "status": "stable", "links":
+        [{"rel": "self", "href": "http://10.0.2.14/key-manager/v1/"}, {"rel": "describedby",
+        "type": "text/html", "href": "https://docs.openstack.org/"}], "media-types":
+        [{"base": "application/json", "type": "application/vnd.openstack.key-manager-v1+json"}]}]}}'
+    headers:
+      Content-Type: [application/json]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Content-Type: [application/json]
+    method: GET
+    uri: http://10.0.2.14/key-manager/v1/secrets
+  response:
+    body:
+      string: '{"secrets": [{"created": "2023-11-10T21:04:25", "updated": "2023-11-10T21:04:25",
+        "status": "ACTIVE", "name": "test1", "secret_type": "passphrase", "expiration":
+        null, "algorithm": "aes", "bit_length": 256, "mode": "cbc", "creator_id":
+        "58e8dcfcbc8a45879bc566b2935ba5e4", "content_types": {"default": "application/octet-stream"},
+        "secret_ref": "http://10.0.2.14/key-manager/v1/secrets/6c654168-efde-43eb-88e6-234c555960a5"},
+        {"created": "2023-11-10T21:06:36", "updated": "2023-11-10T21:06:36", "status":
+        "ACTIVE", "name": "test3", "secret_type": "passphrase", "expiration": "2024-11-01T01:00:00",
+        "algorithm": "aes", "bit_length": 256, "mode": "cbc", "creator_id": "58e8dcfcbc8a45879bc566b2935ba5e4",
+        "content_types": {"default": "application/octet-stream"}, "secret_ref": "http://10.0.2.14/key-manager/v1/secrets/97665f55-5901-4127-98e4-848a014b89a7"},
+        {"created": "2023-11-10T21:04:09", "updated": "2023-11-10T21:04:09", "status":
+        "ACTIVE", "name": "test2", "secret_type": "opaque", "expiration": null, "algorithm":
+        "aes", "bit_length": 256, "mode": "cbc", "creator_id": "58e8dcfcbc8a45879bc566b2935ba5e4",
+        "content_types": {"default": "application/octet-stream"}, "secret_ref": "http://10.0.2.14/key-manager/v1/secrets/ca99f71b-cc02-4b74-9f6d-d8d84b70c2fb"}],
+        "total": 3}'
+    headers:
+      Content-Type: [application/json]
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_openstack/tests/test_secret.py
+++ b/tools/c7n_openstack/tests/test_secret.py
@@ -1,0 +1,25 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from common_openstack import OpenStackTest
+
+
+class VolumeTest(OpenStackTest):
+
+    def test_secret_without_expiration(self):
+        factory = self.replay_flight_data('test_secret_without_expiration')
+        p = self.load_policy({
+            'name': 'secrets-without-expiration',
+            'resource': 'openstack.secret',
+            'filters': [
+                {
+                    'type': 'value',
+                    'key': 'expires_at',
+                    'value': None
+                }
+            ]
+        },
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+        self.assertIsNone(resources[0]['expires_at'])
+        self.assertIsNone(resources[1]['expires_at'])


### PR DESCRIPTION
A resource `secret` has been created.

I do not know if this is the best option to implement this part, maybe there're better solutions:

https://github.com/cloud-custodian/cloud-custodian/blob/815df7588c7584e97b59abc8c1e209dd4a516eb8/tools/c7n_openstack/c7n_openstack/query.py#L30-L41

The reason it needs to be implemented is that there are two main options to make a call to list resources, for example for listing instances:
Option #1:
```
conn.compute.servers()
```
Option #2:
```
conn.list_servers()
```
More info: [OpenStack SDK - Getting started](https://docs.openstack.org/openstacksdk/2023.1/user/guides/intro.html)

The second option is not always available, like in this case there is no `list_secrets()` method in openstacksdk.