### PR TITLE
Add management-policy-rules filter for azure.storage

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/storage.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage.py
@@ -194,7 +194,7 @@ class StorageAccountManagementPolicyRulesFilter(ListItemFilter):
     .. code-block:: yaml
 
         policies:
-          - name: storage-no-soft-delete
+          - name: storage-delete-blob-le-3-days
             resource: azure.storage
             filters:
               - type: management-policy-rules

--- a/tools/c7n_azure/c7n_azure/resources/storage.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage.py
@@ -12,7 +12,7 @@ from azure.storage.common.models import Logging, RetentionPolicy
 from azure.storage.file import FileService
 from azure.storage.queue import QueueServiceClient
 from c7n.exceptions import PolicyValidationError
-from c7n.filters.core import type_schema
+from c7n.filters.core import type_schema, ListItemFilter
 from c7n.utils import get_annotation_prefix, local_session
 from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.actions.firewall import SetFirewallAction
@@ -179,6 +179,52 @@ class StorageSetFirewallAction(SetFirewallAction):
             resource['resourceGroup'],
             resource['name'],
             StorageAccountUpdateParameters(network_rule_set=rule_set))
+
+
+@Storage.filter_registry.register("management-policy-rules")
+class StorageAccountManagementPolicyRulesFilter(ListItemFilter):
+    """
+    Filter Storage Accounts based on their management policy rules
+
+    :example:
+
+    Find storage accounts where lifecycle policy configured to remove base Blob
+    after less or equal than 3 days
+
+    .. code-block:: yaml
+
+        policies:
+          - name: storage-no-soft-delete
+            resource: azure.storage
+            filters:
+              - type: management-policy-rules
+                attrs:
+                  - type: value
+                    key: definition.actions.baseBlob.delete.daysAfterModificationGreaterThan
+                    value: 3
+                    op: le
+
+    """
+    schema = type_schema(
+        "management-policy-rules",
+        attrs={"$ref": "#/definitions/filters_common/list_item_attrs"},
+        count={"type": "number"},
+        count_op={"$ref": "#/definitions/filters_common/comparison_operators"}
+    )
+    item_annotation_key = "c7n:management-policy-rules"
+    annotate_items = True
+
+    def get_item_values(self, resource):
+        try:
+            item = self.manager.get_client().management_policies.get(
+                resource_group_name=resource["resourceGroup"],
+                account_name=resource["name"],
+                management_policy_name="default"
+            )
+            return item.serialize(True)["properties"]["policy"].get("rules", [])
+        except Exception as e:  # azure.core.exceptions.ResourceNotFoundError
+            self.log.error(e)
+            return []  # no rules
 
 
 @Storage.filter_registry.register('firewall-rules')

