### PR TITLE
Changes order of elifs in utils.py so one isn't skipped

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -927,9 +927,9 @@ def get_eni_resource_type(eni):
         rtype = 'hsm'
     elif description.startswith('CloudHsm ENI'):
         rtype = 'hsmv2'
-    elif description.startswith('AWS Lambda VPC'):
-        rtype = 'lambda'
     elif description.startswith('AWS Lambda VPC ENI'):
+        rtype = 'lambda'
+    elif description.startswith('AWS Lambda VPC'):
         rtype = 'lambda'
     elif description.startswith('Interface for NAT Gateway'):
         rtype = 'nat'


### PR DESCRIPTION
A simple little change here.

The way it is now, since `AWS Lambda VPC` is within `AWS Lambda VPC ENI`, the ENI elif will never get run bc the shorter elif will catch the strings containing ENI. Putting the  shorter string behind the longer one guarantees the longer one will catch the ones it should and the rest will be caught by the shorter one. 

(another solution would be to delete the `AWS Lambda VPC ENI` elif entirely since they're both assigning rtype to lambda but there is probably a good reason you have it split like that.)