### PR TITLE
releng - add initial nix support via flake 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744599653,
+        "narHash": "sha256-nysSwVVjG4hKoOjhjvE6U5lIKA8sEr1d1QzEfZsannU=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "7dba6dbc73120e15b558754c26024f6c93015dd7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746540146,
+        "narHash": "sha256-QxdHGNpbicIrw5t6U3x+ZxeY/7IEJ6lYbvsjXmcxFIM=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e09c10c24ebb955125fda449939bfba664c467fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747441483,
+        "narHash": "sha256-W8BFXk5R0TuJcjIhcGoMpSOaIufGXpizK0pm+uTqynA=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "582024dc64663e9f88d467c2f7f7b20d278349de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,203 @@
+{
+  description = "cloud-custodian flake using uv2nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      uv2nix,
+      pyproject-nix,
+      pyproject-build-systems,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+
+      # Load a uv workspace from a workspace root.
+      # Uv2nix treats all uv projects as workspace projects.
+      workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./.; };
+
+      # Create package overlay from workspace.
+      overlay = workspace.mkPyprojectOverlay {
+        # Prefer prebuilt binary wheels as a package source.
+        sourcePreference = "wheel"; 
+      };
+
+      # Create a filtering overlay to remove c7n-awscc
+      filterAwsccOverlay = final: prev: 
+        let
+          # Remove c7n-awscc from the set of packages
+          filteredPkgs = lib.filterAttrs (name: value: name != "c7n-awscc") prev;
+        in
+          filteredPkgs;
+
+      # Extend generated overlay with build fixups
+      pyprojectOverrides = final: prev:
+        let
+          # Helper function to add setuptools to a package's build dependencies
+          addSetuptools = pkgName: prev.${pkgName}.overrideAttrs (old: {
+            nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+              final.setuptools
+            ];
+          });
+          
+          packagesNeedingSetuptools = [
+            "crcmod"
+            "cos-python-sdk-v5"
+            "netifaces"
+            "placebo"
+          ];
+          
+          setupToolsOverrides = builtins.listToAttrs (
+            map (name: { inherit name; value = addSetuptools name; }) 
+            packagesNeedingSetuptools
+          );
+        in
+          setupToolsOverrides;
+
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+      python = pkgs.python312;
+
+      pythonSet =
+        (pkgs.callPackage pyproject-nix.build.packages {
+          inherit python;
+        }).overrideScope
+          (
+            lib.composeManyExtensions [
+              pyproject-build-systems.overlays.default
+              overlay
+              filterAwsccOverlay  # Apply our filter for c7n-awscc
+              pyprojectOverrides
+            ]
+          );
+
+      # ====== DEVELOPMENT ENVIRONMENT (EDITABLE) ======
+      editableOverlay = workspace.mkEditablePyprojectOverlay {
+        root = "$REPO_ROOT";
+        members = [ "c7n" ];
+      };
+
+      editablePythonSet = pythonSet.overrideScope (
+        lib.composeManyExtensions [
+          editableOverlay
+
+          (final: prev: {
+            c7n = prev.c7n.overrideAttrs (old: {
+              src = lib.fileset.toSource {
+                root = old.src;
+                fileset = lib.fileset.unions [
+                  (old.src + "/pyproject.toml")
+                  (old.src + "/README.md")
+                  (old.src + "/c7n/__init__.py")
+                ];
+              };
+
+              nativeBuildInputs =
+                old.nativeBuildInputs
+                ++ final.resolveBuildSystem {
+                  editables = [ ];
+                };
+            });
+          })
+        ]
+      );
+
+      # For editable development environment
+      virtualenv = editablePythonSet.mkVirtualEnv "c7n-dev-env" (
+        lib.filterAttrs (name: value: name != "c7n-awscc") workspace.deps.all
+      );
+      
+      appEnv = pythonSet.mkVirtualEnv "c7n-app-env" (
+        lib.filterAttrs (name: value: name != "c7n-awscc") workspace.deps.default
+      );
+      
+      # Create a wrapper script that uses the appEnv environment
+      appScript = pkgs.writeShellScriptBin "custodian" ''
+        exec ${appEnv}/bin/custodian "$@"
+      '';
+
+    in
+    {
+      # Use the wrapper script for the default package
+      packages.x86_64-linux.default = appScript;
+
+      # Make custodian runnable with `nix run`
+      apps.x86_64-linux = {
+        default = {
+          type = "app";
+          program = "${appScript}/bin/custodian";
+        };
+      };
+
+      # Development shells
+      devShells.x86_64-linux = {
+        # Impure development environment
+        impure = pkgs.mkShell {
+          packages = [
+            python
+            pkgs.uv
+          ];
+          env =
+            {
+              # Prevent uv from managing Python downloads
+              UV_PYTHON_DOWNLOADS = "never";
+              # Force uv to use nixpkgs Python interpreter
+              UV_PYTHON = python.interpreter;
+            }
+            // lib.optionalAttrs pkgs.stdenv.isLinux {
+              # Python libraries often load native shared objects using dlopen(3).
+              LD_LIBRARY_PATH = lib.makeLibraryPath pkgs.pythonManylinuxPackages.manylinux1;
+            };
+          shellHook = ''
+            unset PYTHONPATH
+          '';
+        };
+
+        uv2nix = pkgs.mkShell {
+          packages = [
+            virtualenv
+            pkgs.uv
+          ];
+
+          env = {
+            UV_NO_SYNC = "1";
+
+            # Force uv to use Python interpreter from venv
+            UV_PYTHON = "${virtualenv}/bin/python";
+
+            # Prevent uv from downloading managed Python's
+            UV_PYTHON_DOWNLOADS = "never";
+          };
+
+          shellHook = ''
+            # Undo dependency propagation by nixpkgs.
+            unset PYTHONPATH
+            echo "Welcome to uv2nix dev shell!"
+          '';
+        };
+      };
+    };
+}


### PR DESCRIPTION
this provides two devShells: `uv2nix` and `impure`. 

also, makes `custodian` work with `nix run`

**Caveats**:
- `c7n-awscc` is not included in the editable shell since it has impure inputs from s3 bucket

you can try running it by:
` nix run github:hussainsultan/cloud-custodian?ref=releng/uv-switch`

Once merged, users could run the custodian cli by `nix run github:cloud-custodian/cloud-custodian` as a default app. 

depends on #10140 