### PR TITLE
aws: set "Content-Type: gzip" for s3 output

### DIFF
--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -730,7 +730,8 @@ class S3Output(BlobOutput):
             path, self.bucket, key,
             extra_args={
                 'ACL': 'bucket-owner-full-control',
-                'ServerSideEncryption': 'AES256'})
+                'ServerSideEncryption': 'AES256',
+                'ContentEncoding': 'gzip'})
 
 
 @clouds.register('aws')

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -157,7 +157,7 @@ class S3OutputTest(TestUtils):
             fh.name,
             "cloud-custodian",
             "%s/foo.txt" % output.key_prefix.lstrip('/'),
-            extra_args={"ACL": "bucket-owner-full-control", "ServerSideEncryption": "AES256"},
+            extra_args={"ACL": "bucket-owner-full-control", "ServerSideEncryption": "AES256", "ContentEncoding": "gzip"},
         )
 
     def test_sans_prefix(self):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -157,7 +157,11 @@ class S3OutputTest(TestUtils):
             fh.name,
             "cloud-custodian",
             "%s/foo.txt" % output.key_prefix.lstrip('/'),
-            extra_args={"ACL": "bucket-owner-full-control", "ServerSideEncryption": "AES256", "ContentEncoding": "gzip"},
+            extra_args={
+                "ACL": "bucket-owner-full-control",
+                "ServerSideEncryption": "AES256",
+                "ContentEncoding": "gzip"
+            },
         )
 
     def test_sans_prefix(self):
@@ -175,7 +179,11 @@ class S3OutputTest(TestUtils):
             fh.name,
             "cloud-custodian",
             "%s/foo.txt" % output.key_prefix.lstrip('/'),
-            extra_args={"ACL": "bucket-owner-full-control", "ServerSideEncryption": "AES256"},
+            extra_args={
+                "ACL": "bucket-owner-full-control",
+                "ServerSideEncryption": "AES256",
+                "ContentEncoding": "gzip"
+            },
         )
 
 


### PR DESCRIPTION
Accidentally closed #10246 , quoting from that:

> we use cloud-custodian on aws with s3 output and serve the output files using a lightweight S3 proxy. output files are compressed by default and Content-Encoding metadata is set to binary/octet-stream.
> 
> this creates issues with checking file content from browser. I think setting this metadata during upload will change nothing but all objects will have correct encoding metadata.