### PR TITLE
aws - mu - avoid unnecessary lambda updates for vpc config

### DIFF
--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -984,6 +984,41 @@ class PolicyLambdaProvision(Publish):
                 },
             )
         )
+        self.assertTrue(
+            delta(
+                {
+                    "VpcConfig": {
+                        "SubnetIds": ["s-1", "s-2"],
+                        "SecurityGroupIds": ["sg-1", "sg-2"],
+                    }
+                },
+                {
+                    "VpcConfig": {
+                        "SubnetIds": ["s-1", "s-2"],
+                        "SecurityGroupIds": ["sg-1", "sg-2"],
+                        "Ipv6AllowedForDualStack": True,
+                    }
+                },
+            )
+        )
+        self.assertTrue(
+            delta(
+                {
+                    "VpcConfig": {
+                        "SubnetIds": ["s-1", "s-2"],
+                        "SecurityGroupIds": ["sg-1", "sg-2"],
+                        "VpcId": "vpc-12345",
+                    }
+                },
+                {
+                    "VpcConfig": {
+                        "SubnetIds": ["s-1", "s-2"],
+                        "SecurityGroupIds": ["sg-1", "sg-2"],
+                        "VpcId": "vpc-23456",
+                    }
+                },
+            )
+        )
         self.assertFalse(delta({}, {"DeadLetterConfig": {}}))
 
         self.assertTrue(delta({}, {"DeadLetterConfig": {"TargetArn": "arn"}}))
@@ -996,6 +1031,20 @@ class PolicyLambdaProvision(Publish):
 
         self.assertFalse(
             delta({}, {"VpcConfig": {"SecurityGroupIds": [], "SubnetIds": []}})
+        )
+        self.assertFalse(
+            delta(
+                {"VpcConfig": {
+                    "SecurityGroupIds": [],
+                    "SubnetIds": [],
+                }},
+                {"VpcConfig": {
+                    "SecurityGroupIds": [],
+                    "SubnetIds": [],
+                    "VpcId": "",
+                    "Ipv6AllowedForDualStack": False,
+                }},
+            )
         )
 
     def test_different_lambda_handler(self):


### PR DESCRIPTION
The `VpcId` and `Ipv6AllowedForDualStack` keys may be present-but-empty in an existing function's configuration. Only trigger a Lambda function config update if those properties meaningfully change.

Closes #9557