### PR TITLE
docs(quickstart): fix typo isntructions

### DIFF
--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -168,7 +168,7 @@ supported modes in Cloud Custodian::
 Cloud Provider Specific Help
 ----------------------------
 
-For specific setup isntructions for AWS, Azure, and GCP, visit the relevant getting started
+For specific setup instructions for AWS, Azure, and GCP, visit the relevant getting started
 page.
 
 - :ref:`AWS <aws-gettingstarted>`


### PR DESCRIPTION
Found a typo on page & section https://cloudcustodian.io/getting-started/#cloud-provider-specific-help