### PR TITLE
aws - subnet filter - public option for nat route checking

### DIFF
--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -63,8 +63,6 @@ class SubnetFilter(MatchResourceValidator, RelatedResourceFilter):
                operator: or
                igw: True
                nat: True
-               key: SubnetId
-               value: present
 
     """
 

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -156,7 +156,8 @@ class SubnetFilter(MatchResourceValidator, RelatedResourceFilter):
         elif not self.check_nat and not found_nat:
             return True
         return False
-    
+
+
 class VpcFilter(MatchResourceValidator, RelatedResourceFilter):
     """Filter a resource by its associated vpc."""
     schema = type_schema(

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -59,15 +59,12 @@ class SubnetFilter(MatchResourceValidator, RelatedResourceFilter):
          - name: public-ec2
            resource: aws.ec2
            filters:
-             - or:
-               - type: subnet
-                 igw: True
-                 key: SubnetId
-                 value: present
-               - type: subnet
-                 nat: True
-                 key: SubnetId
-                 value: present
+             - type: subnet
+               operator: or
+               igw: True
+               nat: True
+               key: SubnetId
+               value: present
 
     """
 

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -59,7 +59,7 @@ class SubnetFilter(MatchResourceValidator, RelatedResourceFilter):
          - name: public-ec2
            resource: aws.ec2
            filters:
-             -or:
+             - or:
                - type: subnet
                  igw: True
                  key: SubnetId

