### PR TITLE
aws - memorydb - add support for cluster

### DIFF
--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -1,0 +1,139 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from .aws import AWS
+from c7n.query import (
+    QueryResourceManager, TypeInfo, DescribeSource)
+from c7n.actions import BaseAction
+from c7n.utils import local_session, type_schema
+from c7n.tags import RemoveTag, Tag, TagActionFilter, TagDelayedAction
+
+
+class DescribeMemoryDb(DescribeSource):
+
+    def augment(self, resources):
+        resources = super(DescribeMemoryDb, self).augment(resources)
+        client = local_session(self.manager.session_factory).client('memorydb')
+        results = []
+        for r in resources:
+            r['Tags'] = self.manager.retry(
+                    client.list_tags, ResourceArn=r['ARN']).get('TagList', [])
+            results.append(r)
+        return results
+
+
+@AWS.resources.register('memorydb')
+class MemoryDb(QueryResourceManager):
+    """AWS MemoryDb
+
+    https://docs.aws.amazon.com/memorydb/latest/devguide/what-is-memorydb-for-redis.html
+    """
+
+    class resource_type(TypeInfo):
+
+        service = 'memorydb'
+        enum_spec = ('describe_clusters', 'Clusters', None)
+        arn = 'ARN'
+        arn_type = 'memorydb'
+        id = name = 'Name'
+        cfn_type = 'AWS::MemoryDB::Cluster'
+        permission_prefix = 'memorydb'
+
+    source_mapping = {'describe': DescribeMemoryDb}
+
+
+@MemoryDb.action_registry.register('tag')
+class TagMemoryDb(Tag):
+    """Create tags on MemoryDb
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+            - name: memory-db-tag
+              resource: aws.memorydb
+              actions:
+                - type: tag
+                  key: test
+                  value: something
+    """
+    permissions = ('memorydb:TagResource',)
+
+    def process_resource_set(self, client, resources, new_tags):
+        for r in resources:
+            client.tag_resource(ResourceArn=r["ARN"], Tags=new_tags)
+
+
+@MemoryDb.action_registry.register('remove-tag')
+class RemoveMemoryDb(RemoveTag):
+    """Remove tags from a memorydb cluster
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+            - name: memorydb-remove-tag
+              resource: aws.memorydb
+              actions:
+                - type: remove-tag
+                  tags: ["tag-key"]
+    """
+    permissions = ('memorydb:UntagResource',)
+
+    def process_resource_set(self, client, resources, tags):
+        for r in resources:
+            client.untag_resource(ResourceArn=r['ARN'], TagKeys=tags)
+
+
+@MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
+
+
+@MemoryDb.action_registry.register('mark-for-op')
+class MarkMemoryDbForOp(TagDelayedAction):
+    """Mark memorydb for future actions
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: memorydb-tag-mark
+            resource: aws.memorydb
+            filters:
+              - "tag:delete": present
+            actions:
+              - type: mark-for-op
+                op: delete
+                days: 1
+    """
+
+
+@MemoryDb.action_registry.register('delete')
+class DeleteMemoryDb(BaseAction):
+    """Delete a memorydb cluster
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: memorydb-delete
+            resource: aws.memorydb
+            actions:
+              - type: delete
+                FinalSnapshotName: test-snapshot
+    """
+    schema = type_schema('delete', FinalSnapshotName={'type': 'string'})
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('memorydb')
+        FinalSnapshotName = self.data.get('FinalSnapshotName', '')
+        for r in resources:
+            try:
+                client.delete_cluster(
+                    ClusterName=r['Name'],
+                    FinalSnapshotName=FinalSnapshotName
+                )
+            except client.exceptions.ResourceNotFoundException:
+                continue

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -86,12 +86,8 @@ class RemoveMemoryDbTag(RemoveTag):
             client.untag_resource(ResourceArn=r['ARN'], TagKeys=tags)
 
 
-@MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
-
-
-@MemoryDb.action_registry.register('mark-for-op')
-class MemoryDbMarkForOp(TagDelayedAction):
-    pass
+MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
+MemoryDb.action_registry.register('mark-for-op', TagDelayedAction)
 
 
 @MemoryDb.action_registry.register('delete')

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -66,7 +66,7 @@ class TagMemoryDb(Tag):
 
 
 @MemoryDb.action_registry.register('remove-tag')
