### PR TITLE
fix: add canonical_group for better matching in admission controller mode

### DIFF
--- a/tools/c7n_kube/c7n_kube/policy.py
+++ b/tools/c7n_kube/c7n_kube/policy.py
@@ -85,8 +85,6 @@ class ValidatingControllerMode(K8sEventMode):
 
     def _handle_group(self, request, value):
         group = request["resource"]["group"]
-        if group == "" and "core" in value:
-            return True
         return group == value
 
     def _handle_resources(self, request, value):
@@ -141,12 +139,9 @@ class ValidatingControllerMode(K8sEventMode):
         else:
             # set default values based on our models
             resource = model.plural.lower()
-            group = model.group.lower()
+            group = model.canonical_group
             version = model.version.lower()
             scope = "Namespaced" if model.namespaced else "Cluster"
-
-        if group == "core":
-            group = ""
 
         resources = []
 

--- a/tools/c7n_kube/c7n_kube/query.py
+++ b/tools/c7n_kube/c7n_kube/query.py
@@ -151,6 +151,7 @@ class TypeMeta(type):
 
 class TypeInfo(metaclass=TypeMeta):
     group = None
+    canonical_group = None
     version = None
     enum_spec = ()
     namespaced = True
@@ -160,5 +161,6 @@ class TypeInfo(metaclass=TypeMeta):
 
 class CustomTypeInfo(TypeInfo, metaclass=TypeMeta):
     group = "CustomObjects"
+    canonical_group = None
     version = ""
     enum_spec = ("list_cluster_custom_object", "items", None)

--- a/tools/c7n_kube/c7n_kube/resources/apps/daemonset.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/daemonset.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class DaemonSet(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Apps"
+        canonical_group = "apps"
         version = "V1"
         patch = "patch_namespaced_daemon_set"
         delete = "delete_namespaced_daemon_set"

--- a/tools/c7n_kube/c7n_kube/resources/apps/deployment.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/deployment.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class Deployment(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Apps"
+        canonical_group = "apps"
         version = "V1"
         patch = "patch_namespaced_deployment"
         delete = "delete_namespaced_deployment"

--- a/tools/c7n_kube/c7n_kube/resources/apps/replicaset.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/replicaset.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class ReplicaSet(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Apps"
+        canonical_group = "apps"
         version = "V1"
         patch = "patch_namespaced_replica_set"
         delete = "delete_namespaced_replica_set"

--- a/tools/c7n_kube/c7n_kube/resources/apps/statefulset.py
+++ b/tools/c7n_kube/c7n_kube/resources/apps/statefulset.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class StatefulSet(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Apps"
+        canonical_group = "apps"
         version = "V1"
         patch = "patch_namespaced_stateful_set"
         delete = "delete_namespaced_stateful_set"

--- a/tools/c7n_kube/c7n_kube/resources/core/configmap.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/configmap.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class ConfigMap(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         patch = "patch_namespaced_config_map"
         delete = "delete_namespaced_config_map"

--- a/tools/c7n_kube/c7n_kube/resources/core/namespace.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/namespace.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class Namespace(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         namespaced = False
         patch = "patch_namespace"

--- a/tools/c7n_kube/c7n_kube/resources/core/node.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/node.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class Node(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         namespaced = False
         patch = "patch_node"

--- a/tools/c7n_kube/c7n_kube/resources/core/pod.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/pod.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class Pod(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         patch = "patch_namespaced_pod"
         delete = "delete_namespaced_pod"

--- a/tools/c7n_kube/c7n_kube/resources/core/replicationcontroller.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/replicationcontroller.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class ReplicationController(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         patch = "patch_namespaced_replication_controller"
         delete = "delete_namespaced_replication_controller"

--- a/tools/c7n_kube/c7n_kube/resources/core/secret.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/secret.py
@@ -10,6 +10,7 @@ from c7n_kube.provider import resources
 class Secret(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         patch = "patch_namespaced_secret"
         delete = "delete_namespaced_secret"

--- a/tools/c7n_kube/c7n_kube/resources/core/service.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/service.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class Service(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         patch = "patch_namespaced_service"
         delete = "delete_namespaced_service"

--- a/tools/c7n_kube/c7n_kube/resources/core/serviceaccount.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/serviceaccount.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class ServiceAccount(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         patch = "patch_namespaced_service_account"
         delete = "delete_namespaced_service_account"

--- a/tools/c7n_kube/c7n_kube/resources/core/volume.py
+++ b/tools/c7n_kube/c7n_kube/resources/core/volume.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class PersistentVolume(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         namespaced = False
         patch = "patch_persistent_volume"
@@ -21,6 +22,7 @@ class PersistentVolume(QueryResourceManager):
 class PersistentVolumeClaim(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "Core"
+        canonical_group = ""
         version = "V1"
         patch = "patch_namespaced_persistent_volume_claim"
         delete = "delete_namespaced_persistent_volume_claim"

--- a/tools/c7n_kube/c7n_kube/resources/rbac/role.py
+++ b/tools/c7n_kube/c7n_kube/resources/rbac/role.py
@@ -9,6 +9,7 @@ from c7n_kube.provider import resources
 class ClusterRole(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "RbacAuthorization"
+        canonical_group = "rbac.authorization.k8s.io"
         version = "V1"
         patch = "patch_cluster_role"
         delete = "delete_cluster_role"
@@ -21,6 +22,7 @@ class ClusterRole(QueryResourceManager):
 class NamespacedRole(QueryResourceManager):
     class resource_type(TypeInfo):
         group = "RbacAuthorization"
+        canonical_group = "rbac.authorization.k8s.io"
         version = "V1"
         patch = "patch_namespaced_role"
         delete = "delete_namespaced_role"


### PR DESCRIPTION
addresses #9205 

we use the `group` attribute in the resource definition for client class instantiation, adding an additional `canonical_group` attribute to match against groups defined by the k8s api more clearly