### PR TITLE
Add afd endpoint and afd custom domain resources

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/afd_custom_domain.py
+++ b/tools/c7n_azure/c7n_azure/resources/afd_custom_domain.py
@@ -1,0 +1,50 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ChildArmResourceManager
+
+
+@resources.register('afd-custom-domain')
+class AfdCustomDomain(ChildArmResourceManager):
+    """AFD custom domain resource
+
+    :example:
+
+    Returns all AFD custom domains where minimum tls version is not TLS12
+
+    .. code-block:: yaml
+
+        policies:
+          - name: standard-verizon
+            resource: azure.afd-custom-domain
+            filters:
+              - type: value
+                key: properties.tlsSettings.minimumTlsVersion
+                op: ne
+                value: TLS12
+
+    """
+
+    class resource_type(ChildArmResourceManager.resource_type):
+        doc_groups = ['Media']
+
+        service = 'azure.mgmt.cdn'
+        client = 'CdnManagementClient'
+        enum_spec = ('afd_custom_domains', 'list_by_profile', None)
+        parent_manager_name = 'cdnprofile'
+        default_report_fields = (
+            'name',
+            'resourceGroup',
+            'properties.hostName',
+            '"c7n:parent-id"'
+        )
+        resource_type = 'Microsoft.Cdn/profiles/customdomains'
+
+        @classmethod
+        def extra_args(cls, parent_resource):
+            return {
+                'resource_group_name': parent_resource['resourceGroup'],
+                'profile_name': parent_resource['name']
+            }
+

--- a/tools/c7n_azure/c7n_azure/resources/afd_custom_domain.py
+++ b/tools/c7n_azure/c7n_azure/resources/afd_custom_domain.py
@@ -47,4 +47,3 @@ class AfdCustomDomain(ChildArmResourceManager):
                 'resource_group_name': parent_resource['resourceGroup'],
                 'profile_name': parent_resource['name']
             }
-

--- a/tools/c7n_azure/c7n_azure/resources/afd_endpoint.py
+++ b/tools/c7n_azure/c7n_azure/resources/afd_endpoint.py
@@ -1,0 +1,47 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ChildArmResourceManager
+
+
+@resources.register('afd-endpoint')
+class AfdEndpoint(ChildArmResourceManager):
+    """Lists exising Azure Front Door endpoints
+
+    :example:
+
+    Returns all enabled Front Door endpoints
+
+    .. code-block:: yaml
+
+        policies:
+          - name: enabled-front-door-endpoints
+            resource: azure.afd-endpoint
+            filters:
+              - type: value
+                key: properties.enabledState
+                value: Enabled
+
+    """
+
+    class resource_type(ChildArmResourceManager.resource_type):
+        doc_groups = ['Media']
+
+        service = 'azure.mgmt.cdn'
+        client = 'CdnManagementClient'
+        enum_spec = ('afd_endpoints', 'list_by_profile', None)
+        default_report_fields = (
+            'name',
+            'location',
+            'resourceGroup',
+            '"c7n:parent-id"'
+        )
+        resource_type = 'Microsoft.Cdn/profiles/afdendpoints'
+        # seems like cdn profile and afd profile are the same
+        parent_manager_name = 'cdnprofile'
+
+        @classmethod
+        def extra_args(cls, parent_resource):
+            return {'resource_group_name': parent_resource['resourceGroup'],
+                    'profile_name': parent_resource['name']}

--- a/tools/c7n_azure/c7n_azure/resources/cdn_custom_domain.py
+++ b/tools/c7n_azure/c7n_azure/resources/cdn_custom_domain.py
@@ -8,11 +8,11 @@ from c7n_azure.utils import ResourceIdParser
 
 @resources.register('cdn-custom-domain')
 class CdnCustomDomain(ChildArmResourceManager):
-    """CDN Endpoint Resource
+    """CDN Custom Domain Resource
 
     :example:
 
