### PR TITLE
aws - transfer-server - fix detail-spec

### DIFF
--- a/c7n/resources/transfer.py
+++ b/c7n/resources/transfer.py
@@ -14,7 +14,7 @@ class TransferServer(QueryResourceManager):
         service = 'transfer'
         enum_spec = ('list_servers', 'Servers', {'MaxResults': 60})
         detail_spec = (
-            'describe_server', 'ServerId', 'ServerId', None)
+            'describe_server', 'ServerId', 'ServerId', 'Server')
         id = name = 'ServerId'
         arn_type = "server"
         cfn_type = 'AWS::Transfer::Server'

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -17,6 +17,7 @@ class TestTransferServer(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["ServerId"], "s-4a6d521483294bd79")
         self.assertEqual(resources[0]["State"], "ONLINE")
+        self.assertEqual(resources[0]["SecurityPolicyName"], "TransferSecurityPolicy-2020-06")
 
     def test_stop_server(self):
         session_factory = self.replay_flight_data("test_transfer_server_stop")


### PR DESCRIPTION
Pull details from the `Server` key in the `describe_server` response.