### PR TITLE
releng - remove beta label on gcp

### DIFF
--- a/docs/source/gcp/gettingstarted.rst
+++ b/docs/source/gcp/gettingstarted.rst
@@ -1,9 +1,9 @@
 .. _gcp_gettingstarted:
 
-Getting Started (Beta)
-======================
+Getting Started
+===============
 
-The GCP provider (Beta) is an optional package which can be installed to enable
+The GCP provider is an optional package which can be installed to enable
 writing policies which interact with GCP related resources.
 
 


### PR DESCRIPTION

update docs to remove beta label on gcp, even gmail dropped the label after 10 years ;-)

