### PR TITLE
aws - rds-snapshot - fix cross-account "everyone_only" behavior

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1258,6 +1258,7 @@ class CrossAccountAccess(CrossAccountAccessFilter):
 
     def process(self, resources, event=None):
         self.accounts = self.get_accounts()
+        self.everyone_only = self.data.get("everyone_only", False)
         results = []
         with self.executor_factory(max_workers=2) as w:
             futures = []
@@ -1284,6 +1285,8 @@ class CrossAccountAccess(CrossAccountAccessFilter):
                     'DBSnapshotAttributesResult']['DBSnapshotAttributes']}
             r[self.attributes_key] = attrs
             shared_accounts = set(attrs.get('restore', []))
+            if self.everyone_only:
+                shared_accounts = {a for a in shared_accounts if a == 'all'}
             delta_accounts = shared_accounts.difference(self.accounts)
             if delta_accounts:
                 r[self.annotation_key] = list(delta_accounts)

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -453,6 +453,7 @@ class CrossAccountSnapshot(CrossAccountAccessFilter):
 
     def process(self, resources, event=None):
         self.accounts = self.get_accounts()
+        self.everyone_only = self.data.get("everyone_only", False)
         results = []
         with self.executor_factory(max_workers=2) as w:
             futures = []
@@ -474,6 +475,8 @@ class CrossAccountSnapshot(CrossAccountAccessFilter):
                          'DBClusterSnapshotAttributesResult']['DBClusterSnapshotAttributes']}
             r[self.attributes_key] = attrs
             shared_accounts = set(attrs.get('restore', []))
+            if self.everyone_only:
+                shared_accounts = {a for a in shared_accounts if a == 'all'}
             delta_accounts = shared_accounts.difference(self.accounts)
             if delta_accounts:
                 r[self.annotation_key] = list(delta_accounts)

