### PR TITLE
aws - allow excluding specific processes when resuming ASGs

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1580,7 +1580,7 @@ class Resume(Action):
         exclude={
             'type': 'array',
             'title': 'ASG Processes to not resume',
-            'items': {'enum': ASG_PROCESSES}},
+            'items': {'enum': list(ASG_PROCESSES)}},
         delay={'type': 'number'})
 
     permissions = ("autoscaling:ResumeProcesses", "ec2:StartInstances")

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1592,7 +1592,7 @@ class Resume(Action):
             'title': 'ASG Processes to not resume',
             'items': {'enum': ASG_PROCESSES}},
         delay={'type': 'number'})
-    
+
     permissions = ("autoscaling:ResumeProcesses", "ec2:StartInstances")
 
     def process(self, asgs):

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1574,23 +1574,12 @@ class Resume(Action):
                     delay: 300
 
     """
-    ASG_PROCESSES = [
-        "Launch",
-        "Terminate",
-        "HealthCheck",
-        "ReplaceUnhealthy",
-        "AZRebalance",
-        "AlarmNotification",
-        "ScheduledActions",
-        "AddToLoadBalancer",
-        "InstanceRefresh"]
-
     schema = type_schema(
         'resume',
         exclude={
             'type': 'array',
             'title': 'ASG Processes to not resume',
-            'items': {'enum': ASG_PROCESSES}},
+            'items': {'enum': Suspend.ASG_PROCESSES}},
         delay={'type': 'number'})
 
     permissions = ("autoscaling:ResumeProcesses", "ec2:StartInstances")

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -1574,12 +1574,13 @@ class Resume(Action):
                     delay: 300
 
     """
+    ASG_PROCESSES = Suspend.ASG_PROCESSES
     schema = type_schema(
         'resume',
         exclude={
             'type': 'array',
             'title': 'ASG Processes to not resume',
-            'items': {'enum': Suspend.ASG_PROCESSES}},
+            'items': {'enum': ASG_PROCESSES}},
         delay={'type': 'number'})
 
     permissions = ("autoscaling:ResumeProcesses", "ec2:StartInstances")


### PR DESCRIPTION
This PR creates parity between the ASG resume/suspend features. Currently, you are only able to exclude specific ASG processes when suspending an ASG. We would like the ability to exclude processes when resuming an ASG after offhours.

Without this, we are running into issues because it will resume the ASG process: https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#suspendprocess. We do not want the ASG to resume AZRebalance.

"""
Autoscaling groups automatically include multiple [scaling processes](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html#process-types) that keep our ASGs healthy. In some cases, you may want to disable certain scaling activities.

An example of this is if you are running multiple AZs in an ASG while using a Kubernetes Autoscaler. The autoscaler will remove specific instances that are not being used. In some cases, the AZRebalance process will rescale the ASG without warning.
"""