### PR TITLE
Fixing compute disk resource manager class type

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/compute.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/compute.py
@@ -1,4 +1,4 @@
-    # Copyright The Cloud Custodian Authors.
+# Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
 import re

--- a/tools/c7n_gcp/c7n_gcp/resources/compute.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/compute.py
@@ -1,4 +1,4 @@
-# Copyright The Cloud Custodian Authors.
+    # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
 import re
@@ -361,7 +361,7 @@ class Disk(QueryResourceManager):
         version = 'v1'
         component = 'disks'
         scope = 'zone'
-        enum_spec = ('aggregatedList', 'items.*.disks[]', None)
+        enum_spec = ('list', 'items[]', None)
         name = id = 'name'
         labels = True
         default_report_fields = ["name", "sizeGb", "status", "zone"]


### PR DESCRIPTION
In current implementation, API being used in Aggregated APIs while scope is zone, which will create an issue while doing disk operations. Fixing API enum specs.