### PR TITLE
Fix network security group and flow-logs in another resource group

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/network_security_group.py
+++ b/tools/c7n_azure/c7n_azure/resources/network_security_group.py
@@ -308,7 +308,7 @@ class FlowLogs(ValueFilter):
 
         return [
             client.flow_logs.get(
-                resource['resourceGroup'],
+                parsed_id['resource_group'],
                 parsed_id['name'],
                 parsed_id['resource_name']
             ).serialize(True).get('properties')


### PR DESCRIPTION
### Azure flow-logs in different resource group

Custodian fails with exception if there is a network security group with flow-logs from another resource group attached to it.
<img width="1799" alt="image" src="https://github.com/user-attachments/assets/6d91011c-01d7-480e-bbbc-4b413d358e19">
