### PR TITLE
releng - poetry addon group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 install:
 	@if [[ -z "$(VIRTUAL_ENV)" ]]; then echo "Create and Activate VirtualEnv First, ie. python3 -m venv .venv && source .venv/bin/activate"; exit 1; fi
-	poetry install
+	poetry install --with addons
 	for pkg in $(PKG_SET); do echo "Install $$pkg" && cd $$pkg && poetry install --all-extras && cd ../..; done
 
 .PHONY: test

--- a/docker/c7n
+++ b/docker/c7n
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/c7n
+++ b/docker/c7n
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:24.04 as build-env
+FROM ubuntu:24.04 AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/c7n-distroless
+++ b/docker/c7n-distroless
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM debian:10-slim as build-env
+FROM debian:10-slim AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/c7n-kube
+++ b/docker/c7n-kube
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/c7n-kube
+++ b/docker/c7n-kube
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:24.04 as build-env
+FROM ubuntu:24.04 AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/c7n-kube-distroless
+++ b/docker/c7n-kube-distroless
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/c7n-kube-distroless
+++ b/docker/c7n-kube-distroless
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM debian:10-slim as build-env
+FROM debian:10-slim AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/c7n-org
+++ b/docker/c7n-org
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:24.04 as build-env
+FROM ubuntu:24.04 AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/c7n-org-distroless
+++ b/docker/c7n-org-distroless
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM debian:10-slim as build-env
+FROM debian:10-slim AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/mailer
+++ b/docker/mailer
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/mailer
+++ b/docker/mailer
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:24.04 as build-env
+FROM ubuntu:24.04 AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/mailer-distroless
+++ b/docker/mailer-distroless
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM debian:10-slim as build-env
+FROM debian:10-slim AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/policystream
+++ b/docker/policystream
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/policystream
+++ b/docker/policystream
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM ubuntu:24.04 as build-env
+FROM ubuntu:24.04 AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/docker/policystream-distroless
+++ b/docker/policystream-distroless
@@ -1,12 +1,12 @@
 # Dockerfiles are generated from tools/dev/dockerpkg.py
-FROM debian:10-slim as build-env
+FROM debian:10-slim AS build-env
 
 ARG POETRY_VERSION="1.8.3"
 SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential     curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local
