### PR TITLE
Add VPC Resolver Query Logging Filter

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -3333,3 +3333,119 @@ class UsedByNetworkAddress(Filter):
                     if rtype == self.data.get('resource-type'):
                         results.append(r)
         return results
+
+
+@Vpc.filter_registry.register('resolver-query-logging')
+class ResolverQueryLoggingFilter(Filter):
+    """Filter VPCs based on Route 53 Resolver query logging configuration.
+
+    This filter checks if VPCs have Route 53 Resolver query logging enabled
+    and optionally verifies if logs are being sent to a specific S3 destination.
+
+    :Example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: vpc-missing-resolver-query-logs
+                resource: vpc
+                filters:
+                  - type: resolver-query-logging
+                    state: false
+
+              - name: vpc-resolver-logs-to-specific-bucket
+                resource: vpc
+                filters:
+                  - type: resolver-query-logging
+                    state: true
+                    bucket: my-logging-bucket
+
+              - name: vpc-resolver-logs-to-specific-bucket
+                resource: vpc
+                filters:
+                  - type: resolver-query-logging
+                    state: true
+                    bucket: my-security-logs-bucket
+    """
+    schema = type_schema(
+        'resolver-query-logging',
+        state={'type': 'boolean', 'default': True},
+        bucket={'type': 'string'},
+        **{'s3-destination': {'type': 'boolean'}}
+    )
+
+    permissions = (
+        'route53resolver:ListResolverQueryLogConfigs',
+        'route53resolver:ListResolverQueryLogConfigAssociations'
+    )
+
+    annotation_key = 'c7n:resolver-logging'
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('route53resolver')
+
+        target_state = self.data.get('state', True)
+        check_bucket = self.data.get('bucket')
+        check_s3_destination = self.data.get('s3-destination')
+
+        try:
+            vpc_to_config = {}
+            paginator = client.get_paginator('list_resolver_query_log_config_associations')
+            for page in paginator.paginate():
+                for assoc in page.get('ResolverQueryLogConfigAssociations', []):
+                    if (assoc['ResourceId'].startswith('vpc-') and
+                        assoc['Status'] in ['ACTIVE', 'CREATING']):
+                        vpc_to_config[assoc['ResourceId']] = assoc['ResolverQueryLogConfigId']
+
+            log_configs = {}
+            if target_state:
+                paginator = client.get_paginator('list_resolver_query_log_configs')
+                for page in paginator.paginate():
+                    for config in page.get('ResolverQueryLogConfigs', []):
+                        if config['Status'] in ['COMPLETE', 'CREATING', 'ACTIVE', 'CREATED']:
+                            log_configs[config['Id']] = config
+
+        except Exception as e:
+            self.log.warning(f"Error fetching resolver query log configurations: {e}")
+            return resources
+
+        results = []
+        for vpc in resources:
+            vpc_id = vpc['VpcId']
+            has_logging = vpc_id in vpc_to_config
+            config_id = vpc_to_config.get(vpc_id)
+            config = log_configs.get(config_id, {}) if config_id else {}
+
+            vpc[self.annotation_key] = {
+                'enabled': has_logging,
+                'config_id': config_id,
+                'destination_arn': config.get('DestinationArn', ''),
+                'config_status': config.get('Status', ''),
+                'config_name': config.get('Name', ''),
+                'bucket_name': ''
+            }
+
+            destination_arn = config.get('DestinationArn', '')
+            if destination_arn.startswith('arn:aws:s3:::'):
+                bucket_name = destination_arn[13:]
+                if '/' in bucket_name:
+                    bucket_name = bucket_name.split('/')[0]
+                vpc[self.annotation_key]['bucket_name'] = bucket_name
+
+            if has_logging != target_state:
+                continue
+
+            if (check_bucket or check_s3_destination) and has_logging:
+                destination_arn = config.get('DestinationArn', '')
+                if not destination_arn.startswith('arn:aws:s3:::'):
+                    continue
+
+                # Only check specific bucket if specified
+                if check_bucket:
+                    current_bucket = vpc[self.annotation_key]['bucket_name']
+                    if current_bucket != check_bucket:
+                        continue
+
+            results.append(vpc)
+
+        return results

