### PR TITLE
Replace EC2 tagging with Universal Tagging 

### DIFF
--- a/CreateUniversalTagTestFiles.py
+++ b/CreateUniversalTagTestFiles.py
@@ -1,0 +1,51 @@
+import json
+import os
+
+DATA_DIRS = os.path.dirname(os.path.realpath(__file__)) + "/tests/data/placebo/"
+folder_list = [folder for folder in os.listdir(DATA_DIRS) if os.path.isdir(os.path.join(DATA_DIRS, folder))]
+
+for folder in folder_list:
+    for file in os.listdir(DATA_DIRS + folder):
+        if "ec2.CreateTags" in file:
+            with open(DATA_DIRS + folder + "/" + file, "r") as f:
+                data = json.load(f)
+                new_json = data
+                if data["data"]["ResponseMetadata"] == {}:
+                    new_json["data"]["FailedResourcesMap"] = {}
+                elif "HTTPHeaders" in data["data"]["ResponseMetadata"]:
+                    new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["content-type"] = "application/x-amz-json-1.1"
+                    if "vary" in data["data"]["ResponseMetadata"]["HTTPHeaders"]:
+                        del new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["vary"]
+                    if "transfer-encoding" in data["data"]["ResponseMetadata"]["HTTPHeaders"]:
+                        del new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["transfer-encoding"]
+                    if "content-length" not in data["data"]["ResponseMetadata"]["HTTPHeaders"]:
+                        new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["content-length"] = "25"
+                    new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["x-amzn-requestid"] = new_json["data"]["ResponseMetadata"]["RequestId"]
+                suffix = ""
+                if "_" in file:
+                    suffix = "_" + file.rsplit("_",1)[1].split(".")[0]
+                with open(DATA_DIRS + folder + "/tagging.TagResources"+suffix+".json", "wt+") as f2:
+                    json.dump(new_json, f2, indent=2)
+                    print(new_json)
+
+        if "ec2.DeleteTags" in file:
+            with open(DATA_DIRS + folder + "/" + file, "r") as f:
+                data = json.load(f)
+                new_json = data
+                if data["data"]["ResponseMetadata"] == {}:
+                    new_json["data"]["FailedResourcesMap"] = {}
+                elif "HTTPHeaders" in data["data"]["ResponseMetadata"]:
+                    new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["content-type"] = "application/x-amz-json-1.1"
+                    if "vary" in data["data"]["ResponseMetadata"]["HTTPHeaders"]:
+                        del new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["vary"]
+                    if "transfer-encoding" in data["data"]["ResponseMetadata"]["HTTPHeaders"]:
+                        del new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["transfer-encoding"]
+                    if "content-length" not in data["data"]["ResponseMetadata"]["HTTPHeaders"]:
+                        new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["content-length"] = "0"
+                    new_json["data"]["ResponseMetadata"]["HTTPHeaders"]["x-amzn-requestid"] = new_json["data"]["ResponseMetadata"]["RequestId"]
+                suffix = ""
+                if "_" in file:
+                    suffix = "_" + file.rsplit("_",1)[1].split(".")[0]
+                with open(DATA_DIRS + folder + "/tagging.UntagResources"+suffix+".json", "wt+") as f2:
+                    json.dump(new_json, f2, indent=2)
+                    print(new_json)

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -18,7 +18,7 @@ from c7n.exceptions import ClientError, ResourceLimitExceeded, PolicyExecutionEr
 from c7n.filters import FilterRegistry, MetricsFilter
 from c7n.manager import ResourceManager
 from c7n.registry import PluginRegistry
-from c7n.tags import register_ec2_tags, register_universal_tags, universal_augment
+from c7n.tags import register_universal_tags, universal_augment
 from c7n.utils import (
     local_session, generate_arn, get_retry, chunks, camelResource, jmespath_compile, get_path)
 
@@ -196,8 +196,8 @@ class QueryMeta(type):
             if m.service == 'ec2':
                 # Generic ec2 resource tag support
                 if getattr(m, 'taggable', True):
