### PR TITLE
tools/c7n_left - add failing test for attribute presence testing

### DIFF
--- a/tests/terraform/attribute_value_presence/main.tf
+++ b/tests/terraform/attribute_value_presence/main.tf
@@ -1,0 +1,11 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "attribute_with_direct_reference" {
+    permissions_boundary = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_iam_role" "attribute_with_interpolated_reference" {
+    permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryPolicy"
+}
+
+resource "aws_iam_role" "attribute_not_present" {}

--- a/tests/terraform/attribute_value_presence/main.tf
+++ b/tests/terraform/attribute_value_presence/main.tf
@@ -1,11 +1,11 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role" "attribute_with_direct_reference" {
-    permissions_boundary = data.aws_caller_identity.current.account_id
+  permissions_boundary = data.aws_caller_identity.current.account_id
 }
 
 resource "aws_iam_role" "attribute_with_interpolated_reference" {
-    permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryPolicy"
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/BoundaryPolicy"
 }
 
 resource "aws_iam_role" "attribute_not_present" {}

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -2265,11 +2265,7 @@ def test_attribute_value_presence(tmp_path):
         {
             "name": "aws-role-permission-boundary-specified",
             "resource": ["terraform.aws_iam_role"],
-            "filters": [
-                {
-                    "permissions_boundary": "present"
-                }
-            ]
+            "filters": [{"permissions_boundary": "present"}],
         },
         terraform_dir / "attribute_value_presence",
         tmp_path,

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -2256,3 +2256,26 @@ def test_merge_locals_with_apply_time_values(tmp_path):
     assert {r.resource.name for r in resources} == {
         "aws_db_parameter_group.untagged",
     }
+
+
+@pytest.mark.xfail(reason="https://github.com/cloud-custodian/cloud-custodian/issues/10119")
+def test_attribute_value_presence(tmp_path):
+
+    resources = run_policy(
+        {
+            "name": "aws-role-permission-boundary-specified",
+            "resource": ["terraform.aws_iam_role"],
+            "filters": [
+                {
+                    "permissions_boundary": "present"
+                }
+            ]
+        },
+        terraform_dir / "attribute_value_presence",
+        tmp_path,
+    )
+    assert len(resources) == 2
+    assert {r.resource.name for r in resources} == {
+        "aws_iam_role.attribute_with_direct_reference",
+        "aws_iam_role.attribute_with_interpolated_reference",
+    }


### PR DESCRIPTION
It should be possible to use Custodian "present" and "absent" checks to tell whether attributes exist on a resource (even if they have null values).

Currently tfparse returns unresolvable reference values as null, and since JMESPath expressions treat _missing_ values as null the two cases look the same to c7n-left.

See also: https://github.com/cloud-custodian/cloud-custodian/issues/10119