### PR TITLE
aws - ecs-service - modify-definition with resize support

### DIFF
--- a/c7n/filters/costhub.py
+++ b/c7n/filters/costhub.py
@@ -94,13 +94,21 @@ class CostHubRecommendation(Filter):
         frm = RecommendationManager(self.manager.ctx, data={'filters': self.data.get('attrs', [])})
 
         for rec in recommendations['items']:
-            if rec['resourceArn'] not in r_map:
+            rec_rarn = rec['resourceArn']
+
+            # a few of the recommendation resources use a version
+            # qualifier which won't match the innate/latest arn coming
+            # from describe sources (sans qualifier)
+            if rec_rarn.count(':') == 7:
+                rec_rarn, _ = rec_rarn.rsplit(':', 1)
+
+            if rec_rarn not in r_map:
                 continue
             if not frm.filter_resources([rec], event):
                 continue
-            r = r_map[rec['resourceArn']]
+            r = r_map[rec_rarn]
             r[self.annotation_key] = rec
-            results.add(rec['resourceArn'])
+            results.add(rec_rarn)
         return [r for rid, r in r_map.items() if rid in results]
 
     @classmethod

--- a/c7n/filters/costhub.py
+++ b/c7n/filters/costhub.py
@@ -74,7 +74,6 @@ class CostHubRecommendation(Filter):
     def process(self, resources, event=None):
         client = local_session(self.manager.session_factory).client(
             'cost-optimization-hub', region_name='us-east-1')
