### PR TITLE
gcp - bucket - fix gcp-scc mode use

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/storage.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/storage.py
@@ -26,8 +26,14 @@ class Bucket(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command(
-                'get', {'bucket': resource_info['bucket_name']})
+            # pull mode passes the bucket name in the info using bucket_name.
+            # gcp-scc mode passes in the full resourceName
+            if not (bucket_name := resource_info.get("bucket_name")):
+                # There is no nice way to return no resource, so if there is no
+                # resourceName in the info, we will raise a KeyError.
+                bucket_name = resource_info["resourceName"].removeprefix("//storage.googleapis.com/")
+
+            return client.execute_command("get", {"bucket": bucket_name})
 
 
 @Bucket.filter_registry.register('iam-policy')

--- a/tools/c7n_gcp/c7n_gcp/resources/storage.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/storage.py
@@ -31,7 +31,8 @@ class Bucket(QueryResourceManager):
             if not (bucket_name := resource_info.get("bucket_name")):
                 # There is no nice way to return no resource, so if there is no
                 # resourceName in the info, we will raise a KeyError.
-                bucket_name = resource_info["resourceName"].removeprefix("//storage.googleapis.com/")
+                prefix = "//storage.googleapis.com/"
+                bucket_name = resource_info["resourceName"].removeprefix(prefix)
 
             return client.execute_command("get", {"bucket": bucket_name})
 


### PR DESCRIPTION
When `gcp-scc` mode handles an incoming finding the `resolve_resources` call constructs a finding_details dict with the `project_id` and `resourceName`. This is then passed into the resource manager `get_resource` call, which defaults to delegate to  the `get` method on the `resource_type`.

The `resourceName` in the scc findings are of the form `//storage.googleapis.com/<bucket-name>`.