### PR TITLE
c7n-left - fix policy severity level filtering for --warn-on

### DIFF
--- a/tools/c7n_left/c7n_left/cli.py
+++ b/tools/c7n_left/c7n_left/cli.py
@@ -179,7 +179,7 @@ def get_config(
         format=format,
     )
     config["exec_filter"] = ExecutionFilter.parse(config.filters)
-    config["warn_filter"] = ExecutionFilter.parse(config.warn_on)
+    config["warn_filter"] = ExecutionFilter.parse(config.warn_on, severity_direction='gte')
     return config
 
 

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "c7n_left"
-version = "0.3.12"
+version = "0.3.13"
 description = "Custodian policies for IAAC definitions"
 authors = ["Cloud Custodian Project"]
 license = "Apache-2"


### PR DESCRIPTION

the default severity filtering for --filter would take a level and higher criticality items, ie. medium would get high, critical as well. for --warn-on we want to reverse the comparision and take lower level items (medium would get low and unknown.