-class RemoveMemoryDb(RemoveTag):
+class RemoveMemoryDbTag(RemoveTag):
     """Remove tags from a memorydb cluster
     :example:
 
@@ -91,8 +91,8 @@ MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
 
 
 @MemoryDb.action_registry.register('mark-for-op')
-class MarkNetworkFirewallForOp(TagDelayedAction):
-
+class MemoryDbMarkForOp(TagDelayedAction):
+    pass
 
 @MemoryDb.action_registry.register('delete')
 class DeleteMemoryDbResource(BaseAction):

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -34,7 +34,7 @@ class MemoryDb(QueryResourceManager):
         service = 'memorydb'
         enum_spec = ('describe_clusters', 'Clusters', None)
         arn = 'ARN'
-        arn_type = 'memorydb'
+        arn_type = 'cluster'
         id = name = 'Name'
         cfn_type = 'AWS::MemoryDB::Cluster'
         permission_prefix = 'memorydb'

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -106,6 +106,7 @@ class DeleteMemoryDbResource(BaseAction):
                 FinalSnapshotName: test-snapshot
     """
     schema = type_schema('delete', FinalSnapshotName={'type': 'string'})
+    permissions = ('memorydb:DeleteCluster',)
 
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('memorydb')

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -86,8 +86,7 @@ class RemoveMemoryDbTag(RemoveTag):
             client.untag_resource(ResourceArn=r['ARN'], TagKeys=tags)
 
 
-
-MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
+@MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
 
 
 @MemoryDb.action_registry.register('mark-for-op')

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -93,6 +93,7 @@ class RemoveMemoryDbTag(RemoveTag):
 class MemoryDbMarkForOp(TagDelayedAction):
     pass
 
+
 @MemoryDb.action_registry.register('delete')
 class DeleteMemoryDbResource(BaseAction):
     """Delete a memorydb cluster

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -86,6 +86,10 @@ class RemoveMemoryDb(RemoveTag):
             client.untag_resource(ResourceArn=r['ARN'], TagKeys=tags)
 
 
+@MemoryDb.action_registry.register('mark-for-op', TagDelayedAction)
+@MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
+
+
 @MemoryDb.action_registry.register('delete')
 class DeleteMemoryDb(BaseAction):
     """Delete a memorydb cluster
@@ -114,26 +118,3 @@ class DeleteMemoryDb(BaseAction):
                 )
             except client.exceptions.ResourceNotFoundException:
                 continue
-
-
-@MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
-
-
-@MemoryDb.action_registry.register('mark-for-op')
-class MarkMemoryDbForOp(TagDelayedAction):
-    """Mark memorydb for future actions
-
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: memorydb-tag-mark
-            resource: aws.memorydb
-            filters:
-              - "tag:delete": present
-            actions:
-              - type: mark-for-op
-                op: delete
-                days: 1
-    """

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -91,7 +91,7 @@ class RemoveMemoryDb(RemoveTag):
 
 
 @MemoryDb.action_registry.register('delete')
-class DeleteMemoryDb(BaseAction):
+class DeleteMemoryDbResource(BaseAction):
     """Delete a memorydb cluster
 
     :example:

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -86,8 +86,12 @@ class RemoveMemoryDb(RemoveTag):
             client.untag_resource(ResourceArn=r['ARN'], TagKeys=tags)
 
 
-@MemoryDb.action_registry.register('mark-for-op', TagDelayedAction)
-@MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
+
+MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
+
+
+@MemoryDb.action_registry.register('mark-for-op')
+class MarkNetworkFirewallForOp(TagDelayedAction):
 
 
 @MemoryDb.action_registry.register('delete')

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -86,29 +86,6 @@ class RemoveMemoryDb(RemoveTag):
             client.untag_resource(ResourceArn=r['ARN'], TagKeys=tags)
 
 
-@MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
-
-
-@MemoryDb.action_registry.register('mark-for-op')
-class MarkMemoryDbForOp(TagDelayedAction):
-    """Mark memorydb for future actions
-
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: memorydb-tag-mark
-            resource: aws.memorydb
-            filters:
-              - "tag:delete": present
-            actions:
-              - type: mark-for-op
-                op: delete
-                days: 1
-    """
-
-
 @MemoryDb.action_registry.register('delete')
 class DeleteMemoryDb(BaseAction):
     """Delete a memorydb cluster
