### PR TITLE
feat: expand source jsonschema

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -475,11 +475,22 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
 
     @property
     def source_type(self):
-        return self.data.get('source', 'describe')
+        value = self.data.get('source', 'describe')
+        if isinstance(value, str):
+            return value
+        # Here we assume that the data has been validated, so the other
+        # alternative is that the source is a dict with the name attribute
+        # being a valid source type.
+        return value["name"]
+
+    @property
+    def source_config(self):
+        value = self.data.get('source', 'describe')
+        return value if isinstance(value, dict) else {}
 
     def get_source(self, source_type):
         if source_type in self.source_mapping:
-            return self.source_mapping.get(source_type)(self)
+            return self.source_mapping[source_type](self)
         if source_type in sources:
             return sources[source_type](self)
         raise KeyError("Invalid Source %s" % source_type)

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -296,7 +296,20 @@ def generate(resource_types=()):
                 'tags': {'type': 'array', 'items': {'type': 'string'}},
                 'metadata': {'type': 'object'},
                 'mode': {'$ref': '#/definitions/policy-mode'},
-                'source': {'enum': list(sources.keys())},
+                'source': {
+                    'anyOf': [
+                        {'enum': list(sources.keys())},
+                        {
+                            'type': 'object',
+                            # Other properties of the source other than the name itself
+                            # are up to the source itself to define.
+                            'required': ['name'],
+                            'properties': {
+                                'name': {'enum': list(sources.keys())},
+                            },
+                        },
+                    ]
+                },
                 'actions': {
                     'type': 'array',
                 },

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,69 @@
+import pytest
+
+from c7n.config import Config
+from c7n.exceptions import PolicyValidationError
+from c7n.loader import PolicyLoader
+from c7n.query import sources
+
+
+class SourceTest:
+    def __init__(self, manager):
+        self.manager = manager
+        self.config = manager.source_config
+
+
+@pytest.fixture()
+def testing_source():
+    sources.register('testing', SourceTest)
+    yield
+    sources.unregister('testing')
+
+
+class TestSchemaSource:
+    @pytest.fixture(autouse=True)
+    def setup(self, testing_source):
+        self.loader = PolicyLoader(Config.empty())
+
+    def load(self, policy_data):
+        collection = self.loader.load_data({"policies": [policy_data]}, 'memory://')
+        return collection.policies[0]
+
+    def test_unknown_source(self):
+        data = {
+            "name": "test",
+            "resource": "ec2",
+            "source": "unknown",
+        }
+        with pytest.raises(PolicyValidationError) as err:
+            self.load(data)
+        assert "'unknown' is not valid under any of the given schemas" in str(err.value)
+
+    def test_testing_source_name(self):
+        data = {
+            "name": "test",
+            "resource": "ec2",
+            "source": "testing",
+        }
+        p = self.load(data)
+        source = p.resource_manager.source
+        assert isinstance(source, SourceTest)
+        assert source.manager.data == data
+        assert source.config == {}
+
+    def test_testing_source_object(self):
+        data = {
+            "name": "test",
+            "resource": "ec2",
+            "source": {
+                "name": "testing",
+                "query": "something",
+            },
+        }
+        p = self.load(data)
+        source = p.resource_manager.source
+        assert isinstance(source, SourceTest)
+        assert source.manager.data == data
+        assert source.config == {
+            "name": "testing",
+            "query": "something",
+        }


### PR DESCRIPTION
Allow the source definition to be an object, with the name being the type, and other attributes up to the source itself.

This will allow attributes of the source to be kept with the source rather than the top level `query` policy attribute.