### PR TITLE
releng - switch out to uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ members = [
   "tools/c7n_azure",
   "tools/c7n_gcp",
   "tools/c7n_org",
+  "tools/c7n_policystream",
   "tools/c7n_tencentcloud"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ members = [
   "tools/c7n_left",
   "tools/c7n_mailer",
   "tools/c7n_org",
+  "tools/c7n_openstack",
   "tools/c7n_policystream",
   "tools/c7n_tencentcloud"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ members = [
   "tools/c7n_azure",
   "tools/c7n_gcp",
   "tools/c7n_kube",
+  "tools/c7n_mailer",
   "tools/c7n_org",
   "tools/c7n_policystream",
   "tools/c7n_tencentcloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ members = [
   "tools/c7n_azure",
   "tools/c7n_gcp",
   "tools/c7n_kube",
+  "tools/c7n_left",
   "tools/c7n_mailer",
   "tools/c7n_org",
   "tools/c7n_policystream",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,11 @@ members = [
   "tools/c7n_kube",
   "tools/c7n_left",
   "tools/c7n_mailer",
-  "tools/c7n_org",
+  "tools/c7n_oci",
   "tools/c7n_openstack",
+  "tools/c7n_org",
   "tools/c7n_policystream",
+  "tools/c7n_sphinxext",
   "tools/c7n_tencentcloud"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,17 @@ addons = [
     "psutil>=5.7",
 ]
 
+[tool.uv.sources]
+c7n = { workspace = true }
+
+[tool.uv.workspace]
+members = [
+  "tools/c7n_azure",
+  "tools/c7n_gcp",
+  "tools/c7n_org",
+  "tools/c7n_tencentcloud"
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,69 +1,69 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "cryptography>=44",
+    "boto3<2.0.0,>=1.12.31",
+    "jsonschema>=4.18",
+    "argcomplete>=1.12.3",
+    "python-dateutil<3.0.0,>=2.8.2",
+    "pyyaml>=5.4.0",
+    "tabulate<1.0.0,>=0.9.0",
+    "docutils<0.19,>=0.18",
+    "urllib3<1.27,>=1.25.4",
+    "setuptools<79",
+]
 name = "c7n"
 version = "0.9.44"
 description = "Cloud Custodian - Policy Rules Engine"
-authors = ["Cloud Custodian Project"]
 readme = "README.md"
-homepage = "https://cloudcustodian.io"
-documentation = "https://cloudcustodian.io/docs"
-repository = "https://github.com/cloud-custodian/cloud-custodian"
-license = "Apache-2.0"
-packages = [
-    { include = "c7n" }]
-classifiers=[
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
+]
 
-[tool.poetry.urls]
+[project.urls]
 "Bug Tracker" = "https://github.com/cloud-custodian/cloud-custodian/issues"
+homepage = "https://cloudcustodian.io"
+repository = "https://github.com/cloud-custodian/cloud-custodian"
+documentation = "https://cloudcustodian.io/docs"
 
-[tool.poetry.scripts]
-custodian = 'c7n.cli:main'
+[project.scripts]
+custodian = "c7n.cli:main"
 
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-cryptography = ">=44"
-boto3 = "^1.12.31"
-jsonschema = ">=4.18"
-argcomplete = ">=1.12.3"
-python-dateutil = "^2.8.2"
-pyyaml = ">=5.4.0"
-tabulate = "^0.9.0"
-docutils = ">=0.18, <0.19"
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
-# workaround for: https://github.com/pypa/setuptools/issues/4956
-setuptools = "<79"
+[dependency-groups]
+dev = [
+    "ruff~=0.11",
+    "docker[websockets]<8.0.0,>=7.1.0",
+    "black<25.0,>=23.1",
+    "pytest<8",
+    "coverage<8,>=7",
+    "placebo<1,>=0",
+    "pytest-xdist<4.0,>=3.0",
+    "pytest-cov<6,>=3",
+    "pytest-terraform<0.8,>=0.6",
+    "vcrpy>=4.0.2",
+    "twine<6.0.0,>=3.1.1",
+    "pytest-sugar<1.1.0,>=0.9.2",
+    "click<9.0,>=8.0",
+    "freezegun<2.0.0,>=1.2.2",
+    "pytest-recording<0.14.0,>=0.12.1",
+    "moto<6.0,>=5.0",
+    "openapi-spec-validator<1.0.0,>=0.7.1",
+]
+addons = [
+    "aws-xray-sdk<3.0,>=2.14",
+    "jsonpatch<2.0,>=1.25",
+    "psutil>=5.7",
+]
 
-[tool.poetry.group.dev.dependencies]
-
-ruff = "~0.11"
-docker = {extras = ["websockets"], version = "^7.1.0"}
-black = ">=23.1,<25.0"
-pytest = "<8"
-coverage = "^7"
-placebo = "^0"
-pytest-xdist = "^3.0"
-pytest-cov = ">=3,<6"
-pytest-terraform = ">=0.6,<0.8"
-vcrpy = ">=4.0.2"
-twine = ">=3.1.1,<6.0.0"
-pytest-sugar = ">=0.9.2,<1.1.0"
-click = "^8.0"
-freezegun = "^1.2.2"
-pytest-recording = ">=0.12.1,<0.14.0"
-moto = "^5.0"
-openapi-spec-validator = "^0.7.1"
-
-[tool.poetry.group.addons]
-optional = true
-
-[tool.poetry.group.addons.dependencies]
-
-aws-xray-sdk = "^2.14"
-jsonpatch = "^1.25"
-psutil = ">=5.7"
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.black]
 skip-string-normalization = true
@@ -72,6 +72,9 @@ line-length = 100
 [tool.ruff]
 line-length = 100
 exclude = ["__init__.py"]
+
+[tool.ruff.format]
+quote-style = "preserve"
 
 [tool.ruff.lint]
 preview = true
@@ -90,7 +93,3 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::PendingDeprecationWarning"
 ]
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ c7n = { workspace = true }
 members = [
   "tools/c7n_azure",
   "tools/c7n_gcp",
+  "tools/c7n_kube",
   "tools/c7n_org",
   "tools/c7n_policystream",
   "tools/c7n_tencentcloud"

--- a/tools/c7n_azure/pyproject.toml
+++ b/tools/c7n_azure/pyproject.toml
@@ -1,108 +1,111 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n @ file:///${PROJECT_ROOT}/../..",
+    "azure-mgmt-authorization<2.0.0,>=1.0.0",
+    "azure-mgmt-advisor<10.0.0,>=9.0.0",
+    "azure-mgmt-apimanagement<2.0.0,>=1.0.0",
+    "azure-mgmt-appconfiguration==0.7.0",
+    "azure-mgmt-applicationinsights<2.0.0,>=1.0.0",
+    "azure-mgmt-automation==0.1.1",
+    "azure-mgmt-batch<16.0.0,>=15.0.0",
+    "azure-mgmt-cognitiveservices<12.0.0,>=11.0.0",
+    "azure-mgmt-cosmosdb<7.0.0,>=6.1.0",
+    "azure-mgmt-costmanagement<2.0.0,>=1.0.0",
+    "azure-mgmt-containerinstance<8.0.0,>=7.0.0",
+    "azure-mgmt-compute<30.0.0,>=29.1.0",
+    "azure-mgmt-cdn<13.0.0,>=12.0.0",
+    "azure-mgmt-containerregistry<15.0.0,>=14.0.0",
+    "azure-mgmt-containerservice<16.0.0,>=15.0.0",
+    "azure-mgmt-databricks==1.0.0b1",
+    "azure-mgmt-datalake-analytics<1.0.0,>=0.5.0",
+    "azure-mgmt-datalake-store<1.0.0,>=0.5.0",
+    "azure-mgmt-datafactory<2.0.0,>=1.0.0",
+    "azure-mgmt-desktopvirtualization<2.0.0,>=1.0.0",
+    "azure-mgmt-dns==8.0.0b1",
+    "azure-mgmt-eventgrid<11.0.0,>=10.3.0b4",
+    "azure-mgmt-eventhub<12.0.0,>=11.0.0",
+    "azure-mgmt-hdinsight<8.0.0,>=7.0.0",
+    "azure-mgmt-iothub<2.0.0,>=1.0.0",
+    "azure-mgmt-keyvault<9.0.0,>=8.0.0",
+    "azure-mgmt-kusto<3.0.0,>=2.2.0",
+    "azure-mgmt-machinelearningservices==2.0.0b2",
+    "azure-mgmt-managementgroups==1.0.0b1",
+    "azure-mgmt-network<29.0.0,>=28.0.0",
+    "azure-mgmt-redhatopenshift<2.0.0,>=1.2.0",
+    "azure-mgmt-resourcegraph<8.0.0,>=7.0.0",
+    "azure-mgmt-resource<17.0.0,>=16.0.0",
+    "azure-mgmt-rdbms==10.2.0b17",
+    "azure-mgmt-search<9.0.0,>=8.0.0",
+    "azure-mgmt-sql<2.0.0,>=1.0.0",
+    "azure-mgmt-storage<23.0.0,>=22.1.1",
+    "azure-mgmt-streamanalytics<2.0.0,>=1.0.0rc1",
+    "azure-mgmt-subscription<2.0.0,>=1.0.0",
+    "azure-mgmt-web<4.0.0,>=3.0.0",
+    "azure-mgmt-logic<10.0.0,>=9.0.0",
+    "azure-storage-blob<13.0.0,>=12.8.0",
+    "azure-storage-queue<13.0.0,>=12.1.5",
+    "azure-cosmosdb-table<2.0.0,>=1.0.6",
+    "applicationinsights<1.0.0,>=0.11.9",
+    "apscheduler<4.0.0,>=3.6.3",
+    "distlib<1.0.0,>=0.3.0",
+    "PyJWT<3.0.0,>=1.7.1",
+    "adal<2.0.0,>=1.2.6",
+    "requests<3.0.0,>=2.22.0",
+    "azure-functions<2.0.0,>=1.0.8",
+    "azure-graphrbac<1.0.0,>=0.61.1",
+    "netaddr<1.0.0,>=0.7.19",
+    "azure-storage-file<3.0.0,>=2.1.0",
+    "azure-mgmt-policyinsights<2.0.0,>=1.0.0",
+    "azure-mgmt-monitor<3.0.0,>=2.0.0",
+    "click<9.0,>=8.0",
+    "azure-cosmos<4.0.0,>=3.1.2",
+    "azure-mgmt-redis<15.0.0,>=14.5.0",
+    "azure-keyvault-secrets<5.0.0,>=4.2.0",
+    "azure-keyvault-keys<5.0.0,>=4.3.1",
+    "azure-keyvault-certificates<5.0.0,>=4.2.1",
+    "azure-identity<2.0.0,>=1.5.0",
+    "azure-keyvault<5.0.0,>=4.1.0",
+    "azure-storage-file-share<13.0.0,>=12.4.1",
+    "cryptography>=3.4.6",
+    "azure-mgmt-msi<2.0.0,>=1.0.0",
+    "jmespath<2.0.0,>=1.0.0",
+    "azure-mgmt-servicefabric<2.0.0,>=1.0.0",
+    "azure-mgmt-trafficmanager<1.0.0,>=0.51.0",
+    "azure-mgmt-frontdoor<2.0.0,>=1.0.0",
+    "azure-mgmt-security<8.0.0,>=7.0.0",
+    "azure-mgmt-servicebus<9.0.0,>=8.2.0",
+    "azure-mgmt-appplatform<9.0.0,>=8.0.0",
+    "azure-mgmt-recoveryservices<3.0.0,>=2.4.0",
+    "azure-mgmt-signalr==0.4.0",
+    "azure-mgmt-synapse<3.0.0,>=2.0.0",
+    "azure-mgmt-recoveryservicesbackup<8.0.0,>=7.0.0",
+    "urllib3<1.27,>=1.25.4",
+]
 name = "c7n_azure"
 version = "0.7.43"
 description = "Cloud Custodian - Azure Support"
 readme = "readme.md"
-homepage="https://cloudcustodian.io"
-repository="https://github.com/cloud-custodian/cloud-custodian"
-documentation="https://cloudcustodian.io/docs/"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2.0"
-classifiers=[
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
+[tool.uv.sources]
+c7n = { path = "../.." }
 
-azure-mgmt-authorization = "^1.0.0"
-azure-mgmt-advisor = "^9.0.0"
-azure-mgmt-apimanagement = "^1.0.0"
-azure-mgmt-appconfiguration = "0.7.0"
-azure-mgmt-applicationinsights = "^1.0.0"
-azure-mgmt-automation = "0.1.1"
-azure-mgmt-batch = "^15.0.0"
-azure-mgmt-cognitiveservices = "^11.0.0"
-azure-mgmt-cosmosdb = "^6.1.0"
-azure-mgmt-costmanagement = "^1.0.0"
-azure-mgmt-containerinstance = "^7.0.0"
-azure-mgmt-compute = "^29.1.0"
-azure-mgmt-cdn = "^12.0.0"
-azure-mgmt-containerregistry = "^14.0.0"
-azure-mgmt-containerservice = "^15.0.0"
-azure-mgmt-databricks = "1.0.0b1"
-azure-mgmt-datalake-analytics = "^0.5.0"
-azure-mgmt-datalake-store = "^0.5.0"
-azure-mgmt-datafactory = "^1.0.0"
-azure-mgmt-desktopvirtualization = "^1.0.0"
-azure-mgmt-dns = "8.0.0b1"
-azure-mgmt-eventgrid = "^10.3.0b4"
-azure-mgmt-eventhub = "^11.0.0"
-azure-mgmt-hdinsight = "^7.0.0"
-azure-mgmt-iothub = "^1.0.0"
-azure-mgmt-keyvault = "^8.0.0"
-azure-mgmt-kusto = "^2.2.0"
-azure-mgmt-machinelearningservices = "2.0.0b2"
-azure-mgmt-managementgroups = "1.0.0b1"
-azure-mgmt-network = "^28.0.0"
-azure-mgmt-redhatopenshift = "^1.2.0"
-azure-mgmt-resourcegraph = "^7.0.0"
-azure-mgmt-resource = "^16.0.0"
-azure-mgmt-rdbms = "10.2.0b17"
-azure-mgmt-search = "^8.0.0"
-azure-mgmt-sql = "^1.0.0"
-azure-mgmt-storage = "^22.1.1"
-azure-mgmt-streamanalytics = "^1.0.0rc1"
-azure-mgmt-subscription = "^1.0.0"
-azure-mgmt-web = "^3.0.0"
-azure-mgmt-logic = "^9.0.0"
-azure-storage-blob = "^12.8.0"
-azure-storage-queue = "^12.1.5"
-azure-cosmosdb-table = "^1.0.6"
-applicationinsights = "^0.11.9"
-apscheduler = "^3.6.3"
-distlib = "^0.3.0"
-PyJWT = ">=1.7.1,<3.0.0"
-adal = "^1.2.6"
-requests = "^2.22.0"
-azure-functions = { version = "^1.0.8", python = "~3" }
-azure-graphrbac = "^0.61.1"
-netaddr = "^0.7.19"
-azure-storage-file = "^2.1.0"
-azure-mgmt-policyinsights = "^1.0.0"
-azure-mgmt-monitor = "^2.0.0"
-click = "^8.0"
-azure-cosmos = "^3.1.2"
-azure-mgmt-redis = "^14.5.0"
-azure-keyvault-secrets = "^4.2.0"
-azure-keyvault-keys = "^4.3.1"
-azure-keyvault-certificates = "^4.2.1"
-azure-identity = "^1.5.0"
-azure-keyvault = "^4.1.0"
-azure-storage-file-share = "^12.4.1"
-cryptography = ">=3.4.6"
-azure-mgmt-msi = "^1.0.0"
-jmespath = "^1.0.0"
-azure-mgmt-servicefabric = "^1.0.0"
-azure-mgmt-trafficmanager = "^0.51.0"
-azure-mgmt-frontdoor = "^1.0.0"
-azure-mgmt-security = "^7.0.0"
-azure-mgmt-servicebus = "^8.2.0"
-azure-mgmt-appplatform = "^8.0.0"
-azure-mgmt-recoveryservices = "^2.4.0"
-azure-mgmt-signalr = "0.4.0"
-azure-mgmt-synapse = "^2.0.0"
-azure-mgmt-recoveryservicesbackup = "^7.0.0"
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
+[project.urls]
+homepage = "https://cloudcustodian.io"
+repository = "https://github.com/cloud-custodian/cloud-custodian"
+documentation = "https://cloudcustodian.io/docs/"
 
-[tool.poetry.group.dev.dependencies]
-vcrpy-unittest = ">=0.1.7"
-parameterized = ">=0.7.1"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[dependency-groups]
+dev = [
+    "vcrpy-unittest>=0.1.7",
+    "parameterized>=0.7.1",
+]

--- a/tools/c7n_azure/pyproject.toml
+++ b/tools/c7n_azure/pyproject.toml
@@ -96,9 +96,6 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 
-[tool.uv.sources]
-c7n = { path = "../.." }
-
 [project.urls]
 homepage = "https://cloudcustodian.io"
 repository = "https://github.com/cloud-custodian/cloud-custodian"

--- a/tools/c7n_gcp/pyproject.toml
+++ b/tools/c7n_gcp/pyproject.toml
@@ -25,9 +25,6 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 
-[tool.uv.sources]
-c7n = { path = "../.." }
-
 [project.urls]
 homepage = "https://cloudcustodian.io"
 repository = "https://github.com/cloud-custodian/cloud-custodian"

--- a/tools/c7n_gcp/pyproject.toml
+++ b/tools/c7n_gcp/pyproject.toml
@@ -1,38 +1,41 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n",
+    "retrying<2.0.0,>=1.3.3",
+    "google-api-python-client<3.0,>=2.0",
+    "google-cloud-logging<4.0,>=3.2",
+    "google-auth<3.0.0,>=2.1.0",
+    "google-cloud-monitoring<3.0.0,>=2.5.0",
+    "google-cloud-storage<3.0,>=2.7",
+    "pyrate-limiter<3.0.0,>=2.8.4",
+    "urllib3<1.27,>=1.25.4",
+]
 name = "c7n_gcp"
 version = "0.4.43"
 description = "Cloud Custodian - Google Cloud Provider"
 readme = "readme.md"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
+]
+
+[tool.uv.sources]
+c7n = { path = "../.." }
+
+[project.urls]
 homepage = "https://cloudcustodian.io"
 repository = "https://github.com/cloud-custodian/cloud-custodian"
 documentation = "https://cloudcustodian.io/docs/"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2.0"
-classifiers = [
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+
+[dependency-groups]
+dev = [
+    "freezegun<2.0.0,>=1.2.2",
+    "pytest<8.0",
+    "pytest-terraform<1.0.0,>=0.7.0",
 ]
-
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
-
-retrying = "^1.3.3"
-google-api-python-client = "^2.0"
-google-cloud-logging = "^3.2"
-google-auth = "^2.1.0"
-google-cloud-monitoring = "^2.5.0"
-google-cloud-storage = "^2.7"
-pyrate-limiter = "^2.8.4"
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
-
-[tool.poetry.group.dev.dependencies]
-freezegun = "^1.2.2"
-pytest = "<8.0"
-pytest-terraform = "^0.7.0"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"

--- a/tools/c7n_kube/pyproject.toml
+++ b/tools/c7n_kube/pyproject.toml
@@ -1,37 +1,39 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n",
+    "kubernetes>=10.0.1",
+    "jsonpatch<2.0,>=1.32",
+    "urllib3<1.27,>=1.25.4",
+]
 name = "c7n_kube"
 version = "0.2.43"
 description = "Cloud Custodian - Kubernetes Provider"
 readme = "readme.md"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
+]
+
+[project.urls]
 homepage = "https://cloudcustodian.io"
 repository = "https://github.com/cloud-custodian/cloud-custodian"
 documentation = "https://cloudcustodian.io/docs/"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2.0"
