### PR TITLE
releng - add python 3.12 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
         python-version: ["3.11"]
         include:
           - os: ubuntu-latest
+            python-version: "3.12"
+          - os: ubuntu-latest
             python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.9"


### PR DESCRIPTION
 add python 3.12 to ci to see what breaks

