### PR TITLE
releng - use larger runner for docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
           - mailer
           - policystream
           - c7n-left
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v4
       - name: ${{ matrix.image }} build and push


### PR DESCRIPTION
our docker builds have been intermittently failing on c7n-left builds, generally timing out on pip install when doing qemu builds for arm64.
https://github.com/cloud-custodian/cloud-custodian/actions/workflows/docker.yml?query=event%3Aschedule

as an interim solution, try using some of the larger x86 builders to see if that can resolve. the larger builders are provided
by virtue of cncf's enteprise github plan.

if this doesn't resolve, we'll need to do something more invasive to resolve by redoing our docker building configuration to allow
for native hosts builds and piecing together the multi arch image.

https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

