### PR TITLE
azure.subscription.filters

### DIFF
--- a/tools/c7n_azure/tests_azure/cassettes/TestNetworkWatcherFilter.test_query.json
+++ b/tools/c7n_azure/tests_azure/cassettes/TestNetworkWatcherFilter.test_query.json
@@ -1,0 +1,109 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47?api-version=2019-11-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Mon, 07 Feb 2022 10:12:23 GMT"
+                    ],
+                    "content-length": [
+                        "403"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47",
+                        "authorizationSource": "RoleBased",
+                        "managedByTenants": [],
+                        "subscriptionId": "ea42f556-5106-4743-99b0-c129bfa71a47",
+                        "tenantId": "00000000-0000-0000-0000-000000000003",
+                        "displayName": "Pay-As-You-Go-Student02",
+                        "state": "Enabled",
+                        "subscriptionPolicies": {
+                            "locationPlacementId": "Public_2014-09-01",
+                            "quotaId": "PayAsYouGo_2014-09-01",
+                            "spendingLimit": "Off"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Network/networkWatchers?api-version=2020-08-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "3b9da6df-e824-43cc-90d4-edabf67bc519",
+                        "886a7500-868a-44e2-9571-880879a6d125"
+                    ],
+                    "date": [
+                        "Mon, 07 Feb 2022 10:12:25 GMT"
+                    ],
+                    "content-length": [
+                        "768"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "NetworkWatcher_eastus",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_eastus",
+                                "etag": "W/\"07ba0fdc-c699-4988-95f1-b858e7c17fa4\"",
+                                "type": "Microsoft.Network/networkWatchers",
+                                "location": "eastus",
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "runningOperationIds": []
+                                }
+                            },
+                            {
+                                "name": "NetworkWatcher_eastus2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_eastus2",
+                                "etag": "W/\"de621547-7c22-4bd6-bac0-69fc28195a4d\"",
+                                "type": "Microsoft.Network/networkWatchers",
+                                "location": "eastus2",
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "runningOperationIds": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_subscription.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_subscription.py
@@ -104,3 +104,29 @@ class SubscriptionDiagnosticSettingsFilterTest(BaseTest):
         }, validate=True)
 
         self.assertEqual(0, len(p.run()))
+
+
+class TestNetworkWatcherFilter(BaseTest):
+
+    def test_query(self):
+        p = self.load_policy({
+            'name': 'test-network-watcher',
+            'resource': 'azure.subscription',
+            'filters': [{'not': [{
+                'type': 'network-watcher',
+            }]}],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('ea42f556-5106-4743-99b0-c129bfa71a47', resources[0]['subscriptionId'])
+
+    def test_schema_validate(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-network-watcher',
+                'resource': 'azure.subscription',
+                'filters': [{'not': [{
+                    'type': 'network-watcher',
+                }]}],
+            }, validate=True)
+            self.assertTrue(p)


### PR DESCRIPTION
## network-watcher filter
```yaml
policies:
  - name: cis_net_netwatcher
    resource: azure.subscription
    description: |
      Network Watcher is disabled across the subscription
    filters:
      - type: network-watcher-filter
```