### PR TITLE
aws - ds - trust-relationships filter

### DIFF
--- a/tests/data/placebo/test_directory_trust_relationship/ds.DescribeDirectories_1.json
+++ b/tests/data/placebo/test_directory_trust_relationship/ds.DescribeDirectories_1.json
@@ -1,0 +1,62 @@
+{
+    "status_code": 200,
+    "data": {
+        "DirectoryDescriptions": [
+            {
+                "DirectoryId": "d-9067d77ae2",
+                "Name": "custodian.example.com",
+                "ShortName": "custodian",
+                "Size": "Small",
+                "Edition": "Standard",
+                "Alias": "d-9067d77ae2",
+                "AccessUrl": "d-9067d77ae2.awsapps.com",
+                "DnsIpAddrs": [
+                    "172.31.5.185",
+                    "172.31.39.74"
+                ],
+                "Stage": "Active",
+                "LaunchTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 11,
+                    "hour": 12,
+                    "minute": 39,
+                    "second": 1,
+                    "microsecond": 553000
+                },
+                "StageLastUpdatedDateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 11,
+                    "hour": 13,
+                    "minute": 6,
+                    "second": 49,
+                    "microsecond": 370000
+                },
+                "Type": "MicrosoftAD",
+                "VpcSettings": {
+                    "VpcId": "vpc-d2d616b5",
+                    "SubnetIds": [
+                        "subnet-914763e7",
+                        "subnet-e3b194de"
+                    ],
+                    "SecurityGroupId": "sg-002fdd9ea733e490b",
+                    "AvailabilityZones": [
+                        "us-east-1a",
+                        "us-east-1e"
+                    ]
+                },
+                "SsoEnabled": false,
+                "DesiredNumberOfDomainControllers": 2,
+                "RegionsInfo": {
+                    "PrimaryRegion": "us-east-1",
+                    "AdditionalRegions": []
+                },
+                "OsVersion": "SERVER_2019"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_directory_trust_relationship/ds.DescribeTrusts_1.json
+++ b/tests/data/placebo/test_directory_trust_relationship/ds.DescribeTrusts_1.json
@@ -1,0 +1,48 @@
+{
+    "status_code": 200,
+    "data": {
+        "Trusts": [
+            {
+                "DirectoryId": "d-9067d77ae2",
+                "TrustId": "t-906764b0c1",
+                "RemoteDomainName": "cloudcustodian.io",
+                "TrustType": "External",
+                "TrustDirection": "One-Way: Outgoing",
+                "TrustState": "Failed",
+                "CreatedDateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 21,
+                    "hour": 8,
+                    "minute": 45,
+                    "second": 23,
+                    "microsecond": 700000
+                },
+                "LastUpdatedDateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 21,
+                    "hour": 8,
+                    "minute": 45,
+                    "second": 47,
+                    "microsecond": 649000
+                },
+                "StateLastUpdatedDateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 21,
+                    "hour": 8,
+                    "minute": 45,
+                    "second": 47,
+                    "microsecond": 649000
+                },
+                "TrustStateReason": "The specified domain either does not exist or could not be contacted. Name: cloudcustodian.io",
+                "SelectiveAuth": "Disabled"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_directory_trust_relationship/ds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_directory_trust_relationship/ds.ListTagsForResource_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -201,6 +201,24 @@ class DirectoryTests(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertTrue("c7n:Settings" in resources[0])
 
+    def test_directory_trust_relationship(self):
+        factory = self.replay_flight_data("test_directory_trust_relationship")
+        p = self.load_policy(
+            {
+                "name": "trust-relationship",
+                "resource": "directory",
+                "filters": [{"type": "trust", "key": "RemoteDomainName",
+                        "value": "cloudcustodian.io"},
+                        {"type": "trust", "key": "TrustDirection",
+                            "value": "One-Way: Outgoing"}],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertTrue("c7n:Trusts" in resources[0])
+        self.assertEqual(resources[0]["c7n:Trusts"][0]['RemoteDomainName'], "cloudcustodian.io")
+
 
 class CloudDirectoryQueryParse(BaseTest):
 


### PR DESCRIPTION
Adds trust relationship filter to Directory Service (DS).

Ref:
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ds/describe-trusts.html
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ds/client/describe_trusts.html