### PR TITLE
chore: remove duplicate function

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/kms.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/kms.py
@@ -189,10 +189,6 @@ class KmsCryptoKeyVersion(ChildResourceManager):
         def _get_location(cls, resource):
             return resource["name"].split('/')[3]
 
-        @classmethod
-        def _get_location(cls, resource):
-            return resource["name"].split('/')[3]
-
 
 @resources.register('kms-location')
 class KmsLocation(QueryResourceManager):


### PR DESCRIPTION
The `_get_location` method id declared twice. Most likely here due to a git merge update.