### PR TITLE
docs - add sphinxcontrib.jquery extension to fix doc search

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'c7n_sphinxext.docgen',
     'myst_parser',
-    'sphinx_markdown_tables'
+    'sphinx_markdown_tables',
+    'sphinxcontrib.jquery',
 ]
 
 # Extract only a classes docstrings


### PR DESCRIPTION
The Read the Docs theme for sphinx relies on jQuery in a few spots. It looks like we already have a sphinxcontrib-jquery dependency, but weren't referencing it as an extension in conf.py.

Adding this seems more "workaround" than fix - it may be worth following the related upstream issue or monkeypatching our way around jQuery in c7n-sphinxext.

See also: https://github.com/readthedocs/sphinx_rtd_theme/issues/1546

Closes #9651 