### PR TITLE
Feature/s3 data access points handlers

### DIFF
--- a/c7n/filters/iamaccess.py
+++ b/c7n/filters/iamaccess.py
@@ -240,6 +240,14 @@ class PolicyChecker:
             return True
         return bool(set(map(_account, c['values'])).difference(self.allowed_orgid))
 
+    def handle_s3_dataaccesspointaccount(self, s, c):
+        return bool(set(map(_account, c['values'])).difference(self.allowed_accounts))
+    
+    def handle_s3_dataaccesspointarn(self, s, c):
+        return bool(set(map(_account, c['values'])).difference(self.allowed_accounts))
+    
+    def handle_s3_x_amz_acl(self, s, c):
+        return False
 
 class CrossAccountAccessFilter(Filter):
     """Check a resource's embedded iam policy for cross account access.

--- a/tests/data/iam/s3-data-accesspoint-account.json
+++ b/tests/data/iam/s3-data-accesspoint-account.json
@@ -1,0 +1,37 @@
+[
+    {
+        "Id": "DataAccessPointAccountInvalid",
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Actions": ["s3:PutObject"],
+                "Principal": ["*"],
+                "StatementId": "cab89702-05f0-4751-818e-ced6e98ef5f9",
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::data-accesspoint-invalid/*", "arn:aws:s3:::data-accesspoint-invalid"],
+                    "Condition": {
+                        "StringEquals": {
+                            "s3:DataAccessPointAccount": ["444456789012"]
+                        }
+                    }
+            }
+        ]
+    },
+    {
+        "Id": "DataAccessPointAccountValid",
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Actions": ["s3:PutObject"],
+                "StatementId": "cab89702-05f0-4751-818e-ced6e98ef5f9",
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::data-accesspoint-valid/*", "arn:aws:s3:::data-accesspoint-valid"],
+                    "Condition": {
+                        "StringEquals": {
+                            "s3:DataAccessPointAccount": ["123456789012"]
+                        }
+                    }
+            }
+        ]
+    } 
+]

--- a/tests/data/iam/s3-data-accesspoint-account.json
+++ b/tests/data/iam/s3-data-accesspoint-account.json
@@ -12,8 +12,8 @@
                     "Condition": {
                         "StringEquals": {
                             "s3:DataAccessPointAccount": ["444456789012"]
-                        }
                     }
+                }
             }
         ]
     },
@@ -23,14 +23,15 @@
         "Statement": [
             {
                 "Actions": ["s3:PutObject"],
+                "Principal": ["*"],
                 "StatementId": "cab89702-05f0-4751-818e-ced6e98ef5f9",
                 "Effect": "Allow",
                 "Resource": ["arn:aws:s3:::data-accesspoint-valid/*", "arn:aws:s3:::data-accesspoint-valid"],
                     "Condition": {
                         "StringEquals": {
                             "s3:DataAccessPointAccount": ["123456789012"]
-                        }
                     }
+                }
             }
         ]
     } 

--- a/tests/data/iam/s3-data-accesspoint-arn.json
+++ b/tests/data/iam/s3-data-accesspoint-arn.json
@@ -23,6 +23,7 @@
         "Statement": [
             {
                 "Actions": ["s3:PutObject"],
+                "Principal": ["*"],
                 "StatementId": "cab89702-05f0-4751-818e-ced6e98ef5f9",
                 "Effect": "Allow",
                 "Resource": ["arn:aws:s3:::data-accesspoint/*", "arn:aws:s3:::data-accesspoint"],

--- a/tests/data/iam/s3-data-accesspoint-arn.json
+++ b/tests/data/iam/s3-data-accesspoint-arn.json
@@ -1,0 +1,37 @@
+[
+    {
+        "Id": "DataAccessPointArnValid",
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Actions": ["s3:PutObject"],
+                "Principal": ["*"],
+                "StatementId": "cab89702-05f0-4751-818e-ced6e98ef5f9",
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::data-accesspoint/*", "arn:aws:s3:::data-accesspoint"],
+                    "Condition": {
+                        "StringLike": {
+                            "s3:DataAccessPointArn": ["arn:aws:s3:us-east-1:123456789012:accesspoint/*"]
+                        }
+                    }
+            }
+        ]
+    },
+    {
+        "Id": "DataAccessPointArnInvalid",
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Actions": ["s3:PutObject"],
+                "StatementId": "cab89702-05f0-4751-818e-ced6e98ef5f9",
+                "Effect": "Allow",
+                "Resource": ["arn:aws:s3:::data-accesspoint/*", "arn:aws:s3:::data-accesspoint"],
+                    "Condition": {
+                        "StringLike": {
+                            "s3:DataAccessPointArn": ["arn:aws:s3:us-east-1:444456789012:accesspoint/*"]
+                        }
+                    }
+            }
+        ]
+    } 
+]

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -2351,6 +2351,20 @@ class CrossAccountChecker(TestCase):
             violations = checker.check(p)
             self.assertEqual(bool(violations), expected)
 
+    def test_data_access_point_account(self):
+        policies = load_data("iam/s3-data-accesspoint-account.json")
+        checker = PolicyChecker({'allowed_accounts': ['123456789012']})
+        for p, expected in zip(policies, [True, False]):
+            violations = checker.check(p)
+            self.assertEqual(bool(violations), expected)
+
+    def test_data_access_point_arn(self):
+        policies = load_data("iam/s3-data-accesspoint-arn.json")
+        checker = PolicyChecker({'allowed_accounts': ['123456789012']})
+        for p, expected in zip(policies, [False, True]):
+            violations = checker.check(p)
+            self.assertEqual(bool(violations), expected)
+
     def test_s3_policies_vpc(self):
         policies = load_data("iam/s3-policies.json")
         checker = PolicyChecker({"allowed_accounts": {"123456789012"}})


### PR DESCRIPTION
Some s3 bucket policies contain data access point or ACL conditions which allow access to the bucket or its objects. 
With these conditions, we want to check if they provide cross account access. Currently, there are no handlers configured to manage these conditions.

For example:

```
"Condition": {
     "StringEquals": { 
          "s3:DataAccessPointAccount": "123456789012"
			}
```

Resolves #9408