### PR TITLE
Adds float to multiplier variable to resolve TypeError

### DIFF
--- a/c7n/resources/quotas.py
+++ b/c7n/resources/quotas.py
@@ -324,7 +324,7 @@ class Increase(Action):
         multiplier = self.data.get('multiplier', 1.2)
         error = None
         for r in resources:
-            count = math.ceil(multiplier * r['Value'])
+            count = math.ceil(float(multiplier) * r['Value'])
             if not r['Adjustable']:
                 continue
             try:


### PR DESCRIPTION
This resolves a TypeError when multiplying the `multiplier` with the value.

fixes #9790 