### PR TITLE
aws - iam-role - bugfix for IAM role ARN parsing

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -81,7 +81,7 @@ class DescribeRole(DescribeSource):
         client = local_session(self.manager.session_factory).client('iam')
         resources = []
         for rid in resource_ids:
-            if rid.startswith('arn'):
+            if rid.startswith('arn:'):
                 rid = Arn.parse(rid).resource
             try:
                 result = self.manager.retry(client.get_role, RoleName=rid)


### PR DESCRIPTION
Bug fix for IAM role ARN parsing. When an IAM role name starts with "arn" (e.g. "arnarnarn_my_rolename"), the `cloudtrail` policy fails with an `Invalid Arn` error.

### Error
```
[ERROR]	2024-12-12T20:05:10.230Z	4cb45460-3342-4f46-a9d0-e50d23cbd6a6	error during policy execution
Traceback (most recent call last):
  File "/var/task/c7n/handler.py", line 170, in dispatch_event
    p.push(event, context)
  File "/var/task/c7n/policy.py", line 1347, in push
    return mode.run(event, lambda_ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/task/c7n/policy.py", line 502, in run
    resources = self.resolve_resources(event)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/task/c7n/policy.py", line 737, in resolve_resources
    return super().resolve_resources(event)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/task/c7n/policy.py", line 484, in resolve_resources
    resources = self.policy.resource_manager.get_resources(resource_ids)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/task/c7n/query.py", line 586, in get_resources
    resources = self.source.get_resources(ids)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/task/c7n/resources/iam.py", line 86, in get_resources
    rid = Arn.parse(rid).resource
          ^^^^^^^^^^^^^^
  File "/var/task/c7n/resources/aws.py", line 303, in parse
    raise ValueError("Invalid Arn")
ValueError: Invalid Arn
```

### Sample Policy
```
policies:
  - name: iam-role-no-ssm-policy-remediate-event
    resource: iam-role
    mode:
      type: cloudtrail
      events:
        - event: CreateRole
          ids: requestParameters.roleName
          source: iam.amazonaws.com
        - event: DetachRolePolicy
          ids: requestParameters.roleName
          source: iam.amazonaws.com
    filters:
      - type: value
        key: AssumeRolePolicyDocument.Statement[].Principal.Service[]
        op: intersect
        value:
          - ec2.amazonaws.com
      - type: no-specific-managed-policy
        value: my-ssm-policy
    actions:
      - type: set-policy
        state: attached
        arn: arn:aws:iam::{account_id}:policy/my-ssm-policy
```

On a side note, `responseElements.role.arn` can not be used as an input ID. When **Path** is not `/` (e.g. "Path": "/my-custom-path/"), ARN will contain `/` after `role/` (e.g. "arn:aws:iam::111122223333:role/my-custom-path/my-role") and c7n doesn't parse it correctly and fails with a following error.
```
[WARNING] 2024-12-19T23:48:50.933Z a1ce1a53-070a-4e9b-8bf8-7691ec5faadd event ids not resolved: ['arn:aws:iam::111122223333:role/my-custom-path/my-role'] error:An error occurred (ValidationError) when calling the GetRole operation: The specified value for roleName is invalid. It must contain only alphanumeric characters and/or the following: +=,.@_-
```