### PR TITLE
releng - update cosign version

### DIFF
--- a/.github/composites/docker-build-push/action.yaml
+++ b/.github/composites/docker-build-push/action.yaml
@@ -123,7 +123,7 @@ runs:
       if: "${{ inputs.push == 'true' }}"
       uses: sigstore/cosign-installer@v3
       with:
-        cosign-release: 'v1.13.0'
+        cosign-release: 'v1.13.6'
 
     - name: Sign
       if: "${{ inputs.push == 'true' }}"


### PR DESCRIPTION

saw a trunk commit with a ci failure on a tuf certificate / trust root, try updating to latest minor version
of cosign (they have a separate major version release).