-    Returns all CDN endpoints without Https provisioning
+    Returns all CDN custom domains without Https provisioning
 
     .. code-block:: yaml
 

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ResourceMap = {
     "azure.advisor-recommendation": "c7n_azure.resources.advisor.AdvisorRecommendation",
+    "azure.afd-endpoint": "c7n_azure.resources.afd_endpoint.AfdEndpoint",
+    "azure.afd-custom-domain": "c7n_azure.resources.afd_custom_domain.AfdCustomDomain",
     "azure.aks": "c7n_azure.resources.k8s_service.KubernetesService",
     "azure.app-insights": "c7n_azure.resources.appinsights.AzureAppInsights",
     "azure.app-service-environment": "c7n_azure.resources.app_service_environment.AppServiceEnvironment",  # noqa

--- a/tools/c7n_azure/tests_azure/cassettes/AfdCustomDomainTest.test_find_with_mintlsversion_12.json
+++ b/tools/c7n_azure/tests_azure/cassettes/AfdCustomDomainTest.test_find_with_mintlsversion_12.json
@@ -1,0 +1,119 @@
+{
+  "version": 1,
+  "interactions": [
+    {
+      "request": {
+        "method": "GET",
+        "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Cdn/profiles?api-version=2020-09-01",
+        "body": null,
+        "headers": {}
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "date": [
+            "Wed, 10 May 2023 23:13:24 GMT"
+          ],
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "x-ms-ratelimit-remaining-subscription-resource-requests": [
+            "49"
+          ],
+          "cache-control": [
+            "no-cache"
+          ],
+          "content-length": [
+            "1341"
+          ]
+        },
+        "body": {
+          "data": {
+            "value": [
+              {
+                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/cfb-vevmhnkx/providers/Microsoft.Cdn/profiles/MyFrontDoor-Success",
+                "type": "Microsoft.Cdn/profiles",
+                "name": "MyFrontDoor-Success",
+                "location": "Global",
+                "kind": "frontdoor",
+                "tags": {
+                  "product_id": "13742",
+                  "created_by": "carol_brothers@mckinsey.com"
+                },
+                "sku": {
+                  "name": "Premium_AzureFrontDoor"
+                },
+                "properties": {
+                  "frontDoorId": "faa236ce-e892-4c16-8115-0d2b047f718f",
+                  "resourceState": "Active",
+                  "provisioningState": "Succeeded"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/cfb-vevmhnkx/providers/Microsoft.Cdn/profiles/MyFrontDoor-Success/customDomains?api-version=2020-09-01",
+        "body": null,
+        "headers": {}
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "date": [
+            "Wed, 10 May 2023 23:13:25 GMT"
+          ],
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "cache-control": [
+            "no-cache"
+          ],
+          "content-length": [
+            "12"
+          ]
+        },
+        "body": {
+          "data": {
+            "value": [
+              {
+                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/cfb-vevmhnkx/providers/Microsoft.Cdn/profiles/MyFrontDoor-Success/customdomains/test-custom-domain",
+                "name": "test-custom-domain",
+                "type": "Microsoft.Cdn/profiles/customdomains",
+                "properties": {
+                  "tlsSettings": {
+                    "certificateType": "ManagedCertificate",
+                    "minimumTlsVersion": "TLS12"
+                  },
+                  "azureDnsZone": {
+                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/cfb-vevmhnkx/providers/Microsoft.Network/dnsZones/sub-domain-green.domain.com"
+                  },
+                  "provisioningState": "Succeeded",
+                  "deploymentStatus": "NotStarted",
+                  "domainValidationState": "Pending",
+                  "hostName": "contosogreen.fabrikam.com",
+                  "validationProperties": {
+                    "validationToken": "_o93h0b9tqoehoaifi99r5ucquw3sy3l",
+                    "expirationDate": "2024-11-21T11:28:37.0854737+00:00"
+                  }
+                },
+                "c7n:parent-id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/cfb-vevmhnkx/providers/Microsoft.Cdn/profiles/MyFrontDoor-Success",
+                "resourceGroup": "cfb-vevmhnkx"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/AfdEndpointTest.test_find_enabled_endpoints.json
+++ b/tools/c7n_azure/tests_azure/cassettes/AfdEndpointTest.test_find_enabled_endpoints.json
@@ -1,0 +1,113 @@
+{
+  "version": 1,
+  "interactions": [
+    {
+      "request": {
+        "method": "GET",
+        "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Cdn/profiles?api-version=2020-09-01",
+        "body": null,
+        "headers": {}
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "date": [
+            "Wed, 10 May 2023 23:13:24 GMT"
+          ],
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "x-ms-ratelimit-remaining-subscription-resource-requests": [
+            "49"
+          ],
+          "cache-control": [
+            "no-cache"
+          ],
+          "content-length": [
+            "1341"
+          ]
+        },
+        "body": {
+          "data": {
+            "value": [
+              {
+                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/cfb-vevmhnkx/providers/Microsoft.Cdn/profiles/MyFrontDoor-Success",
+                "type": "Microsoft.Cdn/profiles",
+                "name": "MyFrontDoor-Success",
+                "location": "Global",
+                "kind": "frontdoor",
+                "tags": {
+                  "product_id": "13742",
+                  "created_by": "carol_brothers@mckinsey.com"
+                },
+                "sku": {
+                  "name": "Premium_AzureFrontDoor"
+                },
+                "properties": {
+                  "frontDoorId": "faa236ce-e892-4c16-8115-0d2b047f718f",
+                  "resourceState": "Active",
+                  "provisioningState": "Succeeded"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/cfb-vevmhnkx/providers/Microsoft.Cdn/profiles/MyFrontDoor-Success/afdEndpoints?api-version=2020-09-01",
+        "body": null,
+        "headers": {}
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "date": [
+            "Wed, 10 May 2023 23:13:25 GMT"
+          ],
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "cache-control": [
+            "no-cache"
+          ],
+          "content-length": [
+            "12"
+          ]
+        },
+        "body": {
+          "data": {
+            "value": [
+              {
+                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/cfb-vevmhnkx/providers/Microsoft.Cdn/profiles/MyFrontDoor-Success/afdendpoints/test-endpoint",
+                "name": "test-endpoint",
+                "type": "Microsoft.Cdn/profiles/afdendpoints",
+                "location": "Global",
+                "tags": {
+                  "ComplianceStatus": "Green",
+                  "CustodianRule": "ecc-azure-432-dep_frontdoor_latest_tls"
+                },
+                "properties": {
+                  "enabledState": "Enabled",
+                  "provisioningState": "Succeeded",
+                  "deploymentStatus": "NotStarted",
+                  "hostName": "test-endpoint-bqdde2aeewh3gxgh.z01.azurefd.net"
+                },
+                "c7n:parent-id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/cfb-vevmhnkx/providers/Microsoft.Cdn/profiles/MyFrontDoor-Success",
+                "resourceGroup": "cfb-vevmhnkx"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_afd_custom_domain.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_afd_custom_domain.py
@@ -1,0 +1,27 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from ..azure_common import BaseTest
+
+
+class AfdCustomDomainTest(BaseTest):
+
+    def test_afd_custom_domain_schema_validate(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-azure-afd-custom-domain',
+                'resource': 'azure.afd-custom-domain'
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_find_with_mintlsversion_12(self):
+        p = self.load_policy({
+            'name': 'test-azure-afd-custom-domain',
+            'resource': 'azure.afd-custom-domain',
+            'filters': [
+                {'type': 'value',
+                 'key': 'properties.tlsSettings.minimumTlsVersion',
+                 'value': 'TLS12'}],
+        })
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'test-custom-domain')

--- a/tools/c7n_azure/tests_azure/tests_resources/test_afd_endpoint.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_afd_endpoint.py
@@ -25,4 +25,3 @@ class AfdEndpointTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['name'], 'test-endpoint')
-

--- a/tools/c7n_azure/tests_azure/tests_resources/test_afd_endpoint.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_afd_endpoint.py
@@ -1,0 +1,28 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from ..azure_common import BaseTest
+
+
+class AfdEndpointTest(BaseTest):
+
+    def test_afd_endpoint_schema_validate(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-azure-afd-endpoint',
+                'resource': 'azure.afd-endpoint'
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_find_enabled_endpoints(self):
+        p = self.load_policy({
+            'name': 'test-azure-afd-endpoint',
+            'resource': 'azure.afd-endpoint',
+            'filters': [
+                {'type': 'value',
+                 'key': 'properties.enabledState',
+                 'value': 'Enabled'}],
+        })
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'test-endpoint')
+


### PR DESCRIPTION
Azure Front Door endpoint
```yaml
policies:
  - name: enabled-front-door-endpoints
    resource: azure.afd-endpoint
    filters:
      - type: value
        key: properties.enabledState
        value: Enabled
```

Azure Front Door custom domain
```yaml
policies:
  - name: standard-verizon
    resource: azure.afd-custom-domain
    filters:
      - type: value
        key: properties.tlsSettings.minimumTlsVersion
        op: ne
        value: TLS12
```