### PR TITLE
releng - pin freeze wheel to previous release due to error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build Wheels
         shell: bash
         run: |
-          poetry self add poetry-plugin-freeze
+          poetry self add poetry-plugin-freeze==1.0.5
           pip install twine
           make pkg-build-wheel
 


### PR DESCRIPTION

using 1.0.6 gets an error during artifact generation

poetry freeze-wheel
freezing wheels
Preparing build environment with build-system requirements poetry-core>=1.0.0, boto3
Dependency walk failed at urllib3 (>=1.25.4,<1.27)
make: *** [Makefile:125: pkg-build-wheel] Error 1

