### PR TITLE
Support Additional AWS Partitions for Mailer SNS Delivery

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/sns_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/sns_delivery.py
@@ -74,7 +74,7 @@ class SnsDelivery:
         return sns_addrs_to_resources_map
 
     def target_is_sns(self, target):
-        if target.startswith("arn:aws:sns"):
+        if target.startswith(("arn:aws:sns", "arn:aws-cn:sns", "arn:aws-us-gov:sns")):
             return True
         return False
 


### PR DESCRIPTION
Adjust logic to check if Mailer Target is SNS is SNS in different partitions