### PR TITLE
docs - fix invalid example policies, add note to notify docs

### DIFF
--- a/c7n/actions/notify.py
+++ b/c7n/actions/notify.py
@@ -150,8 +150,15 @@ class Notify(BaseNotify):
     extraction, batch periods, etc.
 
     For expedience and flexibility then, we instead send the data to
-    an sqs queue, for processing. ie. actual communications can be enabled
-    with the c7n-mailer tool, found under tools/c7n_mailer.
+    an sqs queue, for processing.
+
+    .. note::
+
+       The ``notify`` action does not produce complete, human-readable messages
+       on its own. Instead, the `c7n-mailer`_ tool renders and delivers
+       messages by combining ``notify`` output with formatted templates.
+
+       .. _c7n-mailer: ../../tools/c7n-mailer.html
 
     Attaching additional string message attributes are supported on the SNS
     transport, with the exception of the ``mtype`` attribute, which is a

--- a/docs/source/aws/topics/config.rst
+++ b/docs/source/aws/topics/config.rst
@@ -61,8 +61,8 @@ lambda.
         role: MyLambdaConfigRole
       filters:
         - type: image
-          tag: "NotSupported"
-	  value: absent
+          key: "tag:NotSupported"
+          value: absent
 
 
 Filter

--- a/docs/source/aws/topics/securityhub.rst
+++ b/docs/source/aws/topics/securityhub.rst
@@ -64,10 +64,10 @@ guard duty (note custodian also has support for guard duty events directly).
 
    policies:
      - name: remediate
-       resource: aws.iam
+       resource: aws.iam-user
        mode:
          type: hub-finding
-	 role: MyRole
+         role: MyRole
        filters:
          - type: event
            key: detail.findings[].ProductFields.aws/securityhub/ProductName


### PR DESCRIPTION
Address a couple pieces of doc-related feedback:

- Invalid example policies (#9798)
- `notify` output needs `c7n-mailer` to produce human-readable messages (#7351)

Additions/clarifications/etc from folks involved in either discussion are welcome.