### PR TITLE
tests - correct assertion logic from truthiness check to equality check

### DIFF
--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -172,7 +172,7 @@ class TestEc2NetworkLocation(BaseTest):
         client = factory().client('ec2')
         resp = client.describe_instances()
 
-        self.assertTrue(len(resp['Reservations'][0]['Instances']), 1)
+        self.assertEqual(len(resp['Reservations'][0]['Instances']), 1)
         self.assertTrue(
             len(resp['Reservations'][0]['Instances'][0]['State']['Name']),
             'terminated'

--- a/tests/test_fsx.py
+++ b/tests/test_fsx.py
@@ -318,7 +318,7 @@ class TestFSx(BaseTest):
         client = session_factory().client('fsx')
         fs = client.describe_file_systems(
             FileSystemIds=[resources[0]['FileSystemId']])['FileSystems']
-        self.assertTrue(len(fs), 1)
+        self.assertEqual(len(fs), 1)
         self.assertEqual(fs[0]['Lifecycle'], 'DELETING')
         backups = client.describe_backups(
             Filters=[
@@ -364,7 +364,7 @@ class TestFSx(BaseTest):
         client = session_factory().client('fsx')
         fs = client.describe_file_systems(
             FileSystemIds=[resources[0]['FileSystemId']])['FileSystems']
-        self.assertTrue(len(fs), 1)
+        self.assertEqual(len(fs), 1)
         self.assertEqual(fs[0]['Lifecycle'], 'DELETING')
         backups = client.describe_backups(
             Filters=[
@@ -404,7 +404,7 @@ class TestFSx(BaseTest):
         client = session_factory().client('fsx')
         fs = client.describe_file_systems(
             FileSystemIds=[resources[0]['FileSystemId']])['FileSystems']
-        self.assertTrue(len(fs), 1)
+        self.assertEqual(len(fs), 1)
         self.assertNotEqual(fs[0]['Lifecycle'], 'DELETING')
 
     def test_fsx_arn_in_event(self):
@@ -577,7 +577,7 @@ class TestFSxBackup(BaseTest):
         tags = None
         for b in backups:
             if b['BackupId'] == backup_id:
-                self.assertTrue(len(b['Tags']), 1)
+                self.assertEqual(len(b['Tags']), 1)
                 tags = b['Tags']
         self.assertTrue(tags)
         self.assertEqual(tags[0]['Key'], 'tag-test')
@@ -615,7 +615,7 @@ class TestFSxBackup(BaseTest):
         tags = None
         for b in backups:
             if b['BackupId'] == backup_id:
-                self.assertTrue(len(b['Tags']), 1)
+                self.assertEqual(len(b['Tags']), 1)
                 tags = [t for t in b['Tags'] if t['Key'] == 'maid_status']
         self.assertTrue(tags)
 

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -490,7 +490,7 @@ class PolicyLambdaProvision(Publish):
             for i in mgr.list_functions()
             if i["FunctionName"] == "custodian-s3-bucket-policy"
         ]
-        self.assertTrue(len(functions), 1)
+        self.assertEqual(len(functions), 1)
 
     def test_cwe_trail(self):
         session_factory = self.replay_flight_data("test_cwe_trail", zdata=True)

--- a/tools/c7n_gcp/tests/test_artifactregistry.py
+++ b/tools/c7n_gcp/tests/test_artifactregistry.py
@@ -12,6 +12,6 @@ class ArtifactRegistryRepositoryTest(BaseTest):
             session_factory=factory)
         resources = p.run()
 
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/'
                                                'locations/us-central1/repositories/test')

--- a/tools/c7n_gcp/tests/test_datafusion.py
+++ b/tools/c7n_gcp/tests/test_datafusion.py
@@ -13,7 +13,7 @@ class DatafusionInstanceTest(BaseTest):
             session_factory=factory)
         resources = p.run()
 
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/'
                                                'locations/us-central1/'
                                                'instances/instance-311-green')

--- a/tools/c7n_gcp/tests/test_gcp_secretmanager.py
+++ b/tools/c7n_gcp/tests/test_gcp_secretmanager.py
@@ -14,6 +14,6 @@ class GCPSecretTest(BaseTest):
             session_factory=factory)
         resources = p.run()
 
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/'
                                                'secrets/defectdojo_token')

--- a/tools/c7n_gcp/tests/test_gcp_secretmanager.py
+++ b/tools/c7n_gcp/tests/test_gcp_secretmanager.py
@@ -14,6 +14,6 @@ class GCPSecretTest(BaseTest):
             session_factory=factory)
         resources = p.run()
 
-        self.assertEqual(len(resources), 1)
+        self.assertEqual(len(resources), 3)
         self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/'
                                                'secrets/defectdojo_token')

--- a/tools/c7n_gcp/tests/test_osconfig.py
+++ b/tools/c7n_gcp/tests/test_osconfig.py
@@ -13,7 +13,7 @@ class PatchDeploymentTest(BaseTest):
             session_factory=factory)
         resources = p.run()
 
-        self.assertTrue(len(resources), 1)
+        self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['name'], 'projects/cloud-custodian/patchDeployments/test')
 
         assert p.resource_manager.get_urns(resources) == [


### PR DESCRIPTION
# PR Summary
This small PR corrects test assertions that improperly used `assertTrue` for equality checks. It now utilizes `assertEqual` for accurate list length.