### PR TITLE
ecs-container-instance get_resources fails

### DIFF
--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -937,6 +937,12 @@ class ContainerInstance(query.ChildResourceManager):
             source = 'describe-ecs-container-instance'
         return source
 
+    def get_resources(self, ids, cache=True, augment=True):
+        # The get_resources call in the source calls into the
+        # process_cluster_resources. This actually returns fully
+        # augmented resources, so the augment call actually fails
+        # because augment is expecting tuples.
+        return super().get_resources(ids, cache=cache, augment=False)
 
 @query.sources.register('describe-ecs-container-instance')
 class ECSContainerInstanceDescribeSource(ECSClusterResourceDescribeSource):
@@ -947,7 +953,7 @@ class ECSContainerInstanceDescribeSource(ECSClusterResourceDescribeSource):
             r = client.describe_container_instances(
                 cluster=cluster_id,
                 include=['TAGS'],
-                containerInstances=container_instances).get('containerInstances', [])
+                containerInstances=service_set).get('containerInstances', [])
             # Many Container Instance API calls require the cluster_id, adding as a
             # custodian specific key in the resource
             for i in r:

--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -943,6 +943,7 @@ class ContainerInstance(query.ChildResourceManager):
         # because augment is expecting tuples.
         return super().get_resources(ids, cache=cache, augment=False)
 
+
 @query.sources.register('describe-ecs-container-instance')
 class ECSContainerInstanceDescribeSource(ECSClusterResourceDescribeSource):
 


### PR DESCRIPTION
There are two problems fixed here:
* When the ECSContainerInstanceDescribeSource was chunking up the ids for the boto call, it then ignored the batch and just used all the IDs (which will fail if bigger than the max batch size).
* The ECSClusterResourceDescribeSource implementation of get_resources returns lists of fully augmented resources which then fails to get augmented an additional time due to the augment function expecting tuples. So we override the call on the resource manager to not ask for augmentation when getting resources by id.

I think this would have only been noticed in lambda policies on `aws.ecs-container-instance` resources, as pull mode just calls `resources` on the resource manager.