-classifiers = [
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+
+[project.scripts]
+c7n-kube = "c7n_kube.cli:cli"
+
+[dependency-groups]
+dev = [
+    "pytest<8.0",
+    "vcrpy>=4.0.2",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
-
-kubernetes = ">=10.0.1"
-jsonpatch = "^1.32"
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
-
-[tool.poetry.dev-dependencies]
-pytest = "<8.0"
-vcrpy = ">=4.0.2"
-
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-
-[tool.poetry.scripts]
-"c7n-kube" = "c7n_kube.cli:cli"
-# backward compatability, keep c7n-kates entrypoint for now
-"c7n-kates" = "c7n_kube.cli:cli"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/tools/c7n_left/pyproject.toml
+++ b/tools/c7n_left/pyproject.toml
@@ -1,35 +1,43 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n",
+    "click>=8.0",
+    "rich<15.0,>=14.0",
+    "tfparse<1.0,>=0.6",
+    "python-hcl2<5.0.0,>=4.3.2",
+]
 name = "c7n_left"
 version = "0.3.30"
 description = "Custodian policies for IAAC definitions"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2"
 readme = "README.md"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
+]
+
+[project.urls]
 homepage = "https://cloudcustodian.io"
 repository = "https://github.com/cloud-custodian/cloud-custodian"
 documentation = "https://cloudcustodian.io/docs/"
