### PR TITLE
aws - vpc route53 resolver rules

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -3223,7 +3223,6 @@ class VpcResolverRulesAssociatedFilter(BaseAction):
     schema = type_schema('resolver-rules-associated',
     name={'type': 'string'},
     associated={'type': 'boolean'},
-    owner={'type': 'string'},
     required=['name', 'associated'])
     
     def get_all(self, client, type, key):
@@ -3236,7 +3235,6 @@ class VpcResolverRulesAssociatedFilter(BaseAction):
         results = []
         target_rule_name = self.data['name']
         associated = self.data['associated']
-        owner = self.data.get('owner', None)
         client = local_session(self.manager.session_factory).client('route53resolver')
 
         rules = self.get_all(client, 'list_resolver_rules', 'ResolverRules')

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -3199,3 +3199,126 @@ class CrossAZRouteTable(Filter):
                 results.append(resource)
 
         return results
+
+
+@Vpc.filter_registry.register('resolver-rules-associated')
+class VpcResolverRulesAssociatedFilter(BaseAction):
+    """Filter VPCs which have either missing or matching groups of Route53 Resolver Rules and annotate for action.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: vpcs-missing-resolver-rules
+                resource: vpc
+                filters:
+                  - type: resolver-rules-associated
+                    name: my-rule.*
+                    associated: False
+    """
+    permissions = (
+        'route53resolver:ListResolverRules',
+        'route53resolver:ListResolverRuleAssociations')
+    schema = type_schema('resolver-rules-associated',
+    name={'type': 'string'},
+    associated={'type': 'boolean'},
+    owner={'type': 'string'},
+    required=['name', 'associated'])
+    
+    def get_all(self, client, type, key):
+        paginator = client.get_paginator(type)
+        paginator.PAGE_ITERATOR_CLS = query.RetryPageIterator
+        results = paginator.paginate().build_full_result().get(key, [])
+        return results
+
+    def process(self, resources, event=None):
+        results = []
+        target_rule_name = self.data['name']
+        associated = self.data['associated']
+        owner = self.data.get('owner', None)
+        client = local_session(self.manager.session_factory).client('route53resolver')
+
+        rules = self.get_all(client, 'list_resolver_rules', 'ResolverRules')
+        rules_set = set()
+        for rule in rules:
+            if re.match(target_rule_name, rule['Name']):
+                rules_set.add(rule['Id'])
+
+        rule_associations = self.get_all(client, 'list_resolver_rule_associations', 'ResolverRuleAssociations')
+        vpc_rule_map = {}
+        for a in rule_associations:
+            if a['VPCId'] in vpc_rule_map:
+                vpc_rule_map[a['VPCId']] += [a['ResolverRuleId']]
+            else:
+                vpc_rule_map[a['VPCId']] = [a['ResolverRuleId']]
+
+        for r in resources:
+            if not associated:
+                if r['VpcId'] in vpc_rule_map:
+                    r['c7n:MissingResolverRules'] = list(rules_set - set(vpc_rule_map[r['VpcId']]))
+                else:
+                    r['c7n:MissingResolverRules'] = list(rules_set)
+
+                if len(r['c7n:MissingResolverRules']) > 0:
+                    results.append(r)
+            else:
+                if r['VpcId'] in vpc_rule_map:
+                    r['c7n:MatchingResolverRules'] = list(rules_set.intersection(set(vpc_rule_map[r['VpcId']])))
+                    results.append(r)
+
+        return results
+
+
+@Vpc.action_registry.register('associate-resolver-rules')
+class AssociateResolverRule(BaseAction):
+    """Associates or disasssociates VPC from Route53 Resolver Rules. Use in conjunction with filter "resolver-rules-associated". 
+    
+    :example:
+    
+    .. code-block:: yaml
+        policies:
+          - name: vpc-remediate-missing-resolver-rules
+            resource: vpc
+            filters:
+                - type: resolver-rule-associated
+                  name: my-rule.*
+                  associated: False
+            actions:
+                - type: associate-resolver-rules
+                  remove: False
+    """
+    permissions = (
+        'route53resolver:AssociateResolverRule',
+        'route53resolver:DisassociateResolverRule')
+    schema = type_schema('associate-resolver-rules', remove={'type': 'boolean'})
+    
+    def validate(self):
+        found = False
+        for f in self.manager.iter_filters():
+            if isinstance(f, VpcResolverRulesAssociatedFilter):
+                found = True
+                break
+        if not found:
+            # try to ensure idempotent usage
+            raise PolicyValidationError(
+                "'associate-resolver-rules' action should be used in conjunction \
+                    with 'resolver-rules-associated' filter")
+        return self
+    
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('route53resolver')
+        remove = self.data.get('remove', False)
+
+        for vpc in resources:
+            if not remove:
+                for ruleId in vpc['c7n:MissingResolverRules']:
+                    client.associate_resolver_rule(
+                        ResolverRuleId=ruleId,
+                        Name="c7n Rule Association",
+                        VPCId=vpc['VpcId'])
+            else:
+                for ruleId in vpc['c7n:MatchingResolverRules']:
+                    client.disassociate_resolver_rule(
+                        ResolverRuleId=ruleId,
+                        VPCId=vpc['VpcId'])

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -3265,7 +3265,8 @@ class VpcResolverRulesAssociatedFilter(BaseAction):
             else:
                 if r['VpcId'] in vpc_rule_map:
                     r['c7n:MatchingResolverRules'] = list(rules_set.intersection(set(vpc_rule_map[r['VpcId']])))
