### PR TITLE
aws - dynamodb-table - avoid key errors in continuous-backup filter

### DIFF
--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -116,7 +116,7 @@ class TableContinuousBackupFilter(ValueFilter):
                 continue
 
     def __call__(self, r):
-        return super().__call__(r[self.annotation_key])
+        return super().__call__(r.get(self.annotation_key, {}))
 
 
 @Table.action_registry.register('set-continuous-backup')

--- a/tests/data/placebo/test_dynamodb_continuous_backup_filter/dynamodb.DescribeContinuousBackups_2.json
+++ b/tests/data/placebo/test_dynamodb_continuous_backup_filter/dynamodb.DescribeContinuousBackups_2.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Message": "Table not found: mosdef-deleted",
+            "Code": "TableNotFoundException"
+        },
+        "ResponseMetadata": {},
+        "message": "Table not found: mosdef-deleted"
+    }
+}

--- a/tests/data/placebo/test_dynamodb_continuous_backup_filter/dynamodb.DescribeTable_2.json
+++ b/tests/data/placebo/test_dynamodb_continuous_backup_filter/dynamodb.DescribeTable_2.json
@@ -1,0 +1,54 @@
+{
+    "status_code": 200,
+    "data": {
+        "Table": {
+            "AttributeDefinitions": [
+                {
+                    "AttributeName": "ArtistId",
+                    "AttributeType": "S"
+                }
+            ],
+            "TableName": "mosdef2-deleted",
+            "KeySchema": [
+                {
+                    "AttributeName": "ArtistId",
+                    "KeyType": "HASH"
+                }
+            ],
+            "TableStatus": "ACTIVE",
+            "CreationDateTime": {
+                "__class__": "datetime",
+                "year": 2019,
+                "month": 1,
+                "day": 29,
+                "hour": 13,
+                "minute": 39,
+                "second": 48,
+                "microsecond": 333000
+            },
+            "ProvisionedThroughput": {
+                "NumberOfDecreasesToday": 0,
+                "ReadCapacityUnits": 0,
+                "WriteCapacityUnits": 0
+            },
+            "TableSizeBytes": 0,
+            "ItemCount": 0,
+            "TableArn": "arn:aws:dynamodb:us-east-1:644160558196:table/mosdef2-deleted",
+            "TableId": "0f64ca00-386f-4b55-b403-acd215e81072",
+            "BillingModeSummary": {
+                "BillingMode": "PAY_PER_REQUEST",
+                "LastUpdateToPayPerRequestDateTime": {
+                    "__class__": "datetime",
+                    "year": 2019,
+                    "month": 1,
+                    "day": 29,
+                    "hour": 13,
+                    "minute": 39,
+                    "second": 48,
+                    "microsecond": 333000
+                }
+            }
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_dynamodb_continuous_backup_filter/dynamodb.ListTables_1.json
+++ b/tests/data/placebo/test_dynamodb_continuous_backup_filter/dynamodb.ListTables_1.json
@@ -2,7 +2,8 @@
     "status_code": 200,
     "data": {
         "TableNames": [
-            "mosdef2-DDBTable-VV01OCO2TJ72"
+            "mosdef2-DDBTable-VV01OCO2TJ72",
+            "mosdef2-deleted"
         ],
         "ResponseMetadata": {}
     }

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -143,8 +143,7 @@ class DynamodbTest(BaseTest):
                     {
                         "type": "continuous-backup",
                         "key": "PointInTimeRecoveryDescription.PointInTimeRecoveryStatus",
-                        "value": "ENABLED",
-                        "op": "ne"
+                        "value": "DISABLED",
                     }
                 ]
             },


### PR DESCRIPTION
It's possible for Custodian to describe a DynamoDB table but then be unable to list its continuous backups (most clearly if the table is deleted between the initial describe and continuous backup check).

In those cases, match against an empty dict placeholder value.

Updated the existing continuous-backup test case to reproduce the `KeyError` Jasmine C described in [this Slack thread](https://www.linen.dev/s/cloud-custodian/t/16357070/hello-i-have-written-a-policy-to-try-and-identify-dynamodb-r#0d18f936-a0c6-44a6-bc81-c7354d38b6b9).