### PR TITLE
aws - resolver-logs - skip operations on shared resources

### DIFF
--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -589,6 +589,8 @@ class ResolverQueryLogConfig(QueryResourceManager):
     def augment(self, rqlcs):
         client = local_session(self.session_factory).client('route53resolver')
         for rqlc in rqlcs:
+            if rqlc['OwnerId'] != self.account_id:
+                continue  # don't try to fetch tags for shared resources
             rqlc['Tags'] = self.retry(
                 client.list_tags_for_resource,
                 ResourceArn=rqlc['Arn'])['Tags']
@@ -645,6 +647,9 @@ class ResolverQueryLogConfigAssociate(BaseAction):
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('route53resolver')
         vpc_ids = self.get_vpc_id()
+
+        # Don't try to take action on resources the active account doesn't own
+        resources = self.filter_resources(resources, 'OwnerId', (self.manager.account_id,))
 
         for resource in resources:
             for vpc_id in vpc_ids:

--- a/tests/data/placebo/test_resolver_query_log_config_associate_skip_shared/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_resolver_query_log_config_associate_skip_shared/ec2.DescribeVpcs_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Vpcs": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_resolver_query_log_config_associate_skip_shared/route53resolver.ListResolverQueryLogConfigAssociations_1.json
+++ b/tests/data/placebo/test_resolver_query_log_config_associate_skip_shared/route53resolver.ListResolverQueryLogConfigAssociations_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "TotalCount": 1,
+        "TotalFilteredCount": 1,
+        "ResolverQueryLogConfigAssociations": [
+            {
+                "Id": "rqlca-a3591a308c9344f3",
+                "ResolverQueryLogConfigId": "rqlc-ff0edcdf72814d4d",
+                "ResourceId": "vpc-06fbfb0683669c546",
+                "Status": "FAILED",
+                "Error": "ACCESS_DENIED",
+                "ErrorMessage": "Account is not authorized to perform this operation.",
+                "CreationTime": "2025-05-27T17:48:54.515912049Z"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_resolver_query_log_config_associate_skip_shared/route53resolver.ListResolverQueryLogConfigs_1.json
+++ b/tests/data/placebo/test_resolver_query_log_config_associate_skip_shared/route53resolver.ListResolverQueryLogConfigs_1.json
@@ -1,0 +1,34 @@
+{
+    "status_code": 200,
+    "data": {
+        "TotalCount": 2,
+        "TotalFilteredCount": 2,
+        "ResolverQueryLogConfigs": [
+            {
+                "Id": "rqlc-9a0ca4b672e41b1",
+                "OwnerId": "111111111111",
+                "Status": "CREATED",
+                "ShareStatus": "SHARED_WITH_ME",
+                "AssociationCount": 0,
+                "Arn": "arn:aws:route53resolver:us-east-2:111111111111:resolver-query-log-config/rqlc-9a0ca4b672e41b1",
+                "Name": "c7ntest-shared",
+                "DestinationArn": "arn:aws:s3:::ima-good-bucket",
+                "CreatorRequestId": "a9928bd4-e173-47ea-8a43-92f90cbf1610",
+                "CreationTime": "2025-05-27T17:12:54.559388056Z"
+            },
+            {
+                "Id": "rqlc-ff0edcdf72814d4d",
+                "OwnerId": "644160558196",
+                "Status": "CREATED",
+                "ShareStatus": "NOT_SHARED",
+                "AssociationCount": 1,
+                "Arn": "arn:aws:route53resolver:us-east-2:644160558196:resolver-query-log-config/rqlc-ff0edcdf72814d4d",
+                "Name": "c7ntest",
+                "DestinationArn": "arn:aws:s3:::ajsbx-c7n",
+                "CreatorRequestId": "cff4024d-e28e-4389-9866-0b70044ddc04",
+                "CreationTime": "2025-05-27T17:12:12.208142337Z"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_resolver_query_log_config_associate_skip_shared/route53resolver.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_resolver_query_log_config_associate_skip_shared/route53resolver.ListTagsForResource_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -443,6 +443,28 @@ class TestResolverQueryLogConfig(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['Id'], "rqlc-01234567891234")
 
+    def test_resolver_query_log_config_associate_skip_shared(self):
+        session_factory = self.replay_flight_data(
+            'test_resolver_query_log_config_associate_skip_shared',
+            region='us-east-2'
+        )
+        p = self.load_policy({
+            'name': 'r53-resolver-query-log-config-associate-skip-shared',
+            'filters': [{
+                'type': 'value', 'key': 'Name', 'op': 'contains', 'value': 'c7n'}],
+            'resource': 'resolver-logs',
+            'actions': [{
+                'type': 'associate-vpc', 'vpcid': 'vpc-06fbfb0683669c546'}]},
+            config={'region': 'us-east-2'},
+            session_factory=session_factory
+        )
+        with self.capture_logging(level=logging.WARNING) as log_output:
+            p.run()
+            self.assertIn(
+                'implicitly filtered 1 of 2 resources key:OwnerId',
+                log_output.getvalue()
+            )
+
     def test_resolver_query_log_config_not_associated(self):
         session_factory = self.replay_flight_data(
             'test_resolver_query_log_config_associate_2')


### PR DESCRIPTION
Don't try to fetch tags or list/change VPC associations for resources the active account doesn't own.

Closes #9673