### PR TITLE
gcp - fix for getting resource id instead of name when the metrics key is resourece.labels.instance_id

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/filters/metrics.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/metrics.py
@@ -157,6 +157,8 @@ class GCPMetricsFilter(Filter):
         batch_size = len(self.filter)
         for r in resources:
             resource_name = self.manager.resource_type.get_metric_resource_name(r)
+            if self.metric_key == 'resource.labels.instance_id':
+                resource_name = self.manager.resource_type.get_metric_resource_id(r)
             resource_filter_item = '{} = "{}"'.format(self.metric_key, resource_name)
             resource_filter.append(resource_filter_item)
             resource_filter.append(' OR ')
@@ -169,6 +171,7 @@ class GCPMetricsFilter(Filter):
 
         resource_filter.pop()
         batched_resources.append(resource_filter)
+
         return batched_resources
 
     def get_batched_query_filter(self, resources):
@@ -195,6 +198,8 @@ class GCPMetricsFilter(Filter):
     def process_resource(self, resource):
         resource_metric = resource.setdefault('c7n.metrics', {})
         resource_name = self.manager.resource_type.get_metric_resource_name(resource)
+        if self.metric_key == 'resource.labels.instance_id':
+            resource_name = self.manager.resource_type.get_metric_resource_id(resource)
         metric = self.resource_metric_dict.get(resource_name)
         if not metric and not self.missing_value:
             return False

--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -416,6 +416,10 @@ class TypeInfo(metaclass=TypeMeta):
         return resource.get(cls.name)
 
     @classmethod
+    def get_metric_resource_id(cls, resource):
+        return resource['id']
+
+    @classmethod
     def get_urns(cls, resources, project_id):
         """Generate URNs for the resources.
 


### PR DESCRIPTION
This PR is for this issue [https://github.com/orgs/cloud-custodian/discussions/9280](https://github.com/orgs/cloud-custodian/discussions/9280).

