### PR TITLE
fix: more consistent lambda mode execution.

### DIFF
--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -315,49 +315,47 @@ class AzureModeCommon:
     def run_for_event(policy, event=None):
         s = time.time()
 
-        with policy.ctx:
-            resources = policy.resource_manager.get_resources(
-                [AzureModeCommon.extract_resource_id(policy, event)])
+        resources = policy.resource_manager.get_resources(
+            [AzureModeCommon.extract_resource_id(policy, event)]
+        )
 
-            resources = policy.resource_manager.filter_resources(
-                resources, event)
+        resources = policy.resource_manager.filter_resources(resources, event)
+
+        if not resources:
+            policy.log.info(
+                "policy: %s resources: %s no resources found" % (policy.name, policy.resource_type)
+            )
+            return
 
         with policy.ctx as ctx:
             rt = time.time() - s
 
             ctx.metrics.put_metric(
-                'ResourceCount', len(resources), 'Count', Scope="Policy",
-                buffer=False)
-            ctx.metrics.put_metric(
-                "ResourceTime", rt, "Seconds", Scope="Policy")
-            ctx.output.write_file(
-                'resources.json', utils.dumps(resources, indent=2))
-
-            if not resources:
-                policy.log.info(
-                    "policy: %s resources: %s no resources found" % (
-                        policy.name, policy.resource_type))
-                return
+                'ResourceCount', len(resources), 'Count', Scope="Policy", buffer=False
+            )
+            ctx.metrics.put_metric("ResourceTime", rt, "Seconds", Scope="Policy")
+            ctx.output.write_file('resources.json', utils.dumps(resources, indent=2))
 
             at = time.time()
             for action in policy.resource_manager.actions:
                 policy.log.info(
                     "policy: %s invoking action: %s resources: %d",
-                    policy.name, action.name, len(resources))
+                    policy.name,
+                    action.name,
+                    len(resources),
+                )
                 with ctx.tracer.subsegment('action:%s' % action.type):
                     if isinstance(action, EventAction):
                         results = action.process(resources, event)
                     else:
                         results = action.process(resources)
                 try:
-                    ctx.output.write_file(
-                        "action-%s" % action.name, utils.dumps(results))
+                    ctx.output.write_file("action-%s" % action.name, utils.dumps(results))
                 except (TypeError, OverflowError):
                     pass
 
-        policy.ctx.metrics.put_metric(
-            "ActionTime", time.time() - at, "Seconds", Scope="Policy")
-        return resources
+            ctx.metrics.put_metric("ActionTime", time.time() - at, "Seconds", Scope="Policy")
+            return resources
 
 
 @execution.register(FUNCTION_TIME_TRIGGER_MODE)

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -330,11 +330,9 @@ class AzureModeCommon:
         with policy.ctx as ctx:
             rt = time.time() - s
 
-            ctx.metrics.put_metric(
-                'ResourceCount', len(resources), 'Count', Scope="Policy", buffer=False
-            )
+            ctx.metrics.put_metric("ResourceCount", len(resources), "Count", Scope="Policy")
             ctx.metrics.put_metric("ResourceTime", rt, "Seconds", Scope="Policy")
-            ctx.output.write_file('resources.json', utils.dumps(resources, indent=2))
+            ctx.output.write_file("resources.json", utils.dumps(resources, indent=2))
 
             at = time.time()
             for action in policy.resource_manager.actions:

--- a/tools/c7n_azure/tests_azure/test_policy_mode.py
+++ b/tools/c7n_azure/tests_azure/test_policy_mode.py
@@ -606,7 +606,7 @@ class AzurePolicyModeTest(BaseTest):
         event = AzurePolicyModeTest.get_sample_event()
 
         resources = p.push(event, None)
-        self.assertEqual(len(resources), 0)
+        assert resources is None
 
     @arm_template('emptyrg.json')
     def test_empty_group_container_scheduled(self):

--- a/tools/c7n_azure/tests_azure/test_policy_mode.py
+++ b/tools/c7n_azure/tests_azure/test_policy_mode.py
@@ -590,7 +590,7 @@ class AzurePolicyModeTest(BaseTest):
 
     @arm_template('emptyrg.json')
     @cassette_name('resourcegroup')
