### PR TITLE
azure - wait for async tag operation results from tests

### DIFF
--- a/tools/c7n_azure/tests_azure/tools_tags.py
+++ b/tools/c7n_azure/tests_azure/tools_tags.py
@@ -57,4 +57,4 @@ def get_tags(client, rg_name, vm_name):
 
 
 def set_tags(client, rg_name, vm_name, tags):
-    client.virtual_machines.begin_update(rg_name, vm_name, VirtualMachineUpdate(tags=tags))
+    client.virtual_machines.begin_update(rg_name, vm_name, VirtualMachineUpdate(tags=tags)).result()


### PR DESCRIPTION
This attempts to address the flaky Azure test issues raised in #10152. I've been able to reproduce the failures, but only in certain situations.

This change does no harm to commits that were already consistently working, but seems to make the tests reliably pass in cases where I was seeing intermittent failures.