### PR TITLE
aws - quotas - usage filter - followup on error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ line-length = 100
 [tool.ruff]
 line-length = 100
 exclude = ["__init__.py"]
+target-version = "py311"
 
 [tool.ruff.lint]
 preview = true


### PR DESCRIPTION
This is a followup for #9897 that addresses the review comment there.


Namely continue in the face of an error across all quotas, and then raise at the end.