-classifiers = [
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+
+[project.scripts]
+c7n-left = "c7n_left.cli:cli"
+
+[dependency-groups]
+dev = [
+    "pytest<8.0",
+    "pytest-terraform<1.0.0,>=0.7.0",
 ]
 
-[tool.poetry.scripts]
-c7n-left = 'c7n_left.cli:cli'
-
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
-
-click = ">=8.0"
-rich = "^14.0"
-tfparse = "^0.6"
-python-hcl2 = "^4.3.2"
-
-[tool.poetry.group.dev.dependencies]
-pytest = "<8.0"
-pytest-terraform = "^0.7.0"
-
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["c7n_left"]

--- a/tools/c7n_mailer/pyproject.toml
+++ b/tools/c7n_mailer/pyproject.toml
@@ -1,56 +1,65 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "Jinja2<4.0,>=3.0",
+    "boto3>=1.11.12",
+    "jsonschema>=4.18",
+    "python-dateutil<3.0.0,>=2.8.1",
+    "pyyaml>=5.4.0",
+    "sendgrid<7.0.0,>=6.1.1",
+    "datadog<1.0.0,>=0.34.0",
+    "ldap3<3.0.0,>=2.6.1",
+    "redis<6.0,>=5.0",
+    "jsonpointer>=2.0",
+    "jsonpatch<2.0,>=1.25",
+    "types-six<2.0.0,>=1.16.10",
+    "importlib-metadata<9.0,>=8.0",
+    "urllib3<1.27,>=1.25.4",
+]
 name = "c7n_mailer"
 version = "0.6.43"
 description = "Cloud Custodian - Reference Mailer"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2.0"
 readme = "README.md"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
