### PR TITLE
aws - workspaces-web - small bugfix on browser policy

### DIFF
--- a/c7n/resources/workspaces.py
+++ b/c7n/resources/workspaces.py
@@ -548,7 +548,7 @@ class BrowerPolicyFilter(ValueFilter):
         client = local_session(self.manager.session_factory).client('workspaces-web')
         results = []
         for r in resources:
-            if self.policy_annotation not in r:
+            if (self.policy_annotation not in r) and ('browserSettingsArn' in r):
                 browserSettings = self.manager.retry(
                     client.get_browser_settings,
                     browserSettingsArn=r['browserSettingsArn']).get('browserSettings')


### PR DESCRIPTION
## Overview
Small bugfix for the browser-settings filter for workspaces-web resource.

Check `browserSettingsArn` exists before `browserSettingsArn=r['browserSettingsArn']).get('browserSettings')`. If a portal does not have any browser settings set, it would throw a KeyError for 'browserSettingsArn'.