### PR TITLE
releng - ensure use of pypi for awscli install

### DIFF
--- a/.github/composites/docs-publish/action.yaml
+++ b/.github/composites/docs-publish/action.yaml
@@ -21,8 +21,7 @@ runs:
     - name: Install Deps
       shell: bash
       run: |
-        pip config --site unset global.index-url
-        pip install -U awscli
+        pip install -U awscli --index-url https://pypi.org/simple
 
     - name: Publish
       shell: bash


### PR DESCRIPTION
trunk merges have had an issue for  the last week, it wasn't as i initially thought a pip change, but an action cache invalidation that cause this to trigger.
use a safer option for ensuring we get awscli from our preferred location (pypi).

