### PR TITLE
shift-left - handle a null tag map on a resource

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -251,7 +251,7 @@ class BaseValueFilter(Filter):
             # as labels without values.
             # Azure schema: 'tags': {'key': 'value'}
             elif 'tags' in i:
-                r = i.get('tags', {}).get(tk, None)
+                r = (i.get('tags', {}) or {}).get(tk, None)
         elif k in i:
             r = i.get(k)
         elif k not in self.expr:

--- a/tools/c7n_left/c7n_left/core.py
+++ b/tools/c7n_left/c7n_left/core.py
@@ -10,7 +10,7 @@ import os
 from c7n.actions import ActionRegistry
 from c7n.cache import NullCache
 from c7n.config import Config
-from c7n.filters import FilterRegistry
+from c7n.filters import FilterRegistry, ValueFilter
 from c7n.manager import ResourceManager
 
 from c7n.provider import Provider, clouds
@@ -336,8 +336,18 @@ class PolicyResourceResult:
         }
 
 
+class LeftValueFilter(ValueFilter):
+    def get_resource_value(self, k, i, regex=None):
+        if k.startswith('tag:') and 'tags' in i:
+            tk = k.split(':', 1)[1]
+            r = (i.get('tags', {}) or {}).get(tk)
+            return r
+        return super().get_resource_value(k, i, regex)
+
+
 class IACResourceManager(ResourceManager):
     filter_registry = FilterRegistry("iac.filters")
+    filter_registry.register('value', LeftValueFilter)
     action_registry = ActionRegistry("iac.actions")
     log = log
 

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "c7n_left"
-version = "0.3.14"
+version = "0.3.15"
 description = "Custodian policies for IAAC definitions"
 authors = ["Cloud Custodian Project"]
 license = "Apache-2"

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -621,6 +621,32 @@ def test_graph_merge_function(policy_env):
     assert log_group["tags"] == {"Env": "Public", "Component": "application"}
 
 
+def test_null_tag_value(policy_env):
+    policy_env.write_tf(
+        """
+        variable app_tags {
+          type = map(string)
+        }
+        resource "aws_instance" "app" {
+          ami = "ami-123"
+          instance_type = "t4.medium"
+          tags = var.app_tags
+        }
+        """
+    )
+
+    policy_env.write_policy(
+        {
+            "name": "check-null-tags",
+            "resource": "terraform.aws_instance",
+            "filters": [{"tag:Env": "absent"}],
+        }
+    )
+
+    results = policy_env.run()
+    assert len(results) == 1
+
+
 def test_traverse_to_data(policy_env):
     policy_env.write_tf(
         """


### PR DESCRIPTION


with terraform resources and variables without a value or default, we can get a null value for tags, handle
that with appropriate default. 

the fix is applied in c7n value filter, and a separate subclass for c7n left to allow for the later to have an interim release.