--- a/tests/data/placebo/test_eni_private_subnet/ec2.DescribeNetworkInterfaces_1.json
+++ b/tests/data/placebo/test_eni_private_subnet/ec2.DescribeNetworkInterfaces_1.json
@@ -1,0 +1,147 @@
+{
+    "status_code": 200,
+    "data": {
+        "NetworkInterfaces": [
+            {
+                "Attachment": {
+                    "AttachmentId": "ela-attach-04b47a37eac5a4278",
+                    "DeleteOnTermination": false,
+                    "DeviceIndex": 1,
+                    "InstanceOwnerId": "amazon-aws",
+                    "Status": "attached"
+                },
+                "AvailabilityZone": "us-west-2a",
+                "Description": "VPC Endpoint Interface vpce-0dfaa364d994a6a2f",
+                "Groups": [
+                    {
+                        "GroupId": "sg-031f71960759a8d50",
+                        "GroupName": "oip-vpc-endpoint-sg"
+                    }
+                ],
+                "InterfaceType": "vpc_endpoint",
+                "Ipv6Addresses": [],
+                "MacAddress": "06:eb:64:3f:f4:27",
+                "NetworkInterfaceId": "eni-054de8d628e757d05",
+                "OwnerId": "644160558196",
+                "PrivateDnsName": "ip-10-0-2-196.us-west-2.compute.internal",
+                "PublicDnsName": "",
+                "PrivateIpAddress": "10.0.2.196",
+                "PrivateIpAddresses": [
+                    {
+                        "Primary": true,
+                        "PrivateDnsName": "ip-10-0-2-196.us-west-2.compute.internal",
+                        "PrivateIpAddress": "10.0.2.196"
+                    }
+                ],
+                "RequesterId": "644160558196",
+                "RequesterManaged": true,
+                "SourceDestCheck": true,
+                "Status": "in-use",
+                "SubnetId": "subnet-0616e6e6a767403e1",
+                "TagSet": [],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "Operator": {
+                    "Managed": false
+                }
+            },
+            {
+                "Association": {
+                    "AllocationId": "eipalloc-05ba3a8f351f45975",
+                    "AssociationId": "eipassoc-0aa0d4baf8f53fe5e",
+                    "IpOwnerId": "644160558196",
+                    "PublicDnsName": "ec2-54-188-51-165.us-west-2.compute.amazonaws.com",
+                    "PublicIp": "54.188.51.165"
+                },
+                "Attachment": {
+                    "AttachmentId": "ela-attach-00ca26a5d51efa747",
+                    "DeleteOnTermination": false,
+                    "DeviceIndex": 1,
+                    "InstanceOwnerId": "amazon-aws",
+                    "Status": "attached"
+                },
+                "AvailabilityZone": "us-west-2a",
+                "Description": "Interface for NAT Gateway nat-01e6556a25454e5f2",
+                "Groups": [],
+                "InterfaceType": "nat_gateway",
+                "Ipv6Addresses": [],
+                "MacAddress": "06:1b:0c:ae:fa:a1",
+                "NetworkInterfaceId": "eni-02f9c1d34f40af967",
+                "OwnerId": "644160558196",
+                "PrivateDnsName": "ip-10-0-1-153.us-west-2.compute.internal",
+                "PublicDnsName": "ec2-54-188-51-165.us-west-2.compute.amazonaws.com",
+                "PublicIpDnsNameOptions": {
+                    "DnsHostnameType": "public-ipv4-dns-name",
+                    "PublicIpv4DnsName": "ec2-54-188-51-165.us-west-2.compute.amazonaws.com"
+                },
+                "PrivateIpAddress": "10.0.1.153",
+                "PrivateIpAddresses": [
+                    {
+                        "Association": {
+                            "AllocationId": "eipalloc-05ba3a8f351f45975",
+                            "AssociationId": "eipassoc-0aa0d4baf8f53fe5e",
+                            "IpOwnerId": "644160558196",
+                            "PublicDnsName": "ec2-54-188-51-165.us-west-2.compute.amazonaws.com",
+                            "PublicIp": "54.188.51.165"
+                        },
+                        "Primary": true,
+                        "PrivateDnsName": "ip-10-0-1-153.us-west-2.compute.internal",
+                        "PrivateIpAddress": "10.0.1.153"
+                    }
+                ],
+                "RequesterId": "644160558196",
+                "RequesterManaged": true,
+                "SourceDestCheck": false,
+                "Status": "in-use",
+                "SubnetId": "subnet-012f22da152a7028e",
+                "TagSet": [],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "Operator": {
+                    "Managed": false
+                }
+            },
+            {
+                "Attachment": {
+                    "AttachmentId": "ela-attach-0b64aa1dda24ac683",
+                    "DeleteOnTermination": false,
+                    "DeviceIndex": 1,
+                    "InstanceOwnerId": "amazon-aws",
+                    "Status": "attached"
+                },
+                "AvailabilityZone": "us-west-2b",
+                "Description": "VPC Endpoint Interface vpce-0dfaa364d994a6a2f",
+                "Groups": [
+                    {
+                        "GroupId": "sg-031f71960759a8d50",
+                        "GroupName": "oip-vpc-endpoint-sg"
+                    }
+                ],
+                "InterfaceType": "vpc_endpoint",
+                "Ipv6Addresses": [],
+                "MacAddress": "02:1f:11:b5:c5:6d",
+                "NetworkInterfaceId": "eni-0f14f3abcf2d8086c",
+                "OwnerId": "644160558196",
+                "PrivateDnsName": "ip-10-0-3-64.us-west-2.compute.internal",
+                "PublicDnsName": "",
+                "PrivateIpAddress": "10.0.3.64",
+                "PrivateIpAddresses": [
+                    {
+                        "Primary": true,
+                        "PrivateDnsName": "ip-10-0-3-64.us-west-2.compute.internal",
+                        "PrivateIpAddress": "10.0.3.64"
+                    }
+                ],
+                "RequesterId": "644160558196",
+                "RequesterManaged": true,
+                "SourceDestCheck": true,
+                "Status": "in-use",
+                "SubnetId": "subnet-084d19d6ad68535e0",
+                "TagSet": [],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "Operator": {
+                    "Managed": false
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_eni_private_subnet/ec2.DescribeRouteTables_1.json
+++ b/tests/data/placebo/test_eni_private_subnet/ec2.DescribeRouteTables_1.json
@@ -1,0 +1,494 @@
+{
+    "status_code": 200,
+    "data": {
+        "RouteTables": [
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-00f971f6b10bdd2dd",
+                        "RouteTableId": "rtb-091022547181ef961",
+                        "SubnetId": "subnet-08f4d99d9fd07ee45",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-091022547181ef961",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-078ca7ffe93afa56b",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-09322087ca008cdd9",
+                        "RouteTableId": "rtb-00d80b09c32f7e42d",
+                        "SubnetId": "subnet-0616e6e6a767403e1",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-00d80b09c32f7e42d",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "NatGatewayId": "nat-01e6556a25454e5f2",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-0c2ee8edb1b517f79",
+                        "RouteTableId": "rtb-0924932c4d2267746",
+                        "SubnetId": "subnet-084d19d6ad68535e0",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-0924932c4d2267746",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "NatGatewayId": "nat-01e6556a25454e5f2",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-0adb632d4ffc3f760",
+                        "RouteTableId": "rtb-0081daa9bdae64acd",
+                        "SubnetId": "subnet-0085520753b0e8b4b",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-0081daa9bdae64acd",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": true,
+                        "RouteTableAssociationId": "rtbassoc-0419ca9c5fe8f96c2",
+                        "RouteTableId": "rtb-0ba4ba0fab842cad5",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-0ba4ba0fab842cad5",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-00c7b526e33d9322f",
+                        "RouteTableId": "rtb-017cfb895be415587",
+                        "SubnetId": "subnet-00db2baffb3daf94a",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-017cfb895be415587",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-07f8490bd300e7b5c",
+                        "RouteTableId": "rtb-0ed127e4d7310acdc",
+                        "SubnetId": "subnet-022e07053d6d7f752",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-0ed127e4d7310acdc",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-078ca7ffe93afa56b",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-0a3f01849bc78043a",
+                        "RouteTableId": "rtb-09525ee9aeaffd722",
+                        "SubnetId": "subnet-0cd62659464062acd",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-09525ee9aeaffd722",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-0835503fd3d933815",
+                        "RouteTableId": "rtb-03059d9c635080cea",
+                        "SubnetId": "subnet-0e902996b1a140005",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-03059d9c635080cea",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-078ca7ffe93afa56b",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-0e8ca603bd39b28bf",
+                        "RouteTableId": "rtb-003d1aa740ccdc1b1",
+                        "SubnetId": "subnet-0946dd024c4339783",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-003d1aa740ccdc1b1",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-078ca7ffe93afa56b",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-0fa83f9c89181c6a8",
+                        "RouteTableId": "rtb-08fcf7c4992d4b7b8",
+                        "SubnetId": "subnet-09dcdd6719ad7ebec",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-08fcf7c4992d4b7b8",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "NatGatewayId": "nat-01e6556a25454e5f2",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-00c6ea15a5fc941eb",
+                        "RouteTableId": "rtb-0e5cb287885c5e2f3",
+                        "SubnetId": "subnet-0af2e260e11be4d23",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-0e5cb287885c5e2f3",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-078ca7ffe93afa56b",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            },
+            {
+                "Associations": [
+                    {
+                        "Main": false,
+                        "RouteTableAssociationId": "rtbassoc-0cdee440d0b2b4b28",
+                        "RouteTableId": "rtb-00bb5cf6de297383b",
+                        "SubnetId": "subnet-012f22da152a7028e",
+                        "AssociationState": {
+                            "State": "associated"
+                        }
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-00bb5cf6de297383b",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/21",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-078ca7ffe93afa56b",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-00a54069",
+                        "GatewayId": "vpce-09dde693c87e2b557",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    },
+                    {
+                        "DestinationPrefixListId": "pl-68a54001",
+                        "GatewayId": "vpce-0a3093e2a8e039953",
+                        "Origin": "CreateRoute",
+                        "State": "active"
+                    }
+                ],
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "OwnerId": "644160558196"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_eni_private_subnet/ec2.DescribeSubnets_1.json
+++ b/tests/data/placebo/test_eni_private_subnet/ec2.DescribeSubnets_1.json
@@ -1,0 +1,86 @@
+{
+    "status_code": 200,
+    "data": {
+        "Subnets": [
+            {
+                "AvailabilityZoneId": "usw2-az2",
+                "MapCustomerOwnedIpOnLaunch": false,
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "SubnetArn": "arn:aws:ec2:us-west-2:644160558196:subnet/subnet-012f22da152a7028e",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                },
+                "BlockPublicAccessStates": {
+                    "InternetGatewayBlockMode": "off"
+                },
+                "SubnetId": "subnet-012f22da152a7028e",
+                "State": "available",
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "CidrBlock": "10.0.1.128/27",
+                "AvailableIpAddressCount": 26,
+                "AvailabilityZone": "us-west-2a",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": false
+            },
+            {
+                "AvailabilityZoneId": "usw2-az1",
+                "MapCustomerOwnedIpOnLaunch": false,
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "SubnetArn": "arn:aws:ec2:us-west-2:644160558196:subnet/subnet-084d19d6ad68535e0",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                },
+                "BlockPublicAccessStates": {
+                    "InternetGatewayBlockMode": "off"
+                },
+                "SubnetId": "subnet-084d19d6ad68535e0",
+                "State": "available",
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "CidrBlock": "10.0.3.0/24",
+                "AvailableIpAddressCount": 249,
+                "AvailabilityZone": "us-west-2b",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": false
+            },
+            {
+                "AvailabilityZoneId": "usw2-az2",
+                "MapCustomerOwnedIpOnLaunch": false,
+                "OwnerId": "644160558196",
+                "AssignIpv6AddressOnCreation": false,
+                "Ipv6CidrBlockAssociationSet": [],
+                "SubnetArn": "arn:aws:ec2:us-west-2:644160558196:subnet/subnet-0616e6e6a767403e1",
+                "EnableDns64": false,
+                "Ipv6Native": false,
+                "PrivateDnsNameOptionsOnLaunch": {
+                    "HostnameType": "ip-name",
+                    "EnableResourceNameDnsARecord": false,
+                    "EnableResourceNameDnsAAAARecord": false
+                },
+                "BlockPublicAccessStates": {
+                    "InternetGatewayBlockMode": "off"
+                },
+                "SubnetId": "subnet-0616e6e6a767403e1",
+                "State": "available",
+                "VpcId": "vpc-003377c0084c5bcd5",
+                "CidrBlock": "10.0.2.0/24",
+                "AvailableIpAddressCount": 246,
+                "AvailabilityZone": "us-west-2a",
+                "DefaultForAz": false,
+                "MapPublicIpOnLaunch": false
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -161,6 +161,7 @@ def test_eni_igw_subnet(test):
     assert len(resources) == 1
     assert resources[0]['NetworkInterfaceId'] == 'eni-0d47bf614f6182182'
 
+
 def test_eni_nat_subnet(test):
     factory = test.replay_flight_data('test_eni_private_subnet')
     p = test.load_policy({
@@ -175,6 +176,7 @@ def test_eni_nat_subnet(test):
     resources = p.run()
     assert len(resources) == 2
     assert resources[0]['NetworkInterfaceId'] == 'eni-054de8d628e757d05'
+
 
 @terraform('aws_code_build_vpc')
 def test_codebuild_unused(test, aws_code_build_vpc):

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -161,6 +161,20 @@ def test_eni_igw_subnet(test):
     assert len(resources) == 1
     assert resources[0]['NetworkInterfaceId'] == 'eni-0d47bf614f6182182'
 
+def test_eni_nat_subnet(test):
+    factory = test.replay_flight_data('test_eni_private_subnet')
+    p = test.load_policy({
+        'name': 'private-eni',
+        'resource': 'aws.eni',
+        'filters': [
+            {'type': 'subnet',
+             'key': 'SubnetId',
+             'value': 'present',
+             'nat': True}
+        ]}, session_factory=factory)
+    resources = p.run()
+    assert len(resources) == 2
+    assert resources[0]['NetworkInterfaceId'] == 'eni-054de8d628e757d05'
 
 @terraform('aws_code_build_vpc')
 def test_codebuild_unused(test, aws_code_build_vpc):

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -164,6 +164,7 @@ def test_eni_igw_subnet(test):
 
 def test_eni_nat_subnet(test):
     factory = test.replay_flight_data('test_eni_private_subnet')
+
     p = test.load_policy({
         'name': 'private-eni',
         'resource': 'aws.eni',
@@ -176,6 +177,19 @@ def test_eni_nat_subnet(test):
     resources = p.run()
     assert len(resources) == 2
     assert resources[0]['NetworkInterfaceId'] == 'eni-054de8d628e757d05'
+
+    p = test.load_policy({
+        'name': 'egress-eni',
+        'resource': 'aws.eni',
+        'filters': [
+            {'type': 'subnet',
+             'key': 'SubnetId',
+             'value': 'present',
+             'nat': False}
+        ]}, session_factory=factory)
+    resources = p.run()
+    assert len(resources) == 1
+    assert resources[0]['NetworkInterfaceId'] == 'eni-02f9c1d34f40af967'
 
 
 @terraform('aws_code_build_vpc')


### PR DESCRIPTION
filter resources by subnets with a route association to a nat.

related to #7481.

**Example**

```yaml
policies:
  - name: rds-subnet-igw-nat-check
    resource: rds
    description: |
      Checks if RDS Instance is in a subnet that has a route to sends traffic to the internet.
    filters:
      - or:
        - type: subnet
          igw: True
          key: SubnetId
          value: present
        - type: subnet
          nat: True
          key: SubnetId
          value: present
```