-                    results.append(r)
+                    if len(r['c7n:MatchingResolverRules']) > 0:
+                        results.append(r)
 
         return results
 

--- a/tests/data/placebo/test_vpc_resolver_rules_associate/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_associate/ec2.DescribeVpcs_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "Vpcs": [
+            {
+                "CidrBlock": "10.0.0.0/21",
+                "DhcpOptionsId": "dopt-0d073a02a34089222",
+                "State": "available",
+                "VpcId": "vpc-00b1cf44b6c724308",
+                "OwnerId": "644160558196",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-0d9486e0e2f7cc7ed",
+                        "CidrBlock": "10.0.0.0/21",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.AssociateResolverRule_1.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.AssociateResolverRule_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResolverRuleAssociation": {
+            "Id": "rslvr-rrassoc-e0b9b2ab2e7f4303a",
+            "ResolverRuleId": "rslvr-rr-7b28e551dc5e44d19",
+            "Name": "c7n Rule Association",
+            "VPCId": "vpc-00b1cf44b6c724308",
+            "Status": "CREATING",
+            "StatusMessage": "[Trace id: 1-6577aca2-7cf352f018e51b9566ffe942] Creating the association."
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.AssociateResolverRule_2.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.AssociateResolverRule_2.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResolverRuleAssociation": {
+            "Id": "rslvr-rrassoc-f3c176693ad442219",
+            "ResolverRuleId": "rslvr-rr-9a67e96f80a14eb8b",
+            "Name": "c7n Rule Association",
+            "VPCId": "vpc-00b1cf44b6c724308",
+            "Status": "CREATING",
+            "StatusMessage": "[Trace id: 1-6577aca2-06a1ded72e4e1e8135d87910] Creating the association."
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.ListResolverRuleAssociations_1.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.ListResolverRuleAssociations_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "MaxResults": 30,
+        "ResolverRuleAssociations": [
+            {
+                "Id": "rslvr-autodefined-assoc-vpc-00b1cf44b6c724308-internet-resolver",
+                "ResolverRuleId": "rslvr-autodefined-rr-internet-resolver",
+                "Name": "System Rule Association",
+                "VPCId": "vpc-00b1cf44b6c724308",
+                "Status": "COMPLETE",
+                "StatusMessage": ""
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.ListResolverRuleAssociations_2.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.ListResolverRuleAssociations_2.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "MaxResults": 30,
+        "ResolverRuleAssociations": [
+            {
+                "Id": "rslvr-autodefined-assoc-vpc-00b1cf44b6c724308-internet-resolver",
+                "ResolverRuleId": "rslvr-autodefined-rr-internet-resolver",
+                "Name": "System Rule Association",
+                "VPCId": "vpc-00b1cf44b6c724308",
+                "Status": "COMPLETE",
+                "StatusMessage": ""
+            },
+            {
+                "Id": "rslvr-rrassoc-e0b9b2ab2e7f4303a",
+                "ResolverRuleId": "rslvr-rr-7b28e551dc5e44d19",
+                "Name": "c7n Rule Association",
+                "VPCId": "vpc-00b1cf44b6c724308",
+                "Status": "CREATING",
+                "StatusMessage": "[Trace id: 1-6577aca2-7cf352f018e51b9566ffe942] Creating the association."
+            },
+            {
+                "Id": "rslvr-rrassoc-f3c176693ad442219",
+                "ResolverRuleId": "rslvr-rr-9a67e96f80a14eb8b",
+                "Name": "c7n Rule Association",
+                "VPCId": "vpc-00b1cf44b6c724308",
+                "Status": "CREATING",
+                "StatusMessage": "[Trace id: 1-6577aca2-06a1ded72e4e1e8135d87910] Creating the association."
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.ListResolverRules_1.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_associate/route53resolver.ListResolverRules_1.json
@@ -1,0 +1,76 @@
+{
+    "status_code": 200,
+    "data": {
+        "MaxResults": 30,
+        "ResolverRules": [
+            {
+                "Id": "rslvr-autodefined-rr-internet-resolver",
+                "CreatorRequestId": "",
+                "Arn": "arn:aws:route53resolver:us-east-1::autodefined-rule/rslvr-autodefined-rr-internet-resolver",
+                "DomainName": ".",
+                "Status": "COMPLETE",
+                "RuleType": "RECURSIVE",
+                "Name": "Internet Resolver",
+                "OwnerId": "Route 53 Resolver",
+                "ShareStatus": "NOT_SHARED"
+            },
+            {
+                "Id": "rslvr-rr-6dfccbca33114b2a9",
+                "CreatorRequestId": "AWSConsole.5.1702334897014",
+                "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-rule/rslvr-rr-6dfccbca33114b2a9",
+                "DomainName": "test-644160558196.test-test-2.",
+                "Status": "COMPLETE",
+                "StatusMessage": "[Trace id: 1-657791b1-17c379f52c87e1066e3f1f03] Successfully created Resolver Rule.",
+                "RuleType": "SYSTEM",
+                "Name": "test-rule-2",
+                "OwnerId": "644160558196",
+                "ShareStatus": "NOT_SHARED",
+                "CreationTime": "2023-12-11T22:48:17.385099Z",
+                "ModificationTime": "2023-12-11T22:48:17.385099Z"
+            },
+            {
+                "Id": "rslvr-rr-7b28e551dc5e44d19",
+                "CreatorRequestId": "AWSConsole.95.1701394314637",
+                "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-rule/rslvr-rr-7b28e551dc5e44d19",
+                "DomainName": "test-644160558196.test-2.",
+                "Status": "COMPLETE",
+                "StatusMessage": "[Trace id: 1-6569378a-4a863b0b1f3cda5f08bec45f] Successfully created Resolver Rule.",
+                "RuleType": "SYSTEM",
+                "Name": "my-rule-2",
+                "OwnerId": "644160558196",
+                "ShareStatus": "NOT_SHARED",
+                "CreationTime": "2023-12-01T01:31:54.806799Z",
+                "ModificationTime": "2023-12-01T01:31:54.806799Z"
+            },
+            {
+                "Id": "rslvr-rr-9a67e96f80a14eb8b",
+                "CreatorRequestId": "AWSConsole.43.1700609476823",
+                "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-rule/rslvr-rr-9a67e96f80a14eb8b",
+                "DomainName": "test-644160558196.test.",
+                "Status": "COMPLETE",
+                "StatusMessage": "[Trace id: 1-655d3dc5-2313651d61e702ad370bd03a] Successfully created Resolver Rule.",
+                "RuleType": "SYSTEM",
+                "Name": "my-rule",
+                "OwnerId": "644160558196",
+                "ShareStatus": "NOT_SHARED",
+                "CreationTime": "2023-11-21T23:31:17.449116Z",
+                "ModificationTime": "2023-11-21T23:31:17.449116Z"
+            },
+            {
+                "Id": "rslvr-rr-d303ea379ed44288b",
+                "CreatorRequestId": "AWSConsole.93.1701394344995",
+                "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-rule/rslvr-rr-d303ea379ed44288b",
+                "DomainName": "test-644160558196.test-test.",
+                "Status": "COMPLETE",
+                "StatusMessage": "[Trace id: 1-656937a9-207593716fbe02cf10f46143] Successfully created Resolver Rule.",
+                "RuleType": "SYSTEM",
+                "Name": "test-rule",
+                "OwnerId": "644160558196",
+                "ShareStatus": "NOT_SHARED",
+                "CreationTime": "2023-12-01T01:32:25.324690Z",
+                "ModificationTime": "2023-12-01T01:32:25.324690Z"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_disassociate/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_disassociate/ec2.DescribeVpcs_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "Vpcs": [
+            {
+                "CidrBlock": "10.0.0.0/21",
+                "DhcpOptionsId": "dopt-0d073a02a34089222",
+                "State": "available",
+                "VpcId": "vpc-00b1cf44b6c724308",
+                "OwnerId": "644160558196",
+                "InstanceTenancy": "default",
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-0d9486e0e2f7cc7ed",
+                        "CidrBlock": "10.0.0.0/21",
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "IsDefault": false,
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.DisassociateResolverRule_1.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.DisassociateResolverRule_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResolverRuleAssociation": {
+            "Id": "rslvr-rrassoc-a35d1a0bbc724c718",
+            "ResolverRuleId": "rslvr-rr-7b28e551dc5e44d19",
+            "Name": "-",
+            "VPCId": "vpc-00b1cf44b6c724308",
+            "Status": "DELETING",
+            "StatusMessage": "[Trace id: 1-6577aecb-38d0e1437d09f8926657a833] Deleting Association"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.DisassociateResolverRule_2.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.DisassociateResolverRule_2.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResolverRuleAssociation": {
+            "Id": "rslvr-rrassoc-d51b17c53f14c1588",
+            "ResolverRuleId": "rslvr-rr-9a67e96f80a14eb8b",
+            "Name": "-",
+            "VPCId": "vpc-00b1cf44b6c724308",
+            "Status": "DELETING",
+            "StatusMessage": "[Trace id: 1-6577aecb-56824a10393fcc8d03f536f0] Deleting Association"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.ListResolverRuleAssociations_1.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.ListResolverRuleAssociations_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "MaxResults": 30,
+        "ResolverRuleAssociations": [
+            {
+                "Id": "rslvr-autodefined-assoc-vpc-00b1cf44b6c724308-internet-resolver",
+                "ResolverRuleId": "rslvr-autodefined-rr-internet-resolver",
+                "Name": "System Rule Association",
+                "VPCId": "vpc-00b1cf44b6c724308",
+                "Status": "COMPLETE",
+                "StatusMessage": ""
+            },
+            {
+                "Id": "rslvr-rrassoc-a35d1a0bbc724c718",
+                "ResolverRuleId": "rslvr-rr-7b28e551dc5e44d19",
+                "Name": "-",
+                "VPCId": "vpc-00b1cf44b6c724308",
+                "Status": "COMPLETE",
+                "StatusMessage": ""
+            },
+            {
+                "Id": "rslvr-rrassoc-d51b17c53f14c1588",
+                "ResolverRuleId": "rslvr-rr-9a67e96f80a14eb8b",
+                "Name": "-",
+                "VPCId": "vpc-00b1cf44b6c724308",
+                "Status": "COMPLETE",
+                "StatusMessage": ""
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.ListResolverRuleAssociations_2.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.ListResolverRuleAssociations_2.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "MaxResults": 30,
+        "ResolverRuleAssociations": [
+            {
+                "Id": "rslvr-autodefined-assoc-vpc-00b1cf44b6c724308-internet-resolver",
+                "ResolverRuleId": "rslvr-autodefined-rr-internet-resolver",
+                "Name": "System Rule Association",
+                "VPCId": "vpc-00b1cf44b6c724308",
+                "Status": "COMPLETE",
+                "StatusMessage": ""
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.ListResolverRules_1.json
+++ b/tests/data/placebo/test_vpc_resolver_rules_disassociate/route53resolver.ListResolverRules_1.json
@@ -1,0 +1,76 @@
+{
+    "status_code": 200,
+    "data": {
+        "MaxResults": 30,
+        "ResolverRules": [
+            {
+                "Id": "rslvr-autodefined-rr-internet-resolver",
+                "CreatorRequestId": "",
+                "Arn": "arn:aws:route53resolver:us-east-1::autodefined-rule/rslvr-autodefined-rr-internet-resolver",
+                "DomainName": ".",
+                "Status": "COMPLETE",
+                "RuleType": "RECURSIVE",
+                "Name": "Internet Resolver",
+                "OwnerId": "Route 53 Resolver",
+                "ShareStatus": "NOT_SHARED"
+            },
+            {
+                "Id": "rslvr-rr-6dfccbca33114b2a9",
+                "CreatorRequestId": "AWSConsole.5.1702334897014",
+                "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-rule/rslvr-rr-6dfccbca33114b2a9",
+                "DomainName": "test-644160558196.test-test-2.",
+                "Status": "COMPLETE",
+                "StatusMessage": "[Trace id: 1-657791b1-17c379f52c87e1066e3f1f03] Successfully created Resolver Rule.",
+                "RuleType": "SYSTEM",
+                "Name": "test-rule-2",
+                "OwnerId": "644160558196",
+                "ShareStatus": "NOT_SHARED",
+                "CreationTime": "2023-12-11T22:48:17.385099Z",
+                "ModificationTime": "2023-12-11T22:48:17.385099Z"
+            },
+            {
+                "Id": "rslvr-rr-7b28e551dc5e44d19",
+                "CreatorRequestId": "AWSConsole.95.1701394314637",
+                "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-rule/rslvr-rr-7b28e551dc5e44d19",
+                "DomainName": "test-644160558196.test-2.",
+                "Status": "COMPLETE",
+                "StatusMessage": "[Trace id: 1-6569378a-4a863b0b1f3cda5f08bec45f] Successfully created Resolver Rule.",
+                "RuleType": "SYSTEM",
+                "Name": "my-rule-2",
+                "OwnerId": "644160558196",
+                "ShareStatus": "NOT_SHARED",
+                "CreationTime": "2023-12-01T01:31:54.806799Z",
+                "ModificationTime": "2023-12-01T01:31:54.806799Z"
+            },
+            {
+                "Id": "rslvr-rr-9a67e96f80a14eb8b",
+                "CreatorRequestId": "AWSConsole.43.1700609476823",
+                "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-rule/rslvr-rr-9a67e96f80a14eb8b",
+                "DomainName": "test-644160558196.test.",
+                "Status": "COMPLETE",
+                "StatusMessage": "[Trace id: 1-655d3dc5-2313651d61e702ad370bd03a] Successfully created Resolver Rule.",
+                "RuleType": "SYSTEM",
+                "Name": "my-rule",
+                "OwnerId": "644160558196",
+                "ShareStatus": "NOT_SHARED",
+                "CreationTime": "2023-11-21T23:31:17.449116Z",
+                "ModificationTime": "2023-11-21T23:31:17.449116Z"
+            },
+            {
+                "Id": "rslvr-rr-d303ea379ed44288b",
+                "CreatorRequestId": "AWSConsole.93.1701394344995",
+                "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-rule/rslvr-rr-d303ea379ed44288b",
+                "DomainName": "test-644160558196.test-test.",
+                "Status": "COMPLETE",
+                "StatusMessage": "[Trace id: 1-656937a9-207593716fbe02cf10f46143] Successfully created Resolver Rule.",
+                "RuleType": "SYSTEM",
+                "Name": "test-rule",
+                "OwnerId": "644160558196",
+                "ShareStatus": "NOT_SHARED",
+                "CreationTime": "2023-12-01T01:32:25.324690Z",
+                "ModificationTime": "2023-12-01T01:32:25.324690Z"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -3739,3 +3739,29 @@ def test_vpc_delete(test, vpc_delete):
         "Vpcs"
     ]
     test.assertFalse(vpcs)
+
+
+class ResolverRulesTest(BaseTest):
+
+    def test_traffic_mirror_target(self):
+        session_factory = self.record_flight_data('test_vpc_resolver_rules')
+        p = self.load_policy({
+            "name": "vpc-remediate-missing-resolver-rules",
+            "resource": "vpc",
+            "filters": [
+                {
+                    "type": "resolver-rules-associated",
+                    "name": "my-rule.*",
+                    "associated": False
+                }
+            ],
+            # "actions": [
+            #     {
+            #         "type": "associate-resolver-rules",
+            #         "remove": False
+            #     }
+            # ]
+        },
+        session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -3743,8 +3743,8 @@ def test_vpc_delete(test, vpc_delete):
 
 class ResolverRulesTest(BaseTest):
 
-    def test_traffic_mirror_target(self):
-        session_factory = self.record_flight_data('test_vpc_resolver_rules')
+    def test_vpc_resolver_rules_associate(self):
+        session_factory = self.replay_flight_data('test_vpc_resolver_rules_associate')
         p = self.load_policy({
             "name": "vpc-remediate-missing-resolver-rules",
             "resource": "vpc",
@@ -3755,13 +3755,62 @@ class ResolverRulesTest(BaseTest):
                     "associated": False
                 }
             ],
-            # "actions": [
-            #     {
-            #         "type": "associate-resolver-rules",
-            #         "remove": False
-            #     }
-            # ]
+            "actions": [
+                {
+                    "type": "associate-resolver-rules",
+                    "remove": False
+                }
+            ]
         },
         session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        resource = resources[0]
+        vpc_id = resource['VpcId']
+        missing = resource['c7n:MissingResolverRules']
+        self.assertEqual(len(missing), 2)
+
+        client = session_factory().client("route53resolver")
+        associations = client.list_resolver_rule_associations()["ResolverRuleAssociations"]
+        found = 0
+        for a in associations:
+            for ruleId in missing:
+                if ruleId == a['ResolverRuleId']:
+                    self.assertEqual(vpc_id, a['VPCId'])
+                    found += 1
+        self.assertEqual(found, 2)
+
+    def test_vpc_resolver_rules_disassociate(self):
+        session_factory = self.replay_flight_data('test_vpc_resolver_rules_disassociate')
+        p = self.load_policy({
+            "name": "vpc-remediate-matching-resolver-rules",
+            "resource": "vpc",
+            "filters": [
+                {
+                    "type": "resolver-rules-associated",
+                    "name": "my-rule.*",
+                    "associated": True
+                }
+            ],
+            "actions": [
+                {
+                    "type": "associate-resolver-rules",
+                    "remove": True
+                }
+            ]
+        },
+        session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        resource = resources[0]
+        matching = resource['c7n:MatchingResolverRules']
+        self.assertEqual(len(matching), 2)
+
+        client = session_factory().client("route53resolver")
+        associations = client.list_resolver_rule_associations()["ResolverRuleAssociations"]
+        found = 0
+        for a in associations:
+            for ruleId in matching:
+                if ruleId == a['ResolverRuleId']:
+                    found += 1
+        self.assertEqual(found, 0)


### PR DESCRIPTION
Added the ability to filter VPCs by either missing or matching resolver rules; added corresponding action to either associate or disassociate based on missing or matching resolver rules, respectively.

Associate missing resolver rules:

```
        policies:
          - name: vpc-remediate-missing-resolver-rules
            resource: vpc
            filters:
                - type: resolver-rule-associated
                  name: my-rule.*
                  associated: False
            actions:
                - type: associate-resolver-rules
                  remove: False
```

Disassociate matching resolver rules:
```
        policies:
          - name: vpc-remediate-matching-resolver-rules
            resource: vpc
            filters:
                - type: resolver-rule-associated
                  name: my-rule.*
                  associated: True
            actions:
                - type: associate-resolver-rules
                  remove: True
```