### PR TITLE
aws - ecr-image - support server side query in policies and remove extraneous api calls in augment

### DIFF
--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -10,7 +10,7 @@ from c7n.query import (
     ConfigSource, DescribeSource, QueryResourceManager, TypeInfo,
     ChildResourceManager, ChildDescribeSource, ChildResourceQuery, sources)
 from c7n import tags
-from c7n.utils import local_session, type_schema
+from c7n.utils import generate_arn, local_session, type_schema
 
 
 class ConfigECR(ConfigSource):
@@ -72,10 +72,9 @@ class ECRImageQuery(ChildResourceQuery):
 
     def get(self, resource_manager, identities):
         m = self.resolve(resource_manager.resource_type)
-        params = {}
+        params = {'ImageIds': [identities]}
         resources = self.filter(resource_manager, **params)
         resources = [r for r in resources if "{}/{}".format(r[0], r[1][m.id]) in identities]
-
         return resources
 
 
@@ -87,14 +86,33 @@ class RepositoryImageDescribeSource(ChildDescribeSource):
     def get_query(self):
         return super().get_query(capture_parent_id=True)
 
+    def get_query_params(self, query):
+        query = query or {}
+        if 'query' not in self.manager.data:
+            return query
+        for q in self.manager.data['query']:
+            query.update(q)
+        return query
+
     def augment(self, resources):
+        # construct an image arn
+        ecr_manager = self.manager.get_resource_manager(self.manager.resource_type.parent_spec[0])
+        rtype = ecr_manager.resource_type
+
+        repo_arn_map = {}
+        for repo_name in list({repo_name for repo_name, image in resources}):
+            repo_arn_map[repo_name] = generate_arn(
+                rtype.service,
+                region=self.manager.config.region,
+                account_id=self.manager.account_id,
+                resource_type=ecr_manager.resource_type.arn_type,
+                separator="/",
+                resource=repo_name
+            )
+
         results = []
-        client = local_session(self.manager.session_factory).client('ecr')
-        for repositoryName, image in resources:
-            repoArn = client.describe_repositories(
-                repositoryNames=[repositoryName])['repositories'][0]['repositoryArn']
-            imageArn = "{}/{}".format(repoArn, image["imageDigest"])
-            image["imageArn"] = imageArn
+        for repo_name, image in resources:
+            image['imageArn'] = "{}/{}".format(repo_arn_map[repo_name], image['imageDigest'])
             results.append(image)
         return results
 

--- a/tests/data/placebo/test_ecr_image_query/api.ecr.DescribeImages_1.json
+++ b/tests/data/placebo/test_ecr_image_query/api.ecr.DescribeImages_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "imageDetails": [
+            {
+                "registryId": "11111111111",
+                "repositoryName": "c7n-test",
+                "imageDigest": "sha256:1efe7a31d4efda630d96685b336815bb1c1b620416fbc0de3a61acf0f861d239",
+                "imageTags": [
+                    "latest"
+                ],
+                "imageSizeInBytes": 8106854,
+                "imagePushedAt": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 10,
+                    "day": 18,
+                    "hour": 12,
+                    "minute": 32,
+                    "second": 40,
+                    "microsecond": 0
+                },
+                "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_ecr_image_query/api.ecr.DescribeRepositories_1.json
+++ b/tests/data/placebo/test_ecr_image_query/api.ecr.DescribeRepositories_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "repositories": [
+            {
+                "repositoryArn": "arn:aws:ecr:us-east-1:111111111111:repository/c7n-test",
+                "registryId": "111111111111",
+                "repositoryName": "c7n-test",
+                "repositoryUri": "111111111111.dkr.ecr.us-east-1.amazonaws.com/c7n-test",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 10,
+                    "day": 18,
+                    "hour": 12,
+                    "minute": 30,
+                    "second": 52,
+                    "microsecond": 0
+                },
+                "imageTagMutability": "MUTABLE",
+                "imageScanningConfiguration": {
+                    "scanOnPush": true
+                },
+                "encryptionConfiguration": {
+                    "encryptionType": "AES256"
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -289,6 +289,24 @@ class TestECR(BaseTest):
     def test_ecr_set_lifecycle(self):
         pass
 
+    def test_ecr_image_query(self):
+        session_factory = self.replay_flight_data("test_ecr_image_query")
+        p = self.load_policy(
+            {
+                "name": "query-ecr-image",
+                "resource": "aws.ecr-image",
+                "query": [
+                    {
+                        "filter": {
+                            "tagStatus": "TAGGED"
+                        }
+                    }
+                ]
+            },
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_ecr_image_filter_security_finding(self):
         session_factory = self.replay_flight_data("test_ecr_image_filter_security_finding")
         p = self.load_policy(


### PR DESCRIPTION


this allows us to for example fetch only tagged images.

it also fixes a poor augment implementation behavior, where we called describe repos api per image :/ it replaces that with zero api calls per image.



