### PR TITLE
releng - update ci to poetry 1.8.3, docker update to ubuntu 24.04, always pull when building

### DIFF
--- a/.github/composites/docker-build-push/action.yaml
+++ b/.github/composites/docker-build-push/action.yaml
@@ -116,7 +116,7 @@ runs:
         push: true
         pull: true
         platforms: ${{ inputs.platforms }}
-        tags: ${{ steps.meta.outputs.tags }}m
+        tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         file: "docker/${{ inputs.name }}"
         cache-from: type=gha

--- a/.github/composites/docker-build-push/action.yaml
+++ b/.github/composites/docker-build-push/action.yaml
@@ -139,5 +139,5 @@ runs:
         tags=(${TAGS//,/ })
         for i in "${tags[@]}"
         do
-          cosign sign $i:${{ steps.push.outputs.digest }}
+          cosign sign ${{ inputs.repository }}/${{ inputs.name }}@${{ steps.push.outputs.digest }}
         done

--- a/.github/composites/docker-build-push/action.yaml
+++ b/.github/composites/docker-build-push/action.yaml
@@ -106,6 +106,7 @@ runs:
 
     # actually push the multi arch image
     - name: Push
+      id: "push"
       if: "${{ inputs.push == 'true' }}"
       uses: docker/build-push-action@v5
       with:
@@ -134,8 +135,9 @@ runs:
         COSIGN_EXPERIMENTAL: "true"
         TAGS: ${{ steps.meta.outputs.tags }}
       run: |
+        echo "${{ steps.push.outputs.digest }}"
         tags=(${TAGS//,/ })
         for i in "${tags[@]}"
         do
-          cosign sign $i
+          cosign sign $i:${{ steps.push.outputs.digest }}
         done

--- a/.github/composites/docker-build-push/action.yaml
+++ b/.github/composites/docker-build-push/action.yaml
@@ -71,7 +71,7 @@ runs:
       id: install-custodian
       uses: ./.github/composites/install
       with:
-        python-version: "3.12"
+        python-version: "3.11"
 
     # build a single platform image first in order to actually load the image from buildx
     # manifests are not supported yet

--- a/.github/composites/docker-build-push/action.yaml
+++ b/.github/composites/docker-build-push/action.yaml
@@ -71,7 +71,7 @@ runs:
       id: install-custodian
       uses: ./.github/composites/install
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     # build a single platform image first in order to actually load the image from buildx
     # manifests are not supported yet
@@ -84,6 +84,7 @@ runs:
         build-args: |
           POETRY_VERSION=${{ steps.install-custodian.outputs.poetry-version }}
         push: false
+        pull: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         # load the image back into docker for tests.
@@ -112,8 +113,9 @@ runs:
         build-args: |
           POETRY_VERSION=${{ steps.install-custodian.outputs.poetry-version }}
         push: true
+        pull: true
         platforms: ${{ inputs.platforms }}
-        tags: ${{ steps.meta.outputs.tags }}
+        tags: ${{ steps.meta.outputs.tags }}m
         labels: ${{ steps.meta.outputs.labels }}
         file: "docker/${{ inputs.name }}"
         cache-from: type=gha

--- a/.github/composites/install/action.yaml
+++ b/.github/composites/install/action.yaml
@@ -4,7 +4,7 @@ inputs:
   python-version:
     required: true
   poetry-version:
-    default: "1.5.1"
+    default: "1.8.3"
 outputs:
   poetry-version:
     description: "poetry version"

--- a/docker/c7n
+++ b/docker/c7n
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:22.04 as build-env
+FROM ubuntu:24.04 as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"
@@ -83,7 +84,7 @@ RUN if [[ " ${providers[*]} " =~ "oci" ]]; then     . /usr/local/bin/activate &&
 
 RUN mkdir /output
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL name="cli" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
@@ -91,7 +92,7 @@ LABEL name="cli" \
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
-        && apt-get --yes install python3 python3-venv  --no-install-recommends \
+        && apt-get --yes install python3 python3-venv adduser  --no-install-recommends \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"

--- a/docker/c7n-kube
+++ b/docker/c7n-kube
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:22.04 as build-env
+FROM ubuntu:24.04 as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"
@@ -87,7 +88,7 @@ RUN mkdir /output
 ADD tools/c7n_kube /src/tools/c7n_kube
 RUN . /usr/local/bin/activate && cd tools/c7n_kube && poetry install
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL name="kube" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
@@ -95,7 +96,7 @@ LABEL name="kube" \
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
-        && apt-get --yes install python3 python3-venv  --no-install-recommends \
+        && apt-get --yes install python3 python3-venv adduser  --no-install-recommends \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*

--- a/docker/c7n-kube-distroless
+++ b/docker/c7n-kube-distroless
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"

--- a/docker/c7n-left
+++ b/docker/c7n-left
@@ -1,6 +1,6 @@
-FROM chainguard/wolfi-base as builder
+FROM cgr.dev/chainguard/wolfi-base as builder
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 ARG PY_VERSION=3.12
 WORKDIR /app
 
@@ -10,9 +10,10 @@ RUN apk add python-${PY_VERSION} py${PY_VERSION}-pip && \
 USER nonroot
 
 # Install Poetry in its own virtual environment
-RUN python -m venv "${HOME}/tools" && \
+RUN python3 -m venv "${HOME}/tools" && \
     . "${HOME}/tools/bin/activate" && \
-    pip install "poetry==${POETRY_VERSION}"
+    pip install --verbose "poetry==${POETRY_VERSION}"
+
 
 # Copy enough of the c7n source that poetry can
 # use it when installing c7n-left
@@ -26,7 +27,7 @@ WORKDIR /app/c7n/tools/c7n_left
 COPY tools/c7n_left /app/c7n/tools/c7n_left
 RUN python -m venv "${HOME}/venv" && \
     . "${HOME}/venv/bin/activate" && \
-    ~/tools/bin/poetry install --no-dev
+    ~/tools/bin/poetry install --only main
 
 
 FROM chainguard/wolfi-base

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:22.04 as build-env
+FROM ubuntu:24.04 as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"
@@ -87,7 +88,7 @@ RUN mkdir /output
 ADD tools/c7n_org /src/tools/c7n_org
 RUN . /usr/local/bin/activate && cd tools/c7n_org && poetry install
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL name="org" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
@@ -95,7 +96,7 @@ LABEL name="org" \
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
-        && apt-get --yes install python3 python3-venv  --no-install-recommends \
+        && apt-get --yes install python3 python3-venv adduser  --no-install-recommends \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"

--- a/docker/mailer
+++ b/docker/mailer
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:22.04 as build-env
+FROM ubuntu:24.04 as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"
@@ -88,7 +89,7 @@ ADD tools/c7n_mailer /src/tools/c7n_mailer
 RUN . /usr/local/bin/activate && cd tools/c7n_mailer && poetry install --all-extras
 
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL name="mailer" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
@@ -96,7 +97,7 @@ LABEL name="mailer" \
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
-        && apt-get --yes install python3 python3-venv  --no-install-recommends \
+        && apt-get --yes install python3 python3-venv adduser  --no-install-recommends \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"

--- a/docker/policystream
+++ b/docker/policystream
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:22.04 as build-env
+FROM ubuntu:24.04 as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"
@@ -87,7 +88,7 @@ RUN mkdir /output
 ADD tools/c7n_policystream /src/tools/c7n_policystream
 RUN . /usr/local/bin/activate && cd tools/c7n_policystream && poetry install
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL name="policystream" \
       repository="http://github.com/cloud-custodian/cloud-custodian"
@@ -95,7 +96,7 @@ LABEL name="policystream" \
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \
-        && apt-get --yes install python3 python3-venv  --no-install-recommends \
+        && apt-get --yes install python3 python3-venv adduser  --no-install-recommends \
         && rm -Rf /var/cache/apt \
         && rm -Rf /var/lib/apt/lists/* \
         && rm -Rf /var/log/*

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -1,13 +1,14 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 FROM debian:10-slim as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools &&     /usr/local/bin/pip install "poetry==${POETRY_VERSION}"
 ARG PATH="/root/.local/bin:$PATH"

--- a/tools/c7n_azure/c7n_azure/__init__.py
+++ b/tools/c7n_azure/c7n_azure/__init__.py
@@ -1,8 +1,15 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import warnings
 
 import adal
+
+# two azure packages seem to have this issue on invalid escape
+# sequence on their generated code w/ python 3.12
+# (azure.mgmt.resource, azure.mgmt.resourcgraph)
+warnings.filterwarnings("ignore", category=SyntaxWarning)
+
 
 # Quiet logging from dependencies
 adal.set_logging_options({'level': 'WARNING'})

--- a/tools/c7n_azure/c7n_azure/entry.py
+++ b/tools/c7n_azure/c7n_azure/entry.py
@@ -1,6 +1,12 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+# two azure packages seem to have this issue on invalid escape
+# sequence on their generated code w/ python 3.12
+# (azure.mgmt.resource, azure.mgmt.resourcgraph)
+import warnings
+warnings.filterwarnings("ignore", "SyntaxWarning")
+
 # register provider
 from c7n_azure.provider import Azure  # NOQA
 

--- a/tools/c7n_azure/c7n_azure/entry.py
+++ b/tools/c7n_azure/c7n_azure/entry.py
@@ -1,12 +1,6 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-# two azure packages seem to have this issue on invalid escape
-# sequence on their generated code w/ python 3.12
-# (azure.mgmt.resource, azure.mgmt.resourcgraph)
-import warnings
-warnings.filterwarnings("ignore", "SyntaxWarning")
-
 # register provider
 from c7n_azure.provider import Azure  # NOQA
 

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -70,7 +70,8 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential \
+    curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -65,13 +65,14 @@ BOOTSTRAP_STAGE = """\
 # Dockerfiles are generated from tools/dev/dockerpkg.py
 FROM {base_build_image} as build-env
 
-ARG POETRY_VERSION="1.5.1"
+ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
-RUN adduser --disabled-login --gecos "" custodian
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+# todo: 24.04 is trying to standardize on ubuntu as builtin non root.
+RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
 RUN /usr/local/bin/pip install -U pip setuptools && \
     /usr/local/bin/pip install "poetry=={poetry_version}"
@@ -82,13 +83,13 @@ WORKDIR /src
 
 LEFT_BUILD_STAGE = BOOTSTRAP_STAGE + """\
 ADD pyproject.toml poetry.lock README.md /src
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --only main --no-root
 
 ADD c7n /src/c7n/
 RUN . /usr/local/bin/activate && poetry install --only-root
 
 ADD tools/c7n_left /src/tools/c7n_left
-RUN . /usr/local/bin/activate && cd tools/c7n_left && poetry install --without dev
+RUN . /usr/local/bin/activate && cd tools/c7n_left && poetry install --only main
 
 RUN mkdir /output
 """
@@ -125,7 +126,7 @@ LABEL name="{name}" \\
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get --yes update \\
-        && apt-get --yes install python3 python3-venv {packages} --no-install-recommends \\
+        && apt-get --yes install python3 python3-venv adduser {packages} --no-install-recommends \\
         && rm -Rf /var/cache/apt \\
         && rm -Rf /var/lib/apt/lists/* \\
         && rm -Rf /var/log/*
@@ -233,8 +234,8 @@ LABEL "org.opencontainers.image.documentation"="https://cloudcustodian.io/docs"
 class Image:
 
     defaults = dict(
-        base_build_image="ubuntu:22.04",
-        base_target_image="ubuntu:22.04",
+        base_build_image="ubuntu:24.04",
+        base_target_image="ubuntu:24.04",
         poetry_version="${POETRY_VERSION}",
         packages="",
         providers=" ".join(default_providers),


### PR DESCRIPTION

- update ubuntu based docker images to 24.04
- as a consequence of that, python3.12 is now the default
- update to poetry 1.8.3 in ci
- always pull images when building