--- a/tests/data/placebo/test_rds_cluster_snapshot_cross_account_everyone_only/rds.DescribeDBClusterSnapshotAttributes_1.json
+++ b/tests/data/placebo/test_rds_cluster_snapshot_cross_account_everyone_only/rds.DescribeDBClusterSnapshotAttributes_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshotAttributesResult": {
+            "DBClusterSnapshotIdentifier": "c7n-testing-private",
+            "DBClusterSnapshotAttributes": [
+                {
+                    "AttributeName": "restore",
+                    "AttributeValues": []
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_cluster_snapshot_cross_account_everyone_only/rds.DescribeDBClusterSnapshotAttributes_2.json
+++ b/tests/data/placebo/test_rds_cluster_snapshot_cross_account_everyone_only/rds.DescribeDBClusterSnapshotAttributes_2.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshotAttributesResult": {
+            "DBClusterSnapshotIdentifier": "c7n-testing-public",
+            "DBClusterSnapshotAttributes": [
+                {
+                    "AttributeName": "restore",
+                    "AttributeValues": [
+                        "all"
+                    ]
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_cluster_snapshot_cross_account_everyone_only/rds.DescribeDBClusterSnapshotAttributes_3.json
+++ b/tests/data/placebo/test_rds_cluster_snapshot_cross_account_everyone_only/rds.DescribeDBClusterSnapshotAttributes_3.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshotAttributesResult": {
+            "DBClusterSnapshotIdentifier": "c7n-testing-shared",
+            "DBClusterSnapshotAttributes": [
+                {
+                    "AttributeName": "restore",
+                    "AttributeValues": [
+                        "111111111111"
+                    ]
+                }
+            ]
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_cluster_snapshot_cross_account_everyone_only/rds.DescribeDBClusterSnapshots_1.json
+++ b/tests/data/placebo/test_rds_cluster_snapshot_cross_account_everyone_only/rds.DescribeDBClusterSnapshots_1.json
@@ -1,0 +1,143 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshots": [
+            {
+                "AvailabilityZones": [
+                    "us-east-2a",
+                    "us-east-2b",
+                    "us-east-2c"
+                ],
+                "DBClusterSnapshotIdentifier": "c7n-testing-private",
+                "DBClusterIdentifier": "c7n-testing",
+                "SnapshotCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 29,
+                    "hour": 18,
+                    "minute": 30,
+                    "second": 6,
+                    "microsecond": 906000
+                },
+                "Engine": "aurora-postgresql",
+                "EngineMode": "provisioned",
+                "AllocatedStorage": 0,
+                "Status": "available",
+                "Port": 0,
+                "VpcId": "vpc-056651ecc06e0c9d3",
+                "ClusterCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 29,
+                    "hour": 17,
+                    "minute": 56,
+                    "second": 8,
+                    "microsecond": 675000
+                },
+                "MasterUsername": "postgres",
+                "EngineVersion": "15.4",
+                "LicenseModel": "postgresql-license",
+                "SnapshotType": "manual",
+                "PercentProgress": 100,
+                "StorageEncrypted": false,
+                "DBClusterSnapshotArn": "arn:aws:rds:us-east-2:644160558196:cluster-snapshot:c7n-testing-private",
+                "IAMDatabaseAuthenticationEnabled": false,
+                "TagList": [],
+                "DbClusterResourceId": "cluster-BFTQNW3LT4IAW7PKENIKTOHO7A"
+            },
+            {
+                "AvailabilityZones": [
+                    "us-east-2a",
+                    "us-east-2b",
+                    "us-east-2c"
+                ],
+                "DBClusterSnapshotIdentifier": "c7n-testing-public",
+                "DBClusterIdentifier": "c7n-testing",
+                "SnapshotCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 29,
+                    "hour": 18,
+                    "minute": 30,
+                    "second": 6,
+                    "microsecond": 906000
+                },
+                "Engine": "aurora-postgresql",
+                "EngineMode": "provisioned",
+                "AllocatedStorage": 0,
+                "Status": "available",
+                "Port": 0,
+                "VpcId": "vpc-056651ecc06e0c9d3",
+                "ClusterCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 29,
+                    "hour": 17,
+                    "minute": 56,
+                    "second": 8,
+                    "microsecond": 675000
+                },
+                "MasterUsername": "postgres",
+                "EngineVersion": "15.4",
+                "LicenseModel": "postgresql-license",
+                "SnapshotType": "manual",
+                "PercentProgress": 100,
+                "StorageEncrypted": false,
+                "DBClusterSnapshotArn": "arn:aws:rds:us-east-2:644160558196:cluster-snapshot:c7n-testing-public",
+                "SourceDBClusterSnapshotArn": "arn:aws:rds:us-east-2:644160558196:cluster-snapshot:c7n-testing-private",
+                "IAMDatabaseAuthenticationEnabled": false,
+                "TagList": []
+            },
+            {
+                "AvailabilityZones": [
+                    "us-east-2a",
+                    "us-east-2b",
+                    "us-east-2c"
+                ],
+                "DBClusterSnapshotIdentifier": "c7n-testing-shared",
+                "DBClusterIdentifier": "c7n-testing",
+                "SnapshotCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 29,
+                    "hour": 18,
+                    "minute": 30,
+                    "second": 6,
+                    "microsecond": 906000
+                },
+                "Engine": "aurora-postgresql",
+                "EngineMode": "provisioned",
+                "AllocatedStorage": 0,
+                "Status": "available",
+                "Port": 0,
+                "VpcId": "vpc-056651ecc06e0c9d3",
+                "ClusterCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 10,
+                    "day": 29,
+                    "hour": 17,
+                    "minute": 56,
+                    "second": 8,
+                    "microsecond": 675000
+                },
+                "MasterUsername": "postgres",
+                "EngineVersion": "15.4",
+                "LicenseModel": "postgresql-license",
+                "SnapshotType": "manual",
+                "PercentProgress": 100,
+                "StorageEncrypted": false,
+                "DBClusterSnapshotArn": "arn:aws:rds:us-east-2:644160558196:cluster-snapshot:c7n-testing-shared",
+                "SourceDBClusterSnapshotArn": "arn:aws:rds:us-east-2:644160558196:cluster-snapshot:c7n-testing-private",
+                "IAMDatabaseAuthenticationEnabled": false,
+                "TagList": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1079,6 +1079,29 @@ class RDSSnapshotTest(BaseTest):
             {"tidx-pub": ["all"], "tidx-rdx": ["619193117841"]},
         )
 
+    def test_rds_snapshot_access_everyone_only(self):
+        factory = self.replay_flight_data("test_rds_snapshot_access")
+        p = self.load_policy(
+            {
+                "name": "rds-snap-access",
+                "resource": "rds-snapshot",
+                "filters": [{
+                    "type": "cross-account",
+                    "everyone_only": True,
+                }],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            {
+                r["DBSnapshotIdentifier"]: r["c7n:CrossAccountViolations"]
+                for r in resources
+            },
+            {"tidx-pub": ["all"]},
+        )
+
     def test_rds_latest_manual(self):
         # preconditions
         # one db with manual and automatic snapshots


### PR DESCRIPTION
Fix behavior for the `cross-account` filter's `everyone_only` option for `aws.rds-snapshot` and `aws.rds-cluster-snapshot` resource types.

Related to #6881, but not touching the ssm piece here.