### PR TITLE
tests - remove xfail marker for c7n-left test_attribute_value_presence

### DIFF
--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -2260,7 +2260,6 @@ def test_merge_locals_with_apply_time_values(tmp_path):
     }
 
 
-@pytest.mark.xfail(reason="https://github.com/cloud-custodian/cloud-custodian/issues/10119")
 def test_attribute_value_presence(tmp_path):
 
     resources = run_policy(


### PR DESCRIPTION
#10119 was fixed, so we no longer expect the test to fail.