@@ -137,3 +114,26 @@ class DeleteMemoryDb(BaseAction):
                 )
             except client.exceptions.ResourceNotFoundException:
                 continue
+
+
+@MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
+
+
+@MemoryDb.action_registry.register('mark-for-op')
+class MarkMemoryDbForOp(TagDelayedAction):
+    """Mark memorydb for future actions
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: memorydb-tag-mark
+            resource: aws.memorydb
+            filters:
+              - "tag:delete": present
+            actions:
+              - type: mark-for-op
+                op: delete
+                days: 1
+    """

--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -62,7 +62,10 @@ class TagMemoryDb(Tag):
 
     def process_resource_set(self, client, resources, new_tags):
         for r in resources:
-            client.tag_resource(ResourceArn=r["ARN"], Tags=new_tags)
+            try:
+                client.tag_resource(ResourceArn=r["ARN"], Tags=new_tags)
+            except client.exceptions.ClusterNotFoundFault:
+                continue
 
 
 @MemoryDb.action_registry.register('remove-tag')
@@ -83,7 +86,10 @@ class RemoveMemoryDbTag(RemoveTag):
 
     def process_resource_set(self, client, resources, tags):
         for r in resources:
-            client.untag_resource(ResourceArn=r['ARN'], TagKeys=tags)
+            try:
+                client.untag_resource(ResourceArn=r['ARN'], TagKeys=tags)
+            except client.exceptions.ClusterNotFoundFault:
+                continue
 
 
 MemoryDb.filter_registry.register('marked-for-op', TagActionFilter)
@@ -117,5 +123,5 @@ class DeleteMemoryDbResource(BaseAction):
                     ClusterName=r['Name'],
                     FinalSnapshotName=FinalSnapshotName
                 )
-            except client.exceptions.ResourceNotFoundException:
+            except client.exceptions.ClusterNotFoundFault:
                 continue

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -166,6 +166,7 @@ ResourceMap = {
   "aws.lightsail-instance": "c7n.resources.lightsail.Instance",
   "aws.log-group": "c7n.resources.cw.LogGroup",
   "aws.log-metric": "c7n.resources.cw.LogMetric",
+  "aws.memorydb": "c7n.resources.memorydb.MemoryDb",
   "aws.message-broker": "c7n.resources.mq.MessageBroker",
   "aws.message-config": "c7n.resources.mq.MessageConfig",
   "aws.mirror-session": "c7n.resources.vpc.TrafficMirrorSession",

--- a/c7n/resources/s3control.py
+++ b/c7n/resources/s3control.py
@@ -6,7 +6,7 @@ from c7n.manager import resources
 from c7n.resources.aws import Arn
 from c7n.query import QueryResourceManager, TypeInfo, DescribeSource
 from c7n.utils import local_session, type_schema
-from c7n.tags import TagActionFilter, TagDelayedAction, universal_augment
+from c7n.tags import universal_augment
 from c7n.actions import BaseAction
 
 
@@ -161,26 +161,3 @@ class DeleteStorageLens(BaseAction):
                 ConfigId=configId,
                 AccountId=accountId
             )
-
-
-StorageLens.filter_registry.register('marked-for-op', TagActionFilter)
-
-
-@StorageLens.action_registry.register('mark-for-op')
-class MarkStorageLensForOp(TagDelayedAction):
-    """Mark storage lens configuration for future actions
-
-    :example:
-
-    .. code-block:: yaml
-
-        policies:
-          - name: s3-storage-lens-mark
-            resource: aws.s3-storage-lens
-            filters:
-              - "tag:delete": present
-            actions:
-              - type: mark-for-op
-                op: delete
-                days: 1
-    """

