### PR TITLE
aws - appsync - add detail_spec

### DIFF
--- a/c7n/resources/appsync.py
+++ b/c7n/resources/appsync.py
@@ -17,6 +17,7 @@ class GraphQLApi(QueryResourceManager):
     class resource_type(TypeInfo):
         service = 'appsync'
         enum_spec = ('list_graphql_apis', 'graphqlApis', {'maxResults': 25})
+        detail_spec = ('get_graphql_api', 'apiId', 'apiId', None)
         id = 'apiId'
         name = 'name'
         config_type = cfn_type = 'AWS::AppSync::GraphQLApi'


### PR DESCRIPTION
Add detail_spec so that tags show up for graphql

[Resource.json before](https://github.com/matthewdeanmartin/c7n_make/blob/main/test_appsync/out/test/resources_regular.json)

[Resource.json after](https://github.com/matthewdeanmartin/c7n_make/blob/main/test_appsync/out/test/resources.json).

[Test](https://github.com/matthewdeanmartin/c7n_make/blob/main/test_appsync/test_create.py)

Lemme know if y'all want anything more than that.