### PR TITLE
aws - elasticsearch - add the latest TLS security policy

### DIFF
--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -625,7 +625,7 @@ class UpdateTlsConfig(Action):
     """
 
     schema = type_schema('update-tls-config', value={'type': 'string',
-        'enum': ['Policy-Min-TLS-1-0-2019-07', 'Policy-Min-TLS-1-2-2019-07']}, required=['value'])
+        'enum': ['Policy-Min-TLS-1-0-2019-07', 'Policy-Min-TLS-1-2-2019-07', 'Policy-Min-TLS-1-2-PFS-2023-10']}, required=['value'])
     permissions = ('es:UpdateElasticsearchDomainConfig', 'es:ListDomainNames')
 
     def process(self, resources):

--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -625,7 +625,8 @@ class UpdateTlsConfig(Action):
     """
 
     schema = type_schema('update-tls-config', value={'type': 'string',
-        'enum': ['Policy-Min-TLS-1-0-2019-07', 'Policy-Min-TLS-1-2-2019-07', 'Policy-Min-TLS-1-2-PFS-2023-10']}, required=['value'])
+        'enum': ['Policy-Min-TLS-1-0-2019-07', 'Policy-Min-TLS-1-2-2019-07',
+                 'Policy-Min-TLS-1-2-PFS-2023-10']}, required=['value'])
     permissions = ('es:UpdateElasticsearchDomainConfig', 'es:ListDomainNames')
 
     def process(self, resources):


### PR DESCRIPTION
Support the latest TLS security policy:
- Policy-Min-TLS-1-2-PFS-2023-10

**Reference**
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/opensearch/client/update_domain_config.html
- https://docs.aws.amazon.com/securityhub/latest/userguide/opensearch-controls.html#opensearch-8

**Example**
```yaml
    filters:
      - or:
        - type: value
          key: DomainEndpointOptions.EnforceHTTPS
          op: ne
          value: true
        - type: value
          key: DomainEndpointOptions.TLSSecurityPolicy
          op: ne
          value: Policy-Min-TLS-1-2-PFS-2023-10
    actions:
      - type: update-tls-config
        value: Policy-Min-TLS-1-2-PFS-2023-10
```