### PR TITLE
aws - account - switch to describe source

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -19,7 +19,7 @@ from c7n.filters.multiattr import MultiAttrFilter
 from c7n.filters.missing import Missing
 from c7n.manager import ResourceManager, resources
 from c7n.utils import local_session, type_schema, generate_arn, get_support_region, jmespath_search
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import QueryResourceManager, TypeInfo, DescribeSource
 from c7n.filters import ListItemFilter
 
 from c7n.resources.iam import CredentialReport
@@ -34,18 +34,27 @@ retry = staticmethod(QueryResourceManager.retry)
 filters.register('missing', Missing)
 
 
-def get_account(session_factory, config):
-    session = local_session(session_factory)
-    client = session.client('iam')
-    aliases = client.list_account_aliases().get(
-        'AccountAliases', ('',))
-    name = aliases and aliases[0] or ""
-    return {'account_id': config.account_id,
-            'account_name': name}
+class DescribeAccount(DescribeSource):
+
+    def get_account(self):
+        client = local_session(self.manager.session_factory).client("iam")
+        aliases = client.list_account_aliases().get(
+            'AccountAliases', ('',))
+        name = aliases and aliases[0] or ""
+        return {'account_id': self.manager.config.account_id,
+                'account_name': name}
+
+    def resources(self, query=None):
+        if query is None:
+            query = {}
+        return [self.get_account()]
+
+    def get_resources(self, resource_ids):
+        return [self.get_account()]
 
 
 @resources.register('account')
-class Account(ResourceManager):
+class Account(QueryResourceManager):
 
     filter_registry = filters
     action_registry = actions
@@ -62,6 +71,10 @@ class Account(ResourceManager):
         # for posting config rule evaluations
         cfn_type = 'AWS::::Account'
 
+    source_mapping = {
+        'describe': DescribeAccount
+    }
+
     @classmethod
     def get_permissions(cls):
         return ('iam:ListAccountAliases',)
@@ -72,15 +85,6 @@ class Account(ResourceManager):
 
     def get_arns(self, resources):
         return ["arn:::{account_id}".format(**r) for r in resources]
-
-    def get_model(self):
-        return self.resource_type
-
-    def resources(self):
-        return self.filter_resources([get_account(self.session_factory, self.config)])
-
-    def get_resources(self, resource_ids):
-        return [get_account(self.session_factory, self.config)]
 
 
 @filters.register('credential')

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -45,8 +45,6 @@ class DescribeAccount(DescribeSource):
                 'account_name': name}
 
     def resources(self, query=None):
-        if query is None:
-            query = {}
         return [self.get_account()]
 
     def get_resources(self, resource_ids):

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -17,7 +17,7 @@ from c7n.filters import Filter, FilterRegistry, ValueFilter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.filters.multiattr import MultiAttrFilter
 from c7n.filters.missing import Missing
-from c7n.manager import ResourceManager, resources
+from c7n.manager import resources
 from c7n.utils import local_session, type_schema, generate_arn, get_support_region, jmespath_search
 from c7n.query import QueryResourceManager, TypeInfo, DescribeSource
 from c7n.filters import ListItemFilter

--- a/tests/data/placebo/test_account_ebs_encrypt/ec2.EnableEbsEncryptionByDefault_1.json
+++ b/tests/data/placebo/test_account_ebs_encrypt/ec2.EnableEbsEncryptionByDefault_1.json
@@ -2,17 +2,6 @@
     "status_code": 200,
     "data": {
         "EbsEncryptionByDefault": true,
-        "ResponseMetadata": {
-            "RequestId": "d04acedd-1728-4117-afcb-ef5eb113382e",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "content-type": "text/xml;charset=UTF-8",
-                "transfer-encoding": "chunked",
-                "vary": "accept-encoding",
-                "date": "Wed, 10 Jul 2019 09:52:25 GMT",
-                "server": "AmazonEC2"
-            },
-            "RetryAttempts": 0
-        }
+        "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/test_account_ebs_encrypt/ec2.GetEbsEncryptionByDefault_1.json
+++ b/tests/data/placebo/test_account_ebs_encrypt/ec2.GetEbsEncryptionByDefault_1.json
@@ -2,17 +2,6 @@
     "status_code": 200,
     "data": {
         "EbsEncryptionByDefault": false,
-        "ResponseMetadata": {
-            "RequestId": "2dd77269-7c0c-453d-86d8-d12d9bba0b6e",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "content-type": "text/xml;charset=UTF-8",
-                "transfer-encoding": "chunked",
-                "vary": "accept-encoding",
-                "date": "Wed, 10 Jul 2019 09:52:26 GMT",
-                "server": "AmazonEC2"
-            },
-            "RetryAttempts": 0
-        }
+        "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/test_account_ebs_encrypt/ec2.GetEbsEncryptionByDefault_2.json
+++ b/tests/data/placebo/test_account_ebs_encrypt/ec2.GetEbsEncryptionByDefault_2.json
@@ -2,17 +2,6 @@
     "status_code": 200,
     "data": {
         "EbsEncryptionByDefault": true,
-        "ResponseMetadata": {
-            "RequestId": "3fab0909-ac4b-43c2-b789-4bc896e31d41",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "content-type": "text/xml;charset=UTF-8",
-                "transfer-encoding": "chunked",
-                "vary": "accept-encoding",
-                "date": "Wed, 10 Jul 2019 09:52:26 GMT",
-                "server": "AmazonEC2"
-            },
-            "RetryAttempts": 0
-        }
+        "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/test_account_ebs_encrypt/ec2.ModifyEbsDefaultKmsKeyId_1.json
+++ b/tests/data/placebo/test_account_ebs_encrypt/ec2.ModifyEbsDefaultKmsKeyId_1.json
@@ -2,17 +2,6 @@
     "status_code": 200,
     "data": {
         "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/798bc4bb-3079-4a9a-bc27-2c7f2b6c91d0",
-        "ResponseMetadata": {
-            "RequestId": "d2864716-fa98-48e1-ad4c-67c60466f1ac",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "content-type": "text/xml;charset=UTF-8",
-                "transfer-encoding": "chunked",
-                "vary": "accept-encoding",
-                "date": "Wed, 10 Jul 2019 09:52:25 GMT",
-                "server": "AmazonEC2"
-            },
-            "RetryAttempts": 0
-        }
+        "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/test_account_ebs_encrypt/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_ebs_encrypt/iam.ListAccountAliases_1.json
@@ -5,16 +5,6 @@
             "custodian-skunk-works"
         ],
         "IsTruncated": false,
-        "ResponseMetadata": {
-            "RequestId": "6c3b37b7-a2f8-11e9-932d-4b50a97db49e",
-            "HTTPStatusCode": 200,
-            "HTTPHeaders": {
-                "x-amzn-requestid": "6c3b37b7-a2f8-11e9-932d-4b50a97db49e",
-                "content-type": "text/xml",
-                "content-length": "400",
-                "date": "Wed, 10 Jul 2019 09:52:25 GMT"
-            },
-            "RetryAttempts": 0
-        }
+        "ResponseMetadata": {}
     }
 }


### PR DESCRIPTION
Closes: #9329 

This PR switches `resource: aws.account` to DescribeSource model to take advantage of caching. Also re-records a test to validate things are working as expected. 
When I ran tests locally, logs were showing this - `2024-03-06 14:38:55,406: custodian.resources.account:DEBUG Using cached c7n.resources.account.Account: 1`