### PR TITLE
Handle event dicts without a detail key

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -139,8 +139,7 @@ init_env_globals()
 
 def dispatch_event(event, context):
     # default event.detail for EB Scheduler is '{}', not {}
-    if 'detail' in event and event.get('detail') == '{}':
-        event['detail'] = {}
+    event['detail'] = {} if event.get('detail') == '{}' else event.get('detail', {})
     error = event.get('detail', {}).get('errorCode')
     if error and C7N_SKIP_EVTERR:
         log.debug("Skipping failed operation: %s" % error)

--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -139,7 +139,8 @@ init_env_globals()
 
 def dispatch_event(event, context):
     # default event.detail for EB Scheduler is '{}', not {}
-    event['detail'] = {} if event.get('detail') == '{}' else event['detail']
+    if 'detail' in event and event.get('detail') == '{}':
+        event['detail'] = {}
     error = event.get('detail', {}).get('errorCode')
     if error and C7N_SKIP_EVTERR:
         log.debug("Skipping failed operation: %s" % error)


### PR DESCRIPTION
Fixes #9582.

If the `event` dict does contain a `detail` key AND the `detail` key contains an str of `'{}'`, then replace the `detail` value with an empty dict object (`{}`). Otherwise leave the event dict alone.

Addresses a lack of consistency between EventBridge rules (which always have a dict object as the value for `detail`) and EventBridge Scheduler which defaults to an str of `'{}'`.