### PR TITLE
aws - glue - fix table ARN to include the database name

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -364,6 +364,9 @@ class GlueTable(query.ChildResourceManager):
         date = 'CreatedOn'
         arn_type = 'table'
 
+    def get_arns(self, resources):
+        return [self.generate_arn(r['DatabaseName'] + '/' + r['Name']) for r in resources]
+
 
 @query.sources.register('describe-table')
 class DescribeTable(query.ChildDescribeSource):

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -436,6 +436,23 @@ class TestGlueCrawlers(BaseTest):
 
 
 class TestGlueTables(BaseTest):
+
+    def test_arn_format(self):
+        session_factory = self.replay_flight_data("test_glue_table_delete")
+        p = self.load_policy(
+            {
+                "name": "glue-table-query",
+                "resource": "glue-table",
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            p.resource_manager.get_arns(resources)[0],
+            "arn:aws:glue:us-east-1:644160558196:table/test/test"
+        )
+
     def test_tables_delete(self):
         session_factory = self.replay_flight_data("test_glue_table_delete")
         p = self.load_policy(

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -206,7 +206,7 @@ class PolicyMetaLint(BaseTest):
             {'account', 's3', 'hostedzone', 'log-group', 'rest-api', 'redshift-snapshot',
              'rest-stage', 'codedeploy-app', 'codedeploy-group', 'fis-template', 'dlm-policy',
              'apigwv2', 'apigwv2-stage', 'apigw-domain-name', 'fis-experiment',
-             'launch-template-version'})
+             'launch-template-version', 'glue-table'})
         if overrides:
             raise ValueError("unknown arn overrides in %s" % (", ".join(overrides)))
 


### PR DESCRIPTION
Identically-named tables in different DBs previously had the same ARN. This fixes the format to be unambiguous and match https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html#data-catalog-resource-arns