### PR TITLE
aws - mu - remove scope from periodic rules

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -1849,8 +1849,9 @@ class ConfigRule(AWSEventBase):
                                 "The most recent AWS config types are here: http://docs.aws"
                                 ".amazon.com/config/latest/developerguide/resource"
                                 "-config-reference.html.")
-            params['Scope'] = {
-                'ComplianceResourceTypes': [config_type]}
+            if self.data.get('type') != 'config-poll-rule':
+                params['Scope'] = {
+                    'ComplianceResourceTypes': [config_type]}
         else:
             params['Scope']['ComplianceResourceTypes'] = self.data.get(
                 'resource-types', ())
@@ -1876,7 +1877,7 @@ class ConfigRule(AWSEventBase):
         # doesn't seem like we have anything mutable at the moment,
         # since we restrict params, maybe reusing the same policy name
         # with a different resource type.
-        if rule['Scope'] != params['Scope']:
+        if rule.get('Scope') != params.get('Scope'):
             return True
         if rule['Source'] != params['Source']:
             return True

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -191,7 +191,6 @@ class PolicyLambdaProvision(Publish):
             {'ConfigRuleName': 'custodian-configx',
              'Description': 'cloud-custodian lambda policy',
              'MaximumExecutionFrequency': 'Three_Hours',
-             'Scope': {'ComplianceResourceTypes': ['AWS::Kinesis::Stream']},
              'Source': {
                  'Owner': 'CUSTOM_LAMBDA',
                  'SourceDetails': [{'EventSource': 'aws.config',


### PR DESCRIPTION
Remove Scope from Periodic rules. Scope is not supported for periodic rules. With the recent change in AWS Config service, if a scope was added to a periodic rule, the `PutConfigRule` API returns the `InvalidParameterValueException` error.

### Background
We start seeing deployment errors for `config-poll-rule` policies in specific regions like **us-west-2** and **sa-east-1**. We contacted AWS support and confirmed that a change with the config service did occur recently.

Config does not support scopes for periodic rules. Before the change, if a scope was added to a periodic rule no error would occur nor would an error be output. With new change, an error now occurs and is output when customers try to create periodic rules with scopes. 

The AWS Config team mentioned the change is very recent and still in the process of rolling out, so it is possible that the errors are only occurring in certain regions at this time as the rollout is still in process. They did confirm that when finished this will be a global change however.

### Error Log
```
% custodian run -s ~/Documents/$(date +%Y-%m-%d) --cache-period 0 config-custom-ebs-volume-encrypted-at-rest-acp-daily.yml
2025-02-27 11:58:44,503: custodian.policy:INFO Provisioning policy lambda: config-custom-ebs-volume-encrypted-at-rest-acp-daily region: us-west-2
2025-02-27 11:58:45,029: custodian.serverless:INFO Publishing custodian policy lambda function custodian-config-custom-ebs-volume-encrypted-at-rest-acp-daily
2025-02-27 11:59:21,678: custodian.output:ERROR Error while executing policy
Traceback (most recent call last):
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/policy.py", line 587, in provision
    return manager.publish(
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/mu.py", line 402, in publish
    if e.add(func, existing):
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/mu.py", line 1913, in add
    return LambdaRetry(self.client.put_config_rule, ConfigRule=params)
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/utils.py", line 457, in _retry
    return func(*args, **kw)
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/botocore/client.py", line 569, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/botocore/client.py", line 1023, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidParameterValueException: An error occurred (InvalidParameterValueException) when calling the PutConfigRule operation: Scope is not supported for Periodic and Hybrid rules. As a result, rule evaluations for these rules do not reflect scope. Remove scope from rule custodian-config-custom-ebs-volume-encrypted-at-rest-acp-daily to see accurate evaluation results.
2025-02-27 11:59:21,687: custodian.commands:ERROR Error while executing policy config-custom-ebs-volume-encrypted-at-rest-acp-daily, continuing
Traceback (most recent call last):
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/commands.py", line 308, in run
    policy()
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/policy.py", line 1386, in __call__
    resources = mode.provision()
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/policy.py", line 587, in provision
    return manager.publish(
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/mu.py", line 402, in publish
    if e.add(func, existing):
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/mu.py", line 1913, in add
    return LambdaRetry(self.client.put_config_rule, ConfigRule=params)
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/c7n/utils.py", line 457, in _retry
    return func(*args, **kw)
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/botocore/client.py", line 569, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/ntakeuchi/Library/Python/3.9/lib/python/site-packages/botocore/client.py", line 1023, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidParameterValueException: An error occurred (InvalidParameterValueException) when calling the PutConfigRule operation: Scope is not supported for Periodic and Hybrid rules. As a result, rule evaluations for these rules do not reflect scope. Remove scope from rule custodian-config-custom-ebs-volume-encrypted-at-rest-acp-daily to see accurate evaluation results.
2025-02-27 11:59:21,696: custodian.commands:ERROR The following policies had errors while executing
 - config-custom-ebs-volume-encrypted-at-rest-acp-daily
```