### PR TITLE
aws - ec2 query parser should be scoped to describe source only

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -57,7 +57,8 @@ class DescribeEC2(query.DescribeSource):
                 qf_names.add(qd['Name'])
                 qf.append(qd)
         query_params = query_params or {}
-        return query_params['Filters'] = qf
+        query_params['Filters'] = qf
+        return query_params
 
     def augment(self, resources):
         """EC2 API and AWOL Tags

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -41,6 +41,24 @@ actions = ActionRegistry('ec2.actions')
 
 class DescribeEC2(query.DescribeSource):
 
+    def get_query_params(self, query_params):
+        queries = QueryFilter.parse(self.manager.data.get('query', []))
+        qf = []
+        qf_names = set()
+        # allow same name to be specified multiple times and append the queries
+        # under the same name
+        for q in queries:
+            qd = q.query()
+            if qd['Name'] in qf_names:
+                for qf in qf:
+                    if qd['Name'] == qf['Name']:
+                        qf['Values'].extend(qd['Values'])
+            else:
+                qf_names.add(qd['Name'])
+                qf.append(qd)
+        query_params = query_params or {}
+        return query_params['Filters'] = qf
+
     def augment(self, resources):
         """EC2 API and AWOL Tags
 
@@ -129,33 +147,6 @@ class EC2(query.QueryResourceManager):
         'describe': DescribeEC2,
         'config': query.ConfigSource
     }
-
-    def __init__(self, ctx, data):
-        super(EC2, self).__init__(ctx, data)
-        self.queries = QueryFilter.parse(self.data.get('query', []))
-
-    def resources(self, query=None):
-        q = self.resource_query()
-        if q is not None:
-            query = query or {}
-            query['Filters'] = q
-        return super(EC2, self).resources(query=query)
-
-    def resource_query(self):
-        qf = []
-        qf_names = set()
-        # allow same name to be specified multiple times and append the queries
-        # under the same name
-        for q in self.queries:
-            qd = q.query()
-            if qd['Name'] in qf_names:
-                for qf in qf:
-                    if qd['Name'] == qf['Name']:
-                        qf['Values'].extend(qd['Values'])
-            else:
-                qf_names.add(qd['Name'])
-                qf.append(qd)
-        return qf
 
 
 @filters.register('security-group')

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -44,17 +44,14 @@ class DescribeEC2(query.DescribeSource):
     def get_query_params(self, query_params):
         queries = QueryFilter.parse(self.manager.data.get('query', []))
         qf = []
-        qf_names = set()
-        # allow same name to be specified multiple times and append the queries
-        # under the same name
         for q in queries:
             qd = q.query()
-            if qd['Name'] in qf_names:
-                for qf in qf:
-                    if qd['Name'] == qf['Name']:
-                        qf['Values'].extend(qd['Values'])
-            else:
-                qf_names.add(qd['Name'])
+            found = False
+            for f in qf:
+                if qd['Name'] == f['Name']:
+                    f['Values'].extend(qd['Values'])
+                    found = True
+            if not found:
                 qf.append(qd)
         query_params = query_params or {}
         query_params['Filters'] = qf

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -119,7 +119,9 @@ class TestEC2Manager(BaseTest):
         ec2_mgr = self.load_policy({
             'name': 'xyz',
             'resource': 'aws.ec2',
-            "query": [{"tag-key": "CMDBEnvironment"}],
+            "query": [
+                {"instance-state-name": "stopped"},
+                {"tag-key": "CMDBEnvironment"}, {"tag-key": "Owner"}],
             "filters": [{"tag:ASV": "absent"}]}
         ).resource_manager
 
@@ -129,7 +131,11 @@ class TestEC2Manager(BaseTest):
         qf = source.get_query_params(None)
         self.assertEqual(
             qf,
-            {'Filters': [{"Values": ["CMDBEnvironment"], "Name": "tag-key"}]})
+            {'Filters': [
+                {"Values": ["stopped"], "Name": "instance-state-name"},
+                {"Values": ["CMDBEnvironment", "Owner"], "Name": "tag-key"},
+            ]
+        })
 
     def test_filters(self):
         ec2 = self.load_policy({

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -123,12 +123,13 @@ class TestEC2Manager(BaseTest):
             "filters": [{"tag:ASV": "absent"}]}
         ).resource_manager
 
+        source = ec2_mgr.get_source(ec2_mgr.source_type)
         self.assertEqual(len(ec2_mgr.filters), 1)
-        self.assertEqual(len(ec2_mgr.queries), 1)
+
+        qf = source.get_query_params(None)
         self.assertEqual(
-            ec2_mgr.resource_query(),
-            [{"Values": ["CMDBEnvironment"], "Name": "tag-key"}],
-        )
+            qf,
+            {'Filters': [{"Values": ["CMDBEnvironment"], "Name": "tag-key"}]})
 
     def test_filters(self):
         ec2 = self.load_policy({


### PR DESCRIPTION


else parameters for a source like aws config result in error.

policy queries top level key are source specific.


