### PR TITLE
Fix dynamodb URL handling in value_from filter

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -32,6 +32,11 @@ class URIResolver:
 
         if uri.startswith('s3://'):
             contents = self.get_s3_uri(uri)
+        elif uri == 'dynamodb':
+            # Special handling for dynamodb URLs
+            # This is just a placeholder since actual handling is done in ValuesFrom._get_ddb_values
+            # We just need to avoid trying to fetch from this URL directly
+            contents = ""
         else:
             headers.update({"Accept-Encoding": "gzip"})
             req = Request(uri, headers=headers)
@@ -101,13 +106,23 @@ class ValuesFrom:
          format: csv2dict
          expr: key[1]
 
-      # using cql against dynamodb
+      # using PartiQL queries against DynamoDB
       value_from:
          url: dynamodb
          query: |
            select resource_id from exceptions
-           where account_id = '{account_id} and policy = '{policy.name}'
+           where account_id = '{account_id}' and policy = '{policy.name}'
          expr: [].resource_id
+         format: json  # Optional, defaults to json
+
+      # using PartiQL to query a specific DynamoDB table
+      value_from:
+         url: dynamodb
+         query: |
+           select id from "MyTable" 
+           where partition_key = 'some_value'
+         expr: '[*].id'
+         
        # inferred from extension
        format: [json, csv, csv2dict, txt]
     """
@@ -145,6 +160,10 @@ class ValuesFrom:
         self.resolver = URIResolver(manager.session_factory, self.cache)
 
     def get_contents(self):
+        # Special handling for dynamodb URL
+        if self.data['url'] == 'dynamodb':
+            return "", self.data.get('format', 'json')
+
         _, format = os.path.splitext(self.data['url'])
 
         if not format or self.data.get('format'):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -294,3 +294,44 @@ class UrlValueTest(BaseTest):
         self.assertEqual(values.get_values(), {"east-resource"})
         self.assertEqual(cache.saves, 1)
         self.assertEqual(cache.gets, 3)
+
+
+def test_dynamodb_url_type():
+    """Test that the dynamodb URL type is properly handled.
+    
+    This test verifies that using 'url: dynamodb' in a value_from filter
+    doesn't cause an error about unknown URL type.
+    """
+    config = Config.empty(account_id=ACCOUNT_ID)
+    mgr = Bag({"session_factory": None, "_cache": None, "config": config})
+    
+    # Verify that creating a ValuesFrom with 'url: dynamodb' doesn't raise an error
+    values = ValuesFrom({
+        "url": "dynamodb",
+        "query": "select id from mytable",
+        "format": "json",
+        "expr": "[*].id"
+    }, mgr)
+    
+    # Mock the _get_ddb_values method to avoid actually calling DynamoDB
+    values._get_ddb_values = lambda: ["id1", "id2"]
+    
+    # Verify that get_values() doesn't raise an error
+    result = values.get_values()
+    assert result == ["id1", "id2"]
+
+
+def test_uri_resolver_dynamodb():
+    """Test that the URIResolver can handle 'dynamodb' URLs.
+    
+    This test verifies that URIResolver.resolve doesn't raise an error
+    when given a 'dynamodb' URL.
+    """
+    resolver = URIResolver(None, FakeCache())
+    
+    # Verify that resolve() doesn't raise an error for 'dynamodb' URL
+    result = resolver.resolve("dynamodb", {})
+    
+    # The result should be an empty string since the actual handling
+    # is done in ValuesFrom._get_ddb_values
+    assert result == ""


### PR DESCRIPTION
## Issue
When using a `value_from` filter with the `dynamodb` URL type (using PartiQL queries), the following error occurs:
error:unknown url type: 'dynamodb'

This happens because the URIResolver class has no special handling for the `dynamodb` URL type, even though examples in the documentation show this usage.

## Solution
The fix adds special handling for `dynamodb` URLs in two places:

1. Added a condition in `URIResolver.resolve()` to handle `dynamodb` URLs similar to how S3 URLs are handled.
2. Added special handling in `ValuesFrom.get_contents()` for `dynamodb` URLs to bypass format validation.

## Testing
- Added unit tests to verify the fix works
- Manually tested with a policy using `value_from` with a dynamodb URL
- Verified the filter works with hardcoded values

## Notes
This PR only fixes the "unknown URL type" error. 
