### PR TITLE
Fix handling empty EB Scheduler payload

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -138,6 +138,8 @@ init_env_globals()
 
 
 def dispatch_event(event, context):
+    # default event.detail for EB Scheduler is '{}', not {}
+    event['detail'] = {} if event.get('detail') == '{}' else event['detail']
     error = event.get('detail', {}).get('errorCode')
     if error and C7N_SKIP_EVTERR:
         log.debug("Skipping failed operation: %s" % error)


### PR DESCRIPTION
EB Scheduler default payloads contain `event.detail: '{}'` causing an error in dispatch_handler. This change checks to see if detail is a string of empty braces and replaces it with an empty dict to prevent type related exceptions in code expecting a dict.