### PR TITLE
tools/c7n-left - reset traverse filter for each related resource

### DIFF
--- a/tests/terraform/s3_ownership/main.tf
+++ b/tests/terraform/s3_ownership/main.tf
@@ -10,6 +10,14 @@ resource "aws_s3_bucket" "owner_enforced" {
   bucket_prefix = "c7ntest-"
 }
 
+resource "aws_s3_bucket_ownership_controls" "object_writer" {
+  bucket = aws_s3_bucket.owner_preferred.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_ownership_controls" "owner_preferred" {
   bucket = aws_s3_bucket.owner_preferred.id
 

--- a/tools/c7n_left/c7n_left/filters.py
+++ b/tools/c7n_left/c7n_left/filters.py
@@ -124,9 +124,9 @@ class Traverse(Filter):
 
     def match_attrs(self, working_set):
         vfilters = self.get_attr_filters()
-        found = True
         results = []
         for w in working_set:
+            found = True
             for v in vfilters:
                 if not v(w):
                     found = False


### PR DESCRIPTION
When there are multiple instances of the resource type that `traverse` targets, reset `found` before checking each one. Otherwise an early `found = False` effectively skips subsequent resources.

The existing test didn't catch this case because while there was a non-matching `aws_s3_bucket`, there was no non-matching `aws_s3_bucket_ownership_controls`.