### PR TITLE
c7n-left: handle reference list declared in __tfmeta

### DIFF
--- a/tools/c7n_left/c7n_left/providers/terraform/graph.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/graph.py
@@ -95,7 +95,7 @@ class Resolver:
                 continue
             yield r
 
-    def visit(self, block, root=False):
+    def visit(self, block):
         if not isinstance(block, dict):
             return ()
 
@@ -110,10 +110,14 @@ class Resolver:
                 refs.add(v)
             if isinstance(v, (str, int, float, bool)):
                 continue
-            if isinstance(v, dict) and k != "__tfmeta":
-                refs.update(self.visit(v))
+            if isinstance(v, dict):
+                if k == "__tfmeta":
+                    refs.update(r["id"] for r in v.get("references", ()))
+                else:
+                    refs.update(self.visit(v))
             if isinstance(v, list):
-                list(map(self.visit, v))
+                for entry in v:
+                    self.visit(entry)
 
         if refs and block.get("__tfmeta", {}).get("label"):
             self._ref_map.setdefault(bid, []).extend(refs)

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -816,6 +816,56 @@ def test_traverse_multi_resource_nested_or(tmp_path):
     }
 
 
+def test_traverse_match_values(policy_env, test):
+    policy_env.write_tf(
+        """
+resource "r" "r1" {
+  name = "r-r1"
+}
+
+resource "r" "r2" {
+  label = "r-r2"
+}
+
+resource "rr" "res" {
+  rn = [r.r1.name]
+  rl = [r.r2.label]
+}
+        """
+    )
+    policy_env.write_policy(
+        {
+            "name": "test1",
+            "resource": "terraform.rr",
+            "filters": [
+                {
+                    "type": "traverse",
+                    "resources": "r",
+                    "attrs": [{"name": "r-r1"}],
+                }
+            ],
+        },
+    )
+    policy_env.write_policy(
+        {
+            "name": "test2",
+            "resource": "terraform.rr",
+            "filters": [
+                {
+                    "type": "traverse",
+                    "resources": "r",
+                    "attrs": [{"label": "r-r2"}],
+                }
+            ],
+        },
+    )
+    res1, res2 = (r.as_dict() for r in policy_env.run())
+    assert res1["policy"]["name"] == "test1"
+    assert res1["resource"]["__tfmeta"]["path"] == "rr.res"
+    assert res2["policy"]["name"] == "test2"
+    assert res2["resource"]["__tfmeta"]["path"] == "rr.res"
+
+
 def test_traverse_filter_not_found(tmp_path):
     resources = run_policy(
         {


### PR DESCRIPTION
Make use of the changes from
https://github.com/cloud-custodian/tfparse/pull/219 to track all references to
other blocks declared for a block and actual references values, allowing both traverse and value filter to work in that case.