-                    register_ec2_tags(
-                        attrs['filter_registry'], attrs['action_registry'])
+                    register_universal_tags(
+                        attrs['filter_registry'], attrs['action_registry'], True)
             if getattr(m, 'universal_taggable', False):
                 compatibility = isinstance(m.universal_taggable, bool) and True or False
                 register_universal_tags(

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -28,24 +28,6 @@ from c7n import deprecated, utils
 DEFAULT_TAG = "maid_status"
 
 
-def register_ec2_tags(filters, actions):
-    filters.register('marked-for-op', TagActionFilter)
-    filters.register('tag-count', TagCountFilter)
-
-    actions.register('auto-tag-user', AutoTagUser)
-    actions.register('mark-for-op', TagDelayedAction)
-    actions.register('tag-trim', TagTrim)
-
-    actions.register('mark', Tag)
-    actions.register('tag', Tag)
-
-    actions.register('unmark', RemoveTag)
-    actions.register('untag', RemoveTag)
-    actions.register('remove-tag', RemoveTag)
-    actions.register('rename-tag', RenameTag)
-    actions.register('normalize-tag', NormalizeTag)
-
-
 def register_universal_tags(filters, actions, compatibility=True):
     filters.register('marked-for-op', TagActionFilter)
 

--- a/tests/data/placebo/test_asg_propagate_tag_action/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_action/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_asg_propagate_tag_no_instances/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_no_instances/tagging.TagResources_1.json
@@ -1,0 +1,22 @@
+{
+  "status_code": 400,
+  "data": {
+    "Error": {
+      "Code": "MissingParameter",
+      "Message": "The request must contain the parameter resourceIdSet"
+    },
+    "ResponseMetadata": {
+      "RequestId": "f229a23a-def5-4288-8ee0-f754ea63eda2",
+      "HTTPStatusCode": 400,
+      "HTTPHeaders": {
+        "date": "Thu, 21 Nov 2019 18:49:02 GMT",
+        "connection": "close",
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "content-length": "25",
+        "x-amzn-requestid": "f229a23a-def5-4288-8ee0-f754ea63eda2"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/data/placebo/test_asg_propagate_tag_no_instances/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_no_instances/tagging.UntagResources_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "1b312937-e532-443a-99bd-1dab530b4a84"
+    }
+  }
+}

--- a/tests/data/placebo/test_asg_rename/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_asg_rename/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "a41b874b-6a35-47b8-88b1-7d49b0709447",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Thu, 04 May 2017 17:08:57 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "a41b874b-6a35-47b8-88b1-7d49b0709447"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_asg_rename/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_asg_rename/tagging.UntagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "24b97439-153c-4f15-bee0-80fe77c3b379",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Thu, 04 May 2017 17:08:57 GMT",
+        "content-length": "0",
+        "x-amzn-requestid": "24b97439-153c-4f15-bee0-80fe77c3b379"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_asg_tag/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_asg_tag/tagging.TagResources_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "824d2183-1a79-4d3f-bc85-23d2e4e7ca6f"
+    }
+  }
+}

--- a/tests/data/placebo/test_asg_tag/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_asg_tag/tagging.TagResources_2.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "131fee6b-00bc-4641-82a3-5904b1f3a34a"
+    }
+  }
+}

--- a/tests/data/placebo/test_asg_tag/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_asg_tag/tagging.UntagResources_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "1b312937-e532-443a-99bd-1dab530b4a84"
+    }
+  }
+}

--- a/tests/data/placebo/test_copy_related_resource_tag_empty/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_copy_related_resource_tag_empty/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RequestId": "f4b336aa-d331-4029-a67e-49daea8d5a4d",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "content-type": "application/x-amz-json-1.1",
+        "content-length": "221",
+        "date": "Mon, 23 Sep 2019 14:28:40 GMT",
+        "server": "AmazonEC2",
+        "x-amzn-requestid": "f4b336aa-d331-4029-a67e-49daea8d5a4d"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/data/placebo/test_copy_related_resource_tag_multi_ref/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_copy_related_resource_tag_multi_ref/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RequestId": "018f51f4-5b77-4ee7-82e7-dcd208b3286d",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "content-type": "application/x-amz-json-1.1",
+        "content-length": "221",
+        "date": "Thu, 16 May 2019 17:06:38 GMT",
+        "server": "AmazonEC2",
+        "x-amzn-requestid": "018f51f4-5b77-4ee7-82e7-dcd208b3286d"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/data/placebo/test_copy_related_resource_tag_multi_ref/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_copy_related_resource_tag_multi_ref/tagging.TagResources_2.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RequestId": "5b133543-22ed-4c63-ac10-5959b8f444bc",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "content-type": "application/x-amz-json-1.1",
+        "content-length": "221",
+        "date": "Thu, 16 May 2019 17:06:39 GMT",
+        "server": "AmazonEC2",
+        "x-amzn-requestid": "5b133543-22ed-4c63-ac10-5959b8f444bc"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/data/placebo/test_copy_related_tag_resourcegroupstaggingapi/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_copy_related_tag_resourcegroupstaggingapi/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_ebs_copy_instance_tags/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ebs_copy_instance_tags/tagging.TagResources_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "2c64c526-0881-4e44-ad70-81635e971920"
+    }
+  }
+}

