### PR TITLE
aws - fix iam-role config resource ID

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -100,6 +100,7 @@ class Role(QueryResourceManager):
         enum_spec = ('list_roles', 'Roles', None)
         detail_spec = ('get_role', 'RoleName', 'RoleName', 'Role')
         id = name = 'RoleName'
+        config_id = 'RoleId'
         date = 'CreateDate'
         cfn_type = config_type = "AWS::IAM::Role"
         # Denotes this resource type exists across regions


### PR DESCRIPTION
This change uses the correct IAM Role config ID to fix the below config resource mapping error:

<img width="1101" alt="config-resource-error" src="https://github.com/cloud-custodian/cloud-custodian/assets/22411908/dca5e8b9-cee1-43d9-bafe-99aed0abbd31">

Similar previous PR: https://github.com/cloud-custodian/cloud-custodian/pull/9248