### PR TITLE
aws - cloudfront - add origin-access-control resource

### DIFF
--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -89,6 +89,25 @@ class StreamingDistribution(QueryResourceManager):
     }
 
 
+@resources.register("origin-access-control")
+class OriginAccessControl(QueryResourceManager):
+    class resource_type(TypeInfo):
+        service = "cloudfront"
+        arn_type = "origin-access-control"
+        enum_spec = (
+            "list_origin_access_controls",
+            "OriginAccessControlList.Items",
+            None,
+        )
+        id = "Id"
+        description = "Description"
+        name = "Name"
+        signing_protocol = "SigningProtocol"
+        signing_behavior = "SigningBehavior"
+        origin_type = "OriginAccessControlOriginType"
+        cfn_type = config_type = "AWS::CloudFront::OriginAccessControl"
+
+
 Distribution.filter_registry.register('shield-metrics', ShieldMetrics)
 Distribution.filter_registry.register('shield-enabled', IsShieldProtected)
 Distribution.action_registry.register('set-shield', SetShieldProtection)

--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -105,7 +105,7 @@ class OriginAccessControl(QueryResourceManager):
         signing_protocol = "SigningProtocol"
         signing_behavior = "SigningBehavior"
         origin_type = "OriginAccessControlOriginType"
-        cfn_type = config_type = "AWS::CloudFront::OriginAccessControl"
+        cfn_type = "AWS::CloudFront::OriginAccessControl"
 
 
 Distribution.filter_registry.register('shield-metrics', ShieldMetrics)

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -190,6 +190,7 @@ ResourceMap = {
   "aws.org-account": "c7n.resources.org.OrgAccount",
   "aws.org-policy": "c7n.resources.org.OrgPolicy",
   "aws.org-unit": "c7n.resources.org.OrgUnit",
+  "aws.origin-access-control": "c7n.resources.cloudfront.OriginAccessControl",
   "aws.peering-connection": "c7n.resources.vpc.PeeringConnection",
   "aws.pinpoint-app": "c7n.resources.pinpoint.PinpointApp",
   "aws.prefix-list": "c7n.resources.vpc.PrefixList",

--- a/tests/data/placebo/test_origin_access_control/cloudfront.ListOriginAccessControls_1.json
+++ b/tests/data/placebo/test_origin_access_control/cloudfront.ListOriginAccessControls_1.json
@@ -1,0 +1,40 @@
+{
+  "status_code": 200,
+  "data": {
+    "OriginAccessControlList": {
+      "Marker": "",
+      "MaxItems": 200,
+      "IsTruncated": false,
+      "Quantity": 2,
+      "Items": [
+        {
+          "Id": "E65YXOJ2CCHLX2",
+          "Name": "c7n-signing-behavior-always-oac",
+          "SigningProtocol": "sigv4",
+          "SigningBehavior": "always",
+          "OriginAccessControlOriginType": "s3"
+        },
+        {
+          "Id": "E67KI9SC1UA4K7",
+          "Name": "c7n-signing-behavior-never-oac",
+          "SigningProtocol": "sigv4",
+          "SigningBehavior": "never",
+          "OriginAccessControlOriginType": "s3"
+        }
+      ]
+    },
+    "ResponseMetadata": {
+      "RequestId": "073c49bd-c96a-11e8-985e-9d171bfe00d0",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "server": "Server",
+        "date": "Fri, 07 Jul 2024 16:28:18 GMT",
+        "content-type": "application/x-amz-json-1.1",
+        "content-length": "123",
+        "connection": "keep-alive",
+        "x-amzn-requestid": "073c49bd-c96a-11e8-985e-9d171bfe00d0"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -798,6 +798,28 @@ class CloudFront(BaseTest):
             'AwsCloudFrontDistributionDetails',
             'securityhub')
 
+    def test_origin_access_control(self):
+        factory = self.replay_flight_data("test_origin_access_control")
+
+        p = self.load_policy(
+            {
+                "name": "origin-access-control-signing-behavior",
+                "resource": "origin-access-control",
+                "filters": [
+                    {
+                        "type": "value",
+                        "key": "SigningBehavior",
+                        "value": "always",
+                        "op": "eq"
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['Name'], "c7n-signing-behavior-always-oac")
+
 
 class CloudFrontWafV2(BaseTest):
 


### PR DESCRIPTION
- Problem
  - Previously, there were no origin-access-control resources for CloudFront in c7n, so no filtering was possible.

- Resolved
  - With the registration of origin-access-control resources, we can now filter information.