### PR TITLE
aws - lexv2-bot - set maxResults

### DIFF
--- a/c7n/resources/lex.py
+++ b/c7n/resources/lex.py
@@ -28,7 +28,7 @@ class LexBot(query.QueryResourceManager):
 class LexV2Bot(QueryResourceManager):
     class resource_type(query.TypeInfo):
         service = "lexv2-models"
-        enum_spec = ('list_bots', 'botSummaries', None)
+        enum_spec = ('list_bots', 'botSummaries', {'maxResults': 1000})
         arn_type = "bot"
         arn_service = "lex"
         id = "botId"


### PR DESCRIPTION
When testing in a bigger account, AWS only seemed to be getting 10 resources. I'm setting up maxResult so that we can get all the resources back. i didn't find anything in the doc but setting maxResults beyond 1000 throws a traceback
```
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the ListBots operation: 1 validation error detected: Value at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000
2025-01-16 14:19:15,494: custodian.commands:ERROR The following policies had errors while executing
```