--- a/tests/data/placebo/test_ebs_snapshot_copy/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ebs_snapshot_copy/tagging.TagResources_1.json
@@ -1,0 +1,16 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "047c2196-d54f-4a27-bf51-aa3a4430e739",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 27 Jun 2016 13:03:28 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "047c2196-d54f-4a27-bf51-aa3a4430e739"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_autotag_assumed/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ec2_autotag_assumed/tagging.TagResources_1.json
@@ -1,0 +1,16 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "575cfded-69e1-4812-a05e-c781fcadf38c",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Sun, 24 Jul 2016 15:02:40 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "575cfded-69e1-4812-a05e-c781fcadf38c"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_autotag_creator/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ec2_autotag_creator/tagging.TagResources_1.json
@@ -1,0 +1,16 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "71ec822b-820d-497c-9210-cb2d27325bd7",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Sun, 24 Jul 2016 15:02:21 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "71ec822b-820d-497c-9210-cb2d27325bd7"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_autotag_creator/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_ec2_autotag_creator/tagging.TagResources_2.json
@@ -1,0 +1,16 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "f4f4f8d7-5c7c-418f-a849-74c1dd1c6953",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Sun, 24 Jul 2016 15:02:23 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "f4f4f8d7-5c7c-418f-a849-74c1dd1c6953"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_mark/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ec2_mark/tagging.TagResources_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "789962ba-b1bb-4c90-a5f4-cfd214cf183c"
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_mark_hours/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ec2_mark_hours/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "4bd899b5-c62c-4690-945f-9f55fc9809cb",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 20 Feb 2018 15:18:30 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "4bd899b5-c62c-4690-945f-9f55fc9809cb"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_mark_zero/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ec2_mark_zero/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "a6a37391-d242-467e-84ed-bb8b0ac17fc2",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Fri, 24 Nov 2017 14:24:14 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "a6a37391-d242-467e-84ed-bb8b0ac17fc2"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_normalize_tag/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ec2_normalize_tag/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "ba8b52b8-e974-4dd5-b50c-5c9ca75f6711",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 14 Nov 2016 19:13:03 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "ba8b52b8-e974-4dd5-b50c-5c9ca75f6711"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_normalize_tag/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_ec2_normalize_tag/tagging.TagResources_2.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "b5a7bd4f-ae30-439b-9bb9-cb44bd4e6d55",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 14 Nov 2016 19:13:03 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "b5a7bd4f-ae30-439b-9bb9-cb44bd4e6d55"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_propagate_spot_tags/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ec2_propagate_spot_tags/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RequestId": "eff2282f-7b49-46e2-adb2-dce352623dac",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Thu, 29 Mar 2018 09:12:51 GMT",
+        "server": "AmazonEC2",
+        "content-length": "25",
+        "x-amzn-requestid": "eff2282f-7b49-46e2-adb2-dce352623dac"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_rename_tag/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_ec2_rename_tag/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "ba8b52b8-e974-4dd5-b50c-5c9ca75f6711",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 14 Nov 2016 19:13:03 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "ba8b52b8-e974-4dd5-b50c-5c9ca75f6711"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_rename_tag/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_ec2_rename_tag/tagging.TagResources_2.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "b5a7bd4f-ae30-439b-9bb9-cb44bd4e6d55",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 14 Nov 2016 19:13:03 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "b5a7bd4f-ae30-439b-9bb9-cb44bd4e6d55"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_rename_tag/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_ec2_rename_tag/tagging.UntagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "692f315e-3e59-495b-a148-e89293c07a4e",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 14 Nov 2016 19:13:03 GMT",
+        "content-length": "0",
+        "x-amzn-requestid": "692f315e-3e59-495b-a148-e89293c07a4e"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_rename_tag/tagging.UntagResources_2.json
+++ b/tests/data/placebo/test_ec2_rename_tag/tagging.UntagResources_2.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "cdb6d94b-558b-45b7-810a-c168dca9c352",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 14 Nov 2016 19:13:03 GMT",
+        "content-length": "0",
+        "x-amzn-requestid": "cdb6d94b-558b-45b7-810a-c168dca9c352"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_tag_trim/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_ec2_tag_trim/tagging.UntagResources_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "2bf7563d-b678-4fd0-b939-f4e2efd76656"
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_untag/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_ec2_untag/tagging.UntagResources_1.json
@@ -1,0 +1,9 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "HTTPStatusCode": 200,
+      "RequestId": "33514c4c-f6fd-46d8-92e6-45a326dd4885"
+    }
+  }
+}

