### PR TITLE
Adding Connect Analytics dataset cross-account filter

### DIFF
--- a/c7n/resources/connect.py
+++ b/c7n/resources/connect.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
-from c7n.filters import ValueFilter
+from c7n.filters import ValueFilter, Filter
 from c7n.utils import local_session, type_schema
 from c7n.actions import Action
 from c7n.filters.kms import KmsRelatedFilter
@@ -46,69 +46,65 @@ class ConnectInstanceAttributeFilter(ValueFilter):
     annotation_key = 'c7n:InstanceAttribute'
 
     def process(self, resources, event=None):
-
         client = local_session(self.manager.session_factory).client('connect')
         results = []
-
         for r in resources:
             if self.annotation_key not in r:
                 instance_attribute = client.describe_instance_attribute(InstanceId=r['Id'],
                                 AttributeType=str.upper(self.data.get('attribute_type')))
                 instance_attribute.pop('ResponseMetadata', None)
                 r[self.annotation_key] = instance_attribute
-
             if self.match(r[self.annotation_key]):
                 results.append(r)
-
         return results
 
-    @Connect.action_registry.register("set-attributes")
-    class SetAttributes(Action):
-        """Set the attributes for the connect resources
 
-        :example:
+@Connect.action_registry.register("set-attributes")
+class SetAttributes(Action):
+    """Set the attributes for the connect resources
 
-        .. code-block:: yaml
+    :example:
 
-            policies:
-              - name: connect-set-contact-lens
-                resource: connect-instance
-                filters:
-                  - type: instance-attribute
-                    key: Attribute.Value
-                    value: false
-                    attribute_type: CONTACT_LENS
-                actions:
-                  - type: set-attributes
-                    attribute_type: CONTACT_LENS
-                    value: true
-              - name: connect-disable-contact-lens
-                resource: connect-instance
-                filters:
-                  - type: instance-attribute
-                    key: Attribute.Value
-                    value: true
-                    attribute_type: CONTACT_LENS
-                actions:
-                  - type: set-attributes
-                    attribute_type: CONTACT_LENS
-                    value: false
-        """
-        attributes = ["INBOUND_CALLS", "OUTBOUND_CALLS",
-                      "CONTACTFLOW_LOGS", "CONTACT_LENS",
-                      "AUTO_RESOLVE_BEST_VOICES", "USE_CUSTOM_TTS_VOICES",
-                      "EARLY_MEDIA", "MULTI_PARTY_CONFERENCE",
-                      "HIGH_VOLUME_OUTBOUND", "ENHANCED_CONTACT_MONITORING"]
-        schema = type_schema("set-attributes", attribute_type={'anyOf': [{'enum': attributes},
-                  {'type': 'string'}]}, value={}, required=["value", "attribute_type"])
-        permissions = ("connect:UpdateInstanceAttribute",)
+    .. code-block:: yaml
 
-        def process(self, resources):
-            client = local_session(self.manager.session_factory).client('connect')
+        policies:
+          - name: connect-set-contact-lens
+            resource: connect-instance
+            filters:
+              - type: instance-attribute
+                key: Attribute.Value
+                value: false
+                attribute_type: CONTACT_LENS
+            actions:
+              - type: set-attributes
+                attribute_type: CONTACT_LENS
+                value: true
+          - name: connect-disable-contact-lens
+            resource: connect-instance
+            filters:
+              - type: instance-attribute
+                key: Attribute.Value
+                value: true
+                attribute_type: CONTACT_LENS
+            actions:
+              - type: set-attributes
+                attribute_type: CONTACT_LENS
+                value: false
+    """
+    attributes = ["INBOUND_CALLS", "OUTBOUND_CALLS",
+                  "CONTACTFLOW_LOGS", "CONTACT_LENS",
+                  "AUTO_RESOLVE_BEST_VOICES", "USE_CUSTOM_TTS_VOICES",
+                  "EARLY_MEDIA", "MULTI_PARTY_CONFERENCE",
+                  "HIGH_VOLUME_OUTBOUND", "ENHANCED_CONTACT_MONITORING"]
+    schema = type_schema("set-attributes", attribute_type={'anyOf': [{'enum': attributes},
+              {'type': 'string'}]}, value={}, required=["value", "attribute_type"])
+    permissions = ("connect:UpdateInstanceAttribute",)
 
-            for r in resources:
-                client.update_instance_attribute(InstanceId=r["Id"],
-                    AttributeType=self.data.get("attribute_type"), Value=self.data.get("value"))
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('connect')
+        for r in resources:
+            client.update_instance_attribute(InstanceId=r["Id"],
+                AttributeType=self.data.get("attribute_type"), Value=self.data.get("value"))
 
 
 @resources.register('connect-campaign')
