### PR TITLE
aws - workspaces-web - BugFix: empty browser policy, add tests

### DIFF
--- a/c7n/resources/workspaces.py
+++ b/c7n/resources/workspaces.py
@@ -548,18 +548,19 @@ class BrowerPolicyFilter(ValueFilter):
         client = local_session(self.manager.session_factory).client('workspaces-web')
         results = []
         for r in resources:
-            if (self.policy_annotation not in r) and ('browserSettingsArn' in r):
-                browserSettings = self.manager.retry(
-                    client.get_browser_settings,
-                    browserSettingsArn=r['browserSettingsArn']).get('browserSettings')
-                browserPolicy = json.loads(browserSettings['browserPolicy'])
-                r[self.policy_annotation] = browserPolicy
-            if self.match(r[self.policy_annotation]):
-                if self.matched_policy_annotation not in r:
-                    r[self.matched_policy_annotation] = [self.data.get('key')]
-                else:
-                    r[self.matched_policy_annotation].append(self.data.get('key'))
-                results.append(r)
+            if 'browserSettingsArn' in r:
+                if (self.policy_annotation not in r):
+                    browserSettings = self.manager.retry(
+                        client.get_browser_settings,
+                        browserSettingsArn=r['browserSettingsArn']).get('browserSettings')
+                    browserPolicy = json.loads(browserSettings['browserPolicy'])
+                    r[self.policy_annotation] = browserPolicy
+                if self.match(r[self.policy_annotation]):
+                    if self.matched_policy_annotation not in r:
+                        r[self.matched_policy_annotation] = [self.data.get('key')]
+                    else:
+                        r[self.matched_policy_annotation].append(self.data.get('key'))
+                    results.append(r)
         return results
 
 

--- a/tests/data/placebo/test_workspaces_web_empty/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_workspaces_web_empty/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_workspaces_web_empty/workspaces-web.ListPortals_1.json
+++ b/tests/data/placebo/test_workspaces_web_empty/workspaces-web.ListPortals_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "portals": [
+            {
+                "authenticationType": "IAM_Identity_Center",
+                "browserType": "Chrome",
+                "creationDate": {
+                    "__class__": "datetime",
+                    "year": 2025,
+                    "month": 1,
+                    "day": 20,
+                    "hour": 11,
+                    "minute": 55,
+                    "second": 5,
+                    "microsecond": 347000
+                },
+                "displayName": "empty-portal",
+                "instanceType": "standard.regular",
+                "maxConcurrentSessions": 5,
+                "networkSettingsArn": "arn:aws:workspaces-web:us-east-1:644160558196:networkSettings/99993a01-2137-4f43-96b2-16261b96f5c9",
+                "portalArn": "arn:aws:workspaces-web:us-east-1:644160558196:portal/fd2b7f2f-18d7-4497-a1bf-f2348a9c8dea",
+                "portalEndpoint": "fd2b7f2f-18d7-4497-a1bf-f2348a9c8dea.workspaces-web.com",
+                "portalStatus": "Active",
+                "rendererType": "AppStream",
+                "userSettingsArn": "arn:aws:workspaces-web:us-east-1:644160558196:userSettings/f91a198e-9aea-44a5-9eac-9b3270b74782"
+            }
+        ]
+    }
+}

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -487,7 +487,7 @@ class TestWorkspacesWeb(BaseTest):
     # Test for a portal that has disassociated and deleted its browser policy
     # settings.
     def test_workspaces_web_browser_policy_empty(self):
-        session_factory = self.record_flight_data("test_workspaces_web_empty")
+        session_factory = self.replay_flight_data("test_workspaces_web_empty")
         p = self.load_policy(
             {
                 "name": "test-browser-policy-empty",

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -484,6 +484,31 @@ class TestWorkspacesWeb(BaseTest):
 
         self.assertEqual(len(resources), 1)
 
+    # Test for a portal that has disassociated and deleted its browser policy
+    # settings.
+    def test_workspaces_web_browser_policy_empty(self):
+        session_factory = self.record_flight_data("test_workspaces_web_empty")
+        p = self.load_policy(
+            {
+                "name": "test-browser-policy-empty",
+                "resource": "workspaces-web",
+                "filters": [{
+                    "not": [
+                        {
+                            "type": "browser-policy",
+                            "key": "chromePolicies.AllowDeletingBrowserHistory.value",
+                            "op": "eq",
+                            "value": False
+                        }
+                    ]
+                }]
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+
     def test_workspaces_web_subnet(self):
         session_factory = self.replay_flight_data("test_workspaces_web_subnet")
         p = self.load_policy(


### PR DESCRIPTION
Expected:
- If a workspaces-web resource has disassociated its browser policy, then you shouldn't return the resource if you're looking for `chromePolicies.AllowDeletingBrowserHistory.value". You **should** return the resource if there's a "not" in the policy.

Current Outcome:
- The policy errors out when it can't find `'browserSettingsArn'`. There's a key error so it also won't have the following `self.match(r[self.policy_annotation])` .

Solution in this PR:
- move the `if 'browserSettingsArn' in r` conditional up front because you can't match the policy if `browserSettingsArn` doesn't exist.

I added a test with a portal where I deliberately used the AWS CLI to disassociate and delete the browserSettings from the workspaces-web portal.