### PR TITLE
aws - bedrock - add support for model invocation logging configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           key: sphinx-docs-${{ runner.os }}-3.11-v3-${{ hashFiles('**/poetry.lock') }}
 
       - name: Deploy Docs
-        # if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         uses: ./.github/composites/docs-publish
         with:
           aws-role: ${{ secrets.DOCS_PUBLISH_ROLE }}

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -2481,7 +2481,7 @@ class SetBedrockModelInvocationLogging(BaseAction):
         },
     }
 
-    #permissions = ('bedrock:PutModelInvocationLoggingConfiguration',)
+    permissions = ('bedrock:PutModelInvocationLoggingConfiguration',)
     shape = 'PutModelInvocationLoggingConfigurationRequest'
     service = 'bedrock'
 

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -2405,7 +2405,7 @@ class BedrockModelInvocationLogging(ListItemFilter):
     .. code-block:: yaml
 
             policies:
-              - name: bedrock-model-invocation-logging
+              - name: bedrock-model-invocation-logging-configuration
                 resource: account
                 filters:
                   - type: bedrock-model-invocation-logging
@@ -2439,7 +2439,7 @@ class DeleteBedrockModelInvocationLogging(BaseAction):
     .. code-block:: yaml
 
             policies:
-              - name: bedrock-model-invocation-logging
+              - name: delete-bedrock-model-invocation-logging
                 resource: account
                 actions:
                   - type: delete-bedrock-model-invocation-logging
@@ -2461,7 +2461,7 @@ class SetBedrockModelInvocationLogging(BaseAction):
     .. code-block:: yaml
 
             policies:
-              - name: bedrock-model-invocation-logging
+              - name: set-bedrock-model-invocation-logging
                 resource: account
                 actions:
                   - type: set-bedrock-model-invocation-logging

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -2434,6 +2434,8 @@ class SetBedrockModelInvocationLogging(BaseAction):
     """Set Bedrock Model Invocation Logging Configuration on an account.
      https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/put_model_invocation_logging_configuration.html
 
+     To delete a configuration, supply enabled to False
+
     :example:
 
     .. code-block:: yaml

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -2432,7 +2432,6 @@ class BedrockModelInvocationLogging(ListItemFilter):
 @actions.register('delete-bedrock-model-invocation-logging')
 class DeleteBedrockModelInvocationLogging(BaseAction):
     """Delete Bedrock Model Invocation Logging Configuration on an account.
-    
      https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/delete_model_invocation_logging_configuration.html
 
     :example:
@@ -2444,9 +2443,7 @@ class DeleteBedrockModelInvocationLogging(BaseAction):
                 resource: account
                 actions:
                   - type: delete-bedrock-model-invocation-logging
-    
     """
-
     permissions = ('bedrock:DeleteModelInvocationLoggingConfiguration',)
     schema = type_schema('delete-bedrock-model-invocation-logging')
 
@@ -2458,9 +2455,7 @@ class DeleteBedrockModelInvocationLogging(BaseAction):
 @actions.register('set-bedrock-model-invocation-logging')
 class SetBedrockModelInvocationLogging(BaseAction):
     """Set Bedrock Model Invocation Logging Configuration on an account.
-    
      https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/put_model_invocation_logging_configuration.html
