### PR TITLE
aws - kinesis-video - explictly set MaxResults

### DIFF
--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -354,7 +354,7 @@ class KinesisVideoStream(QueryResourceManager):
     class resource_type(TypeInfo):
         service = 'kinesisvideo'
         arn_type = 'stream'
-        enum_spec = ('list_streams', 'StreamInfoList', None)
+        enum_spec = ('list_streams', 'StreamInfoList', {'MaxResults': 10000})
         name = id = 'StreamName'
         arn = 'StreamARN'
         dimension = 'StreamName'


### PR DESCRIPTION
We are getting throttled for on all kinesis-video stream policies with exception - `ClientLimitExceededException` even if there's a retry built in for this exception.
On investigation, we found that the default behavior on MaxResults fetches only 10 resources per call whereas setting it to 10k explicitly changes the behavior to 1000 resources per call. 
Doc - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesisvideo/client/list_streams.html
AWS seems to have a hard limit of 50TPS re: ListStreams (https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/limits.html)

I was also able to test pre and post behavior
```
Current behavior

2024-10-29 21:40:33,369: custodian.output:DEBUG metric:ResourceCount Count:35 policy:kinesis-video-streams restype:kinesis-video scope:policy
2024-10-29 21:40:33,369: custodian.output:DEBUG metric:ApiCalls Count:5 policy:kinesis-video-streams restype:kinesis-video

  "api-stats": {
    "kinesisvideo.ListStreams": 4,
    "tagging.GetResources": 1
  },


Behavior after this change


2024-10-29 21:16:07,260: custodian.output:DEBUG metric:ResourceCount Count:35 policy:kinesis-video-streams restype:kinesis-video scope:policy
2024-10-29 21:16:07,260: custodian.output:DEBUG metric:ApiCalls Count:2 policy:kinesis-video-streams restype:kinesis-video


  "api-stats": {
    "kinesisvideo.ListStreams": 1,
    "tagging.GetResources": 1
  },

```