### PR TITLE
azure - define default values for report metadata attributes

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -21,6 +21,14 @@ class TestEC2Report(BaseTest):
             formatter.to_csv([self.records['full']]),
             [['InstanceId-1', '', 'LaunchTime-1']])
 
+    def test_default_csv_azure(self):
+        resource_type = 'azure.machine-learning-workspace'
+        self.patch(resource_type,
+                   'default_report_fields', ())
+        formatter = Formatter(resource_type)
+        csv = formatter.to_csv([self.records['full']])
+        assert csv
+
     def test_csv(self):
         p = self.load_policy({"name": "report-test-ec2", "resource": "ec2"})
         formatter = Formatter(p.resource_manager.resource_type)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -21,14 +21,6 @@ class TestEC2Report(BaseTest):
             formatter.to_csv([self.records['full']]),
             [['InstanceId-1', '', 'LaunchTime-1']])
 
-    def test_default_csv_azure(self):
-        resource_type = 'azure.machine-learning-workspace'
-        self.patch(resource_type,
-                   'default_report_fields', ())
-        formatter = Formatter(resource_type)
-        csv = formatter.to_csv([self.records['full']])
-        assert csv
-
     def test_csv(self):
         p = self.load_policy({"name": "report-test-ec2", "resource": "ec2"})
         formatter = Formatter(p.resource_manager.resource_type)

--- a/tools/c7n_azure/c7n_azure/query.py
+++ b/tools/c7n_azure/c7n_azure/query.py
@@ -186,8 +186,12 @@ class TypeInfo(metaclass=TypeMeta):
     client = ''
 
     resource = DEFAULT_RESOURCE_AUTH_ENDPOINT
-    # Default id field, resources should override if different (used for meta filters, report etc)
+    # Default id and name fields, resources should override if different
+    # (used for meta filters, report etc)
     id = 'id'
+    name = 'name'
+
+    default_report_fields = ()
 
     @classmethod
     def extra_args(cls, resource_manager):

--- a/tools/c7n_azure/tests_azure/test_report.py
+++ b/tools/c7n_azure/tests_azure/test_report.py
@@ -1,0 +1,30 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from c7n_azure.provider import Azure
+
+from c7n.config import Bag, Config
+from c7n.ctx import ExecutionContext
+from c7n.resources import load_resources
+
+from .azure_common import BaseTest
+
+
+class ReportMetadataTests(BaseTest):
+
+    def test_report_metadata(self):
+        load_resources(('azure.*',))
+        ctx = ExecutionContext(None, Bag(), Config.empty())
+        missing = set()
+        for k, v in Azure.resources.items():
+            model = v(ctx, Config.empty()).get_model()
+            if not getattr(model, "id", None):
+                missing.add("%s~%s" % (k, v))
+            if not getattr(model, "name", None):
+                missing.add("%s~%s" % (k, v))
+            if not hasattr(model, "default_report_fields"):
+                missing.add("%s~%s" % (k, v))
+
+        if missing:
+            raise AssertionError("Missing report metadata on \n %s" % (' \n'.join(sorted(missing))))


### PR DESCRIPTION
Be sure that the core reporting attributes (id, name, default_report_fields) have some defaults for Azure resource types.

This avoids `custodian report` crashes for Azure resource types that:

- Don't derive from `ArmResourceManager` (because that class defines id/name/default_report_fields defaults)
- Don't explicitly define `default_report_fields` and/or a `name` attribute

Closes #10243 (since `azure.machine-learning-workspace` meets those 2 criteria)

Test shamelessly yanked/adapted from https://github.com/cloud-custodian/cloud-custodian/blob/main/tools/c7n_gcp/tests/test_report.py