### PR TITLE
aws - kms-key - add schedule-deletion action 

### DIFF
--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -444,6 +444,9 @@ class KmsPostFinding(PostFinding):
 class KmsKeyScheduleDeletion(BaseAction):
     """Schedule KMS key deletion
 
+    If the number of days is not specified, the default value of 30 days is used.
+    The number of days must be between 7 and 30.
+
     :example:
 
     .. code-block:: yaml

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -743,7 +743,12 @@ class KMSMotoTests(BaseTest):
     @pytest.fixture(autouse=True)
     def use_utc_timezone(self, monkeypatch):
         monkeypatch.setenv("TZ", "UTC")
-        time.tzset()
+        try:
+            time.tzset()
+        except AttributeError:
+            # A windows system should honor the TZ environment variable
+            # when it next calls datetime.now() (so says AI)
+            pass
 
     @moto.mock_aws
     def test_schedule_deletion(self):

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -758,8 +758,9 @@ class KMSMotoTests(BaseTest):
         assert key_meta["KeyState"] == "PendingDeletion"
 
         seven_days_away = datetime.now(UTC) + timedelta(days=7)
-        assert key_meta["DeletionDate"] > seven_days_away
-        assert key_meta["DeletionDate"] < (seven_days_away + timedelta(days=1))
+        deletion_date = key_meta["DeletionDate"].astimezone(UTC)
+        assert deletion_date > seven_days_away
+        assert deletion_date < (seven_days_away + timedelta(days=1))
 
     @moto.mock_aws
     def test_schedule_deletion_default_days(self):
@@ -781,5 +782,6 @@ class KMSMotoTests(BaseTest):
         assert key_meta["KeyState"] == "PendingDeletion"
 
         thirty_days_away = datetime.now(UTC) + timedelta(days=30)
-        assert key_meta["DeletionDate"] > thirty_days_away
-        assert key_meta["DeletionDate"] < (thirty_days_away + timedelta(days=1))
+        deletion_date = key_meta["DeletionDate"].astimezone(UTC)
+        assert deletion_date > thirty_days_away
+        assert deletion_date < (thirty_days_away + timedelta(days=1))

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -757,7 +757,9 @@ class KMSMotoTests(BaseTest):
         key_meta = kms.describe_key(KeyId=key_id)["KeyMetadata"]
         assert key_meta["KeyState"] == "PendingDeletion"
 
-        seven_days_away = datetime.now(UTC) + timedelta(days=7)
+        # Why macOS is your timing off? Subtracting a minute to account for
+        # whatever is messing that up.
+        seven_days_away = datetime.now(UTC) + timedelta(days=7) - timedelta(minutes=1)
         deletion_date = key_meta["DeletionDate"].astimezone(UTC)
         assert deletion_date > seven_days_away
         assert deletion_date < (seven_days_away + timedelta(days=1))
@@ -781,7 +783,9 @@ class KMSMotoTests(BaseTest):
         key_meta = kms.describe_key(KeyId=key_id)["KeyMetadata"]
         assert key_meta["KeyState"] == "PendingDeletion"
 
-        thirty_days_away = datetime.now(UTC) + timedelta(days=30)
+        # Why macOS is your timing off? Subtracting a minute to account for
+        # whatever is messing that up.
+        thirty_days_away = datetime.now(UTC) + timedelta(days=30) - timedelta(minutes=1)
         deletion_date = key_meta["DeletionDate"].astimezone(UTC)
         assert deletion_date > thirty_days_away
         assert deletion_date < (thirty_days_away + timedelta(days=1))


### PR DESCRIPTION
Adds a new action to schedule deletion of KMS keys.

Closes #7896 