### PR TITLE
Upgrade and Secure Temp File Creation

### DIFF
--- a/tools/c7n_azure/tests_azure/tests_resources/test_container_host.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_container_host.py
@@ -489,7 +489,7 @@ class ContainerHostTest(BaseTest):
         host = Host(DEFAULT_EVENT_QUEUE_ID, DEFAULT_EVENT_QUEUE_NAME, DEFAULT_POLICY_STORAGE)
 
         # Create a bad yaml file
-        file_path = tempfile.mktemp(suffix=".yaml")
+        file_path = tempfile.mkstemp(suffix=".yaml")
         with open(file_path, 'w') as f:
             f.write("bad yaml file")
 
@@ -520,7 +520,7 @@ class ContainerHostTest(BaseTest):
                         """
 
         # Create a bad yaml file
-        file_path = tempfile.mktemp(suffix=".yaml")
+        file_path = tempfile.mkstemp(suffix=".yaml")
         with open(file_path, 'w') as f:
             f.write(policy_string)
 
@@ -541,7 +541,7 @@ class ContainerHostTest(BaseTest):
         host = Host(DEFAULT_EVENT_QUEUE_ID, DEFAULT_EVENT_QUEUE_NAME, DEFAULT_POLICY_STORAGE)
 
         # Create a bad yaml file (no name field)
-        file_path = tempfile.mktemp(suffix=".yaml")
+        file_path = tempfile.mkstemp(suffix=".yaml")
         with open(file_path, 'w') as f:
             f.write("""
                         policies:
@@ -579,7 +579,7 @@ class ContainerHostTest(BaseTest):
                         """
 
         # Create a bad yaml file
-        file_path = tempfile.mktemp(suffix=".yaml")
+        file_path = tempfile.mkstemp(suffix=".yaml")
         with open(file_path, 'w') as f:
             f.write(policy_string)
 


### PR DESCRIPTION
This codemod replaces all `tempfile.mktemp` calls to the more secure `tempfile.mkstemp`.

The Python [tempfile documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp) is explicit
that `tempfile.mktemp` should be deprecated to avoid an unsafe and unexpected race condition.
The changes from this codemod look like this:


```diff
  import tempfile
- tempfile.mktemp(...)
+ tempfile.mkstemp(...)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/library/tempfile.html#tempfile.mktemp](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/secure-tempfile](https://docs.pixee.ai/codemods/python/pixee_python_secure-tempfile)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fcloud-custodian%7Cab1dd746a502baba9a04e24b394ae6597bc962d3)

<!--{"type":"DRIP","codemod":"pixee:python/secure-tempfile"}-->