### PR TITLE
aws - add resource client-vpn-endpoint

### DIFF
--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -327,6 +327,7 @@ ResourceMap = {
   "aws.vpc": "c7n.resources.vpc.Vpc",
   "aws.vpc-endpoint": "c7n.resources.vpc.VpcEndpoint",
   "aws.vpc-endpoint-service-configuration": "c7n.resources.vpc.VPCEndpointServiceConfiguration",
+  "aws.client-vpn-endpoint": "c7n.resources.vpc.ClientVpnEndpoint",
   "aws.vpn-connection": "c7n.resources.vpc.VPNConnection",
   "aws.vpn-gateway": "c7n.resources.vpc.VPNGateway",
   "aws.waf": "c7n.resources.waf.WAF",

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2649,6 +2649,22 @@ class VPNGateway(query.QueryResourceManager):
         id_prefix = "vgw-"
 
 
+@resources.register('client-vpn-endpoint')
+class ClientVpnEndpoint(query.QueryResourceManager):
+
+    class resource_type(query.TypeInfo):
+        service = 'ec2'
+        arn_type = 'client-vpn-endpoint'
+        enum_spec = ('describe_client_vpn_endpoints', 'ClientVpnEndpoints', None)
+        name = id = 'ClientVpnEndpointId'
+        filter_name = 'ClientVpnEndpointIds'
+        filter_type = 'list'
+        cfn_type = config_type = 'AWS::EC2::ClientVpnEndpoint'
+        id_prefix = 'cvpn-endpoint-'
+        metrics_namespace = 'AWS/ClientVPN'
+        dimension = 'ClientVpnEndpointId'
+
+
 @resources.register('vpc-endpoint')
 class VpcEndpoint(query.QueryResourceManager):
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -439,7 +439,6 @@ class PolicyMetaLint(BaseTest):
             "AWS::Athena::PreparedStatement",
             "AWS::CustomerProfiles::ObjectType",
             "AWS::EC2::CapacityReservation",
-            "AWS::EC2::ClientVpnEndpoint",
             "AWS::EC2::IPAMScope",
             "AWS::Evidently::Launch",
             "AWS::Forecast::DatasetGroup",


### PR DESCRIPTION
Add initial support for AWS resource "Client VPN Endpoints". (resolves issue #9884)

_PS: This is my first contribution on this project, I'll be happy to receive any feedback or additional instructions._