--- a/tests/data/placebo/test_vpc_resolver_query_logging/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_resolver_query_logging/ec2.DescribeVpcs_1.json
@@ -1,0 +1,59 @@
+{
+    "status_code": 200,
+    "data": {
+      "Vpcs": [
+        {
+          "CidrBlock": "10.0.0.0/16",
+          "DhcpOptionsId": "dopt-24ff1940",
+          "State": "available",
+          "VpcId": "vpc-0503a8b9ddbb3a5c5",
+          "OwnerId": "644160558196",
+          "InstanceTenancy": "default",
+          "CidrBlockAssociationSet": [
+            {
+              "AssociationId": "vpc-cidr-assoc-00f6ac427cf5981b3",
+              "CidrBlock": "10.0.0.0/16",
+              "CidrBlockState": {
+                "State": "associated"
+              }
+            }
+          ],
+          "IsDefault": false,
+          "Tags": [
+            {
+              "Key": "Description",
+              "Value": "Created for ECS cluster c7n-test-cluster"
+            },
+            {
+              "Key": "Name",
+              "Value": "ECS c7n-test-cluster - VPC"
+            }
+          ]
+        },
+        {
+          "CidrBlock": "10.0.0.0/24",
+          "DhcpOptionsId": "dopt-24ff1940",
+          "State": "available",
+          "VpcId": "vpc-029d7b65096a4717d",
+          "OwnerId": "644160558196",
+          "InstanceTenancy": "default",
+          "CidrBlockAssociationSet": [
+            {
+              "AssociationId": "vpc-cidr-assoc-03505ef1c125b5edf",
+              "CidrBlock": "10.0.0.0/24",
+              "CidrBlockState": {
+                "State": "associated"
+              }
+            }
+          ],
+          "IsDefault": false,
+          "Tags": [
+            {
+              "Key": "Name",
+              "Value": "policy-test-vpc"
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/tests/data/placebo/test_vpc_resolver_query_logging/route53resolver.ListResolverQueryLogConfigAssociations_1.json
+++ b/tests/data/placebo/test_vpc_resolver_query_logging/route53resolver.ListResolverQueryLogConfigAssociations_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+      "ResolverQueryLogConfigAssociations": [
+        {
+          "Id": "rqlca-2204474e25d248df",
+          "ResolverQueryLogConfigId": "rqlc-ceb57b1765044c85",
+          "ResourceId": "vpc-0503a8b9ddbb3a5c5",
+          "Status": "ACTIVE",
+          "Error": null,
+          "ErrorMessage": null,
+          "CreationTime": "2025-05-13T18:11:26.221000+00:00"
+        }
+      ]
+    }
+  }

--- a/tests/data/placebo/test_vpc_resolver_query_logging/route53resolver.ListResolverQueryLogConfigs_1.json
+++ b/tests/data/placebo/test_vpc_resolver_query_logging/route53resolver.ListResolverQueryLogConfigs_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+      "ResolverQueryLogConfigs": [
+        {
+          "Id": "rqlc-ceb57b1765044c85",
+          "OwnerId": "644160558196",
+          "Status": "ACTIVE",
+          "ShareStatus": "NOT_SHARED",
+          "AssociationCount": 1,
+          "Arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-query-log-config/rqlc-ceb57b1765044c85",
+          "Name": "test-resolver-query-log-config",
+          "DestinationArn": "arn:aws:s3:::resolver-query-logs-20250513181124788700000003",
+          "CreationTime": "2025-05-13T18:11:25.497000+00:00",
+          "CreatorRequestId": "1234567890"
+        }
+      ]
+    }
+  }

--- a/tests/terraform/vpc_resolver_query_logging/main.tf
+++ b/tests/terraform/vpc_resolver_query_logging/main.tf
@@ -1,0 +1,121 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_vpc" "flow_log_vpc" {
+  id = "vpc-0503a8b9ddbb3a5c5" # ECS c7n-test-cluster - VPC
+}
+
+data "aws_vpc" "no_flow_log_vpc" {
+  id = "vpc-029d7b65096a4717d" # policy-test-vpc
+}
+
+resource "aws_flow_log" "example" {
+  iam_role_arn    = aws_iam_role.flow_log_role.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
+  traffic_type    = "ALL"
+  vpc_id          = data.aws_vpc.flow_log_vpc.id
+}
+
+resource "aws_cloudwatch_log_group" "example" {
+  name = "vpc-flow-logs-test"
+}
+
+resource "aws_iam_role" "flow_log_role" {
+  name_prefix = "flow-logs-role-"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "vpc-flow-logs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "flow_logs_policy" {
+  name_prefix = "flow-logs-policy-"
+  role        = aws_iam_role.flow_log_role.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "resolver_logs" {
+  bucket_prefix = "resolver-query-logs-"
+  force_destroy = true
+}
+
+resource "aws_iam_role" "resolver_logs_role" {
+  name_prefix = "resolver-logs-"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "route53resolver.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "resolver_logs_policy" {
+  role = aws_iam_role.resolver_logs_role.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action   = ["s3:PutObject"]
+      Effect   = "Allow"
+      Resource = "${aws_s3_bucket.resolver_logs.arn}/*"
+    }]
+  })
+}
+
+resource "aws_route53_resolver_query_log_config" "test" {
+  name            = "test-resolver-query-log-config"
+  destination_arn = aws_s3_bucket.resolver_logs.arn
+}
+
+resource "aws_route53_resolver_query_log_config_association" "test" {
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.test.id
+  resource_id                  = data.aws_vpc.flow_log_vpc.id
+}
+
+output "vpc_with_resolver_logging_id" {
+  value = data.aws_vpc.flow_log_vpc.id
+}
+
+output "vpc_without_resolver_logging_id" {
+  value = data.aws_vpc.no_flow_log_vpc.id
+}
+
+output "resolver_log_config_id" {
+  value = aws_route53_resolver_query_log_config.test.id
+}
+
+output "resolver_log_bucket" {
+  value = aws_s3_bucket.resolver_logs.bucket
+}