@@ -137,3 +133,47 @@ class ConnectCampaign(QueryResourceManager):
 @ConnectCampaign.filter_registry.register('kms-key')
 class ConnectCampaignKmsFilter(KmsRelatedFilter):
     RelatedIdsExpression = 'connectInstanceConfig.encryptionConfig.keyArn'
+
+
+@resources.register('connect-analytics-association')
+class ConnectAnalyticsAssociation(QueryResourceManager):
+    """Resource manager for Connect Analytics Data Associations.
+
+    """
+
+    class resource_type(TypeInfo):
+        service = 'connect'
+        arn = id = 'AssociationId'
+        name = 'DataSetId'
+
+    def resources(self, query=None):
+        """
+        Overrides the default resources() method to handle the multi-step
+        enumeration required for analytics data associations.
+        """
+        client = local_session(self.session_factory).client('connect')
+        instance_paginator = client.get_paginator('list_instances')
+        all_associations = []
+        for page in instance_paginator.paginate():
+            for instance in page.get('InstanceSummaryList', []):
+                response = client.list_analytics_data_associations(InstanceId=instance['Id'])
+                all_associations.extend(response.get('Results', []))
+        return self.filter_resources(all_associations)
+
+
+@ConnectAnalyticsAssociation.filter_registry.register('cross-account')
+class ConnectAssociationCrossAccountFilter(Filter):
+    """Flags all Connect analytics associations that target an external account.
+    """
+    schema = type_schema('cross-account')
+    permissions = ()
+
+    def process(self, resources, event=None):
+        current_account_id = self.manager.account_id
+        results = []
+        for r in resources:
+            target_account = r.get('TargetAccountId')
+            if target_account and target_account != current_account_id:
+                r['c7n:CurrentAccountId'] = current_account_id
+                results.append(r)
+        return results

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -83,6 +83,7 @@ ResourceMap = {
     "c7n.resources.comprehend.ComprehendTopicsDetectionJob",
   "aws.config-recorder": "c7n.resources.config.ConfigRecorder",
   "aws.config-rule": "c7n.resources.config.ConfigRule",
+  "aws.connect-analytics-association": "c7n.resources.connect.ConnectAnalyticsAssociation",
   "aws.connect-campaign": "c7n.resources.connect.ConnectCampaign",
   "aws.connect-instance": "c7n.resources.connect.Connect",
   "aws.customer-gateway": "c7n.resources.vpc.CustomerGateway",

--- a/tests/data/placebo/test_connect_analytics_association_cross_account/connect.ListAnalyticsDataAssociations_1.json
+++ b/tests/data/placebo/test_connect_analytics_association_cross_account/connect.ListAnalyticsDataAssociations_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Results": []
+    }
+}

