### PR TITLE
Fix improper url substring validation

### DIFF
--- a/c7n/actions/notify.py
+++ b/c7n/actions/notify.py
@@ -382,14 +382,18 @@ class Notify(BaseNotify):
 
     def send_sqs(self, message, payload):
         queue = self.data['transport']['queue'].format(**message)
+        domain = None
+        if queue.startswith('https://'):
+            domain = queue[len('https://'):].split('/', 1)[0]
+
         if queue.startswith('https://queue.amazonaws.com'):
             region = 'us-east-1'
             queue_url = queue
-        elif 'queue.amazonaws.com' in queue:
-            region = queue[len('https://'):].split('.', 1)[0]
+        elif domain and domain.endswith('queue.amazonaws.com'):
+            region = domain.split('.', 1)[0]
             queue_url = queue
-        elif queue.startswith('https://sqs.'):
-            region = queue.split('.', 2)[1]
+        elif domain and domain.startswith('sqs.'):
+            region = domain.split('.', 2)[1]
             queue_url = queue
         elif queue.startswith('arn:'):
             queue_arn_split = queue.split(':', 5)


### PR DESCRIPTION
Cloud Custodians base notifier is susceptible to an improper URL string validation which may allow an attacker to trick Cloud Custodian into leaking data by sending messages to URLs under the attackers control. The issue allows an attacker who can add items to the transport queue to control the URL that the base notifier sends payloads to. Besides the potential for leaking data, an attacker could also manipulate subsequent workflow by crafting a malicious response to Cloud Custodian.

The issue requires high privileges to exploit: Permissions to deploy policies are necessary.

The issue lies in the two first branches of send_sqs. Assuming that an attacker can control the queue variable defined on line 384, they can get past the first conditional check on line 385-387 if queue does not start with the string https://queue.amazonaws.com. The second conditional checks whether queue.amazonaws.com is a substring of queue. An attacker can bypass that in a number of ways, either by crafting a subdomain of their own domain, for example queue.amazonaws.com.malicious-url.cc, or by including a URL parameter, for example: malicious-url.cc?queue.amazonaws.com. The conditional check on line 388 will return true and queue_url will be assigned the attackers URL. send_sqs will proceed to line 407, and the client will sent the message to the attacker-controlled URL on line 416.

This PR fixes that by changing the conditional check for the URL validation.