### PR TITLE
releng - release workflow - update poetry freeze plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build Wheels
         shell: bash
         run: |
-          poetry self add poetry-plugin-freeze==1.0.5
+          poetry self add poetry-plugin-freeze==1.2.0
           pip install twine
           make pkg-build-wheel
 


### PR DESCRIPTION

we need the latest plugin version to avoid a freezing issue with multiple dependency specs that triggers with urllib3

