### PR TITLE
aws - enable FSx metrics filter for all file system types (#10319)

### DIFF
--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -114,6 +114,7 @@ class MetricsFilter(Filter):
         'es': 'AWS/ES',
         'events': 'AWS/Events',
         'firehose': 'AWS/Firehose',
+        'fsx': 'AWS/FSx',
         'kinesis': 'AWS/Kinesis',
         'lambda': 'AWS/Lambda',
         'logs': 'AWS/Logs',

--- a/c7n/resources/fsx.py
+++ b/c7n/resources/fsx.py
@@ -11,7 +11,7 @@ from c7n.query import (
 from c7n.actions import BaseAction
 from c7n.tags import Tag, TagDelayedAction, RemoveTag, coalesce_copy_user_tags, TagActionFilter
 from c7n.utils import type_schema, local_session, chunks, group_by
-from c7n.filters import Filter, ListItemFilter
+from c7n.filters import Filter, ListItemFilter, MetricsFilter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.filters.vpc import SubnetFilter, VpcFilter
 from c7n.filters.backup import ConsecutiveAwsBackupsFilter
@@ -40,6 +40,7 @@ class FSx(QueryResourceManager):
         date = 'CreationTime'
         cfn_type = 'AWS::FSx::FileSystem'
         id_prefix = 'fs-'
+        dimension = 'FileSystemId'
 
     source_mapping = {
         'describe': DescribeFSx
@@ -157,6 +158,7 @@ class DeleteBackup(BaseAction):
 FSxBackup.filter_registry.register('marked-for-op', TagActionFilter)
 
 FSx.filter_registry.register('marked-for-op', TagActionFilter)
+FSx.filter_registry.register('metrics', MetricsFilter)
 
 
 @FSxBackup.action_registry.register('mark-for-op')

--- a/docs/source/aws/examples/fsxmetricsmonitoring.rst
+++ b/docs/source/aws/examples/fsxmetricsmonitoring.rst
@@ -1,0 +1,23 @@
+Filtering FSx based on CloudWatch metrics 
+=========================================
+
+Find FSx file systems with high CPU utilization
+-----------------------------------------------
+
+Retrieve FSx file systems that have sustained high CPU utilization over the last 7 days:
+
+.. code-block:: yaml
+
+    policies:
+      - name: fsx-high-cpu-utilization
+        resource: fsx
+        description: |
+          Find FSx file systems with sustained high CPU utilization
+          over the last 7 days
+        filters:
+        - type: metrics
+            name: CPUUtilization
+            value: 80
+            op: gte
+            days: 7
+            statistics: Average

--- a/tests/data/placebo/test_fsx_metrics_filter/fsx.DescribeFileSystems_1.json
+++ b/tests/data/placebo/test_fsx_metrics_filter/fsx.DescribeFileSystems_1.json
@@ -1,0 +1,141 @@
+{
+    "status_code": 200,
+    "data": {
+        "FileSystems": [
+            {
+                "OwnerId": "123456789012",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 12,
+                    "day": 19,
+                    "hour": 3,
+                    "minute": 1,
+                    "second": 5,
+                    "microsecond": 75000
+                },
+                "FileSystemId": "fs-01234567890abcdef",
+                "FileSystemType": "ONTAP",
+                "Lifecycle": "AVAILABLE",
+                "StorageCapacity": 1024,
+                "StorageType": "SSD",
+                "VpcId": "vpc-12345678",
+                "SubnetIds": [
+                    "subnet-12345678"
+                ],
+                "NetworkInterfaceIds": [
+                    "eni-1234567890abcdef",
+                    "eni-1234567890abcdef"
+                ],
+                "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+                "ResourceARN": "arn:aws:fsx:us-east-1:123456789012:file-system/fs-01234567890abcdef",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "test-filesystem"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "test"
+                    }
+                ],
+                "OntapConfiguration": {
+                    "DeploymentType": "SINGLE_AZ_1",
+                    "Endpoints": {
+                        "Intercluster": {
+                            "DNSName": "intercluster.fs-01234567890abcdef.fsx.us-east-1.amazonaws.com",
+                            "IpAddresses": [
+                                "10.0.1.100",
+                                "10.0.1.101"
+                            ]
+                        },
+                        "Management": {
+                            "DNSName": "management.fs-01234567890abcdef.fsx.us-east-1.amazonaws.com",
+                            "IpAddresses": [
+                                "10.0.1.102"
+                            ]
+                        }
+                    },
+                    "DiskIopsConfiguration": {
+                        "Mode": "AUTOMATIC",
+                        "Iops": 3072
+                    },
+                    "PreferredSubnetId": "subnet-12345678",
+                    "ThroughputCapacity": 128,
+                    "WeeklyMaintenanceStartTime": "2:04:30",
+                    "HAPairs": 1,
+                    "ThroughputCapacityPerHAPair": 128
+                }
+            },
+            {
+                "OwnerId": "123456789012",
+                "CreationTime": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 4,
+                    "day": 14,
+                    "hour": 9,
+                    "minute": 14,
+                    "second": 51,
+                    "microsecond": 360000
+                },
+                "FileSystemId": "fs-0fedcba9876543210",
+                "FileSystemType": "WINDOWS",
+                "Lifecycle": "AVAILABLE",
+                "StorageCapacity": 32,
+                "StorageType": "SSD",
+                "VpcId": "vpc-87654321",
+                "SubnetIds": [
+                    "subnet-87654321",
+                    "subnet-87654322"
+                ],
+                "NetworkInterfaceIds": [
+                    "eni-1234567890abcdef",
+                    "eni-1234567890abcdef"
+                ],
+                "DNSName": "amznfsxtest.test.local",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+                "ResourceARN": "arn:aws:fsx:us-east-1:123456789012:file-system/fs-0fedcba9876543210",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "test-windows-filesystem"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "test"
+                    }
+                ],
+                "WindowsConfiguration": {
+                    "SelfManagedActiveDirectoryConfiguration": {
+                        "DomainName": "test.local",
+                        "OrganizationalUnitDistinguishedName": "OU=test,DC=test,DC=local",
+                        "FileSystemAdministratorsGroup": "Domain Admins",
+                        "UserName": "testuser",
+                        "DnsIps": [
+                            "10.0.1.200",
+                            "10.0.1.201"
+                        ]
+                    },
+                    "DeploymentType": "MULTI_AZ_1",
+                    "RemoteAdministrationEndpoint": "amznfsxtest.test.local",                        "PreferredSubnetId": "subnet-87654321",
+                    "PreferredFileServerIp": "10.0.1.110",
+                    "ThroughputCapacity": 8,
+                    "WeeklyMaintenanceStartTime": "5:04:30",
+                    "DailyAutomaticBackupStartTime": "10:30",
+                    "AutomaticBackupRetentionDays": 7,
+                    "CopyTagsToBackups": false,
+                    "AuditLogConfiguration": {
+                        "FileAccessAuditLogLevel": "DISABLED",
+                        "FileShareAccessAuditLogLevel": "DISABLED"
+                    },
+                    "DiskIopsConfiguration": {
+                        "Mode": "AUTOMATIC",
+                        "Iops": 96
+                    }
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_fsx_metrics_filter/monitoring.GetMetricStatistics_1.json
+++ b/tests/data/placebo/test_fsx_metrics_filter/monitoring.GetMetricStatistics_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "CPUUtilization",
+        "Datapoints": [
+            {
+                "Timestamp": {
+                    "__class__": "datetime",
+                    "year": 2025,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 22,
+                    "minute": 28,
+                    "second": 0,
+                    "microsecond": 0
+                },
+                "Average": 4.95065478912658,
+                "Unit": "Percent"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_fsx_metrics_filter/monitoring.GetMetricStatistics_2.json
+++ b/tests/data/placebo/test_fsx_metrics_filter/monitoring.GetMetricStatistics_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "CPUUtilization",
+        "Datapoints": [
+            {
+                "Timestamp": {
+                    "__class__": "datetime",
+                    "year": 2025,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 22,
+                    "minute": 28,
+                    "second": 0,
+                    "microsecond": 0
+                },
+                "Average": 6.258722903806756,
+                "Unit": "Percent"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_fsx.py
+++ b/tests/test_fsx.py
@@ -494,6 +494,28 @@ class TestFSx(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(len(resources[0]['c7n:matched-vpcs']), 1)
 
+    def test_fsx_metrics_filter(self):
+        session_factory = self.replay_flight_data('test_fsx_metrics_filter')
+        p = self.load_policy(
+            {
+                'name': 'test-fsx-metrics',
+                'resource': 'fsx',
+                'filters': [
+                    {
+                        'type': 'metrics',
+                        'name': 'CPUUtilization',
+                        'value': 0,
+                        'op': 'gt',
+                        'days': 7,
+                        'statistics': 'Average'
+                    }
+                ]
+            },
+            session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
 
 class TestFSxVolume(BaseTest):
     def test_fsx_volume_query(self):


### PR DESCRIPTION
## Summary

Fixes #10319

This PR enables the `metrics` filter for AWS FSx file systems across all supported types (Windows, Lustre, NetApp ONTAP, and OpenZFS).

## Problem

Previously, the FSx resource lacked support for metrics filter.

## Solution

- Added `dimension = 'FileSystemId'` to FSx TypeInfo in `c7n/resources/fsx.py`
- Registered `MetricsFilter` for FSx resource
- Added `'fsx': 'AWS/FSx'` to `DEFAULT_NAMESPACE` in `c7n/filters/metrics.py`

All FSx file system types use the same CloudWatch dimension (`FileSystemId`), making this a simple, consistent implementation.

## Testing

- Added test `test_fsx_metrics_filter` with flight recording data
- Test covers multiple FSx types (ONTAP and Windows)
- All existing FSx tests continue to pass (25/25)
- No regressions in metrics filter functionality

## Example Usage

```yaml
policies:
  - name: high-cpu-fsx-filesystems
    resource: fsx
    filters:
      - type: metrics
        name: CPUUtilization
        statistics: Average
        value: 80
        op: greater-than
        period: 300