### PR TITLE
aws - fix ASG config resource ID

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -35,7 +35,8 @@ class ASG(query.QueryResourceManager):
         arn = 'AutoScalingGroupARN'
         arn_type = 'autoScalingGroup'
         arn_separator = ":"
-        id = name = 'AutoScalingGroupName'
+        name = 'AutoScalingGroupName'
+        id = 'AutoScalingGroupARN'
         date = 'CreatedTime'
         dimension = 'AutoScalingGroupName'
         enum_spec = ('describe_auto_scaling_groups', 'AutoScalingGroups', None)

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -35,8 +35,8 @@ class ASG(query.QueryResourceManager):
         arn = 'AutoScalingGroupARN'
         arn_type = 'autoScalingGroup'
         arn_separator = ":"
-        name = 'AutoScalingGroupName'
-        id = 'AutoScalingGroupARN'
+        id = name = 'AutoScalingGroupName'
+        config_id = 'AutoScalingGroupARN'
         date = 'CreatedTime'
         dimension = 'AutoScalingGroupName'
         enum_spec = ('describe_auto_scaling_groups', 'AutoScalingGroups', None)


### PR DESCRIPTION
This change uses the correct ASG config ID to fix the below config resource mapping error:

<img width="1101" alt="config-resource-error" src="https://github.com/cloud-custodian/cloud-custodian/assets/22411908/a8b2c65e-6756-42dc-b78d-f894b0779862">
