### PR TITLE
releng - fix c7n-left docker image build

### DIFF
--- a/docker/c7n-left
+++ b/docker/c7n-left
@@ -1,11 +1,10 @@
-FROM cgr.dev/chainguard/wolfi-base as builder
+FROM cgr.dev/chainguard/wolfi-base AS builder
 
-ARG POETRY_VERSION="1.8.3"
+ARG POETRY_VERSION="1.8.4"
 ARG PY_VERSION=3.12
 WORKDIR /app
 
-RUN apk add python-${PY_VERSION} py${PY_VERSION}-pip && \
-    chown -R nonroot.nonroot /app/
+RUN apk add python-${PY_VERSION} py${PY_VERSION}-pip && chown -R nonroot:nonroot /app/
 
 USER nonroot
 
@@ -41,8 +40,7 @@ LABEL "org.opencontainers.image.documentation"="https://cloudcustodian.io/docs"
 ARG PY_VERSION=3.12
 
 WORKDIR /app
-RUN apk add git python-${PY_VERSION} && \
-    chown -R nonroot.nonroot /app/
+RUN apk add git python-${PY_VERSION} && chown -R nonroot:nonroot /app/
 
 COPY --from=builder /home/nonroot/venv/lib/python${PY_VERSION}/site-packages /home/nonroot/.local/lib/python${PY_VERSION}/site-packages
 RUN rm -Rf /home/nonroot/.local/lib/python${PY_VERSION}/site-packages/pip*
@@ -50,6 +48,6 @@ COPY --from=builder /app/c7n/c7n /app/c7n
 COPY --from=builder /app/c7n/tools/c7n_left /app/c7n/tools/c7n_left
 
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
-ENV PYTHONPATH=/app:/app/c7n/tools/c7n_left:/home/nonroot/.local/lib/python${PY_VERSION}/site-packages:$PYTHONPATH
+ENV PYTHONPATH=/app:/app/c7n/tools/c7n_left:/home/nonroot/.local/lib/python${PY_VERSION}/site-packages
 
 ENTRYPOINT [ "python", "-m", "c7n_left.cli"]

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -63,7 +63,7 @@ PHASE_2_PKG_INSTALL_ROOT += "\n".join(
 
 BOOTSTRAP_STAGE = """\
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM {base_build_image} as build-env
+FROM {base_build_image} AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION

the chown argument was incorrect and recent updates to wolfi-base now flag it as an error. this fixes the chown and does a micro version update on poetry
 
