### PR TITLE
Fix event handler bug

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -139,7 +139,8 @@ init_env_globals()
 
 def dispatch_event(event, context):
     # default event.detail for EB Scheduler is '{}', not {}
-    if event.get('detail') == '{}': event['detail'] = {}
+    if event.get('detail') == '{}':
+        event['detail'] = {}
     error = event.get('detail', {}).get('errorCode')
     if error and C7N_SKIP_EVTERR:
         log.debug("Skipping failed operation: %s" % error)

--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -139,8 +139,7 @@ init_env_globals()
 
 def dispatch_event(event, context):
     # default event.detail for EB Scheduler is '{}', not {}
-    if event.get('detail') == '{}':
-        event['detail'] = {}
+    if event.get('detail') == '{}': event['detail'] = {}
     error = event.get('detail', {}).get('errorCode')
     if error and C7N_SKIP_EVTERR:
         log.debug("Skipping failed operation: %s" % error)

--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -139,7 +139,8 @@ init_env_globals()
 
 def dispatch_event(event, context):
     # default event.detail for EB Scheduler is '{}', not {}
-    event['detail'] = {} if event.get('detail') == '{}' else event.get('detail', {})
+    if event.get('detail') == '{}':
+        event['detail'] = {}
     error = event.get('detail', {}).get('errorCode')
     if error and C7N_SKIP_EVTERR:
         log.debug("Skipping failed operation: %s" % error)


### PR DESCRIPTION
The change in EB Scheduler payload ([#9566](https://github.com/cloud-custodian/cloud-custodian/pull/9566)) broke all config-poll-rule policies. When AWS Config rules or a user manually invoke a lambda function, it fails with a KeyError exception below:

```
[ERROR] KeyError: 'detail'
Traceback (most recent call last):
  File "/var/task/custodian_policy.py", line 4, in run
    return handler.dispatch_event(event, context)
  File "/var/task/c7n/handler.py", line 142, in dispatch_event
    event['detail'] = {} if event.get('detail') == '{}' else event['detail']
```