### PR TITLE
Add topic filter to rds-subscription resource

### DIFF
--- a/tests/data/placebo/test_rds_event_subscription_topic_filter/rds.DescribeEventSubscriptions_1.json
+++ b/tests/data/placebo/test_rds_event_subscription_topic_filter/rds.DescribeEventSubscriptions_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "EventSubscriptionsList": [
+            {
+                "CustomerAwsId": "644160558196",
+                "CustSubscriptionId": "c7n-test-pratyush",
+                "SnsTopicArn": "arn:aws:sns:us-east-1:644160558196:c7n-pratyush",
+                "Status": "active",
+                "SubscriptionCreationTime": "2020-07-16 04:08:23.406",
+                "SourceType": "db-instance",
+                "Enabled": true,
+                "EventSubscriptionArn": "arn:aws:rds:us-east-1:644160558196:es:c7n-test-pratyush"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rds_event_subscription_topic_filter/sns.GetTopicAttributes_1.json
+++ b/tests/data/placebo/test_rds_event_subscription_topic_filter/sns.GetTopicAttributes_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "Attributes": {
+      "TopicArn": "arn:aws:sns:us-east-1:644160558196:c7n-pratyush",
+      "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\"],\"Resource\":\"arn:aws:sns:us-east-1:644160558196:my-test-topic\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"644160558196\"}}}]}",
+      "Owner": "644160558196",
+      "SubscriptionsPending": "0",
+      "EffectiveDeliveryPolicy": "{\"http\":{\"defaultHealthyRetryPolicy\":{\"minDelayTarget\":20,\"maxDelayTarget\":20,\"numRetries\":3,\"numMaxDelayRetries\":0,\"numNoDelayRetries\":0,\"numMinDelayRetries\":0,\"backoffFunction\":\"linear\"},\"disableSubscriptionOverrides\":false,\"defaultRequestPolicy\":{\"headerContentType\":\"text/plain; charset=UTF-8\"}}}",
+      "SubscriptionsConfirmed": "0",
+      "DisplayName": "",
+      "SubscriptionsDeleted": "0",
+      "Tags": []
+    },
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_rds_event_subscription_topic_filter/sns.ListTopics_1.json
+++ b/tests/data/placebo/test_rds_event_subscription_topic_filter/sns.ListTopics_1.json
@@ -1,0 +1,11 @@
+{
+  "status_code": 200,
+  "data": {
+    "Topics": [
+      {
+        "TopicArn": "arn:aws:sns:us-east-1:644160558196:c7n-pratyush"
+      }
+    ],
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_rds_event_subscription_topic_filter/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rds_event_subscription_topic_filter/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-east-1:644160558196:es:c7n-test-pratyush",
+                "Tags": [
+                    {
+                        "Key": "name",
+                        "Value": "pratyush"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -2100,6 +2100,17 @@ class RDSEventSubscription(BaseTest):
         response = client.describe_event_subscriptions()
         self.assertEqual(len(response.get('EventSubscriptionsList')), 0)
 
+    def test_rds_event_subscription_topic_filter(self):
+        session_factory = self.replay_flight_data("test_rds_event_subscription_topic_filter")
+        p = self.load_policy({
+            "name": "rds-subscriptions-no-confirmed-topics",
+            "resource": "aws.rds-subscription",
+            "filters": [{"type": "topic", "key": "SubscriptionsConfirmed", "value": 0, "value_type": "integer"}],
+        }, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["c7n:SnsTopic"]["SubscriptionsConfirmed"], "0")
+
 
 class TestRDSParameterGroupFilterModified(BaseTest):
     def test_param_filter_value_cases(self):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -2105,7 +2105,12 @@ class RDSEventSubscription(BaseTest):
         p = self.load_policy({
             "name": "rds-subscriptions-no-confirmed-topics",
             "resource": "aws.rds-subscription",
-            "filters": [{"type": "topic", "key": "SubscriptionsConfirmed", "value": 0, "value_type": "integer"}],
+            "filters": [{
+                "type": "topic",
+                "key": "SubscriptionsConfirmed",
+                "value": 0,
+                "value_type": "integer"
+            }],
         }, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)


### PR DESCRIPTION
Example
```yaml
policies:
  - name: rds-subscriptions-no-confirmed-topics
    resource: aws.rds-subscription
    filters:
      - type: topic
        key: SubscriptionsConfirmed
        value: 0
        value_type: integer
```