+]
+
+[project.urls]
 homepage = "https://cloudcustodian.io"
 repository = "https://github.com/cloud-custodian/cloud-custodian"
 documentation = "https://cloudcustodian.io/docs/"
-classifiers = [
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+
+[project.optional-dependencies]
+gcp = [
+    "c7n_gcp",
+    "google-cloud-secret-manager<3.0.0,>=2.8.0",
+]
+azure = [
+    "c7n_azure",
 ]
 
-[tool.poetry.scripts]
-c7n-mailer = 'c7n_mailer.cli:main'
-c7n-mailer-replay = 'c7n_mailer.replay:main'
+[tool.uv.sources]
+c7n_azure = { workspace = true }
+c7n_gcp = { workspace = true }
 
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-Jinja2 = "^3.0"
-boto3 = ">=1.11.12"
-jsonschema = ">=4.18"
-python-dateutil = "^2.8.1"
-pyyaml = ">=5.4.0"
-sendgrid = "^6.1.1"
-datadog = "^0.34.0"
-ldap3 = "^2.6.1"
-redis = "^5.0"
-jsonpointer = ">=2.0"
-jsonpatch = "^1.25"
-types-six = "^1.16.10"
-importlib-metadata = "^8.0"
+[project.scripts]
+c7n-mailer = "c7n_mailer.cli:main"
+c7n-mailer-replay = "c7n_mailer.replay:main"
 
-# Optional packages for additional provider support
-c7n-gcp = { path = "../c7n_gcp/", develop = true, optional = true }
-c7n-azure = { path = "../c7n_azure/", develop = true, optional = true }
-google-cloud-secret-manager = { version = "^2.8.0", optional = true }
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
-
-[tool.poetry.group.dev.dependencies]
-fakeredis = "^2.0"
-pytest = "<8.0"
-mypy = "^0.931"
-black = ">=23.1,<25.0"
-
-[tool.poetry.extras]
-gcp = ["c7n-gcp", "google-cloud-secret-manager"]
-azure = ["c7n-azure"]
+[dependency-groups]
+dev = [
+    "fakeredis<3.0,>=2.0",
+    "pytest<8.0",
+    "mypy<1.0,>=0.931",
+    "black<25.0,>=23.1",
+]
 
 [build-system]
-requires = ["poetry>=0.12", "setuptools"]
-build-backend = "poetry.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/tools/c7n_oci/pyproject.toml
+++ b/tools/c7n_oci/pyproject.toml
@@ -1,26 +1,29 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n",
+    "oci<3.0,>=2.106",
+]
 name = "c7n_oci"
 version = "0.1.18"
 description = "Cloud Custodian - OCI Support"
 readme = "readme.md"
