### PR TITLE
chore: a few code cleanups

### DIFF
--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -271,13 +271,10 @@ class DescribeRestStage(query.ChildDescribeSource):
     def __init__(self, manager):
         self.manager = manager
         self.query = query.ChildResourceQuery(
-            self.manager.session_factory, self.manager)
-        self.query.capture_parent_id = True
+            self.manager.session_factory, self.manager, capture_parent_id=True)
 
     def get_query(self):
-        query = super(DescribeRestStage, self).get_query()
-        query.capture_parent_id = True
-        return query
+        return super(DescribeRestStage, self).get_query(capture_parent_id=True)
 
     def augment(self, resources):
         results = []
@@ -453,9 +450,7 @@ class RestResource(query.ChildResourceManager):
 class DescribeRestResource(query.ChildDescribeSource):
 
     def get_query(self):
-        query = super(DescribeRestResource, self).get_query()
-        query.capture_parent_id = True
-        return query
+        return super(DescribeRestResource, self).get_query(capture_parent_id=True)
 
     def augment(self, resources):
         results = []

--- a/c7n/resources/code.py
+++ b/c7n/resources/code.py
@@ -366,9 +366,7 @@ class CodeDeployDeployment(QueryResourceManager):
 class DescribeDeploymentGroup(query.ChildDescribeSource):
 
     def get_query(self):
-        query = super().get_query()
-        query.capture_parent_id = True
-        return query
+        return super().get_query(capture_parent_id=True)
 
     def augment(self, resources):
         client = local_session(self.manager.session_factory).client('codedeploy')

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -85,9 +85,7 @@ class RepositoryImageDescribeSource(ChildDescribeSource):
     resource_query_factory = ECRImageQuery
 
     def get_query(self):
-        query = super(RepositoryImageDescribeSource, self).get_query()
-        query.capture_parent_id = True
-        return query
+        return super().get_query(capture_parent_id=True)
 
     def augment(self, resources):
         results = []

--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -133,8 +133,7 @@ class ECSClusterResourceDescribeSource(query.ChildDescribeSource):
     def __init__(self, manager):
         self.manager = manager
         self.query = query.ChildResourceQuery(
-            self.manager.session_factory, self.manager)
-        self.query.capture_parent_id = True
+            self.manager.session_factory, self.manager, capture_parent_id=True)
 
     def get_resources(self, ids, cache=True):
         """Retrieve ecs resources for serverless policies or related resources
@@ -947,7 +946,7 @@ class ECSContainerInstanceDescribeSource(ECSClusterResourceDescribeSource):
             r = client.describe_container_instances(
                 cluster=cluster_id,
                 include=['TAGS'],
-                containerInstances=container_instances).get('containerInstances', [])
+                containerInstances=service_set).get('containerInstances', [])
             # Many Container Instance API calls require the cluster_id, adding as a
             # custodian specific key in the resource
             for i in r:

--- a/c7n/resources/eks.py
+++ b/c7n/resources/eks.py
@@ -18,9 +18,7 @@ from c7n.filters.kms import KmsRelatedFilter
 class NodeGroupDescribeSource(ChildDescribeSource):
 
     def get_query(self):
-        query = super(NodeGroupDescribeSource, self).get_query()
-        query.capture_parent_id = True
-        return query
+        return super().get_query(capture_parent_id=True)
 
     def augment(self, resources):
         results = []

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -369,9 +369,7 @@ class GlueTable(query.ChildResourceManager):
 class DescribeTable(query.ChildDescribeSource):
 
     def get_query(self):
-        query = super(DescribeTable, self).get_query()
-        query.capture_parent_id = True
-        return query
+        return super(DescribeTable, self).get_query(capture_parent_id=True)
 
     def augment(self, resources):
         result = []

--- a/c7n/resources/transfer.py
+++ b/c7n/resources/transfer.py
@@ -150,9 +150,7 @@ class DeleteServer(BaseAction):
 class DescribeTransferUser(ChildDescribeSource):
 
     def get_query(self):
-        query = super().get_query()
-        query.capture_parent_id = True
-        return query
+        return super().get_query(capture_parent_id=True)
 
     def augment(self, resources):
         client = local_session(self.manager.session_factory).client('transfer')


### PR DESCRIPTION
- pass capture_parent_id as a constructor parameter to childResourceQuery
- get resources only for the selected batch when listing ECS instances