@@ -16,11 +16,10 @@ ARG PATH="/root/.local/bin:$PATH"
 WORKDIR /src
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1966,29 +1966,29 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.5.7"
+version = "0.11.9"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.5.7-py3-none-linux_armv6l.whl", hash = "sha256:548992d342fc404ee2e15a242cdbea4f8e39a52f2e7752d0e4cbe88d2d2f416a"},
-    {file = "ruff-0.5.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:00cc8872331055ee017c4f1071a8a31ca0809ccc0657da1d154a1d2abac5c0be"},
-    {file = "ruff-0.5.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf3d86a1fdac1aec8a3417a63587d93f906c678bb9ed0b796da7b59c1114a1e"},
-    {file = "ruff-0.5.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a01c34400097b06cf8a6e61b35d6d456d5bd1ae6961542de18ec81eaf33b4cb8"},
-    {file = "ruff-0.5.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fcc8054f1a717e2213500edaddcf1dbb0abad40d98e1bd9d0ad364f75c763eea"},
-    {file = "ruff-0.5.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f70284e73f36558ef51602254451e50dd6cc479f8b6f8413a95fcb5db4a55fc"},
-    {file = "ruff-0.5.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a78ad870ae3c460394fc95437d43deb5c04b5c29297815a2a1de028903f19692"},
-    {file = "ruff-0.5.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9ccd078c66a8e419475174bfe60a69adb36ce04f8d4e91b006f1329d5cd44bcf"},
-    {file = "ruff-0.5.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7e31c9bad4ebf8fdb77b59cae75814440731060a09a0e0077d559a556453acbb"},
-    {file = "ruff-0.5.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d796327eed8e168164346b769dd9a27a70e0298d667b4ecee6877ce8095ec8e"},
-    {file = "ruff-0.5.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4a09ea2c3f7778cc635e7f6edf57d566a8ee8f485f3c4454db7771efb692c499"},
-    {file = "ruff-0.5.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a36d8dcf55b3a3bc353270d544fb170d75d2dff41eba5df57b4e0b67a95bb64e"},
-    {file = "ruff-0.5.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9369c218f789eefbd1b8d82a8cf25017b523ac47d96b2f531eba73770971c9e5"},
-    {file = "ruff-0.5.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b88ca3db7eb377eb24fb7c82840546fb7acef75af4a74bd36e9ceb37a890257e"},
-    {file = "ruff-0.5.7-py3-none-win32.whl", hash = "sha256:33d61fc0e902198a3e55719f4be6b375b28f860b09c281e4bdbf783c0566576a"},
-    {file = "ruff-0.5.7-py3-none-win_amd64.whl", hash = "sha256:083bbcbe6fadb93cd86709037acc510f86eed5a314203079df174c40bbbca6b3"},
-    {file = "ruff-0.5.7-py3-none-win_arm64.whl", hash = "sha256:2dca26154ff9571995107221d0aeaad0e75a77b5a682d6236cf89a58c70b76f4"},
-    {file = "ruff-0.5.7.tar.gz", hash = "sha256:8dfc0a458797f5d9fb622dd0efc52d796f23f0a1493a9527f4e49a550ae9a7e5"},
+    {file = "ruff-0.11.9-py3-none-linux_armv6l.whl", hash = "sha256:a31a1d143a5e6f499d1fb480f8e1e780b4dfdd580f86e05e87b835d22c5c6f8c"},
+    {file = "ruff-0.11.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:66bc18ca783b97186a1f3100e91e492615767ae0a3be584e1266aa9051990722"},
+    {file = "ruff-0.11.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bd576cd06962825de8aece49f28707662ada6a1ff2db848d1348e12c580acbf1"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1d18b4be8182cc6fddf859ce432cc9631556e9f371ada52f3eaefc10d878de"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0f3f46f759ac623e94824b1e5a687a0df5cd7f5b00718ff9c24f0a894a683be7"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f34847eea11932d97b521450cf3e1d17863cfa5a94f21a056b93fb86f3f3dba2"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f33b15e00435773df97cddcd263578aa83af996b913721d86f47f4e0ee0ff271"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b27613a683b086f2aca8996f63cb3dd7bc49e6eccf590563221f7b43ded3f65"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e0d88756e63e8302e630cee3ce2ffb77859797cc84a830a24473939e6da3ca6"},
+    {file = "ruff-0.11.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:537c82c9829d7811e3aa680205f94c81a2958a122ac391c0eb60336ace741a70"},
+    {file = "ruff-0.11.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:440ac6a7029f3dee7d46ab7de6f54b19e34c2b090bb4f2480d0a2d635228f381"},
+    {file = "ruff-0.11.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:71c539bac63d0788a30227ed4d43b81353c89437d355fdc52e0cda4ce5651787"},
+    {file = "ruff-0.11.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c67117bc82457e4501473c5f5217d49d9222a360794bfb63968e09e70f340abd"},
+    {file = "ruff-0.11.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e4b78454f97aa454586e8a5557facb40d683e74246c97372af3c2d76901d697b"},
+    {file = "ruff-0.11.9-py3-none-win32.whl", hash = "sha256:7fe1bc950e7d7b42caaee2a8a3bc27410547cc032c9558ee2e0f6d3b209e845a"},
+    {file = "ruff-0.11.9-py3-none-win_amd64.whl", hash = "sha256:52edaa4a6d70f8180343a5b7f030c7edd36ad180c9f4d224959c2d689962d964"},
+    {file = "ruff-0.11.9-py3-none-win_arm64.whl", hash = "sha256:bcf42689c22f2e240f496d0c183ef2c6f7b35e809f12c1db58f75d9aa8d630ca"},
+    {file = "ruff-0.11.9.tar.gz", hash = "sha256:ebd58d4f67a00afb3a30bf7d383e52d0e036e6195143c6db7019604a05335517"},
 ]
 
 [[package]]
@@ -2467,4 +2467,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.2,<4.0.0"
-content-hash = "893febfe9daba56f0c38cb96ba228af05f8b39cf5f5d1f3e89c376ceb8b34f0e"
+content-hash = "56193c4c65d8b44023a1353ff96074d274165d6cc1b718b7a941a0b92d791bb6"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2467,4 +2467,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.2,<4.0.0"
-content-hash = "56193c4c65d8b44023a1353ff96074d274165d6cc1b718b7a941a0b92d791bb6"
+content-hash = "d13a4350487c324a50c55865b57c200e3438e594e6699d8c124778a4fccf7495"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ pytest-recording = ">=0.12.1,<0.14.0"
 moto = "^5.0"
 openapi-spec-validator = "^0.7.1"
 
