### PR TITLE
Add support for EMR Serverless Jobs and related metrics

### DIFF
--- a/tools/c7n_awscc/c7n_awscc/resources/emr_serverless_jobs.py
+++ b/tools/c7n_awscc/c7n_awscc/resources/emr_serverless_jobs.py
@@ -1,0 +1,54 @@
+from c7n.provider import resources
+from c7n.query import QueryResourceManager
+from c7n.utils import type_schema
+
+@resources.register('emr-serverless-jobs')
+class EMRServerlessJobs(QueryResourceManager):
+
+    class resource_type:
+        service = 'emr'
+        enum_spec = ('list_jobs', 'Jobs', None)
+        detail_spec = ('describe_job', 'JobId', 'JobId', 'Job')
+        id = 'Id'
+        name = 'Name'
+        date = 'CreatedOn'
+        dimension = None
+from c7n.provider import resources
+from c7n.query import QueryResourceManager
+from c7n.utils import type_schema
+
+@resources.register('emr-serverless-jobs')
+class EMRServerlessJobs(QueryResourceManager):
+
+    class resource_type:
+        service = 'emr'
+        enum_spec = ('list_jobs', 'Jobs', None)
+        detail_spec = ('describe_job', 'JobId', 'JobId', 'Job')
+        id = 'Id'
+        name = 'Name'
+        date = 'CreatedOn'
+        dimension = None
+
+METRICS = ['JobRunTime', 'WorkersUsed']
+
+@resources.register('emr-serverless-jobs')
+class EMRServerlessJobs(QueryResourceManager):
+
+    class resource_type:
+        service = 'emr'
+        enum_spec = ('list_jobs', 'Jobs', None)
+        detail_spec = ('describe_job', 'JobId', 'JobId', 'Job')
+        id = 'Id'
+        name = 'Name'
+        date = 'CreatedOn'
+        dimension = None
+
+    def get_metrics(self):
+        client = local_session(self.session_factory).client('emr')
+        for job in self.resources():
+            response = client.list_metrics(
+                JobId=job['Id'],
+                Metrics=METRICS
+            )
+            job['Metrics'] = response['Metrics']
+

--- a/tools/c7n_awscc/tests/test_emr_serverless_jobs.py
+++ b/tools/c7n_awscc/tests/test_emr_serverless_jobs.py
@@ -1,0 +1,13 @@
+from .common import BaseTest
+
+class TestEMRServerlessJobs(BaseTest):
+
+    def test_emr_serverless_jobs(self):
+        factory = self.replay_flight_data('test_emr_serverless_jobs')
+        p = self.load_policy({
+            'name': 'emr-serverless-jobs',
+            'resource': 'emr-serverless-jobs',
+        }, session_factory=factory)
+        resources = p.run()
+        self.assertTrue(len(resources) > 0)
+


### PR DESCRIPTION
Added support for EMR Serverless Jobs by adding emr_serverless jobs.py file  inside resorce directory of c7_awscc and also a test_emr_serverless_py file in the test folder based on issue#9699. 