### PR TITLE
tools/c7n_left - traverse filter - handle non-value attribute filters

### DIFF
--- a/tools/c7n_left/c7n_left/filters.py
+++ b/tools/c7n_left/c7n_left/filters.py
@@ -3,7 +3,7 @@
 #
 import itertools
 
-from c7n.filters import Filter, ValueFilter, OPERATORS
+from c7n.filters import Filter, OPERATORS
 from c7n.utils import type_schema
 
 
@@ -100,14 +100,7 @@ class Traverse(Filter):
     def get_attr_filters(self):
         if self._vfilters:
             return self._vfilters
-        vfilters = []
-        filter_class = ValueFilter
-        for v in self.data.get("attrs", []):
-            if isinstance(v, dict) and v.get("type"):
-                filter_class = self.manager.filter_registry[v["type"]]
-            vf = filter_class(v, self.manager)
-            vf.annotate = False
-            vfilters.append(vf)
+        vfilters = self.manager.filter_registry.parse(self.data.get("attrs", []), self.manager)
         self._vfilters = vfilters
         return vfilters
 

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -764,10 +764,6 @@ def test_traverse_multi_resource_inside_or(tmp_path):
     }
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Known issue with branching inside attrs: https://github.com/cloud-custodian/cloud-custodian/issues/9690",
-)
 def test_traverse_multi_resource_nested_or(tmp_path):
     resources = run_policy(
         {


### PR DESCRIPTION
Account for filter types other than the default value filter inside a traverse filter's `attrs` block. This allows, among other cases, `or` blocks inside `attrs`. That case previously led to false negatives.

By using `parse()` we benefit from the more nuanced filter-parsing logic [here](https://github.com/cloud-custodian/cloud-custodian/blob/30bbbaca6f1ececb2a3aee8d695f8bf793d51a29/c7n/filters/core.py#L144-L153), which handles the `or`/`and`/`not` cases:

```python
        if isinstance(data, dict) and len(data) == 1 and 'type' not in data:
            op = list(data.keys())[0]
            if op == 'or':
                return self['or'](data, self, manager)
            elif op == 'and':
                return self['and'](data, self, manager)
            elif op == 'not':
                return self['not'](data, self, manager)
```

Closes #9690 