--- a/tests/data/placebo/test_ec2_untag_array/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_ec2_untag_array/tagging.UntagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "8e62c200-b95c-4a18-bd14-d751109578d7",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Wed, 28 Feb 2018 01:09:18 GMT",
+        "content-length": "0",
+        "x-amzn-requestid": "8e62c200-b95c-4a18-bd14-d751109578d7"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_encrypt_volumes/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "717b41af-ddb7-4aca-a284-f722f2893af6",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Thu, 08 Jun 2017 18:18:56 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "717b41af-ddb7-4aca-a284-f722f2893af6"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_encrypt_volumes/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_encrypt_volumes/tagging.TagResources_2.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "e9f41987-3f3b-414b-be99-e084cfe5cb74",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Thu, 08 Jun 2017 18:19:58 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "e9f41987-3f3b-414b-be99-e084cfe5cb74"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_encrypt_volumes/tagging.TagResources_3.json
+++ b/tests/data/placebo/test_encrypt_volumes/tagging.TagResources_3.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "ed2cfe96-58f6-4ee4-a294-00f910458a3f",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Thu, 08 Jun 2017 18:23:18 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "ed2cfe96-58f6-4ee4-a294-00f910458a3f"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_encrypt_volumes/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/tagging.UntagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "4a1959d6-03dc-4770-a626-a667079f13f4",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Thu, 08 Jun 2017 18:24:05 GMT",
+        "content-length": "0",
+        "x-amzn-requestid": "4a1959d6-03dc-4770-a626-a667079f13f4"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_nat_gateways_tag/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_nat_gateways_tag/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "d82a95ea-9221-4aea-8504-55251dca8d5b",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Fri, 08 Sep 2017 20:01:46 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "d82a95ea-9221-4aea-8504-55251dca8d5b"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_network_location_intersection/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_intersection/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "bea4a384-5869-4699-9547-2ba204252b90",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 26 Jun 2017 18:48:07 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "bea4a384-5869-4699-9547-2ba204252b90"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_mismatch/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_match_in_mismatch/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_mismatch/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_network_location_match_in_mismatch/tagging.TagResources_2.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_mismatch_sg/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_match_in_mismatch_sg/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_mismatch_sg/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_network_location_match_in_mismatch_sg/tagging.TagResources_2.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_mismatch_sg/tagging.TagResources_3.json
+++ b/tests/data/placebo/test_network_location_match_in_mismatch_sg/tagging.TagResources_3.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_mismatch_subnet/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_match_in_mismatch_subnet/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_mismatch_subnet/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_network_location_match_in_mismatch_subnet/tagging.TagResources_2.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_mismatch_subnet/tagging.TagResources_3.json
+++ b/tests/data/placebo/test_network_location_match_in_mismatch_subnet/tagging.TagResources_3.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_subnet_missing_ok/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_match_in_subnet_missing_ok/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_triple_intersect/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_match_in_triple_intersect/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_triple_intersect/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_network_location_match_in_triple_intersect/tagging.TagResources_2.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_match_in_triple_intersect/tagging.TagResources_3.json
+++ b/tests/data/placebo/test_network_location_match_in_triple_intersect/tagging.TagResources_3.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_network_location_resource_missing/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_resource_missing/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "913eb15f-77c7-42ed-9813-fd08fd4af6e8",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 26 Jun 2017 18:46:52 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "913eb15f-77c7-42ed-9813-fd08fd4af6e8"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_network_location_sg_cardinality/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_sg_cardinality/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "58aebcc6-5eab-4565-b50c-873da5d26222",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 26 Jun 2017 18:46:19 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "58aebcc6-5eab-4565-b50c-873da5d26222"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_network_location_sg_cardinality/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_network_location_sg_cardinality/tagging.TagResources_2.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "6a202153-6f1c-4c0b-adae-def2d02b68a3",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 26 Jun 2017 18:46:19 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "6a202153-6f1c-4c0b-adae-def2d02b68a3"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_network_location_sg_missing_loc/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_network_location_sg_missing_loc/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "770c7ad4-9161-49e7-b1c2-01d23b31737b",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Mon, 26 Jun 2017 18:37:31 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "770c7ad4-9161-49e7-b1c2-01d23b31737b"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_notify_region_var/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_notify_region_var/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "34b93c6d-1c6c-428c-8771-deb232565523",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 21 Nov 2017 15:40:43 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "34b93c6d-1c6c-428c-8771-deb232565523"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_security_group_revisions_delta/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_security_group_revisions_delta/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "a73c8f3e-d70b-4b7f-ba36-4e12b6baf40f",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 13 Dec 2016 01:00:20 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "a73c8f3e-d70b-4b7f-ba36-4e12b6baf40f"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_security_group_revisions_delta/tagging.TagResources_2.json
+++ b/tests/data/placebo/test_security_group_revisions_delta/tagging.TagResources_2.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "49e5a3fb-2d87-45f4-ae43-c5c1213d85a6",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 13 Dec 2016 01:00:20 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "49e5a3fb-2d87-45f4-ae43-c5c1213d85a6"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_security_group_revisions_delta/tagging.TagResources_3.json
+++ b/tests/data/placebo/test_security_group_revisions_delta/tagging.TagResources_3.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "cdf39330-bc6f-4089-b768-001fcdaf9e10",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 13 Dec 2016 01:00:21 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "cdf39330-bc6f-4089-b768-001fcdaf9e10"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_security_group_revisions_delta/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_security_group_revisions_delta/tagging.UntagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "9fe6c28b-42d0-4208-b4d9-ca1506bff58b",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Tue, 13 Dec 2016 01:00:21 GMT",
+        "content-length": "0",
+        "x-amzn-requestid": "9fe6c28b-42d0-4208-b4d9-ca1506bff58b"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_security_hub_instance/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_security_hub_instance/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "a6a37391-d242-467e-84ed-bb8b0ac17fc2",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Fri, 24 Nov 2017 14:24:14 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "a6a37391-d242-467e-84ed-bb8b0ac17fc2"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_sg_config_patch_pitr/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_sg_config_patch_pitr/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "ad0cfcf7-c848-408f-8ecd-65aec6772973",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Wed, 14 Dec 2016 14:38:12 GMT",
+        "content-length": "25",
+        "x-amzn-requestid": "ad0cfcf7-c848-408f-8ecd-65aec6772973"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_sg_config_patch_pitr/tagging.UntagResources_1.json
+++ b/tests/data/placebo/test_sg_config_patch_pitr/tagging.UntagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RetryAttempts": 0,
+      "HTTPStatusCode": 200,
+      "RequestId": "20561560-eb1f-4930-89d2-23f27fcb6994",
+      "HTTPHeaders": {
+        "server": "AmazonEC2",
+        "content-type": "application/x-amz-json-1.1",
+        "date": "Wed, 14 Dec 2016 14:38:12 GMT",
+        "content-length": "0",
+        "x-amzn-requestid": "20561560-eb1f-4930-89d2-23f27fcb6994"
+      }
+    }
+  }
+}

