### PR TITLE
bug: Add UnsupportedOperationException handling

### DIFF
--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -169,6 +169,13 @@ class KeyRotationStatus(ValueFilter):
                     self.log.warning(
                         "Access denied when getting rotation status on key:%s",
                         resource.get('KeyArn'))
+                elif e.response['Error']['Code'] == 'UnsupportedOperationException':
+                    # This is expected for keys that do not support rotation
+                    # (e.g., imported keys) and keys that are PendingImport
+                    self.log.warning(
+                        "UnsupportedOperationException when getting rotation status on key:%s",
+                        resource.get('KeyArn'))
+                    return None
                 else:
                     raise
 


### PR DESCRIPTION
# Summary
Adds UnsupportedOperationException handling for KMS keys that are PendingImport, has imported key material, or is in a custom key store.

https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html
