### PR TITLE
releng - enable merge queue events for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   pull_request:
     branches:
       - main


### PR DESCRIPTION

per community discussions, we want to try out merge queues as a way to better handle some of our
pull request volume, as it will automatically keep the prs up to date when their submitted to the queue
and re-run tests.