-homepage="https://cloudcustodian.io"
-repository="https://github.com/cloud-custodian/cloud-custodian"
-documentation="https://cloudcustodian.io/docs/"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2.0"
-classifiers=[
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-oci = "^2.106"
+[project.urls]
+homepage = "https://cloudcustodian.io"
+repository = "https://github.com/cloud-custodian/cloud-custodian"
+documentation = "https://cloudcustodian.io/docs/"
 
-[tool.poetry.group.dev.dependencies]
-pytest = "<8.0"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[dependency-groups]
+dev = [
+    "pytest<8.0",
+]

--- a/tools/c7n_openstack/pyproject.toml
+++ b/tools/c7n_openstack/pyproject.toml
@@ -1,31 +1,31 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n",
+    "openstacksdk<1.0.0,>=0.52.0",
+    "urllib3<1.27,>=1.25.4",
+]
 name = "c7n_openstack"
 version = "0.1.34"
 description = "Cloud Custodian - OpenStack Provider"
 readme = "readme.md"
-authors = ["Cloud Custodian Project"]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
+]
+
+[project.urls]
 homepage = "https://cloudcustodian.io"
 repository = "https://github.com/cloud-custodian/cloud-custodian"
 documentation = "https://cloudcustodian.io/docs/"
-license = "Apache-2.0"
-classifiers = [
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+
+[dependency-groups]
+dev = [
+    "pytest<8.0",
+    "vcrpy>=4.0.2",
 ]
-
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
-
-openstacksdk = "^0.52.0"
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
-
-[tool.poetry.group.dev.dependencies]
-pytest = "<8.0"
-vcrpy = ">=4.0.2"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"

--- a/tools/c7n_org/pyproject.toml
+++ b/tools/c7n_org/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 license = {text = "Apache-2.0"}
 requires-python = "<4.0.0,>=3.9.2"
 dependencies = [
-    "c7n @ file:///${PROJECT_ROOT}/../..",
+    "c7n",
     "click>=8.0",
 ]
 name = "c7n_org"

--- a/tools/c7n_org/pyproject.toml
+++ b/tools/c7n_org/pyproject.toml
@@ -1,31 +1,36 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n @ file:///${PROJECT_ROOT}/../..",
+    "click>=8.0",
+]
 name = "c7n_org"
 version = "0.6.43"
 description = "Cloud Custodian - Parallel Execution"
 readme = "README.md"
