### PR TITLE
Use keyword args for `assumed_session()` in `invoke-lambda` action

### DIFF
--- a/c7n/actions/invoke.py
+++ b/c7n/actions/invoke.py
@@ -72,7 +72,8 @@ class LambdaInvoke(EventAction):
 
         if assumed_role:
             self.log.debug('Assuming role: {}'.format(assumed_role))
-            target_session = assumed_session(role_arn=assumed_role, session_name='LambdaAssumedRoleSession', session=session)
+            target_session = assumed_session(
+                role_arn=assumed_role, session_name='LambdaAssumedRoleSession', session=session)
             client = target_session.client('lambda', config=config)
         else:
             client = utils.local_session(


### PR DESCRIPTION
This patch corrects the call to `assumed_session()` in `invoke.py` so that the existing boto3 `Session` is passed into the proper parameter (`session`), rather than being mis‐assigned to `session_policy`.

We now use explicit keyword arguments for clarity and to prevent regressions.

Fixes: https://github.com/cloud-custodian/cloud-custodian/issues/10078