### PR TITLE
aws - ecs - include configuration information

### DIFF
--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -96,7 +96,9 @@ class ECSCluster(query.QueryResourceManager):
         service = 'ecs'
         enum_spec = ('list_clusters', 'clusterArns', None)
         batch_detail_spec = (
-            'describe_clusters', 'clusters', None, 'clusters', {'include': ['TAGS', 'SETTINGS']})
+            'describe_clusters', 'clusters', None, 'clusters', {
+                'include': ['TAGS', 'SETTINGS', 'CONFIGURATIONS']
+            })
         name = "clusterName"
         arn = id = "clusterArn"
         arn_type = 'cluster'

--- a/tests/data/placebo/test_ecs_cluster_exec_cw_logging/ecs.DescribeClusters_1.json
+++ b/tests/data/placebo/test_ecs_cluster_exec_cw_logging/ecs.DescribeClusters_1.json
@@ -1,0 +1,95 @@
+{
+    "status_code": 200,
+    "data": {
+        "clusters": [
+            {
+                "clusterArn": "arn:aws:ecs:us-east-1:111111111111:cluster/ecs-green",
+                "clusterName": "ecs-green-1",
+                "configuration": {
+                    "executeCommandConfiguration": {
+                        "kmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/bde45335-a5b7-5bc6f92da2dd",
+                        "logging": "OVERRIDE",
+                        "logConfiguration": {
+                            "cloudWatchLogGroupName": "/aws/ecs/ecs-green",
+                            "cloudWatchEncryptionEnabled": true,
+                            "s3EncryptionEnabled": false
+                        }
+                    }
+                },
+                "status": "ACTIVE",
+                "registeredContainerInstancesCount": 0,
+                "runningTasksCount": 1,
+                "pendingTasksCount": 0,
+                "activeServicesCount": 1,
+                "statistics": [],
+                "tags": [
+                    {
+                        "key": "ComplianceStatus",
+                        "value": "Green"
+                    }
+                ],
+                "settings": [
+                    {
+                        "name": "containerInsights",
+                        "value": "enabled"
+                    }
+                ],
+                "capacityProviders": [],
+                "defaultCapacityProviderStrategy": []
+            },
+            {
+                "clusterArn": "arn:aws:ecs:us-east-1:111111111111:cluster/ecs-red-1",
+                "clusterName": "ecs-red-1",
+                "configuration": {},
+                "status": "ACTIVE",
+                "registeredContainerInstancesCount": 0,
+                "runningTasksCount": 0,
+                "pendingTasksCount": 0,
+                "activeServicesCount": 1,
+                "statistics": [],
+                "tags": [],
+                "settings": [
+                    {
+                        "name": "containerInsights",
+                        "value": "disabled"
+                    }
+                ],
+                "capacityProviders": [],
+                "defaultCapacityProviderStrategy": []
+            },
+            {
+                "clusterArn": "arn:aws:ecs:us-east-1:111111111111:cluster/ecs-red-2",
+                "clusterName": "ecs-red-2",
+                "configuration": {
+                    "executeCommandConfiguration": {
+                        "logging": "OVERRIDE",
+                        "logConfiguration": {
+                            "cloudWatchLogGroupName": "/aws/ecs/ecs-red",
+                            "cloudWatchEncryptionEnabled": false,
+                            "s3BucketName": "bucket-red-59239",
+                            "s3EncryptionEnabled": false
+                        }
+                    }
+                },
+                "status": "ACTIVE",
+                "registeredContainerInstancesCount": 0,
+                "runningTasksCount": 0,
+                "pendingTasksCount": 0,
+                "activeServicesCount": 1,
+                "statistics": [],
+                "tags": [],
+                "settings": [
+                    {
+                        "name": "containerInsights",
+                        "value": "disabled"
+                    }
+                ],
+                "capacityProviders": [],
+                "defaultCapacityProviderStrategy": []
+            }
+
+        ],
+        "failures": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecs_cluster_exec_cw_logging/ecs.ListClusters_1.json
+++ b/tests/data/placebo/test_ecs_cluster_exec_cw_logging/ecs.ListClusters_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "clusterArns": [
+            "arn:aws:ecs:us-east-1:111111111111:cluster/ecs-green",
+            "arn:aws:ecs:us-east-1:111111111111:cluster/ecs-red-1",
+            "arn:aws:ecs:us-east-1:111111111111:cluster/ecs-red-2"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -73,6 +73,32 @@ class TestEcs(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
+    def test_ecs_cluster_exec_cw_logging(self):
+        session_factory = self.replay_flight_data("test_ecs_cluster_exec_cw_logging")
+        p = self.load_policy(
+        {
+            "name": "ecs-cluster-exec-cw-logging",
+            "resource": "ecs",
+            "filters": [
+                {
+                    "type": "value",
+                    "key": "configuration.executeCommandConfiguration."
+                           "logConfiguration.cloudWatchLogGroupName",
+                    "value": "present"
+                },
+                {
+                    "type": "value",
+                    "key": "configuration.executeCommandConfiguration."
+                           "logConfiguration.cloudWatchEncryptionEnabled",
+                    "value": False
+                }
+            ],
+        },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
 
 class TestEcsService(BaseTest):
 


### PR DESCRIPTION
By default, the configuration section for the AWS ECS cluster is not included in the response ([source documentation](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeClusters.html#API_DescribeClusters_RequestSyntax)).
To check AWS ECS exec logging this configuration is required.

Policy example:
```yaml
policies:
  - name: ecs_exec_logging_encryption_enabled
    resource: ecs
    filters:
      - or:
          - and:
              - type: value
                key: configuration.executeCommandConfiguration.logConfiguration.cloudWatchLogGroupName
                value: present
              - type: value
                key: configuration.executeCommandConfiguration.logConfiguration.cloudWatchEncryptionEnabled
                value: false
          - and:
              - type: value
                key: configuration.executeCommandConfiguration.logConfiguration.s3BucketName
                value: present
              - type: value
                key: configuration.executeCommandConfiguration.logConfiguration.s3EncryptionEnabled
                value: false
```