--- a/tests/data/placebo/test_delete_memorydb/memory-db.DeleteCluster_1.json
+++ b/tests/data/placebo/test_delete_memorydb/memory-db.DeleteCluster_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200,
+    "data": {
+        "Cluster": {
+            "Name": "test-cluster",
+            "Description": "Easy created demo cluster on 2024-05-29T20:55:32.568Z",
+            "Status": "deleting",
+            "NumberOfShards": 1,
+            "ClusterEndpoint": {
+                "Address": "clustercfg.test-cluster.qgcgte.memorydb.us-east-1.amazonaws.com",
+                "Port": 6379
+            },
+            "NodeType": "db.t4g.small",
+            "EngineVersion": "7.1",
+            "EnginePatchVersion": "7.1.0",
+            "ParameterGroupName": "default.memorydb-redis7",
+            "ParameterGroupStatus": "in-sync",
+            "SecurityGroups": [
+                {
+                    "SecurityGroupId": "sg-03c0b84cdad91744f",
+                    "Status": "active"
+                }
+            ],
+            "SubnetGroupName": "test-subnet",
+            "TLSEnabled": true,
+            "ARN": "arn:aws:memorydb:us-east-1:644160558196:cluster/test-cluster",
+            "SnapshotRetentionLimit": 1,
+            "MaintenanceWindow": "mon:08:30-mon:09:30",
+            "SnapshotWindow": "04:00-05:00",
+            "AutoMinorVersionUpgrade": true,
+            "DataTiering": "false"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_delete_memorydb/memory-db.DescribeClusters_1.json
+++ b/tests/data/placebo/test_delete_memorydb/memory-db.DescribeClusters_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "Name": "test-cluster",
+                "Description": "Easy created demo cluster on 2024-05-29T20:55:32.568Z",
+                "Status": "available",
+                "NumberOfShards": 1,
+                "ClusterEndpoint": {
+                    "Address": "clustercfg.test-cluster.qgcgte.memorydb.us-east-1.amazonaws.com",
+                    "Port": 6379
+                },
+                "NodeType": "db.t4g.small",
+                "EngineVersion": "7.1",
+                "EnginePatchVersion": "7.1.0",
+                "ParameterGroupName": "default.memorydb-redis7",
+                "ParameterGroupStatus": "in-sync",
+                "SecurityGroups": [
+                    {
+                        "SecurityGroupId": "sg-03c0b84cdad91744f",
+                        "Status": "active"
+                    }
+                ],
+                "SubnetGroupName": "test-subnet",
+                "TLSEnabled": true,
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:cluster/test-cluster",
+                "SnapshotRetentionLimit": 1,
+                "MaintenanceWindow": "mon:08:30-mon:09:30",
+                "SnapshotWindow": "04:00-05:00",
+                "ACLName": "open-access",
+                "AutoMinorVersionUpgrade": true,
+                "DataTiering": "false"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_delete_memorydb/memory-db.ListTags_1.json
+++ b/tests/data/placebo/test_delete_memorydb/memory-db.ListTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "owner",
+                "Value": "policy"
+            },
+            {
+                "Key": "custodian_cleanup",
+                "Value": "Resource does not meet policy: delete@2024/06/08"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memory_db/memory-db.DescribeClusters_1.json
+++ b/tests/data/placebo/test_memory_db/memory-db.DescribeClusters_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "Name": "test-cluster",
+                "Description": "Easy created demo cluster on 2024-05-29T20:55:32.568Z",
+                "Status": "available",
+                "NumberOfShards": 1,
+                "ClusterEndpoint": {
+                    "Address": "clustercfg.test-cluster.qgcgte.memorydb.us-east-1.amazonaws.com",
+                    "Port": 6379
+                },
+                "NodeType": "db.t4g.small",
+                "EngineVersion": "7.1",
+                "EnginePatchVersion": "7.1.0",
+                "ParameterGroupName": "default.memorydb-redis7",
+                "ParameterGroupStatus": "in-sync",
+                "SecurityGroups": [
+                    {
+                        "SecurityGroupId": "sg-03c0b84cdad91744f",
+                        "Status": "active"
+                    }
+                ],
+                "SubnetGroupName": "test-subnet",
+                "TLSEnabled": true,
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:cluster/test-cluster",
+                "SnapshotRetentionLimit": 1,
+                "MaintenanceWindow": "mon:08:30-mon:09:30",
+                "SnapshotWindow": "04:00-05:00",
+                "ACLName": "open-access",
+                "AutoMinorVersionUpgrade": true,
+                "DataTiering": "false"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memory_db/memory-db.ListTags_1.json
+++ b/tests/data/placebo/test_memory_db/memory-db.ListTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "owner",
+                "Value": "policy"
+            },
+            {
+                "Key": "custodian_cleanup",
+                "Value": "Resource does not meet policy: delete@2024/06/08"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_mark_for_op/memory-db.DescribeClusters_1.json
+++ b/tests/data/placebo/test_memorydb_mark_for_op/memory-db.DescribeClusters_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "Name": "test-cluster",
+                "Description": "Easy created demo cluster on 2024-05-29T20:55:32.568Z",
+                "Status": "deleting",
+                "NumberOfShards": 1,
+                "ClusterEndpoint": {
+                    "Address": "clustercfg.test-cluster.qgcgte.memorydb.us-east-1.amazonaws.com",
+                    "Port": 6379
+                },
+                "NodeType": "db.t4g.small",
+                "EngineVersion": "7.1",
+                "EnginePatchVersion": "7.1.0",
+                "ParameterGroupName": "default.memorydb-redis7",
+                "ParameterGroupStatus": "in-sync",
+                "SecurityGroups": [
+                    {
+                        "SecurityGroupId": "sg-03c0b84cdad91744f",
+                        "Status": "active"
+                    }
+                ],
+                "SubnetGroupName": "test-subnet",
+                "TLSEnabled": true,
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:cluster/test-cluster",
+                "SnapshotRetentionLimit": 1,
+                "MaintenanceWindow": "mon:08:30-mon:09:30",
+                "SnapshotWindow": "04:00-05:00",
+                "ACLName": "open-access",
+                "AutoMinorVersionUpgrade": true,
+                "DataTiering": "false"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_mark_for_op/memory-db.DescribeClusters_2.json
+++ b/tests/data/placebo/test_memorydb_mark_for_op/memory-db.DescribeClusters_2.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "Name": "test-cluster",
+                "Description": "Easy created demo cluster on 2024-05-29T20:55:32.568Z",
+                "Status": "deleting",
+                "NumberOfShards": 1,
+                "ClusterEndpoint": {
+                    "Address": "clustercfg.test-cluster.qgcgte.memorydb.us-east-1.amazonaws.com",
+                    "Port": 6379
+                },
+                "NodeType": "db.t4g.small",
+                "EngineVersion": "7.1",
+                "EnginePatchVersion": "7.1.0",
+                "ParameterGroupName": "default.memorydb-redis7",
+                "ParameterGroupStatus": "in-sync",
+                "SecurityGroups": [
+                    {
+                        "SecurityGroupId": "sg-03c0b84cdad91744f",
+                        "Status": "active"
+                    }
+                ],
+                "SubnetGroupName": "test-subnet",
+                "TLSEnabled": true,
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:cluster/test-cluster",
+                "SnapshotRetentionLimit": 1,
+                "MaintenanceWindow": "mon:08:30-mon:09:30",
+                "SnapshotWindow": "04:00-05:00",
+                "ACLName": "open-access",
+                "AutoMinorVersionUpgrade": true,
+                "DataTiering": "false"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_mark_for_op/memory-db.ListTags_1.json
+++ b/tests/data/placebo/test_memorydb_mark_for_op/memory-db.ListTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "owner",
+                "Value": "policy"
+            },
+            {
+                "Key": "custodian_cleanup",
+                "Value": "Resource does not meet policy: delete@2024/06/08"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_mark_for_op/memory-db.ListTags_2.json
+++ b/tests/data/placebo/test_memorydb_mark_for_op/memory-db.ListTags_2.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "owner",
+                "Value": "policy"
+            },
+            {
+                "Key": "custodian_cleanup",
+                "Value": "Resource does not meet policy: delete@2024/06/08"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_mark_for_op/memory-db.TagResource_1.json
+++ b/tests/data/placebo/test_memorydb_mark_for_op/memory-db.TagResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "owner",
+                "Value": "policy"
+            },
+            {
+                "Key": "custodian_cleanup",
+                "Value": "Resource does not meet policy: delete@2024/06/08"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_tag_untag/memory-db.DescribeClusters_1.json
+++ b/tests/data/placebo/test_memorydb_tag_untag/memory-db.DescribeClusters_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "Name": "test-cluster",
+                "Description": "Easy created demo cluster on 2024-05-29T20:55:32.568Z",
+                "Status": "available",
+                "NumberOfShards": 1,
+                "ClusterEndpoint": {
+                    "Address": "clustercfg.test-cluster.qgcgte.memorydb.us-east-1.amazonaws.com",
+                    "Port": 6379
+                },
+                "NodeType": "db.t4g.small",
+                "EngineVersion": "7.1",
+                "EnginePatchVersion": "7.1.0",
+                "ParameterGroupName": "default.memorydb-redis7",
+                "ParameterGroupStatus": "in-sync",
+                "SecurityGroups": [
+                    {
+                        "SecurityGroupId": "sg-03c0b84cdad91744f",
+                        "Status": "active"
+                    }
+                ],
+                "SubnetGroupName": "test-subnet",
+                "TLSEnabled": true,
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:cluster/test-cluster",
+                "SnapshotRetentionLimit": 1,
+                "MaintenanceWindow": "mon:08:30-mon:09:30",
+                "SnapshotWindow": "04:00-05:00",
+                "ACLName": "open-access",
+                "AutoMinorVersionUpgrade": true,
+                "DataTiering": "false"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_tag_untag/memory-db.ListTags_1.json
+++ b/tests/data/placebo/test_memorydb_tag_untag/memory-db.ListTags_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "owner",
+                "Value": "policy"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_tag_untag/memory-db.ListTags_2.json
+++ b/tests/data/placebo/test_memorydb_tag_untag/memory-db.ListTags_2.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "env",
+                "Value": "dev"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_tag_untag/memory-db.TagResource_1.json
+++ b/tests/data/placebo/test_memorydb_tag_untag/memory-db.TagResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "owner",
+                "Value": "policy"
+            },
+            {
+                "Key": "env",
+                "Value": "dev"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_tag_untag/memory-db.UntagResource_1.json
+++ b/tests/data/placebo/test_memorydb_tag_untag/memory-db.UntagResource_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "env",
+                "Value": "dev"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.GetStorageLensConfiguration_1.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.GetStorageLensConfiguration_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "StorageLensConfiguration": {
+            "Id": "default-account-dashboard",
+            "AccountLevel": {
+                "BucketLevel": {}
+            },
+            "DataExport": {
+                "CloudWatchMetrics": {
+                    "IsEnabled": false
+                }
+            },
+            "IsEnabled": true,
+            "StorageLensArn": "arn:aws:s3:us-east-1:644160558196:storage-lens/default-account-dashboard"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.GetStorageLensConfiguration_2.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.GetStorageLensConfiguration_2.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "StorageLensConfiguration": {
+            "Id": "test-dashboard",
+            "AccountLevel": {
+                "BucketLevel": {}
+            },
+            "DataExport": {
+                "CloudWatchMetrics": {
+                    "IsEnabled": false
+                }
+            },
+            "IsEnabled": true,
+            "StorageLensArn": "arn:aws:s3:us-east-1:644160558196:storage-lens/test-dashboard"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.GetStorageLensConfiguration_3.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.GetStorageLensConfiguration_3.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "StorageLensConfiguration": {
+            "Id": "default-account-dashboard",
+            "AccountLevel": {
+                "BucketLevel": {}
+            },
+            "DataExport": {
+                "CloudWatchMetrics": {
+                    "IsEnabled": false
+                }
+            },
+            "IsEnabled": true,
+            "StorageLensArn": "arn:aws:s3:us-east-1:644160558196:storage-lens/default-account-dashboard"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.GetStorageLensConfiguration_4.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.GetStorageLensConfiguration_4.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "StorageLensConfiguration": {
+            "Id": "test-dashboard",
+            "AccountLevel": {
+                "BucketLevel": {}
+            },
+            "DataExport": {
+                "CloudWatchMetrics": {
+                    "IsEnabled": false
+                }
+            },
+            "IsEnabled": true,
+            "StorageLensArn": "arn:aws:s3:us-east-1:644160558196:storage-lens/test-dashboard"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.ListStorageLensConfigurations_1.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.ListStorageLensConfigurations_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "StorageLensConfigurationList": [
+            {
+                "Id": "default-account-dashboard",
+                "StorageLensArn": "arn:aws:s3:us-east-1:644160558196:storage-lens/default-account-dashboard",
+                "HomeRegion": "us-east-1",
+                "IsEnabled": true
+            },
+            {
+                "Id": "test-dashboard",
+                "StorageLensArn": "arn:aws:s3:us-east-1:644160558196:storage-lens/test-dashboard",
+                "HomeRegion": "us-east-1",
+                "IsEnabled": true
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.ListStorageLensConfigurations_2.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/s3-control.ListStorageLensConfigurations_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "StorageLensConfigurationList": [
+            {
+                "Id": "default-account-dashboard",
+                "StorageLensArn": "arn:aws:s3:us-east-1:644160558196:storage-lens/default-account-dashboard",
+                "HomeRegion": "us-east-1",
+                "IsEnabled": true
+            },
+            {
+                "Id": "test-dashboard",
+                "StorageLensArn": "arn:aws:s3:us-east-1:644160558196:storage-lens/test-dashboard",
+                "HomeRegion": "us-east-1",
+                "IsEnabled": true
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/tagging.GetResources_1.json
@@ -1,0 +1,47 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:s3:us-east-1:644160558196:storage-lens/default-account-dashboard",
+                "Tags": [
+                    {
+                        "Key": "a",
+                        "Value": "b"
+                    },
+                    {
+                        "Key": "CostCenter",
+                        "Value": "1234"
+                    },
+                    {
+                        "Key": "d",
+                        "Value": "d"
+                    },
+                    {
+                        "Key": "e",
+                        "Value": "e"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "maid_status",
+                        "Value": "Resource does not meet policy: delete@2024/02/06"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:s3:us-east-1:644160558196:storage-lens/test-dashboard",
+                "Tags": [
+                    {
+                        "Key": "owner",
+                        "Value": "policy"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/tagging.GetResources_2.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:s3:us-east-1:644160558196:storage-lens/default-account-dashboard",
+                "Tags": [
+                    {
+                        "Key": "a",
+                        "Value": "b"
+                    },
+                    {
+                        "Key": "CostCenter",
+                        "Value": "1234"
+                    },
+                    {
+                        "Key": "d",
+                        "Value": "d"
+                    },
+                    {
+                        "Key": "e",
+                        "Value": "e"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "maid_status",
+                        "Value": "Resource does not meet policy: delete@2024/02/06"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:s3:us-east-1:644160558196:storage-lens/test-dashboard",
+                "Tags": [
+                    {
+                        "Key": "owner",
+                        "Value": "policy"
+                    },
+                    {
+                        "Key": "custodian_cleanup",
+                        "Value": "Resource does not meet policy: delete@2024/06/08"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_storage_lens_mark_for_op/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_s3_storage_lens_mark_for_op/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "FailedResourcesMap": {},
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_memorydb.py
+++ b/tests/test_memorydb.py
@@ -1,0 +1,106 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from .common import BaseTest
+
+class MemoryDbTest(BaseTest):
+
+    def test_memorydb(self):
+        factory = self.replay_flight_data("test_memory_db")
+        p = self.load_policy({
+            'name': 'memorydb',
+            'resource': 'aws.memorydb'},
+            session_factory=factory,
+            config={'region': 'us-east-1'})
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        assert resources[0]['Name'] == 'test-cluster'
+
+    def test_memorydb_tag_untag(self):
+        session_factory = self.replay_flight_data('test_memorydb_tag_untag')
+        tag = {'env': 'dev'}
+        p = self.load_policy(
+            {
+                'name': 'memorydb-tag-untag',
+                'resource': 'memorydb',
+                'filters': [{
+                    'tag:owner': 'policy'
+                }],
+                'actions': [{
+                    'type': 'tag',
+                    'tags': tag
+                },
+                {
+                    'type': 'remove-tag',
+                    'tags': ['owner']
+                }]
+            },
+            session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        client = session_factory().client("memorydb")
+        tags = client.list_tags(ResourceArn=resources[0]["ARN"])["TagList"]
+        self.assertEqual(1, len(tags))
+        new_tag = {}
+        new_tag[tags[0]['Key']] = tags[0]['Value']
+        self.assertEqual(tag, new_tag)
+
+    def test_memorydb_mark_for_op(self):
+        session_factory = self.record_flight_data("test_memorydb_mark_for_op")
+        p = self.load_policy(
+            {
+                "name": "memorydb-mark",
+                "resource": "memorydb",
+                "filters": [
+                    {'tag:owner': 'policy'},
+                ],
+                "actions": [
+                    {
+                        "type": "mark-for-op",
+                        "tag": "custodian_cleanup",
+                        "op": "delete",
+                        "days": 1,
+                    }
+                ],
+            },
+            session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        p = self.load_policy(
+            {
+                "name": "memorydb-marked",
+                "resource": "memorydb",
+                "filters": [
+                    {
+                        "type": "marked-for-op",
+                        "tag": "custodian_cleanup",
+                        "op": "delete",
+                        "skew": 3,
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        assert resources[0]['Name'] == 'test-cluster'
+
+
+    def test_delete_memorydb(self):
+        session_factory = self.replay_flight_data("test_delete_memorydb")
+        p = self.load_policy(
+            {
+                "name": "delete-memorydb",
+                "resource": "memorydb",
+                "filters": [{"tag:owner": "policy"}],
+                "actions": [{
+                                "type": "delete",
+                            }],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual(resources[0]["Name"], "test-cluster")

--- a/tests/test_memorydb.py
+++ b/tests/test_memorydb.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest
 
+
 class MemoryDbTest(BaseTest):
 
     def test_memorydb(self):
@@ -86,7 +87,6 @@ class MemoryDbTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         assert resources[0]['Name'] == 'test-cluster'
-
 
     def test_delete_memorydb(self):
         session_factory = self.replay_flight_data("test_delete_memorydb")

--- a/tests/test_memorydb.py
+++ b/tests/test_memorydb.py
@@ -3,6 +3,7 @@
 from .common import BaseTest
 from unittest.mock import MagicMock
 
+
 class MemoryDbTest(BaseTest):
 
     def test_memorydb(self):

--- a/tests/test_memorydb.py
+++ b/tests/test_memorydb.py
@@ -107,7 +107,7 @@ class MemoryDbTest(BaseTest):
         self.assertEqual(resources[0]["Name"], "test-cluster")
 
     def test_delete_memorydb_exception(self):
-        factory = self.replay_flight_data("test_delete_memorydb_exception")
+        factory = self.replay_flight_data("test_delete_memorydb")
         client = factory().client("memorydb")
         mock_factory = MagicMock()
         mock_factory.region = 'us-east-1'

--- a/tests/test_memorydb.py
+++ b/tests/test_memorydb.py
@@ -46,7 +46,7 @@ class MemoryDbTest(BaseTest):
         self.assertEqual(tag, new_tag)
 
     def test_memorydb_mark_for_op(self):
-        session_factory = self.record_flight_data("test_memorydb_mark_for_op")
+        session_factory = self.replay_flight_data("test_memorydb_mark_for_op")
         p = self.load_policy(
             {
                 "name": "memorydb-mark",


### PR DESCRIPTION
Closes  [issue 8543 ](https://github.com/cloud-custodian/cloud-custodian/issues/8543).

In addition. for s3 storage lens control,  `universal_taggable = object()` is already implemented. Therefore additional `mark-for-op` and `marked-for-op` code for the resource should be removed.

AWS Resource Groups Tagging API doesn't support memorydb. So additional tagging functionality is implemented.