-        id_field = self.manager.resource_type.id
         filter_params = filter_empty({
             'actionTypes': [
                 self.manager.data.get(
@@ -85,8 +84,8 @@ class CostHubRecommendation(Filter):
             'resourceTypes': [self.resource_type_map[self.manager.type]],
         })
         r_map = {}
-        for r in resources:
-            r_map[r[id_field]] = r
+        for arn, r in zip(self.manager.get_arns(resources), resources):
+            r_map[arn] = r
 
         pager = client.get_paginator('list_recommendations')
         recommendations = pager.paginate(filter=filter_params).build_full_result()
@@ -95,13 +94,13 @@ class CostHubRecommendation(Filter):
         frm = RecommendationManager(self.manager.ctx, data={'filters': self.data.get('attrs', [])})
 
         for rec in recommendations['items']:
-            if rec['resourceId'] not in r_map:
+            if rec['resourceArn'] not in r_map:
                 continue
             if not frm.filter_resources([rec], event):
                 continue
-            r = r_map[rec['resourceId']]
+            r = r_map[rec['resourceArn']]
             r[self.annotation_key] = rec
-            results.add(rec['resourceId'])
+            results.add(rec['resourceArn'])
         return [r for rid, r in r_map.items() if rid in results]
 
     @classmethod

--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -3,18 +3,18 @@
 import copy
 from botocore.exceptions import ClientError
 
-from c7n.actions import BaseAction
+from c7n.actions import AutoTagUser, AutoscalingBase, BaseAction
 from c7n.exceptions import PolicyExecutionError
 from c7n.filters import MetricsFilter, ValueFilter, Filter
 from c7n.filters.costhub import CostHubRecommendation
 from c7n.filters.offhours import OffHour, OnHour
+import c7n.filters.vpc as net_filters
 from c7n.manager import resources
 from c7n.utils import local_session, chunks, get_retry, type_schema, group_by, jmespath_compile
 from c7n import query, utils
 from c7n.query import DescribeSource, ConfigSource
+from c7n.resources.aws import Arn
 from c7n.tags import Tag, TagDelayedAction, RemoveTag, TagActionFilter
-from c7n.actions import AutoTagUser, AutoscalingBase
-import c7n.filters.vpc as net_filters
 
 
 def ecs_tag_normalize(resources):
@@ -424,43 +424,91 @@ class SGFilter(net_filters.SecurityGroupFilter):
 class UpdateTemplate(BaseAction):
 
     schema = type_schema(
-        'modify-template',
+        'modify-definition',
         properties={'type': 'object'},
     )
 
+    permissions = ("ecs:RegisterTaskDefinition", "ecs:UpdateService")
+
     def process(self, resources):
         task_def_filter = ServiceTaskDefinitionFilter({}, self.manager)
-        task_defs = task_def_filter.get_task_defs(resources)
+        task_defs = {t['taskDefinitionArn']: t for t in task_def_filter.get_task_defs(resources)}
         client = local_session(self.manager.session_factory).client('ecs')
 
         # we can only modify task definition when ecs is controlling the deployment.
         resources = self.filter_resources(resources, "deploymentController.type", ("ECS",))
 
         for r in resources:
-            r_task_def = task_defs[task_def_filter.related_key]
+            r_task_def = task_defs[r[task_def_filter.related_key]]
             m_task_def = self.get_target_task_def(r, r_task_def)
             if m_task_def is None:
                 continue
             response = client.register_task_definition(**m_task_def)
             task_arn = response['taskDefinition']['taskDefinitionArn']
+            cluster, _ = Arn.parse(r['serviceArn']).resource.split('/', 1)
             client.update_service(
-                cluster=r['cluster'],
-                service=r['service'],
+                cluster=cluster,
+                service=r['serviceName'],
                 taskDefinition=task_arn
             )
+
+    task_def_normalized = [
+        "taskDefinitionArn", "revision", "status",
+        "registeredAt", "registeredBy", "requiresAttributes",
+    ]
+
+    task_def_remap = {
+        "compatibilities": "requiresCompatibilities",
+    }
 
     def get_target_task_def(self, resource, current_task_def):
         target_task_def = copy.deepcopy(current_task_def)
         target_task_def.update(self.data.get('properties', {}))
         cost_optimization = resource.get(CostHubRecommendation.annotation_key)
+
         if cost_optimization and cost_optimization['actionType'] == 'Rightsize':
             cpu, mem = cost_optimization["recommendedResourceSummary"].split("/")
-            cpu = int(cpu.split(" ")[0])
+            cpu = int(float(cpu.split(" ")[0]))
             mem = int(mem.split(" ")[0])
             target_task_def["cpu"] = str(cpu)
             target_task_def["memory"] = str(mem)
-        if target_task_def == current_task_def:
+            target_task_def = self.update_target_containers_size(current_task_def, target_task_def)
+
+        if target_task_def == current_task_def or target_task_def is None:
             return
+
+        # normalize from describe to register formats
+        for k in self.task_def_normalized:
+            target_task_def.pop(k, None)
+        for ck, dk in self.task_def_remap.items():
+            if ck in target_task_def:
+                target_task_def[dk] = target_task_def.pop(ck)
+        tags = []
+        for t in target_task_def.pop('Tags', []):
+            tags.append({'key': t['Key'], 'value': t['Value']})
+        if tags:
+            target_task_def['tags'] = tags
+        return target_task_def
+
+    def update_target_containers_size(self, current_task_def, target_task_def):
+        """Update container memory/size targets.
+
+        We need to update memory/cpu requirements of the containers within
+        the task, so the total of the containers in the task def
+        matches the definition.
+
+        for a task w/ a single container this is simple, make the container match
+        the definition.
+
+        for a multi container task, we need select a heuristic
+        (proportional, largest) with some notion of a floor / min for
+        proportional. for now we punt on multi-container tasks.
+        """
+        if len(target_task_def['containerDefinitions']) > 1:
+            return
+        container_def = target_task_def['containerDefinitions'][0]
+        container_def['memory'] = int(target_task_def['memory'])
+        container_def['cpu'] = int(target_task_def['cpu'])
         return target_task_def
 
 

--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -1,10 +1,12 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+import copy
 from botocore.exceptions import ClientError
 
 from c7n.actions import BaseAction
 from c7n.exceptions import PolicyExecutionError
 from c7n.filters import MetricsFilter, ValueFilter, Filter
+from c7n.filters.costhub import CostHubRecommendation
 from c7n.filters.offhours import OffHour, OnHour
 from c7n.manager import resources
 from c7n.utils import local_session, chunks, get_retry, type_schema, group_by, jmespath_compile
@@ -244,6 +246,10 @@ class RelatedTaskDefinitionFilter(ValueFilter):
     related_key = 'taskDefinition'
 
     def process(self, resources, event=None):
+        self.task_defs = {t['taskDefinitionArn']: t for t in self.get_task_defs(resources)}
+        return super(RelatedTaskDefinitionFilter, self).process(resources)
+
+    def get_task_defs(self, resources):
         task_def_ids = list({s[self.related_key] for s in resources})
         task_def_manager = self.manager.get_resource_manager(
             'ecs-task-definition')
@@ -260,8 +266,7 @@ class RelatedTaskDefinitionFilter(ValueFilter):
         # else just augment the ids
         else:
             task_defs = task_def_manager.augment(task_def_ids)
-        self.task_defs = {t['taskDefinitionArn']: t for t in task_defs}
-        return super(RelatedTaskDefinitionFilter, self).process(resources)
+        return task_defs
 
     def __call__(self, i):
         task = self.task_defs[i[self.related_key]]
@@ -414,6 +419,49 @@ class SGFilter(net_filters.SecurityGroupFilter):
 
 
 @Service.filter_registry.register('network-location', net_filters.NetworkLocation)
+
+@Service.action_registry.register('modify-definition')
+class UpdateTemplate(BaseAction):
+
+    schema = type_schema(
+        'modify-template',
+        properties={'type': 'object'},
+    )
+
+    def process(self, resources):
+        task_def_filter = ServiceTaskDefinitionFilter({}, self.manager)
+        task_defs = task_def_filter.get_task_defs(resources)
+        client = local_session(self.manager.session_factory).client('ecs')
+
+        # we can only modify task definition when ecs is controlling the deployment.
+        resources = self.filter_resources(resources, "deploymentController.type", ("ECS",))
+
+        for r in resources:
+            r_task_def = task_defs[task_def_filter.related_key]
+            m_task_def = self.get_target_task_def(r, r_task_def)
+            if m_task_def is None:
+                continue
+            response = client.register_task_definition(**m_task_def)
+            task_arn = response['taskDefinition']['taskDefinitionArn']
+            client.update_service(
+                cluster=r['cluster'],
+                service=r['service'],
+                taskDefinition=task_arn
+            )
+
+    def get_target_task_def(self, resource, current_task_def):
+        target_task_def = copy.deepcopy(current_task_def)
+        target_task_def.update(self.data.get('properties', {}))
+        cost_optimization = resource.get(CostHubRecommendation.annotation_key)
+        if cost_optimization and cost_optimization['actionType'] == 'Rightsize':
+            cpu, mem = cost_optimization["recommendedResourceSummary"].split("/")
+            cpu = int(cpu.split(" ")[0])
+            mem = int(mem.split(" ")[0])
+            target_task_def["cpu"] = str(cpu)
+            target_task_def["memory"] = str(mem)
+        if target_task_def == current_task_def:
+            return
+        return target_task_def
 
 
 @Service.action_registry.register('modify')

--- a/tests/data/placebo/test_ecs_service_update_definition/cost-optimization-hub.ListRecommendations_1.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/cost-optimization-hub.ListRecommendations_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "items": [
+            {
+                "accountId": "644160558196",
+                "actionType": "Rightsize",
+                "currencyCode": "USD",
+                "currentResourceSummary": "1024.0 vCPU/2048 MB memory",
+                "currentResourceType": "EcsService",
+                "estimatedMonthlyCost": 18.02,
+                "estimatedMonthlySavings": 18.02,
+                "estimatedSavingsPercentage": 50.0,
+                "implementationEffort": "Medium",
+                "lastRefreshTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 2,
+                    "day": 9,
+                    "hour": 13,
+                    "minute": 6,
+                    "second": 38,
+                    "microsecond": 923000
+                },
+                "recommendationId": "ODgwNTg0OTU3Nzk0XzJlZGMyNzE1LWQxMDUtNDBmYi05ZjQ4LTc2YmYxZjg2NWZhZA==",
+                "recommendationLookbackPeriodInDays": 14,
+                "recommendedResourceSummary": "512.0 vCPU/1024 MB memory",
+                "recommendedResourceType": "EcsService",
+                "region": "us-east-2",
+                "resourceArn": "arn:aws:ecs:us-east-2:644160558196:service/dev-redash/redash-server",
+                "resourceId": "dev-redash/redash-server",
+                "restartNeeded": true,
+                "rollbackPossible": true,
+                "source": "ComputeOptimizer",
+                "tags": [
+                    {
+                        "key": "App",
+                        "value": "Redash"
+                    },
+                    {
+                        "key": "stacklet:app",
+                        "value": "redash"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeServices_1.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeServices_1.json
@@ -1,0 +1,153 @@
+{
+    "status_code": 200,
+    "data": {
+        "services": [
+            {
+                "serviceArn": "arn:aws:ecs:us-east-2:644160558196:service/dev-redash/redash-server",
+                "serviceName": "redash-server",
+                "clusterArn": "arn:aws:ecs:us-east-2:644160558196:cluster/dev-redash",
+                "loadBalancers": [
+                    {
+                        "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-2:644160558196:targetgroup/dev-redash/608e176bc37cd1d3",
+                        "containerName": "server",
+                        "containerPort": 5000
+                    }
+                ],
+                "serviceRegistries": [
+                    {
+                        "registryArn": "arn:aws:servicediscovery:us-east-2:644160558196:service/srv-bzzz6xsmtwv5uap7"
+                    }
+                ],
+                "status": "ACTIVE",
+                "desiredCount": 1,
+                "runningCount": 1,
+                "pendingCount": 0,
+                "capacityProviderStrategy": [
+                    {
+                        "capacityProvider": "FARGATE",
+                        "weight": 100,
+                        "base": 0
+                    }
+                ],
+                "platformVersion": "LATEST",
+                "platformFamily": "Linux",
+                "taskDefinition": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:75",
+                "deploymentConfiguration": {
+                    "deploymentCircuitBreaker": {
+                        "enable": false,
+                        "rollback": false
+                    },
+                    "maximumPercent": 200,
+                    "minimumHealthyPercent": 100
+                },
+                "deployments": [
+                    {
+                        "id": "ecs-svc/5377507045281168538",
+                        "status": "PRIMARY",
+                        "taskDefinition": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:75",
+                        "desiredCount": 1,
+                        "pendingCount": 0,
+                        "runningCount": 1,
+                        "failedTasks": 0,
+                        "createdAt": {
+                            "__class__": "datetime",
+                            "year": 2024,
+                            "month": 1,
+                            "day": 26,
+                            "hour": 15,
+                            "minute": 17,
+                            "second": 13,
+                            "microsecond": 482000
+                        },
+                        "updatedAt": {
+                            "__class__": "datetime",
+                            "year": 2024,
+                            "month": 1,
+                            "day": 26,
+                            "hour": 15,
+                            "minute": 20,
+                            "second": 13,
+                            "microsecond": 362000
+                        },
+                        "capacityProviderStrategy": [
+                            {
+                                "capacityProvider": "FARGATE",
+                                "weight": 100,
+                                "base": 0
+                            }
+                        ],
+                        "platformVersion": "1.4.0",
+                        "platformFamily": "Linux",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": [
+                                    "subnet-0b829c7f54fd00883",
+                                    "subnet-0d92e88c50ab9adac",
+                                    "subnet-0e26958394c1a4fc7"
+                                ],
+                                "securityGroups": [
+                                    "sg-037c67c516127610d",
+                                    "sg-03067d2f64ae975d8",
+                                    "sg-04e2c7d46a6745f0c"
+                                ],
+                                "assignPublicIp": "ENABLED"
+                            }
+                        },
+                        "rolloutState": "COMPLETED",
+                        "rolloutStateReason": "ECS deployment ecs-svc/5377507045281168538 completed."
+                    }
+                ],
+                "roleArn": "arn:aws:iam::644160558196:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+                "events": [],
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 5,
+                    "day": 24,
+                    "hour": 14,
+                    "minute": 46,
+                    "second": 50,
+                    "microsecond": 746000
+                },
+                "placementConstraints": [],
+                "placementStrategy": [],
+                "networkConfiguration": {
+                    "awsvpcConfiguration": {
+                        "subnets": [
+                            "subnet-0b829c7f54fd00883",
+                            "subnet-0d92e88c50ab9adac",
+                            "subnet-0e26958394c1a4fc7"
+                        ],
+                        "securityGroups": [
+                            "sg-037c67c516127610d",
+                            "sg-03067d2f64ae975d8",
+                            "sg-04e2c7d46a6745f0c"
+                        ],
+                        "assignPublicIp": "ENABLED"
+                    }
+                },
+                "healthCheckGracePeriodSeconds": 0,
+                "schedulingStrategy": "REPLICA",
+                "deploymentController": {
+                    "type": "ECS"
+                },
+                "tags": [
+                    {
+                        "key": "App",
+                        "value": "Redash"
+                    },
+                    {
+                        "key": "stacklet:app",
+                        "value": "redash"
+                    }
+                ],
+                "createdBy": "arn:aws:iam::644160558196:role/stacklet-deployer",
+                "enableECSManagedTags": true,
+                "propagateTags": "SERVICE",
+                "enableExecuteCommand": false
+            }
+        ],
+        "failures": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeServices_2.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeServices_2.json
@@ -1,0 +1,198 @@
+{
+    "status_code": 200,
+    "data": {
+        "services": [
+            {
+                "serviceArn": "arn:aws:ecs:us-east-2:644160558196:service/dev-redash/redash-server",
+                "serviceName": "redash-server",
+                "clusterArn": "arn:aws:ecs:us-east-2:644160558196:cluster/dev-redash",
+                "loadBalancers": [
+                    {
+                        "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-2:644160558196:targetgroup/dev-redash/608e176bc37cd1d3",
+                        "containerName": "server",
+                        "containerPort": 5000
+                    }
+                ],
+                "serviceRegistries": [
+                    {
+                        "registryArn": "arn:aws:servicediscovery:us-east-2:644160558196:service/srv-bzzz6xsmtwv5uap7"
+                    }
+                ],
+                "status": "ACTIVE",
+                "desiredCount": 1,
+                "runningCount": 1,
+                "pendingCount": 0,
+                "capacityProviderStrategy": [
+                    {
+                        "capacityProvider": "FARGATE",
+                        "weight": 100,
+                        "base": 0
+                    }
+                ],
+                "platformVersion": "LATEST",
+                "platformFamily": "Linux",
+                "taskDefinition": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:77",
+                "deploymentConfiguration": {
+                    "deploymentCircuitBreaker": {
+                        "enable": false,
+                        "rollback": false
+                    },
+                    "maximumPercent": 200,
+                    "minimumHealthyPercent": 100
+                },
+                "deployments": [
+                    {
+                        "id": "ecs-svc/5219324069200109376",
+                        "status": "PRIMARY",
+                        "taskDefinition": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:77",
+                        "desiredCount": 0,
+                        "pendingCount": 0,
+                        "runningCount": 0,
+                        "failedTasks": 0,
+                        "createdAt": {
+                            "__class__": "datetime",
+                            "year": 2024,
+                            "month": 2,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 44,
+                            "second": 57,
+                            "microsecond": 956000
+                        },
+                        "updatedAt": {
+                            "__class__": "datetime",
+                            "year": 2024,
+                            "month": 2,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 44,
+                            "second": 57,
+                            "microsecond": 956000
+                        },
+                        "capacityProviderStrategy": [
+                            {
+                                "capacityProvider": "FARGATE",
+                                "weight": 100,
+                                "base": 0
+                            }
+                        ],
+                        "platformVersion": "1.4.0",
+                        "platformFamily": "Linux",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": [
+                                    "subnet-0b829c7f54fd00883",
+                                    "subnet-0d92e88c50ab9adac",
+                                    "subnet-0e26958394c1a4fc7"
+                                ],
+                                "securityGroups": [
+                                    "sg-037c67c516127610d",
+                                    "sg-03067d2f64ae975d8",
+                                    "sg-04e2c7d46a6745f0c"
+                                ],
+                                "assignPublicIp": "ENABLED"
+                            }
+                        },
+                        "rolloutState": "IN_PROGRESS",
+                        "rolloutStateReason": "ECS deployment ecs-svc/5219324069200109376 in progress."
+                    },
+                    {
+                        "id": "ecs-svc/5377507045281168538",
+                        "status": "ACTIVE",
+                        "taskDefinition": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:75",
+                        "desiredCount": 1,
+                        "pendingCount": 0,
+                        "runningCount": 1,
+                        "failedTasks": 0,
+                        "createdAt": {
+                            "__class__": "datetime",
+                            "year": 2024,
+                            "month": 1,
+                            "day": 26,
+                            "hour": 15,
+                            "minute": 17,
+                            "second": 13,
+                            "microsecond": 482000
+                        },
+                        "updatedAt": {
+                            "__class__": "datetime",
+                            "year": 2024,
+                            "month": 2,
+                            "day": 12,
+                            "hour": 12,
+                            "minute": 44,
+                            "second": 57,
+                            "microsecond": 957000
+                        },
+                        "capacityProviderStrategy": [
+                            {
+                                "capacityProvider": "FARGATE",
+                                "weight": 100,
+                                "base": 0
+                            }
+                        ],
+                        "platformVersion": "1.4.0",
+                        "platformFamily": "Linux",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": [
+                                    "subnet-0b829c7f54fd00883",
+                                    "subnet-0d92e88c50ab9adac",
+                                    "subnet-0e26958394c1a4fc7"
+                                ],
+                                "securityGroups": [
+                                    "sg-037c67c516127610d",
+                                    "sg-03067d2f64ae975d8",
+                                    "sg-04e2c7d46a6745f0c"
+                                ],
+                                "assignPublicIp": "ENABLED"
+                            }
+                        },
+                        "rolloutState": "COMPLETED",
+                        "rolloutStateReason": "ECS deployment ecs-svc/5377507045281168538 completed."
+                    }
+                ],
+                "roleArn": "arn:aws:iam::644160558196:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+                "events": [],
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2022,
+                    "month": 5,
+                    "day": 24,
+                    "hour": 14,
+                    "minute": 46,
+                    "second": 50,
+                    "microsecond": 746000
+                },
+                "placementConstraints": [],
+                "placementStrategy": [],
+                "networkConfiguration": {
+                    "awsvpcConfiguration": {
+                        "subnets": [
+                            "subnet-0b829c7f54fd00883",
+                            "subnet-0d92e88c50ab9adac",
+                            "subnet-0e26958394c1a4fc7"
+                        ],
+                        "securityGroups": [
+                            "sg-037c67c516127610d",
+                            "sg-03067d2f64ae975d8",
+                            "sg-04e2c7d46a6745f0c"
+                        ],
+                        "assignPublicIp": "ENABLED"
+                    }
+                },
+                "healthCheckGracePeriodSeconds": 0,
+                "schedulingStrategy": "REPLICA",
+                "deploymentController": {
+                    "type": "ECS"
+                },
+                "createdBy": "arn:aws:iam::644160558196:role/stacklet-deployer",
+                "enableECSManagedTags": true,
+                "propagateTags": "SERVICE",
+                "enableExecuteCommand": false
+            }
+        ],
+        "failures": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeTaskDefinition_1.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeTaskDefinition_1.json
@@ -1,0 +1,217 @@
+{
+    "status_code": 200,
+    "data": {
+        "taskDefinition": {
+            "taskDefinitionArn": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:75",
+            "containerDefinitions": [
+                {
+                    "name": "server",
+                    "image": "644160558196.dkr.ecr.us-east-1.amazonaws.com/stacklet-redash:842a0206d43c0eb4a69cb31d6debdb52a46cb9e7-9d442028dba0f2e9f6a1bc17aba20c73591810a4",
+                    "cpu": 1024,
+                    "memory": 2048,
+                    "links": [],
+                    "portMappings": [
+                        {
+                            "containerPort": 5000,
+                            "hostPort": 5000,
+                            "protocol": "tcp"
+                        }
+                    ],
+                    "essential": true,
+                    "entryPoint": [],
+                    "command": [
+                        "server"
+                    ],
+                    "environment": [
+                        {
+                            "name": "REDASH_RATELIMIT_ENABLED",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_WEB_WORKERS",
+                            "value": "2"
+                        },
+                        {
+                            "name": "REDASH_LOG_LEVEL",
+                            "value": "DEBUG"
+                        },
+                        {
+                            "name": "REDASH_REDIS_URI",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_MAIL_SERVER",
+                            "value": "localhost"
+                        },
+                        {
+                            "name": "REDASH_MAIL_USE_SSL",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_LOGIN_ENABLED",
+                            "value": "true"
+                        },
+                        {
+                            "name": "ASSETDB_DATABASE_URI",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_CORS_ACCESS_CONTROL_ALLOW_ORIGIN",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_DISABLE_PUBLIC_URLS",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_AUTH_ISSUER",
+                            "value": ""
+                        },
+                        {
+                            "name": "PYTHONUNBUFFERED",
+                            "value": "0"
+                        },
+                        {
+                            "name": "AWS_PARTITION",
+                            "value": "aws"
+                        },
+                        {
+                            "name": "REDASH_MAIL_USERNAME",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_JWT_AUTH_PUBLIC_CERTS_URL",
+                            "value": ""
+                        },
+                        {
+                            "name": "SQLALCHEMY_DB_SCHEMA",
+                            "value": "redash"
+                        },
+                        {
+                            "name": "REDASH_MAIL_PASSWORD",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_MAIL_USE_TLS",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_AUTH_COOKIE_NAME",
+                            "value": "stacklet-auth"
+                        },
+                        {
+                            "name": "REDASH_MAIL_PORT",
+                            "value": "25"
+                        },
+                        {
+                            "name": "REDASH_MAIL_DEFAULT_SENDER",
+                            "value": ""
+                        }
+                    ],
+                    "mountPoints": [],
+                    "volumesFrom": [],
+                    "linuxParameters": {
+                        "capabilities": {},
+                        "devices": []
+                    },
+                    "secrets": [
+                        {
+                            "name": "REDASH_COOKIE_SECRET",
+                            "valueFrom": "arn:aws:ssm:us-east-2:644160558196:parameter/dev/redash/cookie_secret"
+                        },
+                        {
+                            "name": "REDASH_SECRET_KEY",
+                            "valueFrom": "arn:aws:ssm:us-east-2:644160558196:parameter/dev/redash/secret"
+                        }
+                    ],
+                    "privileged": false,
+                    "readonlyRootFilesystem": false,
+                    "dnsServers": [],
+                    "dnsSearchDomains": [],
+                    "extraHosts": [],
+                    "dockerSecurityOptions": [],
+                    "pseudoTerminal": false,
+                    "logConfiguration": {
+                        "logDriver": "awslogs",
+                        "options": {
+                            "awslogs-group": "/fargate/tasks/dev-redash-server",
+                            "awslogs-region": "us-east-2",
+                            "awslogs-stream-prefix": "fargate"
+                        }
+                    }
+                }
+            ],
+            "family": "dev-redash-server",
+            "taskRoleArn": "arn:aws:iam::644160558196:role/dev-redash",
+            "executionRoleArn": "arn:aws:iam::644160558196:role/dev-redash",
+            "networkMode": "awsvpc",
+            "revision": 75,
+            "volumes": [],
+            "status": "ACTIVE",
+            "requiresAttributes": [
+                {
+                    "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+                },
+                {
+                    "name": "ecs.capability.execution-role-awslogs"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.ecr-auth"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.task-iam-role"
+                },
+                {
+                    "name": "ecs.capability.execution-role-ecr-pull"
+                },
+                {
+                    "name": "ecs.capability.secrets.ssm.environment-variables"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+                },
+                {
+                    "name": "ecs.capability.task-eni"
+                }
+            ],
+            "placementConstraints": [],
+            "compatibilities": [
+                "EC2",
+                "FARGATE"
+            ],
+            "requiresCompatibilities": [
+                "FARGATE"
+            ],
+            "cpu": "1024",
+            "memory": "2048",
+            "registeredAt": {
+                "__class__": "datetime",
+                "year": 2024,
+                "month": 1,
+                "day": 26,
+                "hour": 15,
+                "minute": 17,
+                "second": 13,
+                "microsecond": 7000
+            },
+            "registeredBy": "arn:aws:sts::644160558196:assumed-role/stacklet-deployer/atlantis-terraform"
+        },
+        "tags": [
+            {
+                "key": "App",
+                "value": "Redash"
+            },
+            {
+                "key": "stacklet:app",
+                "value": "redash"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeTaskDefinition_2.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeTaskDefinition_2.json
@@ -1,0 +1,200 @@
+{
+    "status_code": 200,
+    "data": {
+        "taskDefinition": {
+            "taskDefinitionArn": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:75",
+            "containerDefinitions": [
+                {
+                    "name": "server",
+                    "image": "644160558196.dkr.ecr.us-east-1.amazonaws.com/stacklet-redash:842a0206d43c0eb4a69cb31d6debdb52a46cb9e7-9d442028dba0f2e9f6a1bc17aba20c73591810a4",
+                    "cpu": 1024,
+                    "memory": 2048,
+                    "links": [],
+                    "portMappings": [
+                        {
+                            "containerPort": 5000,
+                            "hostPort": 5000,
+                            "protocol": "tcp"
+                        }
+                    ],
+                    "essential": true,
+                    "entryPoint": [],
+                    "command": [
+                        "server"
+                    ],
+                    "environment": [
+                        {
+                            "name": "REDASH_RATELIMIT_ENABLED",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_WEB_WORKERS",
+                            "value": "2"
+                        },
+                        {
+                            "name": "REDASH_LOG_LEVEL",
+                            "value": "DEBUG"
+                        },
+                        {
+                            "name": "REDASH_REDIS_URI",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_MAIL_SERVER",
+                            "value": "localhost"
+                        },
+                        {
+                            "name": "REDASH_MAIL_USE_SSL",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_LOGIN_ENABLED",
+                            "value": "true"
+                        },
+                        {
+                            "name": "ASSETDB_DATABASE_URI",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_CORS_ACCESS_CONTROL_ALLOW_ORIGIN",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_DISABLE_PUBLIC_URLS",
+                            "value": "false"
+                        },
+                        {
+                            "name": "PYTHONUNBUFFERED",
+                            "value": "0"
+                        },
+                        {
+                            "name": "AWS_PARTITION",
+                            "value": "aws"
+                        },
+                        {
+                            "name": "REDASH_MAIL_USERNAME",
+                            "value": ""
+                        },
+                        {
+                            "name": "SQLALCHEMY_DB_SCHEMA",
+                            "value": "redash"
+                        },
+                        {
+                            "name": "REDASH_MAIL_PASSWORD",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_MAIL_USE_TLS",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_AUTH_COOKIE_NAME",
+                            "value": "stacklet-auth"
+                        },
+                        {
+                            "name": "REDASH_MAIL_PORT",
+                            "value": "25"
+                        },
+                        {
+                            "name": "REDASH_MAIL_DEFAULT_SENDER",
+                            "value": ""
+                        }
+                    ],
+                    "mountPoints": [],
+                    "volumesFrom": [],
+                    "linuxParameters": {
+                        "capabilities": {},
+                        "devices": []
+                    },
+                    "secrets": [
+                        {
+                            "name": "REDASH_COOKIE_SECRET",
+                            "valueFrom": "arn:aws:ssm:us-east-2:644160558196:parameter/dev/redash/cookie_secret"
+                        },
+                        {
+                            "name": "REDASH_SECRET_KEY",
+                            "valueFrom": "arn:aws:ssm:us-east-2:644160558196:parameter/dev/redash/secret"
+                        }
+                    ],
+                    "privileged": false,
+                    "readonlyRootFilesystem": false,
+                    "dnsServers": [],
+                    "dnsSearchDomains": [],
+                    "extraHosts": [],
+                    "dockerSecurityOptions": [],
+                    "pseudoTerminal": false,
+                    "logConfiguration": {
+                        "logDriver": "awslogs",
+                        "options": {
+                            "awslogs-group": "/fargate/tasks/dev-redash-server",
+                            "awslogs-region": "us-east-2",
+                            "awslogs-stream-prefix": "fargate"
+                        }
+                    }
+                }
+            ],
+            "family": "dev-redash-server",
+            "taskRoleArn": "arn:aws:iam::644160558196:role/dev-redash",
+            "executionRoleArn": "arn:aws:iam::644160558196:role/dev-redash",
+            "networkMode": "awsvpc",
+            "revision": 75,
+            "volumes": [],
+            "status": "ACTIVE",
+            "requiresAttributes": [
+                {
+                    "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+                },
+                {
+                    "name": "ecs.capability.execution-role-awslogs"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.ecr-auth"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.task-iam-role"
+                },
+                {
+                    "name": "ecs.capability.execution-role-ecr-pull"
+                },
+                {
+                    "name": "ecs.capability.secrets.ssm.environment-variables"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+                },
+                {
+                    "name": "ecs.capability.task-eni"
+                }
+            ],
+            "placementConstraints": [],
+            "compatibilities": [
+                "EC2",
+                "FARGATE"
+            ],
+            "requiresCompatibilities": [
+                "FARGATE"
+            ],
+            "cpu": "1024",
+            "memory": "2048",
+            "registeredAt": {
+                "__class__": "datetime",
+                "year": 2024,
+                "month": 1,
+                "day": 26,
+                "hour": 15,
+                "minute": 17,
+                "second": 13,
+                "microsecond": 7000
+            },
+            "registeredBy": "arn:aws:sts::644160558196:assumed-role/stacklet-deployer/atlantis-terraform"
+        },
+        "tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeTaskDefinition_3.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.DescribeTaskDefinition_3.json
@@ -1,0 +1,201 @@
+{
+    "status_code": 200,
+    "data": {
+        "taskDefinition": {
+            "taskDefinitionArn": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:77",
+            "containerDefinitions": [
+                {
+                    "name": "server",
+                    "image": "644160558196.dkr.ecr.us-east-1.amazonaws.com/stacklet-redash:842a0206d43c0eb4a69cb31d6debdb52a46cb9e7-9d442028dba0f2e9f6a1bc17aba20c73591810a4",
+                    "cpu": 512,
+                    "memory": 1024,
+                    "links": [],
+                    "portMappings": [
+                        {
+                            "containerPort": 5000,
+                            "hostPort": 5000,
+                            "protocol": "tcp"
+                        }
+                    ],
+                    "essential": true,
+                    "entryPoint": [],
+                    "command": [
+                        "server"
+                    ],
+                    "environment": [
+                        {
+                            "name": "REDASH_RATELIMIT_ENABLED",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_WEB_WORKERS",
+                            "value": "2"
+                        },
+                        {
+                            "name": "REDASH_LOG_LEVEL",
+                            "value": "DEBUG"
+                        },
+                        {
+                            "name": "REDASH_REDIS_URI",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_MAIL_SERVER",
+                            "value": "localhost"
+                        },
+                        {
+                            "name": "REDASH_MAIL_USE_SSL",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_LOGIN_ENABLED",
+                            "value": "true"
+                        },
+                        {
+                            "name": "ASSETDB_DATABASE_URI",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_CORS_ACCESS_CONTROL_ALLOW_ORIGIN",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_DISABLE_PUBLIC_URLS",
+                            "value": "false"
+                        },
+                        {
+                            "name": "PYTHONUNBUFFERED",
+                            "value": "0"
+                        },
+                        {
+                            "name": "AWS_PARTITION",
+                            "value": "aws"
+                        },
+                        {
+                            "name": "REDASH_MAIL_USERNAME",
+                            "value": ""
+                        },
+                        {
+                            "name": "SQLALCHEMY_DB_SCHEMA",
+                            "value": "redash"
+                        },
+                        {
+                            "name": "REDASH_MAIL_PASSWORD",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_MAIL_USE_TLS",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_AUTH_COOKIE_NAME",
+                            "value": "stacklet-auth"
+                        },
+                        {
+                            "name": "REDASH_MAIL_PORT",
+                            "value": "25"
+                        },
+                        {
+                            "name": "REDASH_MAIL_DEFAULT_SENDER",
+                            "value": ""
+                        }
+                    ],
+                    "mountPoints": [],
+                    "volumesFrom": [],
+                    "linuxParameters": {
+                        "capabilities": {},
+                        "devices": []
+                    },
+                    "secrets": [
+                        {
+                            "name": "REDASH_COOKIE_SECRET",
+                            "valueFrom": "arn:aws:ssm:us-east-2:644160558196:parameter/dev/redash/cookie_secret"
+                        },
+                        {
+                            "name": "REDASH_SECRET_KEY",
+                            "valueFrom": "arn:aws:ssm:us-east-2:644160558196:parameter/dev/redash/secret"
+                        }
+                    ],
+                    "privileged": false,
+                    "readonlyRootFilesystem": false,
+                    "dnsServers": [],
+                    "dnsSearchDomains": [],
+                    "extraHosts": [],
+                    "dockerSecurityOptions": [],
+                    "pseudoTerminal": false,
+                    "logConfiguration": {
+                        "logDriver": "awslogs",
+                        "options": {
+                            "awslogs-group": "/fargate/tasks/dev-redash-server",
+                            "awslogs-region": "us-east-2",
+                            "awslogs-stream-prefix": "fargate"
+                        }
+                    }
+                }
+            ],
+            "family": "dev-redash-server",
+            "taskRoleArn": "arn:aws:iam::644160558196:role/dev-redash",
+            "executionRoleArn": "arn:aws:iam::644160558196:role/dev-redash",
+            "networkMode": "awsvpc",
+            "revision": 77,
+            "volumes": [],
+            "status": "ACTIVE",
+            "requiresAttributes": [
+                {
+                    "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+                },
+                {
+                    "name": "ecs.capability.execution-role-awslogs"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.ecr-auth"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.task-iam-role"
+                },
+                {
+                    "name": "ecs.capability.execution-role-ecr-pull"
+                },
+                {
+                    "name": "ecs.capability.secrets.ssm.environment-variables"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+                },
+                {
+                    "name": "ecs.capability.task-eni"
+                }
+            ],
+            "placementConstraints": [],
+            "compatibilities": [
+                "EC2",
+                "FARGATE"
+            ],
+            "requiresCompatibilities": [
+                "EC2",
+                "FARGATE"
+            ],
+            "cpu": "512",
+            "memory": "1024",
+            "registeredAt": {
+                "__class__": "datetime",
+                "year": 2024,
+                "month": 2,
+                "day": 12,
+                "hour": 12,
+                "minute": 44,
+                "second": 57,
+                "microsecond": 431000
+            },
+            "registeredBy": "arn:aws:sts::644160558196:assumed-role/AWSReservedSSO_AWSAdministratorAccess_03c47de3f7d38dd9/kapil@stacklet.io"
+        },
+        "tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.ListClusters_1.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.ListClusters_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "clusterArns": [
+            "arn:aws:ecs:us-east-2:644160558196:cluster/dev-redash"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.ListServices_1.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.ListServices_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "serviceArns": [
+            "arn:aws:ecs:us-east-2:644160558196:service/dev-redash/redash-worker",
+            "arn:aws:ecs:us-east-2:644160558196:service/dev-redash/redash-server",
+            "arn:aws:ecs:us-east-2:644160558196:service/dev-redash/redash-scheduled-worker"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.RegisterTaskDefinition_1.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.RegisterTaskDefinition_1.json
@@ -1,0 +1,210 @@
+{
+    "status_code": 200,
+    "data": {
+        "taskDefinition": {
+            "taskDefinitionArn": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:77",
+            "containerDefinitions": [
+                {
+                    "name": "server",
+                    "image": "644160558196.dkr.ecr.us-east-1.amazonaws.com/stacklet-redash:842a0206d43c0eb4a69cb31d6debdb52a46cb9e7-9d442028dba0f2e9f6a1bc17aba20c73591810a4",
+                    "cpu": 512,
+                    "memory": 1024,
+                    "links": [],
+                    "portMappings": [
+                        {
+                            "containerPort": 5000,
+                            "hostPort": 5000,
+                            "protocol": "tcp"
+                        }
+                    ],
+                    "essential": true,
+                    "entryPoint": [],
+                    "command": [
+                        "server"
+                    ],
+                    "environment": [
+                        {
+                            "name": "REDASH_RATELIMIT_ENABLED",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_WEB_WORKERS",
+                            "value": "2"
+                        },
+                        {
+                            "name": "REDASH_LOG_LEVEL",
+                            "value": "DEBUG"
+                        },
+                        {
+                            "name": "REDASH_REDIS_URI",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_MAIL_SERVER",
+                            "value": "localhost"
+                        },
+                        {
+                            "name": "REDASH_MAIL_USE_SSL",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_LOGIN_ENABLED",
+                            "value": "true"
+                        },
+                        {
+                            "name": "ASSETDB_DATABASE_URI",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_CORS_ACCESS_CONTROL_ALLOW_ORIGIN",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_DISABLE_PUBLIC_URLS",
+                            "value": "false"
+                        },
+                        {
+                            "name": "PYTHONUNBUFFERED",
+                            "value": "0"
+                        },
+                        {
+                            "name": "AWS_PARTITION",
+                            "value": "aws"
+                        },
+                        {
+                            "name": "REDASH_MAIL_USERNAME",
+                            "value": ""
+                        },
+                        {
+                            "name": "SQLALCHEMY_DB_SCHEMA",
+                            "value": "redash"
+                        },
+                        {
+                            "name": "REDASH_MAIL_PASSWORD",
+                            "value": ""
+                        },
+                        {
+                            "name": "REDASH_MAIL_USE_TLS",
+                            "value": "false"
+                        },
+                        {
+                            "name": "REDASH_JWT_AUTH_COOKIE_NAME",
+                            "value": "stacklet-auth"
+                        },
+                        {
+                            "name": "REDASH_MAIL_PORT",
+                            "value": "25"
+                        },
+                        {
+                            "name": "REDASH_MAIL_DEFAULT_SENDER",
+                            "value": ""
+                        }
+                    ],
+                    "mountPoints": [],
+                    "volumesFrom": [],
+                    "linuxParameters": {
+                        "capabilities": {},
+                        "devices": []
+                    },
+                    "secrets": [
+                        {
+                            "name": "REDASH_COOKIE_SECRET",
+                            "valueFrom": "arn:aws:ssm:us-east-2:644160558196:parameter/dev/redash/cookie_secret"
+                        },
+                        {
+                            "name": "REDASH_SECRET_KEY",
+                            "valueFrom": "arn:aws:ssm:us-east-2:644160558196:parameter/dev/redash/secret"
+                        }
+                    ],
+                    "privileged": false,
+                    "readonlyRootFilesystem": false,
+                    "dnsServers": [],
+                    "dnsSearchDomains": [],
+                    "extraHosts": [],
+                    "dockerSecurityOptions": [],
+                    "pseudoTerminal": false,
+                    "logConfiguration": {
+                        "logDriver": "awslogs",
+                        "options": {
+                            "awslogs-group": "/fargate/tasks/dev-redash-server",
+                            "awslogs-region": "us-east-2",
+                            "awslogs-stream-prefix": "fargate"
+                        }
+                    }
+                }
+            ],
+            "family": "dev-redash-server",
+            "taskRoleArn": "arn:aws:iam::644160558196:role/dev-redash",
+            "executionRoleArn": "arn:aws:iam::644160558196:role/dev-redash",
+            "networkMode": "awsvpc",
+            "revision": 77,
+            "volumes": [],
+            "status": "ACTIVE",
+            "requiresAttributes": [
+                {
+                    "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+                },
+                {
+                    "name": "ecs.capability.execution-role-awslogs"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.ecr-auth"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.task-iam-role"
+                },
+                {
+                    "name": "ecs.capability.execution-role-ecr-pull"
+                },
+                {
+                    "name": "ecs.capability.secrets.ssm.environment-variables"
+                },
+                {
+                    "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+                },
+                {
+                    "name": "ecs.capability.task-eni"
+                }
+            ],
+            "placementConstraints": [],
+            "compatibilities": [
+                "EC2",
+                "FARGATE"
+            ],
+            "requiresCompatibilities": [
+                "EC2",
+                "FARGATE"
+            ],
+            "cpu": "512",
+            "memory": "1024",
+            "registeredAt": {
+                "__class__": "datetime",
+                "year": 2024,
+                "month": 2,
+                "day": 12,
+                "hour": 12,
+                "minute": 44,
+                "second": 57,
+                "microsecond": 431000
+            },
+            "registeredBy": "arn:aws:sts::644160558196:assumed-role/AWSReservedSSO_AWSAdministratorAccess_03c47de3f7d38dd9/kapil@stacklet.io"
+        },
+        "tags": [
+            {
+                "key": "App",
+                "value": "Redash"
+            },
+            {
+                "key": "stacklet:app",
+                "value": "redash"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_service_update_definition/ecs.UpdateService_1.json
+++ b/tests/data/placebo/test_ecs_service_update_definition/ecs.UpdateService_1.json
@@ -1,0 +1,195 @@
+{
+    "status_code": 200,
+    "data": {
+        "service": {
+            "serviceArn": "arn:aws:ecs:us-east-2:644160558196:service/dev-redash/redash-server",
+            "serviceName": "redash-server",
+            "clusterArn": "arn:aws:ecs:us-east-2:644160558196:cluster/dev-redash",
+            "loadBalancers": [
+                {
+                    "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-2:644160558196:targetgroup/dev-redash/608e176bc37cd1d3",
+                    "containerName": "server",
+                    "containerPort": 5000
+                }
+            ],
+            "serviceRegistries": [
+                {
+                    "registryArn": "arn:aws:servicediscovery:us-east-2:644160558196:service/srv-bzzz6xsmtwv5uap7"
+                }
+            ],
+            "status": "ACTIVE",
+            "desiredCount": 1,
+            "runningCount": 1,
+            "pendingCount": 0,
+            "capacityProviderStrategy": [
+                {
+                    "capacityProvider": "FARGATE",
+                    "weight": 100,
+                    "base": 0
+                }
+            ],
+            "platformVersion": "LATEST",
+            "platformFamily": "Linux",
+            "taskDefinition": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:77",
+            "deploymentConfiguration": {
+                "deploymentCircuitBreaker": {
+                    "enable": false,
+                    "rollback": false
+                },
+                "maximumPercent": 200,
+                "minimumHealthyPercent": 100
+            },
+            "deployments": [
+                {
+                    "id": "ecs-svc/5219324069200109376",
+                    "status": "PRIMARY",
+                    "taskDefinition": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:77",
+                    "desiredCount": 0,
+                    "pendingCount": 0,
+                    "runningCount": 0,
+                    "failedTasks": 0,
+                    "createdAt": {
+                        "__class__": "datetime",
+                        "year": 2024,
+                        "month": 2,
+                        "day": 12,
+                        "hour": 12,
+                        "minute": 44,
+                        "second": 57,
+                        "microsecond": 956000
+                    },
+                    "updatedAt": {
+                        "__class__": "datetime",
+                        "year": 2024,
+                        "month": 2,
+                        "day": 12,
+                        "hour": 12,
+                        "minute": 44,
+                        "second": 57,
+                        "microsecond": 956000
+                    },
+                    "capacityProviderStrategy": [
+                        {
+                            "capacityProvider": "FARGATE",
+                            "weight": 100,
+                            "base": 0
+                        }
+                    ],
+                    "platformVersion": "1.4.0",
+                    "platformFamily": "Linux",
+                    "networkConfiguration": {
+                        "awsvpcConfiguration": {
+                            "subnets": [
+                                "subnet-0b829c7f54fd00883",
+                                "subnet-0d92e88c50ab9adac",
+                                "subnet-0e26958394c1a4fc7"
+                            ],
+                            "securityGroups": [
+                                "sg-037c67c516127610d",
+                                "sg-03067d2f64ae975d8",
+                                "sg-04e2c7d46a6745f0c"
+                            ],
+                            "assignPublicIp": "ENABLED"
+                        }
+                    },
+                    "rolloutState": "IN_PROGRESS",
+                    "rolloutStateReason": "ECS deployment ecs-svc/5219324069200109376 in progress."
+                },
+                {
+                    "id": "ecs-svc/5377507045281168538",
+                    "status": "ACTIVE",
+                    "taskDefinition": "arn:aws:ecs:us-east-2:644160558196:task-definition/dev-redash-server:75",
+                    "desiredCount": 1,
+                    "pendingCount": 0,
+                    "runningCount": 1,
+                    "failedTasks": 0,
+                    "createdAt": {
+                        "__class__": "datetime",
+                        "year": 2024,
+                        "month": 1,
+                        "day": 26,
+                        "hour": 15,
+                        "minute": 17,
+                        "second": 13,
+                        "microsecond": 482000
+                    },
+                    "updatedAt": {
+                        "__class__": "datetime",
+                        "year": 2024,
+                        "month": 1,
+                        "day": 26,
+                        "hour": 15,
+                        "minute": 20,
+                        "second": 13,
+                        "microsecond": 362000
+                    },
+                    "capacityProviderStrategy": [
+                        {
+                            "capacityProvider": "FARGATE",
+                            "weight": 100,
+                            "base": 0
+                        }
+                    ],
+                    "platformVersion": "1.4.0",
+                    "platformFamily": "Linux",
+                    "networkConfiguration": {
+                        "awsvpcConfiguration": {
+                            "subnets": [
+                                "subnet-0b829c7f54fd00883",
+                                "subnet-0d92e88c50ab9adac",
+                                "subnet-0e26958394c1a4fc7"
+                            ],
+                            "securityGroups": [
+                                "sg-037c67c516127610d",
+                                "sg-03067d2f64ae975d8",
+                                "sg-04e2c7d46a6745f0c"
+                            ],
+                            "assignPublicIp": "ENABLED"
+                        }
+                    },
+                    "rolloutState": "COMPLETED",
+                    "rolloutStateReason": "ECS deployment ecs-svc/5377507045281168538 completed."
+                }
+            ],
+            "roleArn": "arn:aws:iam::644160558196:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+            "events": [],
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2022,
+                "month": 5,
+                "day": 24,
+                "hour": 14,
+                "minute": 46,
+                "second": 50,
+                "microsecond": 746000
+            },
+            "placementConstraints": [],
+            "placementStrategy": [],
+            "networkConfiguration": {
+                "awsvpcConfiguration": {
+                    "subnets": [
+                        "subnet-0b829c7f54fd00883",
+                        "subnet-0d92e88c50ab9adac",
+                        "subnet-0e26958394c1a4fc7"
+                    ],
+                    "securityGroups": [
+                        "sg-037c67c516127610d",
+                        "sg-03067d2f64ae975d8",
+                        "sg-04e2c7d46a6745f0c"
+                    ],
+                    "assignPublicIp": "ENABLED"
+                }
+            },
+            "healthCheckGracePeriodSeconds": 0,
+            "schedulingStrategy": "REPLICA",
+            "deploymentController": {
+                "type": "ECS"
+            },
+            "createdBy": "arn:aws:iam::644160558196:role/stacklet-deployer",
+            "enableECSManagedTags": true,
+            "propagateTags": "SERVICE",
+            "enableExecuteCommand": false
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_costhub.py
+++ b/tests/test_costhub.py
@@ -24,6 +24,7 @@ def test_cost_hub_ebs(test):
             ],
         },
         session_factory=factory,
+        config={'account_id': '644160558196'}
     )
 
     resources = p.run()

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -185,8 +185,10 @@ class TestEcsService(BaseTest):
             services=[service_name]
         )["services"][0]
 
-        rtask = client.describe_task_definition(taskDefinition=rservice['taskDefinition'])['taskDefinition']
-        ctask = client.describe_task_definition(taskDefinition=cservice['taskDefinition'])['taskDefinition']
+        rtask = client.describe_task_definition(
+            taskDefinition=rservice['taskDefinition'])['taskDefinition']
+        ctask = client.describe_task_definition(
+            taskDefinition=cservice['taskDefinition'])['taskDefinition']
 
         assert cservice['taskDefinition'] != rservice['taskDefinition']
         assert rtask['cpu'] != ctask['cpu']

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -7,6 +7,8 @@ import os
 import time
 
 from c7n.exceptions import PolicyExecutionError
+from c7n.resources.aws import Arn
+
 
 class TestEcs(BaseTest):
     def test_ecs_container_insights_enabled(self):
@@ -160,6 +162,35 @@ class TestEcsService(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertTrue("c7n.metrics" in resources[0])
+
+    def test_ecs_service_modify_definition(self):
+        factory = self.replay_flight_data("test_ecs_service_update_definition", region="us-east-2")
+        p = self.load_policy(
+            {"name": "update-definition",
+             "resource": "aws.ecs-service",
+             "filters": [
+                 {'serviceName': 'redash-server'},
+                 "cost-optimization"],
+             "actions": ["modify-definition"]},
+            config={"region": "us-east-2"},
+            session_factory=factory,
+        )
+        resources = p.run()
+        assert len(resources) == 1
+        rservice = resources.pop()
+        client = factory().client('ecs')
+        cluster, service_name = Arn.parse(rservice['serviceArn']).resource.split('/')
+        cservice = client.describe_services(
+            cluster=cluster,
+            services=[service_name]
+        )["services"][0]
+
+        rtask = client.describe_task_definition(taskDefinition=rservice['taskDefinition'])['taskDefinition']
+        ctask = client.describe_task_definition(taskDefinition=cservice['taskDefinition'])['taskDefinition']
+
+        assert cservice['taskDefinition'] != rservice['taskDefinition']
+        assert rtask['cpu'] != ctask['cpu']
+        assert rtask['memory'] != ctask['memory']
 
     def test_ecs_service_update(self):
         session_factory = self.replay_flight_data("test_ecs_service_update")


### PR DESCRIPTION


rounding out the update with resize support with builtin cost opt hub filtering support by adding ecs.

this one is a little more nuanced due to multiple services referencing the same task-def, current implementation
will end up with a separate task def revision per service. ideally we'd have a separate revision per attribute combo, tbd.