-
     :example:
 
     .. code-block:: yaml

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -2456,6 +2456,7 @@ class DeleteBedrockModelInvocationLogging(BaseAction):
 class SetBedrockModelInvocationLogging(BaseAction):
     """Set Bedrock Model Invocation Logging Configuration on an account.
      https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/put_model_invocation_logging_configuration.html
+
     :example:
 
     .. code-block:: yaml

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -2481,8 +2481,7 @@ class SetBedrockModelInvocationLogging(BaseAction):
         },
     }
 
-
-    permissions = ('bedrock:PutModelInvocationLoggingConfiguration',)
+    #permissions = ('bedrock:PutModelInvocationLoggingConfiguration',)
     shape = 'PutModelInvocationLoggingConfigurationRequest'
     service = 'bedrock'
 

--- a/tests/data/placebo/test_bedrock_model_invocation_logging/bedrock.GetModelInvocationLoggingConfiguration_1.json
+++ b/tests/data/placebo/test_bedrock_model_invocation_logging/bedrock.GetModelInvocationLoggingConfiguration_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "loggingConfig": {
+            "s3Config": {
+                "bucketName": "test-bedrock-1",
+                "keyPrefix": "logging/"
+            },
+            "textDataDeliveryEnabled": true,
+            "imageDataDeliveryEnabled": false,
+            "embeddingDataDeliveryEnabled": true
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_model_invocation_logging/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_bedrock_model_invocation_logging/iam.ListAccountAliases_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_delete_bedrock_model_invocation_logging/bedrock.DeleteModelInvocationLoggingConfiguration_1.json
+++ b/tests/data/placebo/test_delete_bedrock_model_invocation_logging/bedrock.DeleteModelInvocationLoggingConfiguration_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_delete_bedrock_model_invocation_logging/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_delete_bedrock_model_invocation_logging/iam.ListAccountAliases_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_get_bedrock_model_invocation_logging/bedrock.GetModelInvocationLoggingConfiguration_1.json
+++ b/tests/data/placebo/test_get_bedrock_model_invocation_logging/bedrock.GetModelInvocationLoggingConfiguration_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "loggingConfig": {
+            "s3Config": {
+                "bucketName": "test-bedrock-1",
+                "keyPrefix": "logging/"
+            },
+            "textDataDeliveryEnabled": true,
+            "imageDataDeliveryEnabled": true,
+            "embeddingDataDeliveryEnabled": false
+        }
+    }
+}

--- a/tests/data/placebo/test_get_bedrock_model_invocation_logging/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_get_bedrock_model_invocation_logging/iam.ListAccountAliases_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_update_bedrock_model_invocation_logging/bedrock.GetModelInvocationLoggingConfiguration_1.json
+++ b/tests/data/placebo/test_update_bedrock_model_invocation_logging/bedrock.GetModelInvocationLoggingConfiguration_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "loggingConfig": {
+            "s3Config": {
+                "bucketName": "test-bedrock-1",
+                "keyPrefix": "logging/"
+            },
+            "textDataDeliveryEnabled": true,
+            "imageDataDeliveryEnabled": true,
+            "embeddingDataDeliveryEnabled": false
+        }
+    }
+}

--- a/tests/data/placebo/test_update_bedrock_model_invocation_logging/bedrock.PutModelInvocationLoggingConfiguration_1.json
+++ b/tests/data/placebo/test_update_bedrock_model_invocation_logging/bedrock.PutModelInvocationLoggingConfiguration_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_update_bedrock_model_invocation_logging/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_update_bedrock_model_invocation_logging/iam.ListAccountAliases_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1298,16 +1298,16 @@ class AccountTests(BaseTest):
 
 
     def test_get_bedrock_model_invocation_logging(self):
-        factory = self.record_flight_data('test_get_bedrock_model_invocation_logging')
+        factory = self.replay_flight_data('test_get_bedrock_model_invocation_logging')
         p = self.load_policy({
             'name': 'get-bedrock-model-invocation-logging',
             'resource': 'account',
-            'filers': [
+            'filters': [
                             {
                                 "type": "bedrock-model-invocation-logging", 
                                 "attrs": [
                                     {"s3Config": "not-null"},
-                                    {"imageDataDeliveryEnabled": False}
+                                    {"imageDataDeliveryEnabled": True}
                                 ]
                             }
                         ]
@@ -1319,7 +1319,7 @@ class AccountTests(BaseTest):
 
 
     def test_delete_bedrock_model_invocation_logging(self):
-        factory = self.record_flight_data('test_delete_bedrock_model_invocation_logging')
+        factory = self.replay_flight_data('test_delete_bedrock_model_invocation_logging')
         p = self.load_policy({
             'name': 'delete-bedrock-model-invocation-logging',
             'resource': 'account',

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1304,7 +1304,7 @@ class AccountTests(BaseTest):
             'resource': 'account',
             'filters': [
                             {
-                                "type": "bedrock-model-invocation-logging", 
+                                "type": "bedrock-model-invocation-logging",
                                 "attrs": [
                                     {"s3Config": "not-null"},
                                     {"imageDataDeliveryEnabled": True}
@@ -1325,7 +1325,7 @@ class AccountTests(BaseTest):
             'resource': 'account',
             'actions': [
                             {
-                                "type": "delete-bedrock-model-invocation-logging", 
+                                "type": "delete-bedrock-model-invocation-logging",
                             }
                         ]
                         },
@@ -1333,7 +1333,7 @@ class AccountTests(BaseTest):
             session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
-    
+
 
     def test_update_bedrock_model_invocation_logging(self):
         factory = self.replay_flight_data("test_update_bedrock_model_invocation_logging")

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1297,6 +1297,87 @@ class AccountTests(BaseTest):
         self.assertEqual(resources[0]['c7n:ses-max-bounce-rate'], 6)
 
 
+    def test_get_bedrock_model_invocation_logging(self):
+        factory = self.record_flight_data('test_get_bedrock_model_invocation_logging')
+        p = self.load_policy({
+            'name': 'get-bedrock-model-invocation-logging',
+            'resource': 'account',
+            'filers': [
+                            {
+                                "type": "bedrock-model-invocation-logging", 
+                                "attrs": [
+                                    {"s3Config": "not-null"},
+                                    {"imageDataDeliveryEnabled": False}
+                                ]
+                            }
+                        ]
+                        },
+            config={'region': 'us-east-1'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+
+    def test_delete_bedrock_model_invocation_logging(self):
+        factory = self.record_flight_data('test_delete_bedrock_model_invocation_logging')
+        p = self.load_policy({
+            'name': 'delete-bedrock-model-invocation-logging',
+            'resource': 'account',
+            'actions': [
+                            {
+                                "type": "delete-bedrock-model-invocation-logging", 
+                            }
+                        ]
+                        },
+            config={'region': 'us-east-1'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+    
+
+    def test_update_bedrock_model_invocation_logging(self):
+        factory = self.replay_flight_data("test_update_bedrock_model_invocation_logging")
+        p = self.load_policy(
+            {
+                "name": "set-bedrock-model-invocation-logging",
+                "resource": "account",
+                "actions": [
+                    {
+                        "type": "set-bedrock-model-invocation-logging",
+                        "loggingConfig": {
+                            "textDataDeliveryEnabled": True,
+                            "imageDataDeliveryEnabled": True,
+                            "embeddingDataDeliveryEnabled": False,
+                            "s3Config":
+                                {
+                                    "bucketName": "test-bedrock-1",
+                                    "keyPrefix": "logging/"
+                                }
+                        }
+                    }
+                ]
+            },
+            session_factory=factory,
+        )
+
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = local_session(factory).client('bedrock')
+        configuration = client.get_model_invocation_logging_configuration()
+        self.assertEqual(
+            [
+                configuration['loggingConfig']['textDataDeliveryEnabled'],
+                configuration['loggingConfig']['imageDataDeliveryEnabled'],
+                configuration['loggingConfig']['embeddingDataDeliveryEnabled'],
+            ],
+            [
+                True,
+                True,
+                False,
+            ]
+        )
+
+
 class AccountDataEvents(BaseTest):
 
     def make_bucket(self, session_factory, name):

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1325,7 +1325,8 @@ class AccountTests(BaseTest):
             'resource': 'account',
             'actions': [
                             {
-                                "type": "delete-bedrock-model-invocation-logging",
+                                "type": "set-bedrock-model-invocation-logging",
+                                "enabled": False
                             }
                         ]
                         },
@@ -1344,6 +1345,7 @@ class AccountTests(BaseTest):
                 "actions": [
                     {
                         "type": "set-bedrock-model-invocation-logging",
+                        "enabled": True,
                         "loggingConfig": {
                             "textDataDeliveryEnabled": True,
                             "imageDataDeliveryEnabled": True,
@@ -1369,11 +1371,15 @@ class AccountTests(BaseTest):
                 configuration['loggingConfig']['textDataDeliveryEnabled'],
                 configuration['loggingConfig']['imageDataDeliveryEnabled'],
                 configuration['loggingConfig']['embeddingDataDeliveryEnabled'],
+                configuration['loggingConfig']['s3Config']['bucketName'],
+                configuration['loggingConfig']['s3Config']['keyPrefix']
             ],
             [
                 True,
                 True,
                 False,
+                "test-bedrock-1",
+                "logging/"
             ]
         )
 


### PR DESCRIPTION
Closes (https://github.com/cloud-custodian/cloud-custodian/issues/9228)

This PR adds a filter called bedrock-model-invocation-logging at account level to allow users filter logging configurations based on their requirement. It also adds two actions:

1. delete-bedrock-model-invocation-logging: delete the existing bedrock model invocation logging configuration.
2. set-bedrock-model-invocation-logging: update the bedrock model invocation logging configuration.