-homepage = "https://cloudcustodian.io"
-documentation = "https://cloudcustodian.io/docs/tools/c7n-org.html"
-repository = "https://github.com/cloud-custodian/cloud-custodian"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2.0"
-classifiers=[
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
 ]
 
-[tool.poetry.scripts]
-c7n-org = 'c7n_org.cli:cli'
+[project.urls]
+homepage = "https://cloudcustodian.io"
+repository = "https://github.com/cloud-custodian/cloud-custodian"
+documentation = "https://cloudcustodian.io/docs/tools/c7n-org.html"
 
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
+[project.scripts]
+c7n-org = "c7n_org.cli:cli"
 
-click = ">=8.0"
-
-[tool.poetry.dev-dependencies]
-pytest = "<8.0"
+[dependency-groups]
+dev = [
+    "pytest<8.0",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/tools/c7n_policystream/pyproject.toml
+++ b/tools/c7n_policystream/pyproject.toml
@@ -1,39 +1,45 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n",
+    "click<9.0,>=8.0",
+    "pyyaml>=5.4.0",
+    "pygit2>=1.11",
+    "boto3<2.0.0,>=1.12.0",
+    "requests<3.0.0,>=2.22.0",
+    "urllib3<1.27,>=1.25.4",
+]
 name = "c7n_policystream"
 version = "0.4.43"
 description = "Cloud Custodian - Git Commits as Logical Policy Changes"
 readme = "README.md"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
