### PR TITLE
aws - add cfn-stack-resource type and filter

### DIFF
--- a/c7n/filters/__init__.py
+++ b/c7n/filters/__init__.py
@@ -24,3 +24,4 @@ from .iamanalyzer import AccessAnalyzer
 from .metrics import MetricsFilter, ShieldMetrics
 # from .vpc import DefaultVpcBase
 from .waf import WafV2FilterBase, WafClassicRegionalFilterBase
+from .cfn import CloudFormationStackResourceFilter

--- a/c7n/filters/cfn.py
+++ b/c7n/filters/cfn.py
@@ -1,0 +1,32 @@
+from c7n.filters import ValueFilter
+from c7n.manager import resources
+from c7n.utils import type_schema
+
+
+class CloudFormationStackResourceFilter(ValueFilter):
+    annotation_key = "c7n:cfn-stack-resource"
+    schema = type_schema("cfn-stack-resource", rinherit=ValueFilter.schema)
+
+    def process(self, resources, event=None):
+        stack_resource_manager = self.manager.get_resource_manager("cfn-stack-resource")
+        stack_resources = {
+            (r["ResourceType"], r["PhysicalResourceId"]): r
+            for r in stack_resource_manager.resources()
+        }
+        results = []
+        for r in resources:
+            if self.annotation_key not in r:
+                r[self.annotation_key] = stack_resources.get(
+                    (self.manager.get_model().cfn_type, r[self.manager.get_model().id])
+                )
+            if self.match(r[self.annotation_key]):
+                results.append(r)
+        return results
+
+    @classmethod
+    def register_resources(klass, registry, resource_class):
+        if getattr(resource_class.resource_type, "cfn_type", None):
+            resource_class.filter_registry.register("cfn-stack-resource", klass)
+
+
+resources.subscribe(CloudFormationStackResourceFilter.register_resources)

--- a/c7n/resources/cfn.py
+++ b/c7n/resources/cfn.py
@@ -7,7 +7,7 @@ from concurrent.futures import as_completed
 
 from c7n.actions import BaseAction
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import ChildResourceManager, QueryResourceManager, TypeInfo
 from c7n.utils import local_session, type_schema
 from c7n.tags import RemoveTag, Tag
 
@@ -26,6 +26,18 @@ class CloudFormation(QueryResourceManager):
         name = 'StackName'
         date = 'CreationTime'
         cfn_type = config_type = 'AWS::CloudFormation::Stack'
+
+
+@resources.register('cfn-stack-resource')
+class CloudFormationStackResource(ChildResourceManager):
+    permissions = ('cloudformation:DescribeStackResources',)
+
+    class resource_type(TypeInfo):
+        service = 'cloudformation'
+        parent_spec = ('cfn', 'StackName', None)
+        enum_spec = ('describe_stack_resources', 'StackResources', None)
+        name = id = 'PhysicalResourceId'
+        arn = False
 
 
 @CloudFormation.action_registry.register('delete')

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -37,6 +37,7 @@ ResourceMap = {
   "aws.catalog-portfolio": "c7n.resources.servicecatalog.CatalogPortfolio",
   "aws.catalog-product": "c7n.resources.servicecatalog.CatalogProduct",
   "aws.cfn": "c7n.resources.cfn.CloudFormation",
+  "aws.cfn-stack-resource": "c7n.resources.cfn.CloudFormationStackResource",
   "aws.cloud-directory": "c7n.resources.directory.CloudDirectory",
   "aws.cloudhsm-cluster": "c7n.resources.hsm.CloudHSMCluster",
   "aws.cloudsearch": "c7n.resources.cloudsearch.CloudSearch",


### PR DESCRIPTION
Add a `aws.cfn-stack-resource` resource type to list resources deployed as part of CloudFormation stacks.

For any resource type with a `cfn_type` defined, also register a `cfn-stack-resource` filter to match against a resource's CloudFormation stack properties.