### PR TITLE
Add python3.13 runtime, remove 3.8 and 3.9

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -392,8 +392,8 @@ class LambdaMode(ServerlessExecutionMode):
             # Lambda passthrough config
             'layers': {'type': 'array', 'items': {'type': 'string'}},
             'concurrency': {'type': 'integer'},
-            'runtime': {'enum': ['python3.8', 'python3.9', 'python3.10',
-                                 'python3.11', 'python3.12']},
+            'runtime': {'enum': ['python3.10', 'python3.11', 'python3.12',
+                                 'python3.13']},
             'role': {'type': 'string'},
             'handler': {'type': 'string'},
             'pattern': {'type': 'object', 'minProperties': 1},

--- a/tests/data/placebo/test_updated_lambda_architecture/lambda.GetFunctionConfiguration_1.json
+++ b/tests/data/placebo/test_updated_lambda_architecture/lambda.GetFunctionConfiguration_1.json
@@ -4,7 +4,7 @@
         "ResponseMetadata": {},
         "FunctionName": "custodian-ec2-foo-bar",
         "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-ec2-foo-bar",
-        "Runtime": "python3.9",
+        "Runtime": "python3.12",
         "Role": "arn:aws:iam::644160558196:role/custodian-mu",
         "Handler": "custodian_policy.run",
         "CodeSize": 530080,

--- a/tests/data/placebo/test_updated_lambda_architecture/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_updated_lambda_architecture/lambda.GetFunction_1.json
@@ -5,7 +5,7 @@
         "Configuration": {
             "FunctionName": "custodian-ec2-foo-bar",
             "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-ec2-foo-bar",
-            "Runtime": "python3.9",
+            "Runtime": "python3.12",
             "Role": "arn:aws:iam::644160558196:role/custodian-mu",
             "Handler": "custodian_policy.run",
             "CodeSize": 530080,

--- a/tests/data/placebo/test_updated_lambda_architecture/lambda.GetFunction_2.json
+++ b/tests/data/placebo/test_updated_lambda_architecture/lambda.GetFunction_2.json
@@ -5,7 +5,7 @@
         "Configuration": {
             "FunctionName": "custodian-ec2-foo-bar",
             "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-ec2-foo-bar",
-            "Runtime": "python3.9",
+            "Runtime": "python3.12",
             "Role": "arn:aws:iam::644160558196:role/custodian-mu",
             "Handler": "custodian_policy.run",
             "CodeSize": 530080,

--- a/tests/data/placebo/test_updated_lambda_architecture/lambda.UpdateFunctionCode_1.json
+++ b/tests/data/placebo/test_updated_lambda_architecture/lambda.UpdateFunctionCode_1.json
@@ -4,7 +4,7 @@
         "ResponseMetadata": {},
         "FunctionName": "custodian-ec2-foo-bar",
         "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:custodian-ec2-foo-bar:110",
-        "Runtime": "python3.9",
+        "Runtime": "python3.12",
         "Role": "arn:aws:iam::644160558196:role/custodian-mu",
         "Handler": "custodian_policy.run",
         "CodeSize": 530080,

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -152,7 +152,7 @@ class PolicyLambdaProvision(Publish):
                 'mode': {
                     'type': 'cloudtrail',
                     'role': 'arn:aws:iam::644160558196:role/custodian-mu',
-                    'runtime': 'python3.9',
+                    'runtime': 'python3.12',
                     'events': ['RunInstances']}})
             pl1 = PolicyLambda(p1)
             mgr = LambdaManager(session_factory)


### PR DESCRIPTION
Add python3.13 and remove 3.8 and 3.9 as they're no longer supported.