### PR TITLE
aws- cross-account condition multiple keys within the same operator

### DIFF
--- a/c7n/filters/iamaccess.py
+++ b/c7n/filters/iamaccess.py
@@ -200,19 +200,16 @@ class PolicyChecker:
         set_conditions = ('ForAllValues', 'ForAnyValues')
 
         for s_cond_op in list(s['Condition'].keys()):
-            cond = {'op': s_cond_op}
-
             if s_cond_op not in conditions:
                 if not any(s_cond_op.startswith(c) for c in set_conditions):
                     continue
 
-            cond['key'] = list(s['Condition'][s_cond_op].keys())[0]
-            cond['values'] = s['Condition'][s_cond_op][cond['key']]
-            cond['values'] = (
-                isinstance(cond['values'],
-                           str) and (cond['values'],) or cond['values'])
-            cond['key'] = cond['key'].lower()
-            s_cond.append(cond)
+            # Loop over all keys under each operator
+            for key, value in s['Condition'][s_cond_op].items():
+                cond = {'op': s_cond_op}
+                cond['key'] = key.lower()
+                cond['values'] = (value,) if isinstance(value, str) else value
+                s_cond.append(cond)
 
         return s_cond
 

--- a/tests/data/iam/s3-condition-multi-keys.json
+++ b/tests/data/iam/s3-condition-multi-keys.json
@@ -1,0 +1,44 @@
+[
+  {
+    "Id": "OrgID-Valid",
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "Stmt1510843305330",
+        "Action": [
+          "s3:PutObject"
+        ],
+        "Effect": "Allow",
+        "Resource": "arn:aws:s3:::cross-account-valid/*",
+        "Condition": {
+          "StringEquals": {
+            "aws:ResourceOrgID": "o-goodorg",
+            "aws:PrincipalAccount": "123456789012"
+          }
+        },
+        "Principal": "*"
+      }
+    ]
+  },
+  {
+    "Id": "OrgID-Valid",
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "Stmt1510843305330",
+        "Action": [
+          "s3:PutObject"
+        ],
+        "Effect": "Allow",
+        "Resource": "arn:aws:s3:::cross-account-valid/*",
+        "Condition": {
+          "StringEquals": {
+            "aws:ResourceOrgID": "o-badorg",
+            "aws:PrincipalAccount": "123456789123"
+          }
+        },
+        "Principal": "*"
+      }
+    ]
+  }
+]

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -2465,6 +2465,19 @@ class CrossAccountChecker(TestCase):
         for p, expected in zip(policies, [False, True]):
             violations = checker.check(p)
             self.assertEqual(bool(violations), expected)
+    
+    def test_s3_policies_multiple_keys(self):
+        policies = load_data("iam/s3-condition-multi-keys.json")
+        checker = PolicyChecker(
+            {
+                "allowed_accounts": {"123456789012"},
+                "allowed_orgid": {"o-goodorg"}
+            }
+        )
+        for p, expected in zip(policies, [False, True]):
+            violations = checker.check(p)
+            self.assertEqual(bool(violations), expected)
+
 
     def test_s3_resource_org_id(self):
         policies = load_data("iam/s3-resource-orgid.json")

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -2465,7 +2465,7 @@ class CrossAccountChecker(TestCase):
         for p, expected in zip(policies, [False, True]):
             violations = checker.check(p)
             self.assertEqual(bool(violations), expected)
-    
+
     def test_s3_policies_multiple_keys(self):
         policies = load_data("iam/s3-condition-multi-keys.json")
         checker = PolicyChecker(
@@ -2477,7 +2477,6 @@ class CrossAccountChecker(TestCase):
         for p, expected in zip(policies, [False, True]):
             violations = checker.check(p)
             self.assertEqual(bool(violations), expected)
-
 
     def test_s3_resource_org_id(self):
         policies = load_data("iam/s3-resource-orgid.json")


### PR DESCRIPTION
This PR will close issue https://github.com/cloud-custodian/cloud-custodian/issues/10266.