### PR TITLE
aws - examples - add item to events list

### DIFF
--- a/docs/source/aws/examples/securitygroupsdetectremediate.rst
+++ b/docs/source/aws/examples/securitygroupsdetectremediate.rst
@@ -35,6 +35,9 @@ rule additions on them!
              - source: ec2.amazonaws.com
                event: RevokeSecurityGroupIngress
                ids: "requestParameters.groupId"
+             - source: ec2.amazonaws.com
+               event: ModifySecurityGroupRules
+               ids: "requestParameters.ModifySecurityGroupRulesRequest.GroupId"
        filters:
          - or:
                - type: ingress


### PR DESCRIPTION
The action "ModifySecurityGroupRules" weren't listed in the example. If someone creates a compliant rule and changes it to an over-permissive one, the policy will not catch the event.