### PR TITLE
Add GOVERNANCE.md to document project governance structure 

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -76,8 +76,3 @@ Cloud Custodian follows the CNCF Code of Conduct, which is published in `CODE_OF
 - `GOVERNANCE.md` (this document)  
 - `OWNERS.md` (area and core maintainers list)  
 - `CODE_OF_CONDUCT.md` (CNCF Code of Conduct link)
-
-
-
-
-


### PR DESCRIPTION
Requesting to create this file to document the governance framework for Cloud Custodian based on discussions with maintainers