--- a/tests/terraform/vpc_resolver_query_logging/terraform.tfstate
+++ b/tests/terraform/vpc_resolver_query_logging/terraform.tfstate
@@ -1,0 +1,400 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.7",
+  "serial": 10,
+  "lineage": "d89f0fe4-8d2a-e49e-315f-5770108895f9",
+  "outputs": {
+    "resolver_log_bucket": {
+      "value": "resolver-query-logs-20250513181124788700000003",
+      "type": "string"
+    },
+    "resolver_log_config_id": {
+      "value": "rqlc-ceb57b1765044c85",
+      "type": "string"
+    },
+    "vpc_with_resolver_logging_id": {
+      "value": "vpc-0503a8b9ddbb3a5c5",
+      "type": "string"
+    },
+    "vpc_without_resolver_logging_id": {
+      "value": "vpc-029d7b65096a4717d",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "aws_vpc",
+      "name": "flow_log_vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-1:644160558196:vpc/vpc-0503a8b9ddbb3a5c5",
+            "cidr_block": "10.0.0.0/16",
+            "cidr_block_associations": [
+              {
+                "association_id": "vpc-cidr-assoc-00f6ac427cf5981b3",
+                "cidr_block": "10.0.0.0/16",
+                "state": "associated"
+              }
+            ],
+            "default": false,
+            "dhcp_options_id": "dopt-24ff1940",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "filter": null,
+            "id": "vpc-0503a8b9ddbb3a5c5",
+            "instance_tenancy": "default",
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "main_route_table_id": "rtb-0e0e2f980f23fa2b8",
+            "owner_id": "644160558196",
+            "state": null,
+            "tags": {
+              "Description": "Created for ECS cluster c7n-test-cluster",
+              "Name": "ECS c7n-test-cluster - VPC"
+            },
+            "timeouts": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "aws_vpc",
+      "name": "no_flow_log_vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-1:644160558196:vpc/vpc-029d7b65096a4717d",
+            "cidr_block": "10.0.0.0/24",
+            "cidr_block_associations": [
+              {
+                "association_id": "vpc-cidr-assoc-03505ef1c125b5edf",
+                "cidr_block": "10.0.0.0/24",
+                "state": "associated"
+              }
+            ],
+            "default": false,
+            "dhcp_options_id": "dopt-24ff1940",
+            "enable_dns_hostnames": false,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "filter": null,
+            "id": "vpc-029d7b65096a4717d",
+            "instance_tenancy": "default",
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "main_route_table_id": "rtb-0e0d8a8d96778fd2e",
+            "owner_id": "644160558196",
+            "state": null,
+            "tags": {
+              "Name": "policy-test-vpc"
+            },
+            "timeouts": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_cloudwatch_log_group",
+      "name": "example",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:logs:us-east-1:644160558196:log-group:vpc-flow-logs-test",
+            "id": "vpc-flow-logs-test",
+            "kms_key_id": "",
+            "log_group_class": "STANDARD",
+            "name": "vpc-flow-logs-test",
+            "name_prefix": "",
+            "retention_in_days": 0,
+            "skip_destroy": false,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_flow_log",
+      "name": "example",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-1:644160558196:vpc-flow-log/fl-03157c779780efa32",
+            "deliver_cross_account_role": "",
+            "destination_options": [],
+            "eni_id": null,
+            "iam_role_arn": "arn:aws:iam::644160558196:role/flow-logs-role-20250513181124785000000001",
+            "id": "fl-03157c779780efa32",
+            "log_destination": "arn:aws:logs:us-east-1:644160558196:log-group:vpc-flow-logs-test",
+            "log_destination_type": "cloud-watch-logs",
+            "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+            "log_group_name": "vpc-flow-logs-test",
+            "max_aggregation_interval": 600,
+            "subnet_id": null,
+            "tags": null,
+            "tags_all": {},
+            "traffic_type": "ALL",
+            "transit_gateway_attachment_id": null,
+            "transit_gateway_id": null,
+            "vpc_id": "vpc-0503a8b9ddbb3a5c5"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_cloudwatch_log_group.example",
+            "aws_iam_role.flow_log_role",
+            "data.aws_vpc.flow_log_vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "flow_log_role",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::644160558196:role/flow-logs-role-20250513181124785000000001",
+            "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"vpc-flow-logs.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}",
+            "create_date": "2025-05-13T18:11:24Z",
+            "description": "",
+            "force_detach_policies": false,
+            "id": "flow-logs-role-20250513181124785000000001",
+            "inline_policy": [],
+            "managed_policy_arns": [],
+            "max_session_duration": 3600,
+            "name": "flow-logs-role-20250513181124785000000001",
+            "name_prefix": "flow-logs-role-",
+            "path": "/",
+            "permissions_boundary": "",
+            "tags": null,
+            "tags_all": {},
+            "unique_id": "AROAZL6XWCR2KMH54P5XX"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "resolver_logs_role",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::644160558196:role/resolver-logs-20250513181124785000000002",
+            "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53resolver.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+            "create_date": "2025-05-13T18:11:24Z",
+            "description": "",
+            "force_detach_policies": false,
+            "id": "resolver-logs-20250513181124785000000002",
+            "inline_policy": [],
+            "managed_policy_arns": [],
+            "max_session_duration": 3600,
+            "name": "resolver-logs-20250513181124785000000002",
+            "name_prefix": "resolver-logs-",
+            "path": "/",
+            "permissions_boundary": "",
+            "tags": null,
+            "tags_all": {},
+            "unique_id": "AROAZL6XWCR2P4R4YSWGL"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_role_policy",
+      "name": "flow_logs_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "flow-logs-role-20250513181124785000000001:flow-logs-policy-20250513181125079400000004",
+            "name": "flow-logs-policy-20250513181125079400000004",
+            "name_prefix": "flow-logs-policy-",
+            "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\",\"logs:DescribeLogGroups\",\"logs:DescribeLogStreams\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}",
+            "role": "flow-logs-role-20250513181124785000000001"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_iam_role.flow_log_role"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_role_policy",
+      "name": "resolver_logs_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "resolver-logs-20250513181124785000000002:terraform-20250513181125339800000006",
+            "name": "terraform-20250513181125339800000006",
+            "name_prefix": "terraform-",
+            "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"s3:PutObject\"],\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::resolver-query-logs-20250513181124788700000003/*\"}]}",
+            "role": "resolver-logs-20250513181124785000000002"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_iam_role.resolver_logs_role",
+            "aws_s3_bucket.resolver_logs"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_route53_resolver_query_log_config",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:route53resolver:us-east-1:644160558196:resolver-query-log-config/rqlc-ceb57b1765044c85",
+            "destination_arn": "arn:aws:s3:::resolver-query-logs-20250513181124788700000003",
+            "id": "rqlc-ceb57b1765044c85",
+            "name": "test-resolver-query-log-config",
+            "owner_id": "644160558196",
+            "share_status": "NOT_SHARED",
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.resolver_logs"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_route53_resolver_query_log_config_association",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "rqlca-2204474e25d248df",
+            "resolver_query_log_config_id": "rqlc-ceb57b1765044c85",
+            "resource_id": "vpc-0503a8b9ddbb3a5c5"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_route53_resolver_query_log_config.test",
+            "aws_s3_bucket.resolver_logs",
+            "data.aws_vpc.flow_log_vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "resolver_logs",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::resolver-query-logs-20250513181124788700000003",
+            "bucket": "resolver-query-logs-20250513181124788700000003",
+            "bucket_domain_name": "resolver-query-logs-20250513181124788700000003.s3.amazonaws.com",
+            "bucket_prefix": "resolver-query-logs-",
+            "bucket_regional_domain_name": "resolver-query-logs-20250513181124788700000003.s3.us-east-1.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": true,
+            "grant": [
+              {
+                "id": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "resolver-query-logs-20250513181124788700000003",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": null,
+            "tags_all": {},
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/tests/terraform/vpc_resolver_query_logging/terraform.tfstate.backup
+++ b/tests/terraform/vpc_resolver_query_logging/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.5.7",
-  "serial": 11,
+  "serial": 10,
   "lineage": "d89f0fe4-8d2a-e49e-315f-5770108895f9",
   "outputs": {
     "resolver_log_bucket": {
@@ -120,7 +120,7 @@
             "name_prefix": "",
             "retention_in_days": 0,
             "skip_destroy": false,
-            "tags": {},
+            "tags": null,
             "tags_all": {}
           },
           "sensitive_attributes": [],
@@ -149,7 +149,7 @@
             "log_group_name": "vpc-flow-logs-test",
             "max_aggregation_interval": 600,
             "subnet_id": null,
-            "tags": {},
+            "tags": null,
             "tags_all": {},
             "traffic_type": "ALL",
             "transit_gateway_attachment_id": null,
@@ -181,19 +181,14 @@
             "description": "",
             "force_detach_policies": false,
             "id": "flow-logs-role-20250513181124785000000001",
-            "inline_policy": [
-              {
-                "name": "flow-logs-policy-20250513181125079400000004",
-                "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\",\"logs:DescribeLogGroups\",\"logs:DescribeLogStreams\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}"
-              }
-            ],
+            "inline_policy": [],
             "managed_policy_arns": [],
             "max_session_duration": 3600,
             "name": "flow-logs-role-20250513181124785000000001",
             "name_prefix": "flow-logs-role-",
             "path": "/",
             "permissions_boundary": "",
-            "tags": {},
+            "tags": null,
             "tags_all": {},
             "unique_id": "AROAZL6XWCR2KMH54P5XX"
           },
@@ -217,19 +212,14 @@
             "description": "",
             "force_detach_policies": false,
             "id": "resolver-logs-20250513181124785000000002",
-            "inline_policy": [
-              {
-                "name": "terraform-20250513181125339800000006",
-                "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"s3:PutObject\"],\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::resolver-query-logs-20250513181124788700000003/*\"}]}"
-              }
-            ],
+            "inline_policy": [],
             "managed_policy_arns": [],
             "max_session_duration": 3600,
             "name": "resolver-logs-20250513181124785000000002",
             "name_prefix": "resolver-logs-",
             "path": "/",
             "permissions_boundary": "",
-            "tags": {},
+            "tags": null,
             "tags_all": {},
             "unique_id": "AROAZL6XWCR2P4R4YSWGL"
           },
@@ -300,7 +290,7 @@
             "name": "test-resolver-query-log-config",
             "owner_id": "644160558196",
             "share_status": "NOT_SHARED",
-            "tags": {},
+            "tags": null,
             "tags_all": {}
           },
           "sensitive_attributes": [],
@@ -368,7 +358,7 @@
             "logging": [],
             "object_lock_configuration": [],
             "object_lock_enabled": false,
-            "policy": "{\"Id\":\"AWSLogDeliveryWrite20150319\",\"Statement\":[{\"Action\":\"s3:PutObject\",\"Condition\":{\"ArnLike\":{\"aws:SourceArn\":\"arn:aws:logs:us-east-1:644160558196:*\"},\"StringEquals\":{\"aws:SourceAccount\":\"644160558196\",\"s3:x-amz-acl\":\"bucket-owner-full-control\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"delivery.logs.amazonaws.com\"},\"Resource\":\"arn:aws:s3:::resolver-query-logs-20250513181124788700000003/AWSLogs/644160558196/*\",\"Sid\":\"AWSLogDeliveryWrite\"},{\"Action\":\"s3:GetBucketAcl\",\"Condition\":{\"ArnLike\":{\"aws:SourceArn\":\"arn:aws:logs:us-east-1:644160558196:*\"},\"StringEquals\":{\"aws:SourceAccount\":\"644160558196\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"delivery.logs.amazonaws.com\"},\"Resource\":\"arn:aws:s3:::resolver-query-logs-20250513181124788700000003\",\"Sid\":\"AWSLogDeliveryAclCheck\"}],\"Version\":\"2012-10-17\"}",
+            "policy": "",
             "region": "us-east-1",
             "replication_configuration": [],
             "request_payer": "BucketOwner",
@@ -387,7 +377,7 @@
                 ]
               }
             ],
