### PR TITLE
fix(c7n-mailer): seperate slack messages by owner tag in mailer

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -128,9 +128,6 @@ class SlackDelivery:
                     if is_email(resolved_addr):
                         ims = self.retrieve_user_im([resolved_addr])
                         slack_target = ims.get(resolved_addr)
-                        if not slack_target:
-                            self.logger.debug(f"Could not resolve IM for email {resolved_addr}")
-                            continue
                     elif not resolved_addr.startswith("#"):
                         resolved_addr = "#" + resolved_addr
                         slack_target = resolved_addr


### PR DESCRIPTION
Resolves Issue #10241 

Rewrites the logic under slack://tag/XYZ to:

- Group resources by tag value
- Render and send one message per unique tag value
- Accurate delivery to the correct Slack target
- Preserves behavior for all other slack:// and webhook-style targets

