### PR TITLE
docs: add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,68 @@
+<!--
+  Ensure you've read the project's CONTRIBUTING.md and followed coding style and testing guidelines.
+  Title format: [Type] Short description, e.g.: [AWS] Add support for timestream influxdb
+-->
+
+## PR Type
+<!-- Check all that apply -->
+- [ ] Bug fix (non-breaking change)
+- [ ] New feature (non-breaking change)
+- [ ] Breaking change (fix/feature causing existing behavior to change)
+- [ ] Documentation update (standalone)
+- [ ] Code refactor (no functional changes)
+- [ ] Test cases (added/modified)
+- [ ] CI/CD changes
+- [ ] Other (please specify: ______)
+
+
+
+## Related Issues
+<!-- If you use an issue tracker, please put references to them -->
+**Resolves:** #  
+**See also:** #
+
+## Change Description
+
+### Concise Summary
+<!-- 
+  Summarize changes in around 50 characters or less  
+-->
+
+### Technical Details
+<!-- 
+  Explain the problem being solved and why this change is necessary. Focus on:
+  - Motivation behind the change
+  - Architectural decisions
+  - Unintended side effects
+  - Alternative approaches considered
+-->
+
+## Testing
+<!-- 
+  How was this validated? Include at least one:
+  - Added unit/integration test paths
+  - Manual test steps (with CLI commands and outputs):
+    ```bash
+    custodian run -s output policy.yml
+    ```
+  - Screenshots of test results (e.g., resource states pre/post policy execution)
+-->
+
+## Documentation Updates Required
+<!-- Check all that apply -->
+- [ ] Updated markdown docs (file path: ______)
+- [ ] Updated code comments/docstrings
+- [ ] Needs user guide updates (`docs/`)
+- [ ] Needs ReadTheDocs updates
+- [ ] No docs needed (requires maintainer approval)
+
+
+## Checklist
+- [ ] Code follows project style guidelines
+- [ ] Unit/integration tests added/updated
+- [ ] Documentation updated
+- [ ] CHANGELOG updated (if applicable)
+- [ ] All tests pass (local & CI)
+
+## Additional Context
+*(Optional: follow-up tasks, special considerations)*


### PR DESCRIPTION
Adds standardized PR template to improve contribution process with:
- Conventional commits guidance
- Structured change description format
- Explicit documentation update requirements