### PR TITLE
Fix a bug with azure cli login

### DIFF
--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -108,7 +108,6 @@ class AzureCredential:
 
             command = ['account', 'show', '--output', 'json']
             if az_identity_version <= '1.19.0':
-                # in case that version of azure-identity is used.
                 # 1.19 has no patch releases so can check version like that
                 command.insert(0, 'az')
                 command = ' '.join(command)

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -12,7 +12,8 @@ import types
 from azure.common.credentials import BasicTokenAuthentication
 from azure.core.credentials import AccessToken
 from azure.identity import (AzureCliCredential, ClientSecretCredential,
-                            ManagedIdentityCredential, CertificateCredential)
+                            ManagedIdentityCredential, CertificateCredential,
+                            __version__ as az_identity_version)
 from azure.identity._credentials.azure_cli import _run_command
 from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 from requests import HTTPError
@@ -104,7 +105,14 @@ class AzureCredential:
         elif self._auth_params.get('enable_cli_auth'):
             auth_name = 'Azure CLI'
             self._credential = AzureCliCredential()
-            account_info = _run_command('az account show --output json', timeout=10)
+
+            command = ['account', 'show', '--output', 'json']
+            if az_identity_version <= '1.19.0':
+                # in case that version of azure-identity is used
+                command.insert(0, 'az')
+                command = ' '.join(command)
+
+            account_info = _run_command(command, timeout=10)
             account_json = json.loads(account_info)
             self._auth_params['subscription_id'] = account_json['id']
             self._auth_params['tenant_id'] = account_json['tenantId']

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -108,7 +108,8 @@ class AzureCredential:
 
             command = ['account', 'show', '--output', 'json']
             if az_identity_version <= '1.19.0':
-                # in case that version of azure-identity is used
+                # in case that version of azure-identity is used.
+                # 1.19 has no patch releases so can check version like that
                 command.insert(0, 'az')
                 command = ' '.join(command)
 

--- a/tools/c7n_azure/tests_azure/test_session.py
+++ b/tools/c7n_azure/tests_azure/test_session.py
@@ -125,6 +125,19 @@ class SessionTest(BaseTest):
             s = Session()
             self.assertEqual(s.get_subscription_id(), DEFAULT_SUBSCRIPTION_ID)
             self.assertEqual(s.get_tenant_id(), DEFAULT_TENANT_ID)
+        mock_run.assert_called_with(['account', 'show', '--output', 'json'], timeout=10)
+
+    @patch('c7n_azure.session._run_command')
+    @patch('c7n_azure.session.az_identity_version', '1.19.0')
+    def test_initialize_session_old_version(self, mock_run):
+        mock_run.return_value = \
+            f'{{"id":"{DEFAULT_SUBSCRIPTION_ID}", "tenantId":"{DEFAULT_TENANT_ID}"}}'
+
+        with patch.dict(os.environ, {}, clear=True):
+            s = Session()
+            self.assertEqual(s.get_subscription_id(), DEFAULT_SUBSCRIPTION_ID)
+            self.assertEqual(s.get_tenant_id(), DEFAULT_TENANT_ID)
+        mock_run.assert_called_with('az account show --output json', timeout=10)
 
     def test_run_command_signature(self):
         """Catch signature changes in the internal method we use for CLI authentication


### PR DESCRIPTION
`azure-identity==1.20.0` changed the signature of their internal `_run_commnd` to accept a list instead of a string. 
https://github.com/Azure/azure-sdk-for-python/commit/1a9968d09c9de026a6db8fe173b25c6dcde2f2c2
Hence the bug:

```bash
$ custodian run --verbose --cache-period 0 --output-dir ./scan scan/policies.yaml
2025-04-11 10:31:59,018: custodian.cache:DEBUG Disabling cache
2025-04-11 10:31:59,019: custodian.commands:DEBUG Loaded file scan/policies.yaml. Contains 1 policies
2025-04-11 10:31:59,019: custodian.azure.session:ERROR Failed to authenticate.
Traceback (most recent call last):
  File "/Users/Dmytro_Afanasiev1/Projects/cloud-custodian/tools/c7n_azure/c7n_azure/session.py", line 189, in _initialize_session
    self.credentials = AzureCredential(
  File "/Users/Dmytro_Afanasiev1/Projects/cloud-custodian/tools/c7n_azure/c7n_azure/session.py", line 107, in __init__
    account_info = _run_command('az account show --output json', timeout=10)
  File "/Users/Dmytro_Afanasiev1/Projects/cloud-custodian/.venv/lib/python3.10/site-packages/azure/identity/_credentials/azure_cli.py", line 241, in _run_command
    args = [az_path] + command_args
TypeError: can only concatenate list (not "str") to list
```