### PR TITLE
gcp - loadbalancer-target-tcp-proxy - remove stray space from asset_type

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
@@ -85,7 +85,7 @@ class LoadBalancingTargetTcpProxy(QueryResourceManager):
         default_report_fields = [
             "name", "description", "creationTimestamp", "service"
         ]
-        asset_type = " compute.googleapis.com/TargetTcpProxy"
+        asset_type = "compute.googleapis.com/TargetTcpProxy"
         urn_component = "target-tcp-proxy"
 
         @staticmethod


### PR DESCRIPTION
Noticed in passing that the `asset_type` for the resource had a leading space.