### PR TITLE
Add AWS EC2 Capacity Reservation Resource

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -2485,3 +2485,22 @@ class HasSpecificManagedPolicy(SpecificIamProfileManagedPolicy):
                 results.append(r)
 
         return results
+
+
+@resources.register('ec2-capacity-reservation')
+class CapacityReservation(query.QueryResourceManager):
+    """Custodian resource for managing EC2 Capacity Reservation.
+    """
+
+    class resource_type(query.TypeInfo):
+        name = id = 'CapacityReservationIds'
+        service = 'ec2'
+        enum_spec = ('describe_capacity_reservations',
+                     'CapacityReservations', None)
+
+        id_prefix = 'cr-'
+        arn = "CapacityReservationArn"
+        filter_name = 'CapacityReservationIds'
+        filter_type = 'list'
+        cfn_type = config_type = 'AWS::EC2::CapacityReservation'
+        permissions_enum = ('ec2:DescribeCapacityReservations',)

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -2502,5 +2502,5 @@ class CapacityReservation(query.QueryResourceManager):
         arn = "CapacityReservationArn"
         filter_name = 'CapacityReservationIds'
         filter_type = 'list'
-        cfn_type = config_type = 'AWS::EC2::CapacityReservation'
+        cfn_type = 'AWS::EC2::CapacityReservation'
         permissions_enum = ('ec2:DescribeCapacityReservations',)

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -72,6 +72,7 @@ ResourceMap = {
   "aws.ec2-host": "c7n.resources.ec2.DedicatedHost",
   "aws.ec2-reserved": "c7n.resources.ec2.ReservedInstance",
   "aws.ec2-spot-fleet-request": "c7n.resources.ec2.SpotFleetRequest",
+  "aws.ec2-capacity-reservation": "c7n.resources.ec2.CapacityReservation",
   "aws.ecr": "c7n.resources.ecr.ECR",
   "aws.ecr-image": "c7n.resources.ecr.RepositoryImage",
   "aws.ecs": "c7n.resources.ecs.ECSCluster",

--- a/tests/data/placebo/test_ec2_capacity_reservation_query/ec2.DescribeCapacityReservations_1.json
+++ b/tests/data/placebo/test_ec2_capacity_reservation_query/ec2.DescribeCapacityReservations_1.json
@@ -1,0 +1,106 @@
+{
+    "status_code": 200,
+    "data": {
+        "CapacityReservations": [
+            {
+                "CapacityReservationId": "cr-0004ba84180b29fa3",
+                "OwnerId": "999999999999",
+                "CapacityReservationArn": "arn:aws:ec2:ap-southeast-1:999999999999:capacity-reservation/cr-0004ba84180b29fa3",
+                "AvailabilityZoneId": "apse1-az3",
+                "InstanceType": "c5.4xlarge",
+                "InstancePlatform": "Linux/UNIX",
+                "AvailabilityZone": "ap-southeast-1c",
+                "Tenancy": "default",
+                "TotalInstanceCount": 1,
+                "AvailableInstanceCount": 0,
+                "EbsOptimized": false,
+                "EphemeralStorage": false,
+                "State": "active",
+                "StartDate": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 9,
+                    "hour": 0,
+                    "minute": 0,
+                    "second": 20,
+                    "microsecond": 0
+                },
+                "EndDateType": "unlimited",
+                "InstanceMatchCriteria": "open",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 9,
+                    "hour": 0,
+                    "minute": 0,
+                    "second": 19,
+                    "microsecond": 0
+                },
+                "Tags": [
+                    {
+                        "Key": "app",
+                        "Value": "test"
+                    }
+                ],
+                "CapacityAllocations": [
+                    {
+                        "AllocationType": "used",
+                        "Count": 1
+                    }
+                ]
+            },
+            {
+                "CapacityReservationId": "cr-0004dfa40b26a5ca1",
+                "OwnerId": "999999999999",
+                "CapacityReservationArn": "arn:aws:ec2:ap-southeast-1:999999999999:capacity-reservation/cr-0004dfa40b26a5ca1",
+                "AvailabilityZoneId": "apse1-az2",
+                "InstanceType": "c5.large",
+                "InstancePlatform": "Linux/UNIX",
+                "AvailabilityZone": "ap-southeast-1a",
+                "Tenancy": "default",
+                "TotalInstanceCount": 1,
+                "AvailableInstanceCount": 0,
+                "EbsOptimized": false,
+                "EphemeralStorage": false,
+                "State": "active",
+                "StartDate": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 2,
+                    "hour": 4,
+                    "minute": 4,
+                    "second": 13,
+                    "microsecond": 0
+                },
+                "EndDateType": "unlimited",
+                "InstanceMatchCriteria": "open",
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 3,
+                    "day": 2,
+                    "hour": 4,
+                    "minute": 4,
+                    "second": 13,
+                    "microsecond": 0
+                },
+                "Tags": [
+                    {
+                        "Key": "app",
+                        "Value": "test"
+                    }
+                ],
+                "CapacityAllocations": [
+                    {
+                        "AllocationType": "used",
+                        "Count": 1
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -2381,3 +2381,19 @@ class TestEc2HasSpecificManagedPolicyFilter(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+
+class TestCapacityReservation(BaseTest):
+
+    def test_capacity_reservation_query(self):
+        factory = self.replay_flight_data('test_ec2_capacity_reservation_query')
+        p = self.load_policy(
+                {
+                    'name': 'list-ec2-capacity-reservation',
+                    'resource': 'aws.ec2-capacity-reservation'
+                },
+                session_factory=factory,
+                config={'region': 'ap-southeast-1'}
+            )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)


### PR DESCRIPTION
Hi, I am trying to add new support to query the AWS resource ec2 capacity reservation. This is my first PR here, so please help with the review. Thank you.

This will close https://github.com/cloud-custodian/cloud-custodian/issues/6976