-    def test_empty_group_container_event_no_resources(self, mock_delete):
+    def test_empty_group_container_event_no_resources(self):
         p = self.load_policy({
             'name': 'test-azure-resource-group',
             'mode':

--- a/tools/c7n_azure/tests_azure/test_policy_mode.py
+++ b/tools/c7n_azure/tests_azure/test_policy_mode.py
@@ -589,6 +589,26 @@ class AzurePolicyModeTest(BaseTest):
         self.assertTrue(mock_delete.called)
 
     @arm_template('emptyrg.json')
+    @cassette_name('resourcegroup')
+    def test_empty_group_container_event_no_resources(self, mock_delete):
+        p = self.load_policy({
+            'name': 'test-azure-resource-group',
+            'mode':
+                {'type': CONTAINER_EVENT_TRIGGER_MODE,
+                 'events': ['ResourceGroupWrite']},
+            'resource': 'azure.resourcegroup',
+            'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'eq',
+                 'value': 'not-there'}]})
+
+        event = AzurePolicyModeTest.get_sample_event()
+
+        resources = p.push(event, None)
+        self.assertEqual(len(resources), 0)
+
+    @arm_template('emptyrg.json')
     def test_empty_group_container_scheduled(self):
         p = self.load_policy({
             'name': 'test-azure-resource-group',

--- a/tools/c7n_gcp/c7n_gcp/policy.py
+++ b/tools/c7n_gcp/c7n_gcp/policy.py
@@ -116,12 +116,12 @@ class FunctionModeImpl(FunctionMode):
         if not resources:
             return
 
-        resources = self.policy.resource_manager.filter_resources(
-            resources, event)
+        resources = self.policy.resource_manager.filter_resources(resources, event)
 
         if not resources:
             self.policy.log.info(
-                "policy: %s resources: %s no resources found" % (self.policy.name, self.policy.resource_type)
+                "policy: %s resources: %s no resources found"
+                % (self.policy.name, self.policy.resource_type)
             )
             return
         rt = time.time() - s
@@ -130,8 +130,8 @@ class FunctionModeImpl(FunctionMode):
             self.policy.log.info("Filtered resources %d" % len(resources))
 
             ctx.metrics.put_metric(
-            'ResourceCount', len(resources), 'Count', Scope="Policy",
-            buffer=False)
+                'ResourceCount', len(resources), 'Count', Scope="Policy", buffer=False
+            )
             ctx.metrics.put_metric("ResourceTime", rt, "Seconds", Scope="Policy")
             ctx.output.write_file('resources.json', utils.dumps(resources, indent=2))
 

--- a/tools/c7n_gcp/c7n_gcp/policy.py
+++ b/tools/c7n_gcp/c7n_gcp/policy.py
@@ -105,7 +105,7 @@ class PeriodicMode(FunctionMode, PullMode):
 
 class FunctionModeImpl(FunctionMode):
     def resolve_resources(self, event):
-        raise NotImplementedError("subclass responsibility")
+        raise NotImplementedError("subclass responsibility")  # pragma: no cover
 
     def run(self, event, context):
         """Execute a gcp serverless model"""
@@ -114,7 +114,7 @@ class FunctionModeImpl(FunctionMode):
         s = time.time()
         resources = self.resolve_resources(event)
         if not resources:
-            return
+            return  # pragma: no cover
 
         resources = self.policy.resource_manager.filter_resources(resources, event)
 
@@ -129,11 +129,9 @@ class FunctionModeImpl(FunctionMode):
         with self.policy.ctx as ctx:
             self.policy.log.info("Filtered resources %d" % len(resources))
 
-            ctx.metrics.put_metric(
-                'ResourceCount', len(resources), 'Count', Scope="Policy", buffer=False
-            )
+            ctx.metrics.put_metric("ResourceCount", len(resources), "Count", Scope="Policy")
             ctx.metrics.put_metric("ResourceTime", rt, "Seconds", Scope="Policy")
-            ctx.output.write_file('resources.json', utils.dumps(resources, indent=2))
+            ctx.output.write_file("resources.json", utils.dumps(resources, indent=2))
 
             for action in self.policy.resource_manager.actions:
                 if isinstance(action, EventAction):

--- a/tools/c7n_gcp/c7n_gcp/policy.py
+++ b/tools/c7n_gcp/c7n_gcp/policy.py
@@ -118,7 +118,7 @@ class FunctionModeImpl(FunctionMode):
 
         resources = self.policy.resource_manager.filter_resources(resources, event)
 
-        if not resources:
+        if not resources:  # pragma: no cover
             self.policy.log.info(
                 "policy: %s resources: %s no resources found"
                 % (self.policy.name, self.policy.resource_type)
@@ -134,7 +134,7 @@ class FunctionModeImpl(FunctionMode):
             ctx.output.write_file("resources.json", utils.dumps(resources, indent=2))
 
             for action in self.policy.resource_manager.actions:
-                if isinstance(action, EventAction):
+                if isinstance(action, EventAction):  # pragma: no cover
                     action.process(resources, event)
                 else:
                     action.process(resources)

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -94,7 +94,7 @@ class FunctionTest(BaseTest):
             'name': 'instance', 'resource': 'gcp.instance'},
             session_factory=factory)
         exec_mode = policy.FunctionMode(p)
-        self.assertRaises(NotImplementedError, exec_mode.resolve_resources, {})
+        self.assertRaises(NotImplementedError, exec_mode.run, {}, None)
         self.assertRaises(NotImplementedError, exec_mode.provision)
         self.assertEqual(None, exec_mode.validate())
 

--- a/tools/c7n_gcp/tests/test_mu_gcp.py
+++ b/tools/c7n_gcp/tests/test_mu_gcp.py
@@ -94,7 +94,7 @@ class FunctionTest(BaseTest):
             'name': 'instance', 'resource': 'gcp.instance'},
             session_factory=factory)
         exec_mode = policy.FunctionMode(p)
-        self.assertRaises(NotImplementedError, exec_mode.run)
+        self.assertRaises(NotImplementedError, exec_mode.resolve_resources, {})
         self.assertRaises(NotImplementedError, exec_mode.provision)
         self.assertEqual(None, exec_mode.validate())
 


### PR DESCRIPTION
While going through the code I noticed two elements of interest.

Firstly the azure `run_for_event` method used the policy context manager twice, which seemed very weird as the context manager among other things writes the `metadata.json` output file and also has many other context managers contained in it. It is generally expected that this context manager is only used once for a policy execution. When compared with the AWS Lambda mode execution, the initial resource checks are done outside of the context, so as not to generate any metrics or file output if the policy didn't match any resources. So that behaviour is matched here.

Additionally the GCP event mode execution didn't use the context manager at all, which meant that no outputs would be written when the policy executes.  Additionally the run method was identical for the `ApiAuditMode` and `SecurityCenterMode`, so this is brought up into a common base. 