### PR TITLE
doc: fix several minor typos and formatting

### DIFF
--- a/docs/source/gcp/gettingstarted.rst
+++ b/docs/source/gcp/gettingstarted.rst
@@ -26,7 +26,7 @@ Option 1: Install released packages to local Python Environment
 .. code-block:: bash
 
     pip install c7n
-    pip install c7n_gcp
+    pip install c7n-gcp
 
 
 Option 2: Install latest from the repository

--- a/docs/source/kubernetes/gettingstarted.rst
+++ b/docs/source/kubernetes/gettingstarted.rst
@@ -26,7 +26,7 @@ Option 1: Install released packages to local Python Environment
 .. code-block:: bash
 
     pip install c7n
-    pip install c7n_kube
+    pip install c7n-kube
 
 
 Option 2: Install latest from the repository

--- a/docs/source/oci/gettingstarted.rst
+++ b/docs/source/oci/gettingstarted.rst
@@ -27,7 +27,7 @@ Option 1: Install released packages to local Python Environment
 .. code-block:: bash
 
     pip install c7n
-    pip install c7n_oci
+    pip install c7n-oci
 
 
 Option 2: Install latest from the repository

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -48,16 +48,16 @@ To install Cloud Custodian::
 
 To install Cloud Custodian for Azure, you will also need to run::
 
-  pip install c7n_azure # Install Azure package
+  pip install c7n-azure # Install Azure package
 
 To install Cloud Custodian for GCP, you will also need to run::
 
-  pip install c7n_gcp   # Install GCP Package
+  pip install c7n-gcp   # Install GCP Package
 
 
 To install Cloud Custodian for Oracle Cloud Infrastructure (OCI), you will also need to run::
 
-    pip install c7n_oci # Install OCI Package
+    pip install c7n-oci # Install OCI Package
 
 Windows (CMD/PowerShell)
 +++++++++++++++++++++++++++
@@ -71,11 +71,11 @@ To install Cloud Custodian, run::
 
 To install Cloud Custodian for Azure, you will also need to run::
 
-  pip install c7n_azure
+  pip install c7n-azure
 
 To install Cloud Custodian for GCP, you will also need to run::
 
-  pip install c7n_gcp
+  pip install c7n-gcp
 
 Docker
 ++++++

--- a/tools/c7n_gcp/readme.md
+++ b/tools/c7n_gcp/readme.md
@@ -16,7 +16,7 @@ Status - Alpha
 ## via pip
 
 ```
-pip install c7n_gcp
+pip install c7n-gcp
 ```
 
 By default custodian will use credentials associated to the gcloud cli, which will generate

--- a/tools/c7n_left/README.md
+++ b/tools/c7n_left/README.md
@@ -13,7 +13,7 @@ We currently only support python > 3.10 on mac and linux, to run on windows
 we recommend using our docker images.
 
 ```shell
-pip install c7n_left
+pip install c7n-left
 ```
 
 We also provide signed docker images. These images are built on top of chainguard's [wolfi linux

--- a/tools/c7n_openstack/readme.md
+++ b/tools/c7n_openstack/readme.md
@@ -7,7 +7,7 @@ Work in Progress - Not Ready For Use.
 ### Installation
 
 ```
-pip install c7n_openstack
+pip install c7n-openstack
 ```
 
 ### OpenStack Environment Configration

--- a/tools/c7n_org/Dockerfile
+++ b/tools/c7n_org/Dockerfile
@@ -1,1 +1,1 @@
-../../docker/org
+../../docker/c7n-org

--- a/tools/c7n_tencentcloud/readme.md
+++ b/tools/c7n_tencentcloud/readme.md
@@ -7,7 +7,7 @@ a provider for cloud custodian for usage with Tencent Cloud.
 
 ```shell
 
-pip install c7n_tencentcloud
+pip install c7n-tencentcloud
 ```
 
 

--- a/tools/c7n_trailcreator/readme.md
+++ b/tools/c7n_trailcreator/readme.md
@@ -10,14 +10,14 @@ config file of the events and resources of interest is required.
 ## Install
 
 ```shell
-$ pip install c7n_trailcreator
+$ pip install c7n-trailcreator
 
 $ c7n-trailcreator --help
 ```
 
 ## Config File
 
-The config file format here is similiar to what custodian requires
+The config file format here is similar to what custodian requires
 for lambda policies on cloudtrail api events as an event selector.
 
 First for each resource, the custodian resource-type is required
@@ -25,7 +25,7 @@ to be specified, and then for each event, we need to know the
 name of the service, the event name, and a jmespath expression
 to get the resource ids.
 
-Here's a a few examples, covering iam-user, iam-role, and and an s3 bucket.
+Here's a few examples, covering iam-user, iam-role, and an s3 bucket.
 
 
 ```json
@@ -68,8 +68,8 @@ Here's a a few examples, covering iam-user, iam-role, and and an s3 bucket.
 
 Trail creators supports loading data from s3 using s3 select or from cloudtrail s3 using athena.
 
-Note you'll have to pre-created the athena table for cloudtrail previously per
-https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html
+Note you'll have to pre-create the athena table for cloudtrail per
+[https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html](https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html)
 
 Let's use the example config file to load up data for all the roles, buckets, and users created in 2019
 
@@ -130,7 +130,7 @@ INFO:c7n_trailowner:account:644160558196 region:us-east-1 tag 13 iam-role resour
 
 - records: the count of database create events we have for this resource type.
 - users: the number of unique users for whom we have create events.
-- not-found: the number of resources for whom we do not have create events, ie created before or after our trail analysis period.
+- not-found: the number of resources for which we do not have create events, i.e. created before or after our trail analysis period.
 - population: the total number of resources in the account region.
 
 ## Multi Account / Multi Region


### PR DESCRIPTION
* Update python package names to use hyphen instead of underscore (as in [cloudcustodian/www.cloudcustodian.io#10](https://github.com/cloud-custodian/www.cloudcustodian.io/pull/10))
* Fix some minor spelling, repeated words, formatting, etc. in `c7n_trailcreator` README
* Fix a broken symlink that kept showing up when grepping for underscore package names :smile: 