--- a/tools/c7n_azure/tests_azure/cassettes/StorageTest.test_storage_management_policy_rules_filter.json
+++ b/tools/c7n_azure/tests_azure/cassettes/StorageTest.test_storage_management_policy_rules_filter.json
@@ -1,0 +1,236 @@
+{
+  "version": 1,
+  "interactions": [
+    {
+      "request": {
+        "method": "GET",
+        "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2019-04-01",
+        "body": null,
+        "headers": {}
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "date": [
+            "Thu, 02 May 2019 19:33:20 GMT"
+          ],
+          "content-length": [
+            "8686"
+          ],
+          "x-ms-original-request-ids": [
+            "069c8406-e846-4bae-9867-c39ac116c3dc",
+            "c9b4e59b-dec2-48ea-8a4f-11d3c58d2ccd"
+          ],
+          "cache-control": [
+            "no-cache"
+          ]
+        },
+        "body": {
+          "data": {
+            "value": [
+              {
+                "sku": {
+                  "name": "Standard_LRS",
+                  "tier": "Standard"
+                },
+                "kind": "Storage",
+                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_containerservice/providers/Microsoft.Storage/storageAccounts/usm2nughsm6pomstr0",
+                "name": "usm2nughsm6pomstr0",
+                "type": "Microsoft.Storage/storageAccounts",
+                "location": "southcentralus",
+                "tags": {},
+                "properties": {
+                  "networkAcls": {
+                    "bypass": "AzureServices",
+                    "virtualNetworkRules": [],
+                    "ipRules": [],
+                    "defaultAction": "Allow"
+                  },
+                  "supportsHttpsTrafficOnly": false,
+                  "encryption": {
+                    "services": {
+                      "file": {
+                        "enabled": true,
+                        "lastEnabledTime": "2019-05-01T22:31:00.0178514Z"
+                      },
+                      "blob": {
+                        "enabled": true,
+                        "lastEnabledTime": "2019-05-01T22:31:00.0178514Z"
+                      }
+                    },
+                    "keySource": "Microsoft.Storage"
+                  },
+                  "provisioningState": "Succeeded",
+                  "creationTime": "2019-05-01T22:30:59.8772224Z",
+                  "primaryEndpoints": {
+                    "blob": "https://usm2nughsm6pomstr0.blob.core.windows.net/",
+                    "queue": "https://usm2nughsm6pomstr0.queue.core.windows.net/",
+                    "table": "https://usm2nughsm6pomstr0.table.core.windows.net/",
+                    "file": "https://usm2nughsm6pomstr0.file.core.windows.net/"
+                  },
+                  "primaryLocation": "southcentralus",
+                  "statusOfPrimary": "available"
+                }
+              },
+              {
+                "sku": {
+                  "name": "Standard_LRS",
+                  "tier": "Standard"
+                },
+                "kind": "Storage",
+                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Storage/storageAccounts/cloudcustodiantest",
+                "name": "cloudcustodiantest",
+                "type": "Microsoft.Storage/storageAccounts",
+                "location": "westus2",
+                "tags": {},
+                "properties": {
+                  "networkAcls": {
+                    "bypass": "AzureServices",
+                    "virtualNetworkRules": [],
+                    "ipRules": [],
+                    "defaultAction": "Allow"
+                  },
+                  "supportsHttpsTrafficOnly": false,
+                  "encryption": {
+                    "services": {
+                      "file": {
+                        "enabled": true,
+                        "lastEnabledTime": "2019-05-01T21:51:44.9504918Z"
+                      },
+                      "blob": {
+                        "enabled": true,
+                        "lastEnabledTime": "2019-05-01T21:51:44.9504918Z"
+                      }
+                    },
+                    "keySource": "Microsoft.Storage"
+                  },
+                  "provisioningState": "Succeeded",
+                  "creationTime": "2019-05-01T21:51:44.8567460Z",
+                  "primaryEndpoints": {
+                    "blob": "https://cloudcustodiantest.blob.core.windows.net/",
+                    "queue": "https://cloudcustodiantest.queue.core.windows.net/",
+                    "table": "https://cloudcustodiantest.table.core.windows.net/",
+                    "file": "https://cloudcustodiantest.file.core.windows.net/"
+                  },
+                  "primaryLocation": "westus2",
+                  "statusOfPrimary": "available"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_containerservice/providers/Microsoft.Storage/storageAccounts/usm2nughsm6pomstr0/managementPolicies/default",
+        "body": null,
+        "headers": {}
+      },
+      "response": {
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "headers": {
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "date": [
+            "Thu, 02 May 2019 19:33:20 GMT"
+          ],
+          "content-length": [
+            "8686"
+          ],
+          "x-ms-original-request-ids": [
+            "069c8406-e846-4bae-9867-c39ac116c3dc",
+            "c9b4e59b-dec2-48ea-8a4f-11d3c58d2ccd"
+          ],
+          "cache-control": [
+            "no-cache"
+          ]
+        },
+        "body": {
+          "data": {
+            "error": {
+              "code": "ManagementPolicyNotFound",
+              "message": "No ManagementPolicy found for account usm2nughsm6pomstr0"
+            }
+          }
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_functionapp-reqs/providers/Microsoft.Storage/storageAccounts/cloudcustodiantest/managementPolicies/default",
+        "body": null,
+        "headers": {}
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "date": [
+            "Thu, 02 May 2019 19:33:20 GMT"
+          ],
+          "content-length": [
+            "8686"
+          ],
+          "x-ms-original-request-ids": [
+            "069c8406-e846-4bae-9867-c39ac116c3dc",
+            "c9b4e59b-dec2-48ea-8a4f-11d3c58d2ccd"
+          ],
+          "cache-control": [
+            "no-cache"
+          ]
+        },
+        "body": {
+          "data": {
+            "id": "/subscriptions/dd3ce4b8-093a-40da-8369-d50149d0f84a/resourceGroups/369-rg-green/providers/Microsoft.Storage/storageAccounts/sa369green/managementPolicies/default",
+            "name": "DefaultManagementPolicy",
+            "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+            "properties": {
+              "lastModifiedTime": "2024-11-19T10:48:33.515858Z",
+              "policy": {
+                "rules": [
+                  {
+                    "enabled": true,
+                    "name": "test",
+                    "type": "Lifecycle",
+                    "definition": {
+                      "actions": {
+                        "baseBlob": {
+                          "delete": {
+                            "daysAfterModificationGreaterThan": 3.0
+                          }
+                        }
+                      },
+                      "filters": {
+                        "blobTypes": [
+                          "blockBlob"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_storage.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_storage.py
@@ -668,6 +668,26 @@ class StorageTest(BaseTest):
         resources = p.run()
         self.assertEqual(1, len(resources))
 
+    def test_storage_management_policy_rules_filter(self):
+        p = self.load_policy({
+            'name': 'test-azure-mp-rules',
+            'resource': 'azure.storage',
+            'filters': [{
+                'type': 'management-policy-rules',
+                'attrs': [{
+                    'type': 'value',
+                    'key': 'definition.actions.baseBlob.delete.daysAfterModificationGreaterThan',
+                    'value': 3,
+                    'op': 'le'
+                }]
+            }]
+        }, validate=True)
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual(resources[0]['name'], 'cloudcustodiantest')
+        self.assertEqual(len(resources[0]['c7n:management-policy-rules']), 1)
+        self.assertEqual(resources[0]['c7n:management-policy-rules'][0]['name'], 'test')
+
 
 class StorageFirewallFilterTest(BaseTest):
 


### PR DESCRIPTION
Example:

```yaml
policies:
  - name: storage-account
    resource: azure.storage
    filters:
      - type: management-policy-rules
        attrs:
          - type: value
            key: definition.actions.baseBlob.delete.daysAfterModificationGreaterThan
            value: 3
            op: le
```

The endpoint must be always queried with `default` management policy name:
<img width="925" alt="image" src="https://github.com/user-attachments/assets/2362e000-6acc-478e-b85e-31cf41725bda">

Link to sdk docs:
https://learn.microsoft.com/en-us/rest/api/storagerp/management-policies/get?view=rest-storagerp-2023-05-01&tabs=HTTP