-            "tags": {},
+            "tags": null,
             "tags_all": {},
             "timeouts": null,
             "versioning": [

--- a/tests/terraform/vpc_resolver_query_logging/tf_resources.json
+++ b/tests/terraform/vpc_resolver_query_logging/tf_resources.json
@@ -1,0 +1,22 @@
+{
+  "resolver_log_bucket": {
+    "sensitive": false,
+    "type": "string",
+    "value": "resolver-query-logs-20250513181124788700000003"
+  },
+  "resolver_log_config_id": {
+    "sensitive": false,
+    "type": "string",
+    "value": "rqlc-ceb57b1765044c85"
+  },
+  "vpc_with_resolver_logging_id": {
+    "sensitive": false,
+    "type": "string",
+    "value": "vpc-0503a8b9ddbb3a5c5"
+  },
+  "vpc_without_resolver_logging_id": {
+    "sensitive": false,
+    "type": "string",
+    "value": "vpc-029d7b65096a4717d"
+  }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -4362,14 +4362,12 @@ def test_eip_shield_sync_deleted(test, eip_shield_sync):
 
 @terraform('vpc_resolver_query_logging')
 def test_vpc_resolver_query_logging(test):
-    """Test filtering VPCs based on Route 53 Resolver query logging configuration."""
-
     factory = test.replay_flight_data("test_vpc_resolver_query_logging")
 
     vpc_with_logging_id = "vpc-0503a8b9ddbb3a5c5"  # VPC with resolver logging
     vpc_without_logging_id = "vpc-029d7b65096a4717d"  # VPC without resolver logging
 
-    # Test finding VPCs without resolver query logging
+    # Checking VPCs without resolver query logging
     p = test.load_policy(
         {
             "name": "vpc-without-resolver-query-logging",
@@ -4386,7 +4384,7 @@ def test_vpc_resolver_query_logging(test):
     test.assertEqual(resources[0]["VpcId"], vpc_without_logging_id)
     test.assertEqual(resources[0]["c7n:resolver-logging"]["enabled"], False)
 
-    # Test finding VPCs with resolver query logging
+    # Checking VPCs with resolver query logging
     p = test.load_policy(
         {
             "name": "vpc-with-resolver-query-logging",
@@ -4403,7 +4401,7 @@ def test_vpc_resolver_query_logging(test):
     test.assertEqual(resources[0]["VpcId"], vpc_with_logging_id)
     test.assertEqual(resources[0]["c7n:resolver-logging"]["enabled"], True)
 
-    # Test finding VPCs with resolver query logging to any S3 bucket
+    # Checking VPCs with resolver query logging to any S3 bucket
     p = test.load_policy(
         {
             "name": "vpc-with-resolver-query-logging-s3",

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -511,6 +511,68 @@ class VpcTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertTrue("vpce-011d813b183878b82" in resources[0]["VpcEndpointId"])
 
+    @terraform('vpc_resolver_query_logging')
+    def test_vpc_resolver_query_logging(self):
+        factory = self.replay_flight_data("test_vpc_resolver_query_logging")
+
+        vpc_with_logging_id = "vpc-0503a8b9ddbb3a5c5"  # VPC with resolver logging
+        vpc_without_logging_id = "vpc-029d7b65096a4717d"  # VPC without resolver logging
+
+        # Checking VPCs without resolver query logging
+        p = self.load_policy(
+            {
+                "name": "vpc-without-resolver-query-logging",
+                "resource": "vpc",
+                "filters": [
+                    {"VpcId": vpc_without_logging_id},
+                    {"type": "resolver-query-logging", "state": False}
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["VpcId"], vpc_without_logging_id)
+        self.assertEqual(resources[0]["c7n:resolver-logging"]["enabled"], False)
+
+        # Checking VPCs with resolver query logging
+        p = self.load_policy(
+            {
+                "name": "vpc-with-resolver-query-logging",
+                "resource": "vpc",
+                "filters": [
+                    {"VpcId": vpc_with_logging_id},
+                    {"type": "resolver-query-logging", "state": True}
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["VpcId"], vpc_with_logging_id)
+        self.assertEqual(resources[0]["c7n:resolver-logging"]["enabled"], True)
+
+        # Checking VPCs with resolver query logging to any S3 bucket
+        p = self.load_policy(
+            {
+                "name": "vpc-with-resolver-query-logging-s3",
+                "resource": "vpc",
+                "filters": [
+                    {"VpcId": vpc_with_logging_id},
+                    {
+                        "type": "resolver-query-logging",
+                        "state": True,
+                        "s3-destination": True
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["VpcId"], vpc_with_logging_id)
+        self.assertTrue(resources[0]["c7n:resolver-logging"]["destination_arn"])
+
 
 class NetworkLocationTest(BaseTest):
 
@@ -4358,66 +4420,3 @@ def test_eip_shield_sync_deleted(test, eip_shield_sync):
         InclusionFilters={"ResourceTypes": ["ELASTIC_IP_ALLOCATION"]}
     )
     test.assertEqual(len(protections["Protections"]), 1)
-
-
-@terraform('vpc_resolver_query_logging')
-def test_vpc_resolver_query_logging(test):
-    factory = test.replay_flight_data("test_vpc_resolver_query_logging")
-
-    vpc_with_logging_id = "vpc-0503a8b9ddbb3a5c5"  # VPC with resolver logging
-    vpc_without_logging_id = "vpc-029d7b65096a4717d"  # VPC without resolver logging
-
-    # Checking VPCs without resolver query logging
-    p = test.load_policy(
-        {
-            "name": "vpc-without-resolver-query-logging",
-            "resource": "vpc",
-            "filters": [
-                {"VpcId": vpc_without_logging_id},
-                {"type": "resolver-query-logging", "state": False}
-            ],
-        },
-        session_factory=factory,
-    )
-    resources = p.run()
-    test.assertEqual(len(resources), 1)
-    test.assertEqual(resources[0]["VpcId"], vpc_without_logging_id)
-    test.assertEqual(resources[0]["c7n:resolver-logging"]["enabled"], False)
-
-    # Checking VPCs with resolver query logging
-    p = test.load_policy(
-        {
-            "name": "vpc-with-resolver-query-logging",
-            "resource": "vpc",
-            "filters": [
-                {"VpcId": vpc_with_logging_id},
-                {"type": "resolver-query-logging", "state": True}
-            ],
-        },
-        session_factory=factory,
-    )
-    resources = p.run()
-    test.assertEqual(len(resources), 1)
-    test.assertEqual(resources[0]["VpcId"], vpc_with_logging_id)
-    test.assertEqual(resources[0]["c7n:resolver-logging"]["enabled"], True)
-
-    # Checking VPCs with resolver query logging to any S3 bucket
-    p = test.load_policy(
-        {
-            "name": "vpc-with-resolver-query-logging-s3",
-            "resource": "vpc",
-            "filters": [
-                {"VpcId": vpc_with_logging_id},
-                {
-                    "type": "resolver-query-logging",
-                    "state": True,
-                    "s3-destination": True
-                }
-            ],
-        },
-        session_factory=factory,
-    )
-    resources = p.run()
-    test.assertEqual(len(resources), 1)
-    test.assertEqual(resources[0]["VpcId"], vpc_with_logging_id)
-    test.assertTrue(resources[0]["c7n:resolver-logging"]["destination_arn"])

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -4358,3 +4358,68 @@ def test_eip_shield_sync_deleted(test, eip_shield_sync):
         InclusionFilters={"ResourceTypes": ["ELASTIC_IP_ALLOCATION"]}
     )
     test.assertEqual(len(protections["Protections"]), 1)
+
+
+@terraform('vpc_resolver_query_logging')
+def test_vpc_resolver_query_logging(test):
+    """Test filtering VPCs based on Route 53 Resolver query logging configuration."""
+
+    factory = test.replay_flight_data("test_vpc_resolver_query_logging")
+
+    vpc_with_logging_id = "vpc-0503a8b9ddbb3a5c5"  # VPC with resolver logging
+    vpc_without_logging_id = "vpc-029d7b65096a4717d"  # VPC without resolver logging
+
+    # Test finding VPCs without resolver query logging
+    p = test.load_policy(
+        {
+            "name": "vpc-without-resolver-query-logging",
+            "resource": "vpc",
+            "filters": [
+                {"VpcId": vpc_without_logging_id},
+                {"type": "resolver-query-logging", "state": False}
+            ],
+        },
+        session_factory=factory,
+    )
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+    test.assertEqual(resources[0]["VpcId"], vpc_without_logging_id)
+    test.assertEqual(resources[0]["c7n:resolver-logging"]["enabled"], False)
+
+    # Test finding VPCs with resolver query logging
+    p = test.load_policy(
+        {
+            "name": "vpc-with-resolver-query-logging",
+            "resource": "vpc",
+            "filters": [
+                {"VpcId": vpc_with_logging_id},
+                {"type": "resolver-query-logging", "state": True}
+            ],
+        },
+        session_factory=factory,
+    )
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+    test.assertEqual(resources[0]["VpcId"], vpc_with_logging_id)
+    test.assertEqual(resources[0]["c7n:resolver-logging"]["enabled"], True)
+
+    # Test finding VPCs with resolver query logging to any S3 bucket
+    p = test.load_policy(
+        {
+            "name": "vpc-with-resolver-query-logging-s3",
+            "resource": "vpc",
+            "filters": [
+                {"VpcId": vpc_with_logging_id},
+                {
+                    "type": "resolver-query-logging",
+                    "state": True,
+                    "s3-destination": True
+                }
+            ],
+        },
+        session_factory=factory,
+    )
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+    test.assertEqual(resources[0]["VpcId"], vpc_with_logging_id)
+    test.assertTrue(resources[0]["c7n:resolver-logging"]["destination_arn"])


### PR DESCRIPTION
Adding a new filter to the VPC resource to check Route 53 Resolver query logging configuration. This filter allows users to identify VPCs that have DNS query logging enabled/disabled and optionally verify if logs are being sent to S3.