### PR TITLE
Add delete-images action

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/container_registry.py
+++ b/tools/c7n_azure/c7n_azure/resources/container_registry.py
@@ -1,44 +1,42 @@
-import logging
-from c7n_azure.provider import resources
-from c7n_azure.actions.base import AzureBaseAction
-from c7n_azure.resources.arm import ArmResourceManager
-from c7n.utils import type_schema
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
 
-import subprocess
+import logging
+import subprocess  # nosec B404
 import json
 import re
 import datetime
 
-from c7n_azure.actions.base import AzureBaseAction
-from c7n.utils import type_schema
 from c7n_azure.provider import resources
+from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.resources.arm import ArmResourceManager
+from c7n.utils import type_schema
 
 log = logging.getLogger('custodian.azure.acr')
 
-@resources.register('container-registry')
+
+@resources.register('container-registry', aliases=['containerregistry'])
 class ContainerRegistry(ArmResourceManager):
     """Container Registry Resource
 
     :example:
 
-    Returns all container registry named my-test-container-registry
+    This policy will find all Azure Container Registries with encryption disabled.
 
     .. code-block:: yaml
 
         policies:
-        - name: get-container-registry
-          resource: azure.container-registry
-          filters:
-            - type: value
-              key: name
-              op: eq
-              value: my-test-container-registry
+          - name: acr-encryption-disabled
+            resource: azure.container-registry
+            filters:
+              - type: value
+                key: properties.encryption.status
+                value: 'disabled'
 
     """
 
     class resource_type(ArmResourceManager.resource_type):
-        doc_groups = ['ContainerRegistry']
+        doc_groups = ['Containers']
 
         service = 'azure.mgmt.containerregistry'
         client = 'ContainerRegistryManagementClient'
@@ -47,8 +45,8 @@ class ContainerRegistry(ArmResourceManager):
         default_report_fields = (
             'name',
             'location',
-            'sku.name',
             'resourceGroup',
+            'sku.name',
             'properties.adminUserEnabled'
         )
         id = 'id'
@@ -58,6 +56,56 @@ class ContainerRegistry(ArmResourceManager):
 
 @ContainerRegistry.action_registry.register('delete-images')
 class DeleteImagesAction(AzureBaseAction):
+    """
+    Action to delete old images from an Azure Container Registry, keeping a specified number of
+    recent images based on a timestamp cutoff.
+
+    **Key Features**:
+
+    - Deletes images older than a specified number of days.
+    - Keeps a specified number of most recent images after the cutoff.
+    - Supports filtering by repository name using a regex pattern.
+
+    :param days:
+        Number of days to look back for images to delete. Images older than this will be deleted
+    :type days: int
+
+    :param keep:
+        Number of most recent images to keep after the cutoff date.
+    :type keep: int
+
+    :param match:
+        Regex pattern matching repository names. Only process matching repositories.
+    :type match: str
+
+    **Examples**
+
+     Delete all images older than 30 days, keeping the 5 most recent images in each repository:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: delete-old-acr-images
+            resource: azure.container-registry
+            actions:
+              - type: delete-images
+                days: 30
+                keep: 5
+
+     Delete images older than 30 days from repositories with names that start with "myapp":
+
+    .. code-block:: yaml
+
+        policies:
+          - name: delete-old-acr-images-myapp
+            resource: azure.container-registry
+            actions:
+              - type: delete-images
+                days: 30
+                keep: 0
+                match: '^myapp.*'
+
+    """
     schema = type_schema(
         'delete-images',
         required=['days', 'keep'],
@@ -69,67 +117,82 @@ class DeleteImagesAction(AzureBaseAction):
     )
 
     def process(self, resources):
-      results = []
-      for r in resources:
-          updated = self._process_resource(r)
-          if updated is not None:
-              results.append(updated)
-      return results  # this populates resources.json
+        results = []
+
+        # Since this action is applied to a container registry, we want to reflect what images
+        # were deleted in the registry resource itself.
+        for r in resources:
+            updated = self._process_resource(r)
+            if updated is not None:
+                results.append(updated)
+        return results
 
     def _process_resource(self, registry):
-      days = self.data['days']
-      keep = self.data['keep']
-      pattern = self.data.get('match', '.*')
-      now = datetime.datetime.utcnow()
-      cutoff = now - datetime.timedelta(days=days)
+        days = self.data['days']
+        keep = self.data['keep']
+        pattern = self.data.get('match', '.*')
 
