### PR TITLE
Fix EC2 Capacity Reservation Id

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -2493,7 +2493,7 @@ class CapacityReservation(query.QueryResourceManager):
     """
 
     class resource_type(query.TypeInfo):
-        name = id = 'CapacityReservationIds'
+        name = id = 'CapacityReservationId'
         service = 'ec2'
         enum_spec = ('describe_capacity_reservations',
                      'CapacityReservations', None)


### PR DESCRIPTION
Hi, sorry that my previous PR (https://github.com/cloud-custodian/cloud-custodian/pull/9147) is not working properly because I wrongly put the ID, after testing it again to find the resources, the resource ID is not shown in the report.