--- a/tests/data/placebo/test_spot_fleet_request_autoscaling_offhours/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_spot_fleet_request_autoscaling_offhours/tagging.TagResources_1.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "FailedResourcesMap": {}
+  }
+}

--- a/tests/data/placebo/test_tags_copy_related_resource_tag_partial/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_tags_copy_related_resource_tag_partial/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RequestId": "27b38af9-f8e1-4f1a-8f90-3d66e8f29220",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "content-type": "application/x-amz-json-1.1",
+        "content-length": "221",
+        "date": "Fri, 01 Feb 2019 15:28:33 GMT",
+        "server": "AmazonEC2",
+        "x-amzn-requestid": "27b38af9-f8e1-4f1a-8f90-3d66e8f29220"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/data/placebo/test_tags_copy_related_resource_tags_all/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_tags_copy_related_resource_tags_all/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {
+      "RequestId": "64e12027-8fd9-433d-b916-ef7eca61f4cc",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "content-type": "application/x-amz-json-1.1",
+        "content-length": "221",
+        "date": "Fri, 01 Feb 2019 15:22:20 GMT",
+        "server": "AmazonEC2",
+        "x-amzn-requestid": "64e12027-8fd9-433d-b916-ef7eca61f4cc"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}


### PR DESCRIPTION
- Updates to include normalize-tag for universal tagger
- Updates to use universal tagging for ec2
- Make test responses for Universal Tagging based on existing EC2 create tags and EC2 delete tags responses

TODO: update tests, check in with Kapil for additions changes