### PR TITLE
releng - update github actions versions and fix doc build

### DIFF
--- a/.github/composites/docker-build-push/action.yaml
+++ b/.github/composites/docker-build-push/action.yaml
@@ -19,17 +19,17 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     # until we get read only credentials, we'll only login if we're pushing
     # note that we can hit rate limits on pulling though
     - name: Login to Docker Hub
       if: "${{ inputs.push == 'true' }}"
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.HUB_USER }}
         password: ${{ env.HUB_TOKEN }}
@@ -58,7 +58,7 @@ runs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: |
           ${{ inputs.repository }}/${{ inputs.name }}
@@ -78,7 +78,7 @@ runs:
     # https://github.com/docker/buildx/issues/166
     # https://github.com/docker/buildx/issues/59
     - name: Build
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         build-args: |
@@ -106,7 +106,7 @@ runs:
     # actually push the multi arch image
     - name: Push
       if: "${{ inputs.push == 'true' }}"
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         build-args: |
@@ -121,7 +121,7 @@ runs:
 
     - name: Install cosign
       if: "${{ inputs.push == 'true' }}"
-      uses: sigstore/cosign-installer@v2
+      uses: sigstore/cosign-installer@v3
       with:
         cosign-release: 'v1.13.0'
 

--- a/.github/composites/docs-publish/action.yaml
+++ b/.github/composites/docs-publish/action.yaml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: aws-actions/configure-aws-credentials@v2
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/composites/docs-publish/action.yaml
+++ b/.github/composites/docs-publish/action.yaml
@@ -21,6 +21,8 @@ runs:
     - name: Install Deps
       shell: bash
       run: |
+        rm -f ~/.pypirc
+        env
         pip install -U awscli
 
     - name: Publish

--- a/.github/composites/docs-publish/action.yaml
+++ b/.github/composites/docs-publish/action.yaml
@@ -21,8 +21,7 @@ runs:
     - name: Install Deps
       shell: bash
       run: |
-        rm -f ~/.pypirc
-        env
+        pip config --site unset global.index-url
         pip install -U awscli
 
     - name: Publish

--- a/.github/composites/install/action.yaml
+++ b/.github/composites/install/action.yaml
@@ -18,12 +18,12 @@ runs:
       run: pipx install poetry==${{ inputs.poetry-version }}
 
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Set up cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache
       with:
         path: .venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
             docs/source/azure/resources
             docs/source/awscc/resources
             docs/source/tencentcloud/resources
-          key: sphinx-docs-${{ runner.os }}-3.11-v2-${{ hashFiles('**/poetry.lock') }}
+          key: sphinx-docs-${{ runner.os }}-3.11-v3-${{ hashFiles('**/poetry.lock') }}
 
       - name: Build Docs
         shell: bash
@@ -106,7 +106,7 @@ jobs:
             docs/source/azure/resources
             docs/source/awscc/resources
             docs/source/tencentcloud/resources
-          key: sphinx-docs-${{ runner.os }}-3.11-v2-${{ hashFiles('**/poetry.lock') }}
+          key: sphinx-docs-${{ runner.os }}-3.11-v3-${{ hashFiles('**/poetry.lock') }}
 
       - name: Deploy Docs
         # if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.DEFAULT_PY_VERSION }}
       - name: Install Linter
@@ -27,7 +27,7 @@ jobs:
           BLACK_VERSION="$(python tools/dev/lint_version.py black poetry.lock)"
           pip install ruff=="$RUFF_VERSION" black=="$BLACK_VERSION"
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
           # last OSS version
@@ -46,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: Lint
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.DEFAULT_PY_VERSION }}
       - name: Run Bandit
@@ -66,7 +66,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Custodian
         uses: ./.github/composites/install
@@ -75,7 +75,7 @@ jobs:
           poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Set up doc cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: sphinx
         with:
           path: |
@@ -97,7 +97,7 @@ jobs:
         # on its contents, on merges to main we update the cache to prevent
         # staleness.
         if: ${{ github.event_name == 'push' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: |
             docs/build
@@ -109,7 +109,7 @@ jobs:
           key: sphinx-docs-${{ runner.os }}-3.11-v2-${{ hashFiles('**/poetry.lock') }}
 
       - name: Deploy Docs
-        if: ${{ github.event_name == 'push' }}
+        # if: ${{ github.event_name == 'push' }}
         uses: ./.github/composites/docs-publish
         with:
           aws-role: ${{ secrets.DOCS_PUBLISH_ROLE }}
@@ -119,7 +119,7 @@ jobs:
   Docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: c7n build and test
         uses: ./.github/composites/docker-build-push
         with:
@@ -144,10 +144,10 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.8"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
           # last OSS version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
           - c7n-left
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ${{ matrix.image }} build and push
         uses: ./.github/composites/docker-build-push
         env:

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -10,17 +10,17 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_FTEST_ROLE }}
           aws-region: us-east-1
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
           # last OSS version
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: tfcache
         with:
           path: .tfcache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_FTEST_ROLE }}
           aws-region: us-east-1
 
-
       - name: Auth Staging Repository
         shell: bash
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       checks: write    
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
              --path . --since last --skip-provider awscc
           cat release.md
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.AWS_FTEST_ROLE }}
           aws-region: us-east-1
@@ -61,7 +61,7 @@ jobs:
           python tools/dev/poetrypkg.py gen-qa-requires -r . --output wheels-manifest.txt
           make pkg-publish-wheel PKG_REPO=${{ env.PKG_REPO }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: built-wheels
           path: |
@@ -77,17 +77,17 @@ jobs:
       contents: read
       checks: write    
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: built-wheels
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.AWS_FTEST_ROLE }}
           aws-region: us-east-1
@@ -119,13 +119,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: TestWheels
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Custodian
         uses: ./.github/composites/install
         with:
           python-version: "3.11"          
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: built-wheels
 


### PR DESCRIPTION
ci on trunk was failing as a result of some sort of pip settings corruption from the release wheels test.

