### PR TITLE
azure - metric filter - add no_data_action example policies

### DIFF
--- a/docs/source/azure/examples/metrics-general.rst
+++ b/docs/source/azure/examples/metrics-general.rst
@@ -17,6 +17,24 @@ Find VMs with an average Percentage CPU greater than or equal to 75% over the la
             threshold: 75
             timeframe: 12
 
+Find VMs with a maximum Percentage CPU at or below 10% over the last 24 hours (note the use of
+``no_data_action: to_zero`` to treat missing metric values as zeroes)
+
+.. code-block:: yaml
+
+    policies:
+      - name: find-underused-vms
+        description: Find VMs with maximum cpu <= 10% over the last 24 hours
+        resource: azure.vm
+        filters:
+          - type: metric
+            metric: Percentage CPU
+            aggregation: maximum
+            op: lte
+            threshold: 10
+            timeframe: 24
+            no_data_action: to_zero
+
 Find KeyVaults with more than 1000 API hits in the last hour
 
 .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -75,11 +75,11 @@ class MetricFilter(Filter):
     .. code-block:: yaml
 
         policies:
-        - name: find-underused-vms
+          - name: find-underused-vms
             description: Find VMs with maximum cpu <= 10% over the last 24 hours
             resource: azure.vm
             filters:
-            - type: metric
+              - type: metric
                 metric: Percentage CPU
                 aggregation: maximum
                 op: lte

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -69,6 +69,26 @@ class MetricFilter(Filter):
 
     :example:
 
+    Find VMs with a maximum Percentage CPU at or below 10% over the last 24 hours (note the use of
+    ``no_data_action: to_zero`` to treat missing metric values as zeroes)
+
+    .. code-block:: yaml
+
+        policies:
+        - name: find-underused-vms
+            description: Find VMs with maximum cpu <= 10% over the last 24 hours
+            resource: azure.vm
+            filters:
+            - type: metric
+                metric: Percentage CPU
+                aggregation: maximum
+                op: lte
+                threshold: 10
+                timeframe: 24
+                no_data_action: to_zero
+
+    :example:
+
     Find KeyVaults with more than 1000 API hits in the last hour
 
     .. code-block:: yaml


### PR DESCRIPTION
Surface no_data_action in example policies so folks don't have to expand the schema section to see it.

It looks like we're mirroring examples between a dedicated monitoring example page and the metric filter page itself. That seems reasonable.