### PR TITLE
workspaces-web: Add UserAccessLoggingSettings Filter

### DIFF
--- a/tests/data/placebo/test_workspaces_web_user_access_logging_settings/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_workspaces_web_user_access_logging_settings/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:workspaces-web:us-east-1:644160558196:portal/b69475bb-ca94-429a-97c7-4ad50de5a220",
+                "Tags": [
+                    {
+                        "Key": "foo",
+                        "Value": "bar"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_workspaces_web_user_access_logging_settings/workspaces-web.GetUserAccessLoggingSettings_1.json
+++ b/tests/data/placebo/test_workspaces_web_user_access_logging_settings/workspaces-web.GetUserAccessLoggingSettings_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "userAccessLoggingSettings": {
+            "associatedPortalArns": [
+                "arn:aws:workspaces-web:us-east-1:644160558196:portal/b69475bb-ca94-429a-97c7-4ad50de5a220"
+            ],
+            "kinesisStreamArn": "arn:aws:kinesis:us-east-1:644160558196:stream/amazon-workspaces-web-test",
+            "userAccessLoggingSettingsArn": "arn:aws:workspaces-web:us-east-1:644160558196:userAccessLoggingSettings/afec9e0a-75ab-4973-badb-ed41d0a1907a"
+        }
+    }
+}

--- a/tests/data/placebo/test_workspaces_web_user_access_logging_settings/workspaces-web.ListPortals_1.json
+++ b/tests/data/placebo/test_workspaces_web_user_access_logging_settings/workspaces-web.ListPortals_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "portals": [
+            {
+                "authenticationType": "IAM_Identity_Center",
+                "browserSettingsArn": "arn:aws:workspaces-web:us-east-1:644160558196:browserSettings/a9c94f86-1af8-45b9-a00c-d6ca17a73f44",
+                "browserType": "Chrome",
+                "creationDate": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 8,
+                    "day": 8,
+                    "hour": 13,
+                    "minute": 28,
+                    "second": 57,
+                    "microsecond": 757000
+                },
+                "displayName": "test",
+                "instanceType": "standard.regular",
+                "maxConcurrentSessions": 5,
+                "networkSettingsArn": "arn:aws:workspaces-web:us-east-1:644160558196:networkSettings/1edd2ee9-5b4f-4547-9b6e-5c431e4dcebd",
+                "portalArn": "arn:aws:workspaces-web:us-east-1:644160558196:portal/b69475bb-ca94-429a-97c7-4ad50de5a220",
+                "portalEndpoint": "b69475bb-ca94-429a-97c7-4ad50de5a220.workspaces-web.com",
+                "portalStatus": "Active",
+                "rendererType": "AppStream",
+                "userAccessLoggingSettingsArn": "arn:aws:workspaces-web:us-east-1:644160558196:userAccessLoggingSettings/afec9e0a-75ab-4973-badb-ed41d0a1907a",
+                "userSettingsArn": "arn:aws:workspaces-web:us-east-1:644160558196:userSettings/17f7802d-1393-419b-83ed-f7bd22a54c85"
+            }
+        ]
+    }
+}

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -484,6 +484,42 @@ class TestWorkspacesWeb(BaseTest):
 
         self.assertEqual(len(resources), 1)
 
+    def test_workspaces_web_user_access_logging_settings(self):
+        session_factory = self.replay_flight_data(
+            'test_workspaces_web_user_access_logging_settings'
+        )
+        p = self.load_policy(
+            {
+                'name': 'test-workspaces-web-user-access-logging-settings',
+                'resource': 'workspaces-web',
+                'filters': [
+                    {
+                        'type': 'user-access-logging-settings',
+                        'key': 'kinesisStreamArn',
+                        "value": 'present'
+                    }
+                ]
+            }, session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        p = self.load_policy(
+            {
+                'name': 'test-workspaces-web-user-access-logging-settings',
+                'resource': 'workspaces-web',
+                'filters': [
+                    {
+                        'type': 'user-access-logging-settings',
+                        'key': 'kinesisStreamArn',
+                        "value": 'absent'
+                    }
+                ]
+            }, session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
 
 class TestWorkspacesBundleDelete(BaseTest):
 


### PR DESCRIPTION
Add user-access-logging-settings filter to the workspaces-web (Workspaces Secure Browser) resource.

Summary of changes:

- Add filter to workspaces-web
- Add tests to check the filter on an existing resource.

Addresses the following issue:
- https://github.com/cloud-custodian/cloud-custodian/issues/9623