--- a/tests/data/placebo/test_connect_analytics_association_cross_account/connect.ListAnalyticsDataAssociations_2.json
+++ b/tests/data/placebo/test_connect_analytics_association_cross_account/connect.ListAnalyticsDataAssociations_2.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Results": [
+            {
+                "DataSetId": "contact_record",
+                "TargetAccountId": "644160558197",
+                "ResourceShareId": "0cf94d60-a166-47fb-b367-1b79ca9f27f9",
+                "ResourceShareArn": "arn:aws:ram:us-east-1:644160558196:resource-share/0cf94d60-a166-47fb-b367-1b79ca9f27f9"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_connect_analytics_association_cross_account/connect.ListInstances_1.json
+++ b/tests/data/placebo/test_connect_analytics_association_cross_account/connect.ListInstances_1.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "InstanceSummaryList": [
+            {
+                "Id": "2249c2a9-a798-4ebc-aaaf-86685b6a576d",
+                "Arn": "arn:aws:connect:us-east-1:644160558196:instance/2249c2a9-a798-4ebc-aaaf-86685b6a576d",
+                "IdentityManagementType": "CONNECT_MANAGED",
+                "InstanceAlias": "test-pratyush",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 5,
+                    "day": 19,
+                    "hour": 11,
+                    "minute": 35,
+                    "second": 3,
+                    "microsecond": 0
+                },
+                "ServiceRole": "arn:aws:iam::644160558196:role/aws-service-role/connect.amazonaws.com/AWSServiceRoleForAmazonConnect_K9nHKntrsk8djqIsEU1K",
+                "InstanceStatus": "ACTIVE",
+                "InboundCallsEnabled": true,
+                "OutboundCallsEnabled": true,
+                "InstanceAccessUrl": "https://test-pratyush.my.connect.aws"
+            },
+            {
+                "Id": "25f1514d-14d0-4a06-b28f-9df132d33d3d",
+                "Arn": "arn:aws:connect:us-east-1:644160558196:instance/25f1514d-14d0-4a06-b28f-9df132d33d3d",
+                "IdentityManagementType": "CONNECT_MANAGED",
+                "InstanceAlias": "c7ntest",
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 4,
+                    "day": 11,
+                    "hour": 9,
+                    "minute": 58,
+                    "second": 50,
+                    "microsecond": 0
+                },
+                "ServiceRole": "arn:aws:iam::644160558196:role/aws-service-role/connect.amazonaws.com/AWSServiceRoleForAmazonConnect_lwIriO3byDrpDLcnkrpg",
+                "InstanceStatus": "ACTIVE",
+                "InboundCallsEnabled": true,
+                "OutboundCallsEnabled": true,
+                "InstanceAccessUrl": "https://c7ntest.my.connect.aws"
+            }
+        ]
+    }
+}

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -55,17 +55,11 @@ class ConnectTest(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        results = []
-        for r in resources:
-            results.append(
-                session_factory().client('connect').describe_instance_attribute(
-                    InstanceId=r["Id"],
-                    AttributeType=r["c7n:InstanceAttribute"]["Attribute"]["AttributeType"])
-            )
-
-        self.assertEqual(results[0]["Attribute"]["AttributeType"], "CONTACT_LENS")
-        self.assertEqual(results[0]["Attribute"]["Value"], "true")
+        client = session_factory().client('connect')
         self.assertEqual(len(resources), 1)
+        attr = client.describe_instance_attribute(
+            InstanceId=resources[0]["Id"], AttributeType="CONTACT_LENS")
+        self.assertEqual(attr["Attribute"]["Value"], "true")
 
     def test_connect_set_attributes_false(self):
         session_factory = self.replay_flight_data("test_connect_set_attributes_false")
@@ -88,19 +82,15 @@ class ConnectTest(BaseTest):
             session_factory=session_factory
         )
         resources = p.run()
-        results = []
-        for r in resources:
-            results.append(
-                session_factory().client('connect').describe_instance_attribute(
-                    InstanceId=r["Id"],
-                    AttributeType=r["c7n:InstanceAttribute"]["Attribute"]["AttributeType"])
-            )
-        self.assertEqual(results[0]["Attribute"]["AttributeType"], "CONTACT_LENS")
-        self.assertEqual(results[0]["Attribute"]["Value"], "false")
+        client = session_factory().client('connect')
         self.assertEqual(len(resources), 1)
+        attr = client.describe_instance_attribute(
+            InstanceId=resources[0]["Id"], AttributeType="CONTACT_LENS")
+        self.assertEqual(attr["Attribute"]["Value"], "false")
 
 
 class ConnectCampaignTest(BaseTest):
+
     def test_connect_campaign_query(self):
         session_factory = self.replay_flight_data("test_connect_campaign_query")
         p = self.load_policy(
@@ -116,7 +106,7 @@ class ConnectCampaignTest(BaseTest):
         session_factory = self.replay_flight_data("test_connect_campaign_instance_config_filter")
         p = self.load_policy(
             {
-                "name": "connect-instance-attribute-test",
+                "name": "connect-campaign-instance-config-test",
                 "resource": "connect-campaign",
                 'filters': [
                     {
@@ -133,7 +123,7 @@ class ConnectCampaignTest(BaseTest):
         session_factory = self.replay_flight_data("test_connect_campaign_kms_filter")
         p = self.load_policy(
             {
-                "name": "connect-instance-attribute-test",
+                "name": "connect-campaign-kms-filter-test",
                 "resource": "connect-campaign",
                 'filters': [
                     {
@@ -145,3 +135,20 @@ class ConnectCampaignTest(BaseTest):
             }, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 2)
+
+
+class ConnectAnalyticsAssociationTest(BaseTest):
+
+    def test_connect_analytics_association_cross_account(self):
+        session_factory = self.replay_flight_data(
+            "test_connect_analytics_association_cross_account")
+        p = self.load_policy(
+            {
+                "name": "connect-analytics-cross-account",
+                "resource": "connect-analytics-association",
+                "filters": ['cross-account'],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
Adding a cross-account filter for the connect-analytics-association resource to audit data sharing configurations.

I used 'connect-analytics-association' instead of a 'connect-analytics-dataset' resource because the sharing information (specifically the TargetAccountId) is only available on the association object. The dataset resource type does not contain the necessary data to audit cross-account access.