### PR TITLE
enabling glob matching for tags in azure vm

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -258,7 +258,10 @@ class BaseValueFilter(Filter):
             # as labels without values.
             # Azure schema: 'tags': {'key': 'value'}
             elif 'tags' in i:
-                r = (i.get('tags', {}) or {}).get(tk, None)
+                for t in i.get('tags', {}):
+                    if fnmatch.fnmatch(t, tk):
+                        r = i['tags'][t]
+                        break
         elif k in i:
             r = i.get(k)
         elif k not in self.expr:


### PR DESCRIPTION
This will enable us to search azure vm tags based on globs pattern
Ex,
```
filters:
      - or:
        - "tag:[Oo][Ww][Nn][Ee][Rr]": present
```
While previously we couldnt check for case insensitivity for tags we can now check for pattern that matches above glob,which will take care of case insensitive search too
@