### PR TITLE
Add arn generator for aws glue-catalog

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -605,7 +605,7 @@ class GlueDataCatalog(ResourceManager):
 
     def generate_arn(self, res):
         """
-        https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglue.html#awsglue-rootcatalog  # noqa
+        https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglue.html
         One resource per region and one arn per region
         """
         return generate_arn(

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 from concurrent.futures import as_completed
 from c7n.manager import resources, ResourceManager
 from c7n.query import QueryResourceManager, TypeInfo
-from c7n.utils import local_session, chunks, type_schema
+from c7n.utils import local_session, chunks, type_schema, generate_arn
 from c7n.actions import BaseAction, ActionRegistry, RemovePolicyBase
 from c7n.exceptions import PolicyValidationError
 from c7n.filters.vpc import SubnetFilter, SecurityGroupFilter
@@ -599,6 +599,21 @@ class GlueDataCatalog(ResourceManager):
     @classmethod
     def has_arn(cls):
         return True
+
+    def get_arns(self, resources):
+        return [self.generate_arn(res) for res in resources]
+
+    def generate_arn(self, res):
+        """
+        https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglue.html#awsglue-rootcatalog  # noqa
+        One resource per region and one arn per region
+        """
+        return generate_arn(
+            service=self.resource_type.service,
+            resource=self.resource_type.arn_type,
+            region=self.config.region,
+            account_id=self.config.account_id
+        )
 
     def get_model(self):
         return self.resource_type

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -715,6 +715,8 @@ class TestGlueDataCatalog(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        self.assertEqual(p.resource_manager.get_arns(resources),
+                         ['arn:aws:glue:us-east-1:644160558196:catalog'])
 
     def test_catalog_remove_matched(self):
         session_factory = self.replay_flight_data("test_catalog_remove_matched")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -206,7 +206,7 @@ class PolicyMetaLint(BaseTest):
             {'account', 's3', 'hostedzone', 'log-group', 'rest-api', 'redshift-snapshot',
              'rest-stage', 'codedeploy-app', 'codedeploy-group', 'fis-template', 'dlm-policy',
              'apigwv2', 'apigwv2-stage', 'lexv2-bot-alias', 'apigw-domain-name', 'fis-experiment',
-             'launch-template-version', 'glue-table'})
+             'launch-template-version', 'glue-table', 'glue-catalog'})
         if overrides:
             raise ValueError("unknown arn overrides in %s" % (", ".join(overrides)))
 


### PR DESCRIPTION
`has_arn` method of `aws.glue-catalog` returned `True` but the class actually couldn't generate arns.
I added arn generator according to this doc https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglue.html#awsglue-rootcatalog. It generates arns like this one: `arn:aws:glue:eu-central-1:12345678910:catalog`