### PR TITLE
mailer: Escape HTML markup template and subject

### DIFF
--- a/docker/mailer
+++ b/docker/mailer
@@ -15,7 +15,7 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
+RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch markupsafe
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install

--- a/tools/c7n_mailer/tests/common.py
+++ b/tools/c7n_mailer/tests/common.py
@@ -46,7 +46,11 @@ MAILER_CONFIG = {
     "cache_engine": "sqlite",
     "role": "arn:aws:iam::xxxx:role/cloudcustodian-mailer",
     "ldap_uid_tags": ["CreatorName", "Owner"],
-    "templates_folders": [os.path.abspath(os.path.dirname(__file__)), os.path.abspath("/"), ""],
+    "templates_folders": [
+        os.path.abspath(os.path.dirname(__file__)),
+        os.path.abspath("/"),
+        "",
+    ],
 }
 MAILER_CONFIG_AZURE = {
     "queue_url": "asq://storageaccount.queue.core.windows.net/queuename",
@@ -68,7 +72,11 @@ MAILER_CONFIG_GCP = {
     "from_address": "devops@initech.com",
     "queue_url": "projects/c7n-dev/subscriptions/getnotify",
     "smtp_server": "smtp.inittech.com",
-    "templates_folders": [os.path.abspath(os.path.dirname(__file__)), os.path.abspath("/"), ""],
+    "templates_folders": [
+        os.path.abspath(os.path.dirname(__file__)),
+        os.path.abspath("/"),
+        "",
+    ],
 }
 
 RESOURCE_1 = {
@@ -132,7 +140,7 @@ SQS_MESSAGE_1 = {
         "priority_header": "1",
         "type": "notify",
         "transport": {"queue": "xxx", "type": "sqs"},
-        "subject": "{{ account }} AWS EBS Volumes will be DELETED in 15 DAYS!",
+        "subject": "{{ account }} AWS EBS Volumes will be <DELETED> in 15 DAYS!",
     },
     "policy": {
         "filters": [{"Attachments": []}, {"tag:maid_status": "absent"}],
@@ -165,13 +173,19 @@ SQS_MESSAGE_2 = {
     "account": "core-services-dev",
     "account_id": "000000000000",
     "region": "us-east-1",
-    "action": {"type": "notify", "to": ["datadog://?metric_name=EBS_volume.available.size"]},
+    "action": {
+        "type": "notify",
+        "to": ["datadog://?metric_name=EBS_volume.available.size"],
+    },
     "policy": {
         "filters": [{"Attachments": []}, {"tag:maid_status": "absent"}],
         "resource": "ebs",
         "actions": [
             {"type": "mark-for-op", "days": 15, "op": "delete"},
-            {"type": "notify", "to": ["datadog://?metric_name=EBS_volume.available.size"]},
+            {
+                "type": "notify",
+                "to": ["datadog://?metric_name=EBS_volume.available.size"],
+            },
         ],
         "comments": "We are deleting your EBS volumes.",
         "name": "ebs-mark-unattached-deletion",
@@ -627,7 +641,10 @@ GCP_SMTP_MESSAGE = {
                 "template": "default",
                 "to": ["resource-owner", "ldap_uid_tags"],
                 "email_ldap_username_manager": True,
-                "transport": {"topic": "projects/c7n-dev/topics/c7n_notify", "type": "pubsub"},
+                "transport": {
+                    "topic": "projects/c7n-dev/topics/c7n_notify",
+                    "type": "pubsub",
+                },
                 "type": "notify",
             }
         ],

--- a/tools/c7n_mailer/tests/test_email.py
+++ b/tools/c7n_mailer/tests/test_email.py
@@ -379,7 +379,7 @@ class EmailTest(unittest.TestCase):
             assert sendmail_req[0][0] == "my_graph_sendmail_endpoint"
             assert sendmail_req[1]["data"].startswith(
                 '{"message": {"subject": "core-services-dev AWS EBS Volumes'
-                ' will be DELETED in 15 DAYS!"'
+                ' will be &lt;DELETED&gt; in 15 DAYS!"'
             )
 
     def test_ses_send_raw_email(self):


### PR DESCRIPTION
This PR adds logic to escape rendered templates and subjects using the markupsafe library.

In the [utils.py](https://github.com/cloud-custodian/cloud-custodian/blob/d458f0a/tools/c7n_mailer/c7n_mailer/utils.py) of the c7n_mailer tool, the logics use the Jinja2 library to render an HTML email template. The functions `get_message_subject` and `get_jinja_env` take in email message parameters and path for the email template directory as input and use the Jinja2 library to create and render the HTML email template and email subject. The functions are triggered when a policy-registered event has happened and notify actions are required. The parameters passing to the functions are configurable by the policy owner and other cloud users who have access to either the environment or the resources linked to the registered event. Thus it could contain untrusted data and result in possible HTML injection and lead to possible cross-site scripting (XSS) when malicious data is being attached to the template or environment variables. According to the documentation of [Jinja2](https://tedboy.github.io/jinja2/templ10.html), the default configuration for their Template designer does not have automatic HTML escaping because it may be a huge performance hit if it needs to escape all variables, including some variables that are not HTML. In addition, the logic in the `utils.py` of the c7n_mailer tool does not enable HTML escaping by default when using the Jinja2 package nor manually escaping the variable from the Jinja2. Thus it results in possible HTML injection.