### PR TITLE
[Bug] Fix conditional for key error in policystatement filter

### DIFF
--- a/c7n/filters/policystatement.py
+++ b/c7n/filters/policystatement.py
@@ -141,13 +141,15 @@ class HasStatementFilter(Filter):
                                                         resource_statement):
                             found += 1
 
-                    elif req_key in resource_statement:
-                        if (req_value == resource_statement[req_key]):
-                            found += 1
+                    # If req_key is not a partial_match element,
+                    # do a regular full value match for a given req_key
+                    elif req_value == resource_statement.get(req_key):
+                        found += 1
 
                 if found and found == len(required_statement):
                     matched_statements.append(required_statement)
                     break
+
         return matched_statements
 
     def __match_partial_statement(self, partial_match_key,

--- a/c7n/filters/policystatement.py
+++ b/c7n/filters/policystatement.py
@@ -140,10 +140,11 @@ class HasStatementFilter(Filter):
                                                         req_value,
                                                         resource_statement):
                             found += 1
-                    else:
-                        if (req_key in resource_statement) and \
-                            (req_value == resource_statement[req_key]):
+
+                    elif req_key in resource_statement:
+                        if (req_value == resource_statement[req_key]):
                             found += 1
+
                 if found and found == len(required_statement):
                     matched_statements.append(required_statement)
                     break


### PR DESCRIPTION
Since we loop through all of a resource's resource policy statements to find matches, the previous `resource_statement[req_key]` leads to KeyError: 'Action' if the resource statements had a statement that did not have the "action" req_key that the filter is looking for. Using `.get()` instead to avoid key errors.