### PR TITLE
fix: validate policy mode in StructureParser

### DIFF
--- a/c7n/structure.py
+++ b/c7n/structure.py
@@ -61,6 +61,10 @@ class StructureParser:
             raise PolicyValidationError(
                 'policy:%s has unknown keys: %s' % (
                     p['name'], ','.join(pkeys.difference(self.allowed_policy_keys))))
+        if "mode" in p:
+            mode = p["mode"]
+            if not isinstance(mode, dict) or "type" not in mode:
+                raise PolicyValidationError("invalid `mode` declaration")
         if not isinstance(p.get('filters', []), (list, type(None))):
             raise PolicyValidationError((
                 'policy:%s must use a list for filters found:%s' % (

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -82,6 +82,19 @@ class StructureParserTest(BaseTest):
         p = StructureParser()
         p.validate({'policies': [{'name': 'foo', 'resource': 'ec2', 'filters': None}]})
 
+    def test_invalid_mode(self):
+        p = StructureParser()
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [{
+                'name': 'foo', 'resource': 'ec2', 'mode': None}]})
+        self.assertTrue(str(ecm.exception).startswith(
+            'invalid `mode` declaration'))
+        with self.assertRaises(PolicyValidationError) as ecm:
+            p.validate({'policies': [{
+                'name': 'foo', 'resource': 'ec2', 'mode': []}]})
+        self.assertTrue(str(ecm.exception).startswith(
+            'invalid `mode` declaration'))
+
     def test_invalid_filter(self):
         p = StructureParser()
         with self.assertRaises(PolicyValidationError) as ecm:


### PR DESCRIPTION
Add validation for the policy `mode` to `StructureParser`