-      name = registry['name']
-      repos = self._az_cli(['acr', 'repository', 'list', '--name', name])
+        # Get the current time and calculate the cutoff time
+        now = datetime.datetime.utcnow()
+        cutoff = now - datetime.timedelta(days=days)
 
-      # only keep first 3 repos for testing
-      if len(repos) > 3:
-          repos = repos[:3]
+        # Get all repositories in the container registry
+        name = registry['name']
+        repos = self._az_cli(['acr', 'repository', 'list', '--name', name])
 
-      deleted = []
-      DELETED_FR = False
-      for repo in repos:
-          if not re.search(pattern, repo):
-              continue
+        deleted = []  # List to store info about deleted images
+        for repo in repos:
+            # Check if the repository name matches the specified pattern
+            if not re.search(pattern, repo):
+                continue
 
-          self.log.info(f"Checking repo: {repo}")
-          manifests = self._az_cli([
-              'acr', 'repository', 'show-manifests',
-              '--name', name, '--repository', repo
-          ])
-          # Sort by timestamp descending
-          manifests.sort(key=lambda m: m['timestamp'], reverse=True)
+            self.log.info(f"Checking repo: {repo}")
 
-          to_delete = []
-          kept = 0
-          for i, m in enumerate(manifests):
-              timestamp_str = m['timestamp']
-              timestamp_str = re.sub(r'\.(\d{6})\d*Z$', r'.\1Z', timestamp_str)
-              timestamp = datetime.datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%S.%fZ")
-              if timestamp < cutoff:
-                  if kept < keep:
-                      kept += 1
-                  else:
-                      to_delete.append(m)
+            # Get all manifests for the repository
+            manifests = self._az_cli([
+                'acr', 'repository', 'show-manifests',
+                '--name', name, '--repository', repo
+            ])
+            # Sort by timestamp descending
+            manifests.sort(key=lambda m: m['timestamp'], reverse=True)
 
-          for image in to_delete:
-              tag = image['tags'][0] if 'tags' in image else image['digest']
-              self.log.debug(f"Deleting image: {repo}:{tag} (timestamp: {image['timestamp']})")
-              self._az_cli([
-                  'acr', 'repository', 'delete',
-                  '--name', name, '--image', f'{repo}@{image['digest']}', '--yes',
-              ], expect_json=False)
-              deleted.append({'repository': repo, 'tag': tag, 'timestamp': image['timestamp']})
-      
-      registry['c7n:deleted-images'] = deleted
+            to_delete = []
+            kept = 0
+            for i, m in enumerate(manifests):
+                # Convert timestamp to datetime object
+                timestamp_str = m['timestamp']
+                timestamp_str = re.sub(r'\.(\d{6})\d*Z$', r'.\1Z', timestamp_str)
+                timestamp = datetime.datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%S.%fZ")
 
-      return registry
-  
+                # Check if the timestamp is older than the cutoff
+                if timestamp < cutoff:
+                    # Keep specified number of images after the cutoff
+                    if kept < keep:
+                        kept += 1
+                    else:
+                        to_delete.append(m)
+
+            for image in to_delete:
+                # Use image tag in debug output, or digest if no tag is available
+                tag = image['tags'][0] if 'tags' in image else image['digest']
+                self.log.debug(f"Deleting image: {repo}:{tag} (timestamp: {image['timestamp']})")
+
+                # Delete the image from the repository
+                self._az_cli([
+                    'acr', 'repository', 'delete',
+                    '--name', name, '--image', f"{repo}@{image['digest']}", '--yes',
+                ], expect_json=False)  # expect_json=False since command does not return JSON output
+
+                # Append deleted image info to the list
+                deleted.append({'repository': repo, 'tag': tag, 'timestamp': image['timestamp']})
+
+        # Update the registry resource with info on deleted images
+        registry['c7n:deleted-images'] = deleted
+
+        return registry
+
     def _az_cli(self, args, expect_json=True):
-      cmd = ['az'] + args + ['--output', 'json'] if expect_json else ['az'] + args
-      result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, text=True)
-      return json.loads(result.stdout) if expect_json else result.stdout
+        cmd = ['az'] + args + ['--output', 'json'] if expect_json else ['az'] + args
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                check=True, text=True)  # nosec B603
+        return json.loads(result.stdout) if expect_json else result.stdout

