### PR TITLE
aws - quotas - add a special filter in query section to reduce API calls

### DIFF
--- a/c7n/resources/quotas.py
+++ b/c7n/resources/quotas.py
@@ -53,8 +53,13 @@ class ServiceQuota(QueryResourceManager):
     def augment(self, resources):
         client = local_session(self.session_factory).client('service-quotas')
         retry = get_retry(('TooManyRequestsException',))
-        excl_sc = set(self.data.get("metadata", {}).get("exclude_service_codes", []))
-        incl_sc = set(self.data.get("metadata", {}).get("include_service_codes", []))
+
+        excl_sc = incl_sc = set()
+        for q in self.data.get("query", []):
+            if q.get("exclude_service_codes"):
+                excl_sc = set(q.get("exclude_service_codes"))
+            elif q.get("include_service_codes"):
+                incl_sc = set(q.get("include_service_codes"))
 
         def get_quotas(client, s):
             def _get_quotas(client, s, attr):

--- a/c7n/resources/quotas.py
+++ b/c7n/resources/quotas.py
@@ -11,6 +11,7 @@ import math
 from concurrent.futures import as_completed
 from datetime import timedelta, datetime
 from statistics import mean
+from time import sleep
 
 from c7n.actions import Action
 from c7n.exceptions import PolicyExecutionError
@@ -52,6 +53,8 @@ class ServiceQuota(QueryResourceManager):
     def augment(self, resources):
         client = local_session(self.session_factory).client('service-quotas')
         retry = get_retry(('TooManyRequestsException',))
+        excl_sc = set(self.data.get("metadata", {}).get("exclude_service_codes", []))
+        incl_sc = set(self.data.get("metadata", {}).get("include_service_codes", []))
 
         def get_quotas(client, s):
             def _get_quotas(client, s, attr):
@@ -73,6 +76,10 @@ class ServiceQuota(QueryResourceManager):
                     token = response.get('NextToken')
                     new = set(rquotas) - set(quotas)
                     quotas.update(rquotas)
+                    self.log.debug(f"- {s['ServiceCode']} has {len(response['Quotas'])} quotas")
+                    # NOTE fix TooManyRequestsException when calling the ListServiceQuotas
+                    # NOTE sleep before any break, no better choice so far; default quota 10rps
+                    sleep(0.3)
                     if token is None:
                         break
                     # ssm, ec2, kms have bad behaviors.
@@ -93,11 +100,14 @@ class ServiceQuota(QueryResourceManager):
 
         results = []
         # NOTE TooManyRequestsException errors are reported in us-east-1 often
-        # when calling the ListServiceQuotas operation
+        # when calling the ListServiceQuotas operation,
         # set the max_workers to 1 instead of self.max_workers to slow down the rate
         with self.executor_factory(max_workers=1) as w:
             futures = {}
             for r in resources:
+                # Leveraging metadata to exclude unwanted service codes to reduce masive API calls
+                if r["ServiceCode"] in excl_sc or incl_sc and r["ServiceCode"] not in incl_sc:
+                    continue
                 futures[w.submit(get_quotas, client, r)] = r
 
             for f in as_completed(futures):
@@ -217,7 +227,7 @@ class UsageFilter(MetricsFilter):
                     op = self.metric_map['Maximum']
                 else:
                     op = self.metric_map[stat]
-                m = op([x[stat] for x in res['Datapoints']]) / metric_scale
+                m = round(op([x[stat] for x in res['Datapoints']]) / metric_scale, 2)
                 self.log.info(f'{r.get("ServiceName")} {r.get("QuotaName")} usage: {m}/{quota}')
                 if m > (limit / 100) * quota:
                     r[self.annotation_key] = {

--- a/c7n/resources/quotas.py
+++ b/c7n/resources/quotas.py
@@ -76,10 +76,11 @@ class ServiceQuota(QueryResourceManager):
                     token = response.get('NextToken')
                     new = set(rquotas) - set(quotas)
                     quotas.update(rquotas)
-                    self.log.debug(f"- {s['ServiceCode']} has {len(response['Quotas'])} quotas")
-                    # NOTE fix TooManyRequestsException when calling the ListServiceQuotas
-                    # NOTE sleep before any break, no better choice so far; default quota 10rps
-                    sleep(0.3)
+                    self.log.debug(f"{s['ServiceCode']} has {len(response['Quotas'])} quotas")
+
+                    # To fix TooManyRequestsException when calling the ListServiceQuotas
+                    # Sleep before any break, no better option so far; default quota is 10rps
+                    sleep(0.1)
                     if token is None:
                         break
                     # ssm, ec2, kms have bad behaviors.

--- a/docs/source/aws/examples/accountservicelimit.rst
+++ b/docs/source/aws/examples/accountservicelimit.rst
@@ -21,6 +21,20 @@ more than 50% of the limit and raise the limit for 25%.
 Noted that the ``threshold`` in ``service-limit`` filter is an optional field. If
 not mentioned on the policy, the default value is 80.
 
+As there are numerous services available in AWS, you have the option to specify
+the services you wish to include or exclude, thereby preventing prolonged execution times
+and unnecessary API calls. Please utilize either of the attributes:
+"include_service_codes" or "exclude_service_codes". This special filter only works for
+`aws.service-quota`. An example is provided below.
+
+.. code-block:: yaml
+
+   policies:
+     - name: service-quota-usage
+       resource: aws.service-quota
+       metadata:
+         include_service_codes:
+           - ec2
 
 Global Services
   Services like IAM are not region-based. Custodian will put the limit 

--- a/docs/source/aws/examples/accountservicelimit.rst
+++ b/docs/source/aws/examples/accountservicelimit.rst
@@ -32,9 +32,9 @@ and unnecessary API calls. Please utilize either of the attributes:
    policies:
      - name: service-quota-usage
        resource: aws.service-quota
-       metadata:
-         include_service_codes:
-           - ec2
+       query:
+         - include_service_codes:
+             - ec2
 
 Global Services
   Services like IAM are not region-based. Custodian will put the limit 

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -54,6 +54,34 @@ class TestQuotas(BaseTest):
         )['RequestedQuotas']
         self.assertTrue(changes)
 
