### PR TITLE
aws - lambda@edge func expr, unique resourceIds 

### DIFF
--- a/tests/data/placebo/test_lambda_edge_multiple_associations_cache/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_lambda_edge_multiple_associations_cache/cloudfront.ListDistributions_1.json
@@ -1,0 +1,209 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DistributionList": {
+            "Marker": "",
+            "MaxItems": 100,
+            "IsTruncated": false,
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "E3Q5UC7SQLL7MN",
+                    "ARN": "arn:aws:cloudfront::644160558196:distribution/E3Q5UC7SQLL7MN",
+                    "Status": "InProgress",
+                    "LastModifiedTime": {
+                        "__class__": "datetime",
+                        "year": 2024,
+                        "month": 3,
+                        "day": 20,
+                        "hour": 4,
+                        "minute": 15,
+                        "second": 57,
+                        "microsecond": 649000
+                    },
+                    "DomainName": "d1j7wua3tltg12.cloudfront.net",
+                    "Aliases": {
+                        "Quantity": 0
+                    },
+                    "Origins": {
+                        "Quantity": 1,
+                        "Items": [
+                            {
+                                "Id": "c7n-test-bucket.s3.us-east-1",
+                                "DomainName": "c7n-test-bucket.s3.us-east-1.amazonaws.com",
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": ""
+                                },
+                                "ConnectionAttempts": 3,
+                                "ConnectionTimeout": 10,
+                                "OriginShield": {
+                                    "Enabled": false
+                                },
+                                "OriginAccessControlId": ""
+                            }
+                        ]
+                    },
+                    "OriginGroups": {
+                        "Quantity": 0
+                    },
+                    "DefaultCacheBehavior": {
+                        "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "allow-all",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    },
+                    "CacheBehaviors": {
+                        "Quantity": 2,
+                        "Items": [
+                            {
+                                "PathPattern": "/beta/hello",
+                                "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "TrustedKeyGroups": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "ViewerProtocolPolicy": "redirect-to-https",
+                                "AllowedMethods": {
+                                    "Quantity": 2,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ],
+                                    "CachedMethods": {
+                                        "Quantity": 2,
+                                        "Items": [
+                                            "HEAD",
+                                            "GET"
+                                        ]
+                                    }
+                                },
+                                "SmoothStreaming": false,
+                                "Compress": true,
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 1,
+                                    "Items": [
+                                        {
+                                            "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:c7n-lambda-edge-new:1",
+                                            "EventType": "origin-request",
+                                            "IncludeBody": false
+                                        }
+                                    ]
+                                },
+                                "FunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FieldLevelEncryptionId": "",
+                                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                            },
+                            {
+                                "PathPattern": "/beta/world",
+                                "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "TrustedKeyGroups": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "ViewerProtocolPolicy": "redirect-to-https",
+                                "AllowedMethods": {
+                                    "Quantity": 2,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ],
+                                    "CachedMethods": {
+                                        "Quantity": 2,
+                                        "Items": [
+                                            "HEAD",
+                                            "GET"
+                                        ]
+                                    }
+                                },
+                                "SmoothStreaming": false,
+                                "Compress": true,
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 1,
+                                    "Items": [
+                                        {
+                                            "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:test-lambda-edge:4",
+                                            "EventType": "viewer-response",
+                                            "IncludeBody": false
+                                        }
+                                    ]
+                                },
+                                "FunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FieldLevelEncryptionId": "",
+                                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                            }
+                        ]
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "Comment": "",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": true,
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "SSLSupportMethod": "vip",
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "WebACLId": "",
+                    "HttpVersion": "HTTP2",
+                    "IsIPV6Enabled": true,
+                    "Staging": false
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_lambda_edge_multiple_associations_cache/lambda.ListFunctions_1.json
+++ b/tests/data/placebo/test_lambda_edge_multiple_associations_cache/lambda.ListFunctions_1.json
@@ -1,0 +1,74 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Functions": [
+            {
+                "FunctionName": "c7n-lambda-edge-new",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n-lambda-edge-new",
+                "Runtime": "nodejs14.x",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "index.handler",
+                "CodeSize": 376,
+                "Description": "Blueprint for returning HTTP redirect implemented in NodeJS.",
+                "Timeout": 1,
+                "MemorySize": 128,
+                "LastModified": "2023-08-30T03:28:55.000+0000",
+                "CodeSha256": "qxW4g+uEr2cGdO3l52WOfSVjv5TdNG6Pd+rj8YJFjAw=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "6780e2d7-4336-46c1-aba9-f5c6f7aa766a",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ],
+                "EphemeralStorage": {
+                    "Size": 512
+                },
+                "SnapStart": {
+                    "ApplyOn": "None",
+                    "OptimizationStatus": "Off"
+                },
+                "LoggingConfig": {
+                    "LogFormat": "Text",
+                    "LogGroup": "/aws/lambda/c7n-lambda-edge-new"
+                }
+            },
+            {
+                "FunctionName": "test-lambda-edge",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:test-lambda-edge",
+                "Runtime": "nodejs14.x",
+                "Role": "arn:aws:iam::644160558196:role/CloudCustodianRole",
+                "Handler": "index.handler",
+                "CodeSize": 389,
+                "Description": "Blueprint for modifying CloudFront response header implemented in NodeJS.",
+                "Timeout": 1,
+                "MemorySize": 128,
+                "LastModified": "2023-03-15T01:20:54.053+0000",
+                "CodeSha256": "PRrkU1iZ2meuOdge3XCeQPebrEknjcZlEEMBbMAT70g=",
+                "Version": "$LATEST",
+                "TracingConfig": {
+                    "Mode": "PassThrough"
+                },
+                "RevisionId": "7e0c0cd4-45ec-4b9a-a33f-bf2e18d22cbc",
+                "PackageType": "Zip",
+                "Architectures": [
+                    "x86_64"
+                ],
+                "EphemeralStorage": {
+                    "Size": 512
+                },
+                "SnapStart": {
+                    "ApplyOn": "None",
+                    "OptimizationStatus": "Off"
+                },
+                "LoggingConfig": {
+                    "LogFormat": "Text",
+                    "LogGroup": "/aws/lambda/test-lambda-edge"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_lambda_edge_multiple_associations_cache/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_lambda_edge_multiple_associations_cache/tagging.GetResources_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:c7n-lambda-edge-new",
+                "Tags": [
+                    {
+                        "Key": "lambda-console:blueprint",
+                        "Value": "cloudfront-http-redirect"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:lambda:us-east-1:644160558196:function:test-lambda-edge",
+                "Tags": [
+                    {
+                        "Key": "lambda-console:blueprint",
+                        "Value": "cloudfront-modify-response-header"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_lambda_edge_multiple_associations_cache/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_lambda_edge_multiple_associations_cache/tagging.GetResources_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudfront::644160558196:distribution/E3Q5UC7SQLL7MN",
+                "Tags": [
+                    {
+                        "Key": "test",
+                        "Value": "c7n"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -506,6 +506,23 @@ class LambdaTest(BaseTest):
             [r["FunctionName"] for r in resources],
             ["c7n-lambda-edge-new", "test-lambda-edge"])
 
+    def test_lambda_edge_multiple_associations_cache(self):
+        factory = self.replay_flight_data("test_lambda_edge_multiple_associations_cache")
+        p = self.load_policy(
+            {
+                "name": "lambda-edge-filter",
+                "resource": "lambda",
+                "filters": [{"type": "lambda-edge",
+                            "state": True}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+        self.assertEqual(
+            [r["FunctionName"] for r in resources],
+            ["c7n-lambda-edge-new", "test-lambda-edge"])
+
 
 class LambdaTagTest(BaseTest):
 


### PR DESCRIPTION
Closes #9367 

This PR fixes one of the func expressions, changes lambda_dist_map values to be of type set()

Added tests with multiple lambda@edges associated with distribution's `CacheBehaviors` 