### PR TITLE
aws - make account_id available to c7n-org report

### DIFF
--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -249,7 +249,9 @@ For Azure and GCP, only the environment variables
 the system env variables).
 
 c7n-org also supports generating reports for a given policy execution
-across accounts via the `c7n-org report` subcommand.
+across accounts via the `c7n-org report` subcommand. By default,
+account_id is not exposed to the output, but you may append it by
+using `--field AccountID=account_id` in the cli.
 
 ## Additional Azure Instructions
 

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -360,6 +360,7 @@ def report_account(account, region, policies_config, output_path, cache_path, de
             r['policy'] = p.name
             r['region'] = p.options.region
             r['account'] = account['name']
+            r['account_id'] = account['account_id']
             for t in account.get('tags', ()):
                 if ':' in t:
                     k, v = t.split(':', 1)


### PR DESCRIPTION
While generating report with c7n-org, sometimes account_id is wanted. This PR makes account_id available to c7n-org report.

It's possible to include it as a default field (see below). However, that might break some users' automation, if they rely on the output format. Rather, it'd better be `c7n-org report ... --field AccountID=account_id`.

https://github.com/cloud-custodian/cloud-custodian/blob/503d73d89d3b97e94d97b2c8bdc164d0acac40e8/tools/c7n_org/c7n_org/cli.py#L439-L440