--- a/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_all_images_before_cutoff.json
+++ b/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_all_images_before_cutoff.json
@@ -1,0 +1,231 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 6A410BB056B04D8DB16EE6844DC56CBF Ref B: YTO221090814035 Ref C: 2025-07-24T01:45:44Z"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:45:43 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "1531"
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 9AA857E00B3148A283D07D23DB5A0959 Ref B: YTO221090811019 Ref C: 2025-07-24T01:45:44Z"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:45:44 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "1531"
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_basic_pattern.json
+++ b/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_basic_pattern.json
@@ -1,0 +1,118 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 51BF4919D67842B9972046CE865F88A4 Ref B: YTO221090813047 Ref C: 2025-07-24T01:54:33Z"
+                    ],
+                    "content-length": [
+                        "1531"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:54:33 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_delete_images_action.json
+++ b/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_delete_images_action.json
@@ -1,0 +1,231 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-length": [
+                        "1531"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:29:03 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 92785F4DF42E43DD9C4BBB1FB3B827A2 Ref B: YTO221090813051 Ref C: 2025-07-24T01:29:03Z"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-length": [
+                        "1531"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:29:03 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: EAA4F1B4AE49482DBF8231460CA0171D Ref B: YTO221090813051 Ref C: 2025-07-24T01:29:03Z"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_images_before_cutoff_keep_one.json
+++ b/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_images_before_cutoff_keep_one.json
@@ -1,0 +1,118 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "1531"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 5BBE089D957E47EB95399B21F5DDD0CB Ref B: YTO221090813017 Ref C: 2025-07-24T01:51:36Z"
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:51:36 GMT"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_images_exactly_at_cutoff.json
+++ b/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_images_exactly_at_cutoff.json
@@ -1,0 +1,118 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:49:55 GMT"
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ],
+                    "content-length": [
+                        "1531"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: A001DBADEC0044698B821BE09B00F640 Ref B: YTO221090814017 Ref C: 2025-07-24T01:49:55Z"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_no_images_before_cutoff.json
+++ b/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_no_images_before_cutoff.json
@@ -1,0 +1,231 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 8A2AA76FC6AF417DB46B632BBA30C2B4 Ref B: YTO221090814019 Ref C: 2025-07-24T01:47:05Z"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:47:05 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "content-length": [
+                        "1531"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 4486354BBBC941C0B88346EB45A6C919 Ref B: YTO221090812009 Ref C: 2025-07-24T01:47:06Z"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:47:05 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "content-length": [
+                        "1531"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_regex_pattern.json
+++ b/tools/c7n_azure/tests_azure/cassettes/ContainerRegistryTest.test_regex_pattern.json
@@ -1,0 +1,118 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.ContainerRegistry/registries?api-version=2025-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "1531"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 0C1DAD57D6F34B4ABE77304D77470FCA Ref B: YTO221090814035 Ref C: 2025-07-24T01:56:50Z"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Thu, 24 Jul 2025 01:56:50 GMT"
+                    ],
+                    "api-supported-versions": [
+                        "2025-04-01"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "sku": {
+                                    "name": "Premium",
+                                    "tier": "Premium"
+                                },
+                                "type": "Microsoft.ContainerRegistry/registries",
+                                "identity": {
+                                    "principalId": "4b718092-46fe-45d5-8fb7-8830184ab04e",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003",
+                                    "type": "systemAssigned"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/rg-npr-infra-devops/providers/Microsoft.ContainerRegistry/registries/nprinfradevopseastus",
+                                "name": "nprinfradevopseastus",
+                                "location": "eastus",
+                                "tags": {},
+                                "systemData": {
+                                    "createdBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "createdByType": "Application",
+                                    "createdAt": "2024-10-31T20:22:23.6397132+00:00",
+                                    "lastModifiedBy": "57def653-a20e-4d19-acd9-2d195afd39c4",
+                                    "lastModifiedByType": "Application",
+                                    "lastModifiedAt": "2025-07-17T18:31:02.2895931+00:00"
+                                },
+                                "properties": {
+                                    "loginServer": "nprinfradevopseastus.azurecr.io",
+                                    "creationDate": "2024-10-31T20:22:23.6397132Z",
+                                    "provisioningState": "Succeeded",
+                                    "adminUserEnabled": true,
+                                    "networkRuleSet": {
+                                        "defaultAction": "Allow",
+                                        "ipRules": []
+                                    },
+                                    "policies": {
+                                        "quarantinePolicy": {
+                                            "status": "disabled"
+                                        },
+                                        "trustPolicy": {
+                                            "type": "Notary",
+                                            "status": "disabled"
+                                        },
+                                        "retentionPolicy": {
+                                            "days": 7,
+                                            "lastUpdatedTime": "2024-10-31T20:22:31.6050959+00:00",
+                                            "status": "disabled"
+                                        },
+                                        "exportPolicy": {
+                                            "status": "enabled"
+                                        },
+                                        "azureADAuthenticationAsArmPolicy": {
+                                            "status": "enabled"
+                                        }
+                                    },
+                                    "encryption": {
+                                        "status": "disabled"
+                                    },
+                                    "dataEndpointEnabled": false,
+                                    "dataEndpointHostNames": [],
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "networkRuleBypassOptions": "AzureServices",
+                                    "zoneRedundancy": "Disabled",
+                                    "anonymousPullEnabled": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/templates/container_registry.json
+++ b/tools/c7n_azure/tests_azure/templates/container_registry.json
@@ -18,7 +18,7 @@
             "tags": {},
             "scale": null,
             "properties": {
-                "adminUserEnabled": false
+                "adminUserEnabled": true
             },
             "dependsOn": []
         }

--- a/tools/c7n_azure/tests_azure/tests_resources/test_container_registry.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_container_registry.py
@@ -1,6 +1,8 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from ..azure_common import BaseTest, arm_template
+import datetime
+from c7n_azure.resources.container_registry import DeleteImagesAction
 
 
 class ContainerRegistryTest(BaseTest):
@@ -11,15 +13,15 @@ class ContainerRegistryTest(BaseTest):
         with self.sign_out_patch():
             p = self.load_policy({
                 'name': 'test-azure-container-registry',
-                'resource': 'azure.containerregistry'
+                'resource': 'azure.container-registry'
             }, validate=True)
             self.assertTrue(p)
 
     @arm_template('container_registry.json')
     def test_find_by_name(self):
         p = self.load_policy({
-            'name': 'test-azure-containerregistry',
-            'resource': 'azure.containerregistry',
+            'name': 'test-azure-container-registry',
+            'resource': 'azure.container-registry',
             'filters': [
                 {'type': 'value',
                  'key': 'name',
@@ -28,3 +30,436 @@ class ContainerRegistryTest(BaseTest):
         })
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    @arm_template('container_registry.json')
+    def test_delete_images_action(self):
+        """
+        Test the delete-images action in the Azure Container Registry given:
+        - One repo
+        - Two images in the repo, one older than the specified days and one newer
+        - No keep parameter
+        - No match pattern
+
+        Expected outcome:
+        - The older image should be deleted
+        - The newer image should remain
+        """
+        DAYS = 30
+
+        p = self.load_policy({
+            'name': 'test-delete-images',
+            'resource': 'azure.container-registry',
+            'actions': [
+                {
+                    'type': 'delete-images',
+                    'days': DAYS,
+                    'keep': 0
+                }
+            ]
+        }, validate=True)
+
+        def mock_az_cli(self, args, expect_json=False):
+            now = datetime.datetime.utcnow()
+            cutoff = now - datetime.timedelta(days=DAYS)
+
+            date1 = cutoff - datetime.timedelta(days=10)  # 10 days before cutoff (deleted)
+            date2 = cutoff + datetime.timedelta(days=5)   # 5 days after cutoff   (not deleted)
+
+            if 'list' in args:
+                return ['repo1']
+            elif 'show-manifests' in args:
+                return [
+                    {
+                        'tags': ['v1'],
+                        'digest': 'sha256:abcd1234',
+                        'timestamp': date2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    },
+                    {
+                        'tags': ['v2'],
+                        'digest': 'sha256:efgh5678',
+                        'timestamp': date1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    }
+                ]
+            else:
+                return {}  # no-op
+
+        DeleteImagesAction._az_cli = mock_az_cli
+
+        resources = p.run()
+
+        deleted = resources[0].get('c7n:deleted-images', [])
+        self.assertEqual(len(deleted), 1)
+        self.assertEqual(deleted[0]['repository'], 'repo1')
+        self.assertEqual(deleted[0]['tag'], 'v2')
+
+    @arm_template('container_registry.json')
+    def test_all_images_before_cutoff(self):
+        """
+        Test the delete-images action in the Azure Container Registry given:
+        - One repo
+        - Two images in the repo, both older than the specified days
+        - No keep parameter
+        - No match pattern
+
+        Expected outcome:
+        - Both images should be deleted
+        - No images should remain
+        """
+        DAYS = 30
+
+        p = self.load_policy({
+            'name': 'test-delete-images',
+            'resource': 'azure.container-registry',
+            'actions': [
+                {
+                    'type': 'delete-images',
+                    'days': DAYS,
+                    'keep': 0
+                }
+            ]
+        }, validate=True)
+
+        def mock_az_cli(self, args, expect_json=False):
+            now = datetime.datetime.utcnow()
+            cutoff = now - datetime.timedelta(days=DAYS)
+
+            date1 = cutoff - datetime.timedelta(days=10)  # 10 days before cutoff (deleted)
+            date2 = cutoff - datetime.timedelta(days=5)   # 5 days before cutoff   (deleted)
+
+            if 'list' in args:
+                return ['repo1']
+            elif 'show-manifests' in args:
+                return [
+                    {
+                        'tags': ['v1'],
+                        'digest': 'sha256:abcd1234',
+                        'timestamp': date2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    },
+                    {
+                        'tags': ['v2'],
+                        'digest': 'sha256:efgh5678',
+                        'timestamp': date1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    }
+                ]
+            else:
+                return {}  # no-op
+
+        DeleteImagesAction._az_cli = mock_az_cli
+
+        resources = p.run()
+
+        deleted = resources[0].get('c7n:deleted-images', [])
+        self.assertEqual(len(deleted), 2)
+        self.assertEqual(deleted[0]['repository'], 'repo1')
+        self.assertEqual(deleted[0]['tag'], 'v1')
+        self.assertEqual(deleted[1]['repository'], 'repo1')
+        self.assertEqual(deleted[1]['tag'], 'v2')
+
+    @arm_template('container_registry.json')
+    def test_no_images_before_cutoff(self):
+        """
+        Test the delete-images action in the Azure Container Registry given:
+        - One repo
+        - Two images in the repo, both newer than the specified days
+        - No keep parameter
+        - No match pattern
+
+        Expected outcome:
+        - No images should be deleted
+        - Both images should remain
+        """
+        DAYS = 30
+
+        p = self.load_policy({
+            'name': 'test-delete-images',
+            'resource': 'azure.container-registry',
+            'actions': [
+                {
+                    'type': 'delete-images',
+                    'days': DAYS,
+                    'keep': 0
+                }
+            ]
+        }, validate=True)
+
+        def mock_az_cli(self, args, expect_json=False):
+            now = datetime.datetime.utcnow()
+            cutoff = now - datetime.timedelta(days=DAYS)
+
+            date1 = cutoff + datetime.timedelta(days=10)  # 10 days after cutoff (not deleted)
+            date2 = cutoff + datetime.timedelta(days=5)   # 5 days after cutoff   (not deleted)
+
+            if 'list' in args:
+                return ['repo1']
+            elif 'show-manifests' in args:
+                return [
+                    {
+                        'tags': ['v1'],
+                        'digest': 'sha256:abcd1234',
+                        'timestamp': date2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    },
+                    {
+                        'tags': ['v2'],
+                        'digest': 'sha256:efgh5678',
+                        'timestamp': date1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    }
+                ]
+            else:
+                return {}  # no-op
+
+        DeleteImagesAction._az_cli = mock_az_cli
+
+        resources = p.run()
+
+        deleted = resources[0].get('c7n:deleted-images', [])
+        self.assertEqual(len(deleted), 0)
+
+    @arm_template('container_registry.json')
+    def test_images_exactly_at_cutoff(self):
+        """
+        Test the delete-images action in the Azure Container Registry given:
+        - One repo
+        - Two images in the repo, one newer than the specified days, one exactly at the cutoff
+        - No keep parameter
+        - No match pattern
+
+        Expected outcome:
+        - The image at the cutoff should not be deleted
+        - The newer image should also remain
+        """
+        DAYS = 30
+
+        p = self.load_policy({
+            'name': 'test-delete-images',
+            'resource': 'azure.container-registry',
+            'actions': [
+                {
+                    'type': 'delete-images',
+                    'days': DAYS,
+                    'keep': 0
+                }
+            ]
+        }, validate=True)
+
+        def mock_az_cli(self, args, expect_json=False):
+            now = datetime.datetime.utcnow()
+            cutoff = now - datetime.timedelta(days=DAYS)
+
+            date1 = cutoff  # Exactly at cutoff (not deleted)
+            date2 = cutoff + datetime.timedelta(days=5)   # 5 days after cutoff   (not deleted)
+
+            if 'list' in args:
+                return ['repo1']
+            elif 'show-manifests' in args:
+                return [
+                    {
+                        'tags': ['v1'],
+                        'digest': 'sha256:abcd1234',
+                        'timestamp': date2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    },
+                    {
+                        'tags': ['v2'],
+                        'digest': 'sha256:efgh5678',
+                        'timestamp': date1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    }
+                ]
+            else:
+                return {}  # no-op
+
+        DeleteImagesAction._az_cli = mock_az_cli
+
+        resources = p.run()
+
+        deleted = resources[0].get('c7n:deleted-images', [])
+        self.assertEqual(len(deleted), 0)
+
+    @arm_template('container_registry.json')
+    def test_images_before_cutoff_keep_one(self):
+        """
+        Test the delete-images action in the Azure Container Registry given:
+        - One repo
+        - Two images in the repo, both before the cutoff date
+        - Keep parameter set to 1
+        - No match pattern
+
+        Expected outcome:
+        - One image should be deleted
+        - One image should remain due to the keep parameter
+        """
+        DAYS = 30
+
+        p = self.load_policy({
+            'name': 'test-delete-images',
+            'resource': 'azure.container-registry',
+            'actions': [
+                {
+                    'type': 'delete-images',
+                    'days': DAYS,
+                    'keep': 1
+                }
+            ]
+        }, validate=True)
+
+        def mock_az_cli(self, args, expect_json=False):
+            now = datetime.datetime.utcnow()
+            cutoff = now - datetime.timedelta(days=DAYS)
+
+            date1 = cutoff - datetime.timedelta(days=10)  # 10 days before cutoff (deleted)
+            date2 = cutoff - datetime.timedelta(days=5)   # 5 days before cutoff   (not deleted)
+
+            if 'list' in args:
+                return ['repo1']
+            elif 'show-manifests' in args:
+                return [
+                    {
+                        'tags': ['v1'],
+                        'digest': 'sha256:abcd1234',
+                        'timestamp': date2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    },
+                    {
+                        'tags': ['v2'],
+                        'digest': 'sha256:efgh5678',
+                        'timestamp': date1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    }
+                ]
+            else:
+                return {}  # no-op
+
+        DeleteImagesAction._az_cli = mock_az_cli
+
+        resources = p.run()
+
+        deleted = resources[0].get('c7n:deleted-images', [])
+        self.assertEqual(len(deleted), 1)
+        self.assertEqual(deleted[0]['repository'], 'repo1')
+        self.assertEqual(deleted[0]['tag'], 'v2')
+
+    @arm_template('container_registry.json')
+    def test_basic_pattern(self):
+        """
+        Test the delete-images action in the Azure Container Registry given:
+        - Two repos, one matching the pattern and one not
+        - Two images in each repo, both before the cutoff date
+        - No keep parameter
+        - No match pattern
+
+        Expected outcome:
+        - Only two images should be deleted overall, since one repo does not match the pattern
+        """
+        DAYS = 30
+
+        p = self.load_policy({
+            'name': 'test-delete-images',
+            'resource': 'azure.container-registry',
+            'actions': [
+                {
+                    'type': 'delete-images',
+                    'days': DAYS,
+                    'keep': 0,
+                    'match': 'repo1'
+                }
+            ]
+        }, validate=True)
+
+        def mock_az_cli(self, args, expect_json=False):
+            now = datetime.datetime.utcnow()
+            cutoff = now - datetime.timedelta(days=DAYS)
+
+            date1 = cutoff - datetime.timedelta(days=10)  # 10 days before cutoff
+            date2 = cutoff - datetime.timedelta(days=5)   # 5 days before cutoff
+
+            if 'list' in args:
+                return ['repo1', 'repo2']
+            elif 'show-manifests' in args:
+                return [
+                    {
+                        'tags': ['v1'],
+                        'digest': 'sha256:abcd1234',
+                        'timestamp': date2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    },
+                    {
+                        'tags': ['v2'],
+                        'digest': 'sha256:efgh5678',
+                        'timestamp': date1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    }
+                ]
+            else:
+                return {}  # no-op
+
+        DeleteImagesAction._az_cli = mock_az_cli
+
+        resources = p.run()
+
+        deleted = resources[0].get('c7n:deleted-images', [])
+        self.assertEqual(len(deleted), 2)
+        self.assertEqual(deleted[0]['repository'], 'repo1')
+        self.assertEqual(deleted[0]['tag'], 'v1')
+        self.assertEqual(deleted[1]['repository'], 'repo1')
+        self.assertEqual(deleted[1]['tag'], 'v2')
+
+    @arm_template('container_registry.json')
+    def test_regex_pattern(self):
+        """
+        Test the delete-images action in the Azure Container Registry given:
+        - Three repos, two matching the regex pattern and one not
+        - Two images in each repo, both before the cutoff date
+        - No keep parameter
+        - No match pattern
+
+        Expected outcome:
+        - Only four images should be deleted overall, since one repo does not match the pattern
+        """
+        DAYS = 30
+
+        p = self.load_policy({
+            'name': 'test-delete-images',
+            'resource': 'azure.container-registry',
+            'actions': [
+                {
+                    'type': 'delete-images',
+                    'days': DAYS,
+                    'keep': 0,
+                    'match': 'test-.*'
+                }
+            ]
+        }, validate=True)
+
+        def mock_az_cli(self, args, expect_json=False):
+            now = datetime.datetime.utcnow()
+            cutoff = now - datetime.timedelta(days=DAYS)
+
+            date1 = cutoff - datetime.timedelta(days=10)  # 10 days before cutoff
+            date2 = cutoff - datetime.timedelta(days=5)   # 5 days before cutoff
+
+            if 'list' in args:
+                return ['test-repo1', 'test-repo2', 'other-repo']
+            elif 'show-manifests' in args:
+                return [
+                    {
+                        'tags': ['v1'],
+                        'digest': 'sha256:abcd1234',
+                        'timestamp': date2.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    },
+                    {
+                        'tags': ['v2'],
+                        'digest': 'sha256:efgh5678',
+                        'timestamp': date1.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                    }
+                ]
+            else:
+                return {}  # no-op
+
+        DeleteImagesAction._az_cli = mock_az_cli
+
+        resources = p.run()
+
+        deleted = resources[0].get('c7n:deleted-images', [])
+        self.assertEqual(len(deleted), 4)
+        self.assertEqual(deleted[0]['repository'], 'test-repo1')
+        self.assertEqual(deleted[0]['tag'], 'v1')
+        self.assertEqual(deleted[1]['repository'], 'test-repo1')
+        self.assertEqual(deleted[1]['tag'], 'v2')
+        self.assertEqual(deleted[2]['repository'], 'test-repo2')
+        self.assertEqual(deleted[2]['tag'], 'v1')
+        self.assertEqual(deleted[3]['repository'], 'test-repo2')
+        self.assertEqual(deleted[3]['tag'], 'v2')


### PR DESCRIPTION
### Summary

Allow for deleting images based on user controlled image-lifecycle rules with new `delete-images` action on the `azure.container-registry` resource. This allows users to delete images older than certain amount days, keep the next N images, and filter what repositories to run this on using regex.

---

### Example Policy Enabled by This Change

```yaml
policies:
  - name: cleanup-old-dev-acr-images
    resource: azure.container-registry
    actions:
      - type: delete-images
        days: 60          # Minimum age threshold
        keep: 10          # Retain 10 most recent images
        match: "^test-.*"   # (Optional) Match repository prefix 'test-'
```

This policy retains all images from last 60 days, keeps the next 10, then deletes the rest for all repositories with prefix `test-`

---

### Testing

* Verified behavior using live ACRs in Azure
* Confirmed correct detection and filtering of image timestamps
* Added comprehensive unit tests covering:
  * Images before/after cutoff
  * Exact edge conditions
  * Keep count behavior
  * Tag pattern filtering (string and regex)
  * No-match and multi-repo scenarios

---