+]
+
+[project.urls]
 homepage = "https://cloudcustodian.io"
 repository = "https://github.com/cloud-custodian/cloud-custodian"
 documentation = "https://cloudcustodian.io/docs/"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2.0"
-classifiers = [
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+
+[project.scripts]
+c7n-policystream = "policystream:cli"
+
+[dependency-groups]
+dev = [
+    "pytest<8.0",
+    "mock<5.0.0,>=4.0.2",
 ]
-packages = [{"include" = "policystream.py"}]
 
-[tool.poetry.scripts]
-c7n-policystream = 'policystream:cli'
-
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
-
-click = "^8.0"
-pyyaml = ">=5.4.0"
-pygit2 = ">=1.11"
-boto3 = "^1.12.0"
-requests = "^2.22.0"
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
-
-[tool.poetry.dev-dependencies]
-pytest = "<8.0"
-mock = "^4.0.2"
+[tool.hatch.build.targets.wheel]
+only-include = ["policystream.py"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/tools/c7n_sphinxext/pyproject.toml
+++ b/tools/c7n_sphinxext/pyproject.toml
@@ -1,36 +1,34 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Cloud Custodian Project"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n",
+    "Sphinx<8.0,>=7.0",
+    "Pygments>=2.10.0",
+    "sphinx-rtd-theme>=1.0.0",
+    "recommonmark>=0.7.0",
+    "sphinx-markdown-tables>=0.0.12",
+    "myst-parser>=0.18",
+    "click>=8.0",
+    "urllib3<1.27,>=1.25.4",
+]
 name = "c7n_sphinxext"
 version = "1.1.43"
 description = "Cloud Custodian - Sphinx Extensions"
-authors = ["Cloud Custodian Project"]
-license = "Apache-2.0"
-homepage = "https://cloudcustodian.io"
-documentation = "https://cloudcustodian.io/docs"
-repository = "https://github.com/cloud-custodian/cloud-custodian"
-classifiers=[
-   "License :: OSI Approved :: Apache Software License",
-   "Topic :: System :: Systems Administration",
-   "Topic :: System :: Distributed Computing"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Systems Administration",
+    "Topic :: System :: Distributed Computing",
 ]
 readme = "README.md"
 
-[tool.poetry.scripts]
-c7n-sphinxext = 'c7n_sphinxext.docgen:main'
+[project.urls]
+homepage = "https://cloudcustodian.io"
+repository = "https://github.com/cloud-custodian/cloud-custodian"
+documentation = "https://cloudcustodian.io/docs"
 
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
-
-Sphinx = "^7.0"
-Pygments = ">=2.10.0"
-sphinx-rtd-theme = ">=1.0.0"
-recommonmark = ">=0.7.0"
-sphinx_markdown_tables = ">=0.0.12"
-myst-parser = ">=0.18"
-click = ">=8.0"
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[project.scripts]
+c7n-sphinxext = "c7n_sphinxext.docgen:main"

--- a/tools/c7n_tencentcloud/pyproject.toml
+++ b/tools/c7n_tencentcloud/pyproject.toml
@@ -1,31 +1,29 @@
-[tool.poetry]
+[project]
+authors = [
+    {name = "Tencent Cloud"},
+]
+license = {text = "Apache-2.0"}
+requires-python = "<4.0.0,>=3.9.2"
+dependencies = [
+    "c7n",
+    "pytz>=2022.1",
+    "retrying<2.0.0,>=1.3.3",
+    "tencentcloud-sdk-python<4.0.0,>=3.0.783",
+    "cos-python-sdk-v5<2.0.0,>=1.9.21",
+    "freezegun<2.0.0,>=1.5.1",
+    "urllib3<1.27,>=1.25.4",
+]
 name = "c7n_tencentcloud"
 version = "0.1.26"
 description = "Cloud Custodian - Tencent Cloud Provider"
-authors = ["Tencent Cloud"]
-license = "Apache-2.0"
-homepage = "https://cloudcustodian.io"
-documentation = "https://cloudcustodian.io/docs"
 readme = "readme.md"
 
-[tool.poetry.urls]
+[project.urls]
 "Bug Tracker" = "https://github.com/cloud-custodian/cloud-custodian/issues"
+homepage = "https://cloudcustodian.io"
+documentation = "https://cloudcustodian.io/docs"
 
-[tool.poetry.dependencies]
-python = ">=3.9.2,<4.0.0"
-c7n = {path = "../..", develop = true}
-
-pytz = ">=2022.1"
-retrying = "^1.3.3"
-tencentcloud-sdk-python = "^3.0.783"
-cos-python-sdk-v5 = "^1.9.21"
-freezegun = "^1.5.1"
-# workaround for: https://github.com/python-poetry/poetry-plugin-export/issues/183
-urllib3 = ">=1.25.4,<1.27"
-
-[tool.poetry.group.dev.dependencies]
-pytest = "<8.0"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[dependency-groups]
+dev = [
+    "pytest<8.0",
+]


### PR DESCRIPTION
so uv has the promise/premise of being faster and via its workspace feature giving us
a unified lock file across all the packages. atm we solve for each independently and then 
manually check for flapping / conflicting dependencies.

some quick thoughts so far.

we lose some of our automation around version increment, doesn't seem to be something uv handles.

uv sync in a project, removes the other non directly dependened deps from the virtualenv

