### PR TITLE
Value filter mod operator

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -79,6 +79,10 @@ def intersect(x, y):
     return bool(set(x).intersection(y))
 
 
+def mod(x, y):
+    return bool(x % y)
+
+
 OPERATORS = {
     'eq': operator.eq,
     'equal': operator.eq,
@@ -100,7 +104,8 @@ OPERATORS = {
     'not-in': operator_ni,
     'contains': operator.contains,
     'difference': difference,
-    'intersect': intersect}
+    'intersect': intersect,
+    'mod': mod}
 
 
 VALUE_TYPES = [

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1081,6 +1081,22 @@ class TestIntersect(unittest.TestCase):
         self.assertEqual(f(instance(Thing=["C", "D", "E"])), True)
 
 
+class TestModValue(unittest.TestCase):
+    def test_mod(self):
+        f = filters.factory({
+            "type": "value",
+            "key": "Number",
+            "value": 3,
+            "op": "mod"
+        })
+        self.assertEqual(f(instance(Number=3)), False)
+        self.assertEqual(f(instance(Number=6)), False)
+        self.assertEqual(f(instance(Number=24)), False)
+        self.assertEqual(f(instance(Number=2)), True)
+        self.assertEqual(f(instance(Number=5)), True)
+        self.assertEqual(f(instance(Number=23)), True)
+
+
 class TestFilterRegistry(unittest.TestCase):
 
     def test_filter_registry(self):


### PR DESCRIPTION
The fourth remediation step from [ES.6](https://docs.aws.amazon.com/securityhub/latest/userguide/es-controls.html#es-6) tells: `For three Availability Zone deployments, set to a multiple of three to ensure equal distribution across Availability Zones.`. So, I wondered whether it's possible to check a remainder of a division using ValueFilter. What do you think about it?

```yaml
policies:
  - name: multiple-of-3-data-nodes
    resource: aws.elasticsearch
    filters:
        - type: value
          key: ElasticsearchClusterConfig.ZoneAwarenessConfig.AvailabilityZoneCount
          value: 3
          op: eq
        - not:
            - type: value
              key: ElasticsearchClusterConfig.InstanceCount
              op: mod
              value: 3
```