### PR TITLE
Improve Lambda deployment speed and prevent Lambda last update time changes

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -19,6 +19,7 @@ import tempfile
 import zipfile
 import platform
 import re
+from .utils import lambda_cwe_policy_delta
 
 
 # We use this for freezing dependencies for serverless environments
@@ -1207,15 +1208,26 @@ class CloudWatchEventSource(AWSEventBase):
             response = {'RuleArn': rule['Arn']}
 
         client = self.session.client('lambda')
+
         try:
-            client.add_permission(
-                FunctionName=func.name,
-                StatementId=func.event_name,
-                SourceArn=response['RuleArn'],
-                Action='lambda:InvokeFunction',
-                Principal='events.amazonaws.com')
-            log.debug('Added lambda invoke cwe rule permission')
-        except client.exceptions.ResourceConflictException:
+            current_policy_document = json.loads(client.get_policy(FunctionName=func.name)['Policy'])
+        except client.exceptions.ResourceNotFoundException:
+            pass
+        
+        #Improves runtime and prevents updates to lambda version timestamps
+        if lambda_cwe_policy_delta(current_policy_document['Statement'], func.name, response['Arn']):
+            try:
+                client.add_permission(
+                    FunctionName=func.name,
+                    StatementId=func.event_name,
+                    SourceArn=response['RuleArn'],
+                    Action='lambda:InvokeFunction',
+                    Principal='events.amazonaws.com')
+                log.debug('Added lambda invoke cwe rule permission')
+            except client.exceptions.ResourceConflictException:
+                pass
+        else:
+            log.error('Policy already exists for %s' % func.name)
             pass
 
         # Add Targets

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -1010,3 +1010,16 @@ def get_path(path: str, resource: dict):
 def jmespath_compile(expression):
     parsed = C7NJMESPathParser().parse(expression)
     return parsed
+
+    
+def lambda_cwe_policy_delta(json_array, func_name, source_arn):
+    """ Given a json array of lambda resource policy, check if the policy already exists
+    
+    """
+    if not json_array:
+        return True
+    for item in json_array:
+        if item['Sid'] == func_name:
+            if item['Condition']['ArnLike']['AWS:SourceArn'] == source_arn:
+                return False
+    return True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -761,3 +761,19 @@ def test_jmespath_parse_to_json():
         {'foo': '{"]}'}
     )
     assert result is None
+
+def test_lambda_cwe_policy_delta():
+    json_array = [
+        {
+            "Sid": "func_name",
+            "Condition": {
+                "ArnLike": {
+                    "AWS:SourceArn": "source_arn"
+                }
+            }
+        }
+    ]
+    assert utils.lambda_cwe_policy_delta(json_array, 'func_name', 'source_arn') is False
+    assert utils.lambda_cwe_policy_delta(json_array, 'func_name', 'source_arn2') is True
+    assert utils.lambda_cwe_policy_delta(json_array, 'func_name2', 'source_arn') is True
+    assert utils.lambda_cwe_policy_delta([], 'func_name', 'source_arn') is True


### PR DESCRIPTION
Currently when adding a CWE permission to the lambda resource policy a simple Try: Catch is used.
This causes the lambda function to have its Last modified attribute to be updated appearing as though a change has occurred.

The attempt at performing the add_permission is also much slower than first checking if the policy needs to be changed.

This proposal checks if the policy already exists (based on the CWE arn and the current policy name) before attempting to add_permission.

This approach was tested locally with the following results against an already existing policy:


```
import boto3
from dataclasses import dataclass
import json
import time

@dataclass
class func:
    name: str = 'custodian-ec2-new-test-tag'
    event_name: str = 'custodian-ec2-new-test-tag'

client = boto3.client('lambda')
event_client = boto3.client('events')

current_policy = client.get_policy(
    FunctionName=func.name
)
response = event_client.describe_rule(
    Name=func.name
)

current_policy_document = json.loads(client.get_policy(FunctionName=func.name)['Policy'])

def lambda_cwe_policy_delta(json_array, func_name, source_arn):
    if not json_array:
        return True
    for item in json_array:
        if item['Sid'] == func_name:
            if item['Condition']['ArnLike']['AWS:SourceArn'] == source_arn:
                return False
    return True

#Check if policy exists first
def test_with():
    start_time = time.time()
    current_policy_json = json.loads(current_policy['Policy'])
    if lambda_cwe_policy_delta(current_policy_json['Statement'], func.name, response['Arn']):
        try:
            client.add_permission(
                FunctionName=func.name,
                StatementId=func.event_name,
                SourceArn=response['Arn'],
                Action='lambda:InvokeFunction',
                Principal='events.amazonaws.com')
            print('Added lambda invoke cwe rule permission')
        except client.exceptions.ResourceConflictException:
            print('Lambda invoke cwe rule permission already exists')
            pass

    end_time = time.time()
    return(end_time - start_time)

#Only use catch
def test_without():
    start_time = time.time()
    try:
        client.add_permission(
            FunctionName=func.name,
            StatementId=func.event_name,
            SourceArn=response['Arn'],
            Action='lambda:InvokeFunction',
            Principal='events.amazonaws.com')
        print('Added lambda invoke cwe rule permission')
    except client.exceptions.ResourceConflictException:
        print('Lambda invoke cwe rule permission already exists')
        pass
    end_time = time.time()
    return(end_time - start_time)


count = 10
with_time_sec = []
without_time_sec = []
while count > 0 :
    with_time_sec.append(test_with())
    without_time_sec.append(test_without())
    count -= 1
    time.sleep(1)

print('With Time:', [f"{time:.6f}" for time in with_time_sec])
print('Without Time:', [f"{time:.6f}" for time in without_time_sec])
print('With Time Average:', f"{sum(with_time_sec) / len(with_time_sec):.6f}")
print('Without Time Average:', f"{sum(without_time_sec) / len(without_time_sec):.6f}")
print('Without saved the following percentage of time:', f"{(sum(without_time_sec) - sum(with_time_sec)) / sum(with_time_sec) * 100:.2f}%")
```



With the resulting output:
`
With Time: ['0.000078', '0.000205', '0.000236', '0.000163', '0.000228', '0.000126', '0.000273', '0.000232', '0.000215', '0.000231']
Without Time: ['0.065764', '0.077860', '0.072372', '0.064581', '0.061445', '0.069050', '0.074705', '0.070487', '0.072623', '0.076667']
With Time Average: 0.000199
Without Time Average: 0.070555
Without saved the following percentage of time: 35421.64%
`

Please let me know what styling and implementation changes would be needed

Much appreciated!