+[tool.poetry.group.addons]
+optional = true
+
 [tool.poetry.group.addons.dependencies]
 
 aws-xray-sdk = "^2.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ setuptools = "<79"
 
 [tool.poetry.group.dev.dependencies]
 
-ruff = ">=0.3,<0.6"
+ruff = "~0.11"
 docker = {extras = ["websockets"], version = "^7.1.0"}
 black = ">=23.1,<25.0"
 pytest = "<8"
@@ -48,9 +48,6 @@ pytest-xdist = "^3.0"
 pytest-cov = ">=3,<6"
 pytest-terraform = ">=0.6,<0.8"
 vcrpy = ">=4.0.2"
-aws-xray-sdk = "^2.5.0"
-jsonpatch = "^1.25"
-psutil = ">=5.7,<7.0"
 twine = ">=3.1.1,<6.0.0"
 pytest-sugar = ">=0.9.2,<1.1.0"
 click = "^8.0"
@@ -58,6 +55,12 @@ freezegun = "^1.2.2"
 pytest-recording = ">=0.12.1,<0.14.0"
 moto = "^5.0"
 openapi-spec-validator = "^0.7.1"
+
+[tool.poetry.group.addons.dependencies]
+
+aws-xray-sdk = "^2.14"
+jsonpatch = "^1.25"
+psutil = ">=5.7"
 
 [tool.black]
 skip-string-normalization = true

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -44,7 +44,7 @@ def test_s3_express(test):
         config={'account_id': '644160558196', 'region': 'us-east-1'},
         session_factory=session_factory)
     resources = p.run()
-    assert len(resources) ==  1
+    assert len(resources) == 1
     assert p.resource_manager.get_arns(resources) == [
         'arn:aws:s3express:us-east-1:644160558196:bucket/test-zone--use1-az4--x-s3'
     ]

--- a/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
@@ -187,6 +187,6 @@ class KeyVaultKeyRotationFilter(Filter):
             client = self.manager.get_client(vault_url=id.vault_url)
             rotation = client.get_key_rotation_policy(id.name)
             if (self.data.get('state') == 'Disabled' and not rotation.id) or \
-               (self.data.get('state')  == 'Enabled' and rotation.id):
+               (self.data.get('state') == 'Enabled' and rotation.id):
                 matched.append(key)
         return matched

--- a/tools/c7n_gcp/tests/test_dataproc.py
+++ b/tools/c7n_gcp/tests/test_dataproc.py
@@ -39,7 +39,7 @@ def test_data_proc_query(test):
     )
     resources = p.run()
 
-    assert len(resources) ==  1
+    assert len(resources) == 1
     assert resources[0]['clusterName'] == 'cluster-test'
     assert p.resource_manager.get_urns(resources) == [
         'gcp:dataproc:us-central1:cloud-custodian:dataproc/cluster-test'

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -98,11 +98,10 @@ RUN mkdir /output
 BUILD_STAGE = BOOTSTRAP_STAGE + """\
 # Add core & aws packages
 ADD pyproject.toml poetry.lock README.md /src/
-RUN . /usr/local/bin/activate && pip install -qU pip wheel aws-xray-sdk psutil jsonpatch
 
 # Ignore root first pass so if source changes we don't have to invalidate
 # dependency install
-RUN . /usr/local/bin/activate && poetry install --without dev --no-root
+RUN . /usr/local/bin/activate && poetry install --with addons --without dev --no-root
 
 # Now install the root package, we used to do this after dependencies of other providers
 # but since moving c7n to a main dependency in pyproject toml we have to do this one first.

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -70,7 +70,8 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential \
+    curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local

--- a/tools/dev/dockerpkg.py
+++ b/tools/dev/dockerpkg.py
@@ -70,8 +70,7 @@ SHELL ["/bin/bash", "-c"]
 
 # pre-requisite distro deps, and build env setup
 RUN apt-get --yes update
-RUN apt-get --yes install --no-install-recommends build-essential \
-    curl python3-venv python3-dev adduser
+RUN apt-get --yes install --no-install-recommends build-essential curl python3-venv python3-dev adduser
 # todo: 24.04 is trying to standardize on ubuntu as builtin non root.
 RUN adduser --disabled-login --gecos "" custodian
 RUN python3 -m venv /usr/local


### PR DESCRIPTION
docker builds were pulling a couple of packages directly, instead use a separate
poetry group for them, and install the group in docker builds.

- **update ruff, setup new poetry group for addons**
- **use poetry addon group in docker build**