+    # Given the ServiceQuota.augment.get_quotas is a nested function,can't patch it;
+    # This test case is the best we can do at the moment.
+    def test_service_quota_metadata_incl_filter(self):
+        session_factory = self.replay_flight_data('test_service_quota')
+        p = self.load_policy({
+            "name": "service-quota-metaddata-filter",
+            "resource": "aws.service-quota",
+            "metadata": {"include_service_codes": ["ec2"]},
+            },
+            session_factory=session_factory)
+        resources = p.run()
+        # called ListAWSDefaultServiceQuotas once, 6 quotas returned
+        # called servicequotas.ListServiceQuotas once, 2 quotas returned
+        assert len(resources) == 8
+
+    def test_service_quota_metadata_excl_filter(self):
+        session_factory = self.replay_flight_data('test_service_quota')
+        p = self.load_policy({
+            "name": "service-quota-metaddata-filter",
+            "resource": "aws.service-quota",
+            "metadata": {"exclude_service_codes": ["logs"]},
+            },
+            session_factory=session_factory)
+        resources = p.run()
+        # called ListAWSDefaultServiceQuotas twice, 6x2 quotas returned
+        # called servicequotas.ListServiceQuotas twice, 2+1 quotas returned
+        assert len(resources) == 15
+
     def test_usage_metric_filter(self):
         session_factory = self.replay_flight_data('test_service_quota')
         p = self.load_policy({

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -61,7 +61,7 @@ class TestQuotas(BaseTest):
         p = self.load_policy({
             "name": "service-quota-metaddata-filter",
             "resource": "aws.service-quota",
-            "metadata": {"include_service_codes": ["ec2"]},
+            "query": [{"include_service_codes": ["ec2"]}],
             },
             session_factory=session_factory)
         resources = p.run()
@@ -74,7 +74,7 @@ class TestQuotas(BaseTest):
         p = self.load_policy({
             "name": "service-quota-metaddata-filter",
             "resource": "aws.service-quota",
-            "metadata": {"exclude_service_codes": ["logs"]},
+            "query": [{"exclude_service_codes": ["logs"]}],
             },
             session_factory=session_factory)
         resources = p.run()


### PR DESCRIPTION
With the multitude of services available in AWS, the `service-quotas` resource can quickly consume around 500 API calls before reaching any `filters`. Sometimes, users only need to check specific service quotas, and to address this, a special filter is introduced in the `query` (note: it was `metadata`) section. 

This filter significantly reduces the total number of API calls made to both `ListAWSDefaultServiceQuotas` and `ListServiceQuotas`. Taking `ec2` as an example, the total calls are reduced to less than 10. Here's an example:

```yaml
policies:
  - name: service-quota-usage
    resource: aws.service-quota
    query:
      - include_service_codes:
          - ec2
```


-------
NOTE: below info is outdated. Decision has been made that we will use `query` section to do that. Keeping it as history.

_I'm open to suggestions if you have a better idea that can avoid "borrowing" the metadata section. I thought about using the `ServiceCode` value filter, which might be defined in the `filters` section. However, due to the complexity of filter usage, I abandoned this idea. For example, the simplest case would look like this:_

```yaml
filters:
  ServiceCode: ec2
```

or

```yaml
filters:
  not:
    ServiceCode: ec2
```

But things get complicated when dealing with scenarios like the one below:

```yaml
filters:
  or:
    ServiceCode: ec2
    QuotaCode: xxx from eks
```

This kind of complexity makes leveraging the filter challenging.