### PR TITLE
aws - security group - de-duplicate matched egress/ingress rules

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1614,7 +1614,11 @@ class SGPermission(Filter):
                 matched.append(perm)
 
         if matched:
-            resource.setdefault('Matched%s' % self.ip_permissions_key, []).extend(matched)
+            matched_annotation = resource.setdefault('Matched%s' % self.ip_permissions_key, [])
+            # If the same rule matches multiple filters, only add it to the match annotation
+            # once. Note: Because we're looking for unique dicts and those aren't hashable,
+            # we can't conveniently use set() to de-duplicate rules.
+            matched_annotation.extend(m for m in matched if m not in matched_annotation)
             return True
 
 

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -3244,6 +3244,10 @@ class SecurityGroupTest(BaseTest):
                         "Cidr": {
                             "value": "10.42.1.239", "op": "in", "value_type": "cidr"
                         },
+                    },
+                    {
+                        "type": "ingress",
+                        "SelfReference": False
                     }
                 ],
             },


### PR DESCRIPTION
If the same rule matches multiple filters, avoid adding it to an annotation list more than once.

Closes #9659 