### PR TITLE
tests - add c7n-left xfail for merging local map with unknowns

### DIFF
--- a/tests/terraform/merge_locals_with_apply_time_values/main.tf
+++ b/tests/terraform/merge_locals_with_apply_time_values/main.tf
@@ -1,0 +1,48 @@
+locals {
+  default_tags = {
+    Environment = "sandbox"
+  }
+}
+
+variable "tags" {
+  default = {
+    Environment = "sandbox"
+  }
+}
+
+data "http" "example" {
+  url = "https://checkpoint-api.hashicorp.com/v1/check/terraform"
+
+  request_headers = {
+    Accept = "application/json"
+  }
+}
+
+resource "aws_db_parameter_group" "with_local" {
+  name   = "with-local"
+  family = "postgres16"
+
+  tags = merge(
+    local.default_tags,
+    {
+      ApplyTimeVal = data.http.example.status_code
+    }
+  )
+}
+
+resource "aws_db_parameter_group" "with_var" {
+  name   = "with-vars"
+  family = "postgres16"
+
+  tags = merge(
+    var.tags,
+    {
+      ApplyTimeVal = data.http.example.status_code
+    }
+  )
+}
+
+resource "aws_db_parameter_group" "untagged" {
+  name   = "untagged"
+  family = "postgres16"
+}

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -2238,3 +2238,21 @@ def test_merge_null_elements(tmp_path):
     assert {r.resource.name for r in resources} == {
         "aws_instance.untagged",
     }
+
+
+@pytest.mark.xfail(reason="https://github.com/cloud-custodian/tfparse/issues/205")
+def test_merge_locals_with_apply_time_values(tmp_path):
+
+    resources = run_policy(
+        {
+            "name": "aws-tags-using-locals",
+            "resource": ["terraform.aws_*"],
+            "filters": ["taggable", {"tag:Environment": "absent"}],
+        },
+        terraform_dir / "merge_locals_with_apply_time_values",
+        tmp_path,
+    )
+    assert len(resources) == 1
+    assert {r.resource.name for r in resources} == {
+        "aws_instance.untagged",
+    }


### PR DESCRIPTION
Resolving unknown/apply-time values during a map merge should behave the same way whether for locals or vars.