### PR TITLE
Allow to use regex with list of items

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -47,20 +47,26 @@ def glob_match(value, pattern):
     return fnmatch.fnmatch(value, pattern)
 
 
+def _regex_match(value, regex, flags=0):
+    if isinstance(value, list):
+        for item in value:
+            if not isinstance(item, str):
+                continue
+            if re.match(regex, item, flags=flags):
+                return True
+    elif isinstance(value, str):
+        # Note python 2.5+ internally cache regex
+        # would be nice to use re2
+        return bool(re.match(regex, value, flags=flags))
+    return False
+
+
 def regex_match(value, regex):
-    if not isinstance(value, str):
-        return False
-    # Note python 2.5+ internally cache regex
-    # would be nice to use re2
-    return bool(re.match(regex, value, flags=re.IGNORECASE))
+    return _regex_match(value, regex, flags=re.IGNORECASE)
 
 
 def regex_case_sensitive_match(value, regex):
-    if not isinstance(value, str):
-        return False
-    # Note python 2.5+ internally cache regex
-    # would be nice to use re2
-    return bool(re.match(regex, value))
+    return _regex_match(value, regex, flags=0)
 
 
 def operator_in(x, y):


### PR DESCRIPTION
Example:

```yaml
policies:
  - name: spanner_backup_without_privileged_service_account
    resource: gcp.spanner-backup
    filters:
      - type: iam-policy
        doc:
          key: "bindings[*].role"
          op: intersect
          value: ["roles/editor", "roles/owner"]
      - type: iam-policy
        doc:
          key: "bindings[*].members[]"
          op: regex
          value: '^.*gserviceaccount.com' # here
```
If you cannot accept this is there some native way I can match regex over the list of items?