### PR TITLE
aws - shield - mark all resources as global

### DIFF
--- a/c7n/resources/shield.py
+++ b/c7n/resources/shield.py
@@ -20,6 +20,7 @@ class ShieldProtection(QueryResourceManager):
         name = 'Name'
         arn = False
         config_type = 'AWS::Shield::Protection'
+        global_resource = True
 
 
 @resources.register('shield-attack')
@@ -35,6 +36,7 @@ class ShieldAttack(QueryResourceManager):
         filter_name = 'ResourceArns'
         filter_type = 'list'
         arn = False
+        global_resource = True
 
 
 def get_protections_paginator(client):


### PR DESCRIPTION
There's only a us-east-1 endpoint, and it lists protections even for region-specific resources.