### PR TITLE
aws - cloudfront - update the logic for set-attribute

### DIFF
--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -846,6 +846,7 @@ class DistributionUpdateAction(BaseUpdateAction):
 
     def process_distribution(self, client, distribution):
         try:
+
             res = client.get_distribution_config(
                 Id=distribution[self.manager.get_model().id])
             default_config = self.validation_config
@@ -853,7 +854,7 @@ class DistributionUpdateAction(BaseUpdateAction):
 
             # Recursively merge config to allow piecemeal updates of
             # nested structures
-            updatedConfig = merge_dict(config, self.data['attributes'])
+            updatedConfig = merge_dict(self.data['attributes'], config)
             if config == updatedConfig:
                 return
             res = client.update_distribution(

--- a/tests/data/placebo/test_distribution_update_distribution/cloudfront.GetDistributionConfig_1.json
+++ b/tests/data/placebo/test_distribution_update_distribution/cloudfront.GetDistributionConfig_1.json
@@ -2,17 +2,196 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "ETag": "ETAPGKTC9B1VZ",
+        "ETag": "E28BR0TLVGB7OT",
         "DistributionConfig": {
-            "CallerReference": "6441605581961",
+            "CallerReference": "1371ecb7-664d-44f8-9eb4-3ffd904561b9",
+            "Aliases": {
+                "Quantity": 0
+            },
+            "DefaultRootObject": "",
+            "Origins": {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "Id": "c7n-test-bucket.s3.us-east-1",
+                        "DomainName": "c7n-test-bucket.s3.us-east-1.amazonaws.com",
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "ConnectionAttempts": 3,
+                        "ConnectionTimeout": 10,
+                        "OriginShield": {
+                            "Enabled": false
+                        },
+                        "OriginAccessControlId": ""
+                    }
+                ]
+            },
+            "OriginGroups": {
+                "Quantity": 0
+            },
+            "DefaultCacheBehavior": {
+                "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "TrustedKeyGroups": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "ViewerProtocolPolicy": "allow-all",
+                "AllowedMethods": {
+                    "Quantity": 2,
+                    "Items": [
+                        "HEAD",
+                        "GET"
+                    ],
+                    "CachedMethods": {
+                        "Quantity": 2,
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ]
+                    }
+                },
+                "SmoothStreaming": false,
+                "Compress": true,
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FieldLevelEncryptionId": "",
+                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+            },
+            "CacheBehaviors": {
+                "Quantity": 2,
+                "Items": [
+                    {
+                        "PathPattern": "/beta/hello",
+                        "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 1,
+                            "Items": [
+                                {
+                                    "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:c7n-lambda-edge-new:1",
+                                    "EventType": "origin-request",
+                                    "IncludeBody": false
+                                }
+                            ]
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    },
+                    {
+                        "PathPattern": "/beta/world",
+                        "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 1,
+                            "Items": [
+                                {
+                                    "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:test-lambda-edge:4",
+                                    "EventType": "viewer-response",
+                                    "IncludeBody": false
+                                }
+                            ]
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    }
+                ]
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
             "Comment": "",
-            "Enabled": true,
             "Logging": {
                 "Enabled": false,
                 "IncludeCookies": false,
                 "Bucket": "",
                 "Prefix": ""
-            }
+            },
+            "PriceClass": "PriceClass_All",
+            "Enabled": true,
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": true,
+                "SSLSupportMethod": "vip",
+                "MinimumProtocolVersion": "TLSv1",
+                "CertificateSource": "cloudfront"
+            },
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "none",
+                    "Quantity": 0
+                }
+            },
+            "WebACLId": "",
+            "HttpVersion": "http2",
+            "IsIPV6Enabled": true,
+            "ContinuousDeploymentPolicyId": "",
+            "Staging": false
         }
     }
 }

--- a/tests/data/placebo/test_distribution_update_distribution/cloudfront.GetDistributionConfig_2.json
+++ b/tests/data/placebo/test_distribution_update_distribution/cloudfront.GetDistributionConfig_2.json
@@ -2,17 +2,196 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "ETag": "ETAPGKTC9B1VZ",
+        "ETag": "E28BR0TLVGB7OT",
         "DistributionConfig": {
-            "CallerReference": "6441605581961",
+            "CallerReference": "1371ecb7-664d-44f8-9eb4-3ffd904561b9",
+            "Aliases": {
+                "Quantity": 0
+            },
+            "DefaultRootObject": "",
+            "Origins": {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "Id": "c7n-test-bucket.s3.us-east-1",
+                        "DomainName": "c7n-test-bucket.s3.us-east-1.amazonaws.com",
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "ConnectionAttempts": 3,
+                        "ConnectionTimeout": 10,
+                        "OriginShield": {
+                            "Enabled": false
+                        },
+                        "OriginAccessControlId": ""
+                    }
+                ]
+            },
+            "OriginGroups": {
+                "Quantity": 0
+            },
+            "DefaultCacheBehavior": {
+                "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "TrustedKeyGroups": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "ViewerProtocolPolicy": "allow-all",
+                "AllowedMethods": {
+                    "Quantity": 2,
+                    "Items": [
+                        "HEAD",
+                        "GET"
+                    ],
+                    "CachedMethods": {
+                        "Quantity": 2,
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ]
+                    }
+                },
+                "SmoothStreaming": false,
+                "Compress": true,
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FieldLevelEncryptionId": "",
+                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+            },
+            "CacheBehaviors": {
+                "Quantity": 2,
+                "Items": [
+                    {
+                        "PathPattern": "/beta/hello",
+                        "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 1,
+                            "Items": [
+                                {
+                                    "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:c7n-lambda-edge-new:1",
+                                    "EventType": "origin-request",
+                                    "IncludeBody": false
+                                }
+                            ]
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    },
+                    {
+                        "PathPattern": "/beta/world",
+                        "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 1,
+                            "Items": [
+                                {
+                                    "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:test-lambda-edge:4",
+                                    "EventType": "viewer-response",
+                                    "IncludeBody": false
+                                }
+                            ]
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    }
+                ]
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
             "Comment": "",
-            "Enabled": true,
             "Logging": {
                 "Enabled": false,
                 "IncludeCookies": false,
                 "Bucket": "",
                 "Prefix": ""
-            }
+            },
+            "PriceClass": "PriceClass_All",
+            "Enabled": true,
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": true,
+                "SSLSupportMethod": "vip",
+                "MinimumProtocolVersion": "TLSv1",
+                "CertificateSource": "cloudfront"
+            },
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "none",
+                    "Quantity": 0
+                }
+            },
+            "WebACLId": "",
+            "HttpVersion": "http2",
+            "IsIPV6Enabled": true,
+            "ContinuousDeploymentPolicyId": "",
+            "Staging": false
         }
     }
 }

--- a/tests/data/placebo/test_distribution_update_distribution/cloudfront.GetDistributionConfig_3.json
+++ b/tests/data/placebo/test_distribution_update_distribution/cloudfront.GetDistributionConfig_3.json
@@ -2,17 +2,196 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "ETag": "E3SPE6T0EJSAA4",
+        "ETag": "E1JT4ZIQEVTVWF",
         "DistributionConfig": {
-            "CallerReference": "6441605581961",
+            "CallerReference": "1371ecb7-664d-44f8-9eb4-3ffd904561b9",
+            "Aliases": {
+                "Quantity": 0
+            },
+            "DefaultRootObject": "",
+            "Origins": {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "Id": "c7n-test-bucket.s3.us-east-1",
+                        "DomainName": "c7n-test-bucket.s3.us-east-1.amazonaws.com",
+                        "OriginPath": "",
+                        "CustomHeaders": {
+                            "Quantity": 0
+                        },
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": ""
+                        },
+                        "ConnectionAttempts": 3,
+                        "ConnectionTimeout": 10,
+                        "OriginShield": {
+                            "Enabled": false
+                        },
+                        "OriginAccessControlId": ""
+                    }
+                ]
+            },
+            "OriginGroups": {
+                "Quantity": 0
+            },
+            "DefaultCacheBehavior": {
+                "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                "TrustedSigners": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "TrustedKeyGroups": {
+                    "Enabled": false,
+                    "Quantity": 0
+                },
+                "ViewerProtocolPolicy": "allow-all",
+                "AllowedMethods": {
+                    "Quantity": 2,
+                    "Items": [
+                        "HEAD",
+                        "GET"
+                    ],
+                    "CachedMethods": {
+                        "Quantity": 2,
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ]
+                    }
+                },
+                "SmoothStreaming": false,
+                "Compress": true,
+                "LambdaFunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FunctionAssociations": {
+                    "Quantity": 0
+                },
+                "FieldLevelEncryptionId": "",
+                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+            },
+            "CacheBehaviors": {
+                "Quantity": 2,
+                "Items": [
+                    {
+                        "PathPattern": "/beta/hello",
+                        "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 1,
+                            "Items": [
+                                {
+                                    "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:c7n-lambda-edge-new:1",
+                                    "EventType": "origin-request",
+                                    "IncludeBody": false
+                                }
+                            ]
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    },
+                    {
+                        "PathPattern": "/beta/world",
+                        "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 1,
+                            "Items": [
+                                {
+                                    "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:test-lambda-edge:4",
+                                    "EventType": "viewer-response",
+                                    "IncludeBody": false
+                                }
+                            ]
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    }
+                ]
+            },
+            "CustomErrorResponses": {
+                "Quantity": 0
+            },
             "Comment": "",
-            "Enabled": true,
             "Logging": {
                 "Enabled": true,
                 "IncludeCookies": false,
-                "Bucket": "test-logging.s3.amazonaws.com",
+                "Bucket": "e3q5uc7sqll7mn-cloudfront-log-test.s3.amazonaws.com",
                 "Prefix": ""
-            }
+            },
+            "PriceClass": "PriceClass_All",
+            "Enabled": true,
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": true,
+                "SSLSupportMethod": "vip",
+                "MinimumProtocolVersion": "TLSv1",
+                "CertificateSource": "cloudfront"
+            },
+            "Restrictions": {
+                "GeoRestriction": {
+                    "RestrictionType": "none",
+                    "Quantity": 0
+                }
+            },
+            "WebACLId": "",
+            "HttpVersion": "http2",
+            "IsIPV6Enabled": true,
+            "ContinuousDeploymentPolicyId": "",
+            "Staging": false
         }
     }
 }

--- a/tests/data/placebo/test_distribution_update_distribution/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_distribution_update_distribution/cloudfront.ListDistributions_1.json
@@ -9,11 +9,199 @@
             "Quantity": 1,
             "Items": [
                 {
-                    "Id": "E1OQK8XICQK4UM",
-                    "ARN": "arn:aws:cloudfront::123456789012:distribution/E1OQK8XICQK4UM",
-                    "Status": "InProgress",
+                    "Id": "E3Q5UC7SQLL7MN",
+                    "ARN": "arn:aws:cloudfront::644160558196:distribution/E3Q5UC7SQLL7MN",
+                    "Status": "Deployed",
+                    "LastModifiedTime": {
+                        "__class__": "datetime",
+                        "year": 2025,
+                        "month": 9,
+                        "day": 9,
+                        "hour": 15,
+                        "minute": 56,
+                        "second": 6,
+                        "microsecond": 821000
+                    },
+                    "DomainName": "d1j7wua3tltg12.cloudfront.net",
+                    "Aliases": {
+                        "Quantity": 0
+                    },
+                    "Origins": {
+                        "Quantity": 1,
+                        "Items": [
+                            {
+                                "Id": "c7n-test-bucket.s3.us-east-1",
+                                "DomainName": "c7n-test-bucket.s3.us-east-1.amazonaws.com",
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": ""
+                                },
+                                "ConnectionAttempts": 3,
+                                "ConnectionTimeout": 10,
+                                "OriginShield": {
+                                    "Enabled": false
+                                },
+                                "OriginAccessControlId": ""
+                            }
+                        ]
+                    },
+                    "OriginGroups": {
+                        "Quantity": 0
+                    },
+                    "DefaultCacheBehavior": {
+                        "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "TrustedKeyGroups": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "allow-all",
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "Compress": true,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": "",
+                        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                    },
+                    "CacheBehaviors": {
+                        "Quantity": 2,
+                        "Items": [
+                            {
+                                "PathPattern": "/beta/hello",
+                                "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "TrustedKeyGroups": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "ViewerProtocolPolicy": "redirect-to-https",
+                                "AllowedMethods": {
+                                    "Quantity": 2,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ],
+                                    "CachedMethods": {
+                                        "Quantity": 2,
+                                        "Items": [
+                                            "HEAD",
+                                            "GET"
+                                        ]
+                                    }
+                                },
+                                "SmoothStreaming": false,
+                                "Compress": true,
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 1,
+                                    "Items": [
+                                        {
+                                            "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:c7n-lambda-edge-new:1",
+                                            "EventType": "origin-request",
+                                            "IncludeBody": false
+                                        }
+                                    ]
+                                },
+                                "FunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FieldLevelEncryptionId": "",
+                                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                            },
+                            {
+                                "PathPattern": "/beta/world",
+                                "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                                "TrustedSigners": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "TrustedKeyGroups": {
+                                    "Enabled": false,
+                                    "Quantity": 0
+                                },
+                                "ViewerProtocolPolicy": "redirect-to-https",
+                                "AllowedMethods": {
+                                    "Quantity": 2,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ],
+                                    "CachedMethods": {
+                                        "Quantity": 2,
+                                        "Items": [
+                                            "HEAD",
+                                            "GET"
+                                        ]
+                                    }
+                                },
+                                "SmoothStreaming": false,
+                                "Compress": true,
+                                "LambdaFunctionAssociations": {
+                                    "Quantity": 1,
+                                    "Items": [
+                                        {
+                                            "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:test-lambda-edge:4",
+                                            "EventType": "viewer-response",
+                                            "IncludeBody": false
+                                        }
+                                    ]
+                                },
+                                "FunctionAssociations": {
+                                    "Quantity": 0
+                                },
+                                "FieldLevelEncryptionId": "",
+                                "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                            }
+                        ]
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
                     "Comment": "",
-                    "Enabled": true
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": true,
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "SSLSupportMethod": "vip",
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "WebACLId": "",
+                    "HttpVersion": "HTTP2",
+                    "IsIPV6Enabled": true,
+                    "Staging": false
                 }
             ]
         }

--- a/tests/data/placebo/test_distribution_update_distribution/cloudfront.UpdateDistribution_1.json
+++ b/tests/data/placebo/test_distribution_update_distribution/cloudfront.UpdateDistribution_1.json
@@ -2,21 +2,220 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "ETag": "E3SPE6T0EJSAA4",
+        "ETag": "E1JT4ZIQEVTVWF",
         "Distribution": {
-            "Id": "E1OQK8XICQK4UM",
-            "ARN": "arn:aws:cloudfront::123456789012:distribution/E1OQK8XICQK4UM",
+            "Id": "E3Q5UC7SQLL7MN",
+            "ARN": "arn:aws:cloudfront::644160558196:distribution/E3Q5UC7SQLL7MN",
             "Status": "InProgress",
+            "LastModifiedTime": {
+                "__class__": "datetime",
+                "year": 2025,
+                "month": 9,
+                "day": 9,
+                "hour": 16,
+                "minute": 35,
+                "second": 43,
+                "microsecond": 783000
+            },
+            "InProgressInvalidationBatches": 0,
+            "DomainName": "d1j7wua3tltg12.cloudfront.net",
+            "ActiveTrustedSigners": {
+                "Enabled": false,
+                "Quantity": 0
+            },
+            "ActiveTrustedKeyGroups": {
+                "Enabled": false,
+                "Quantity": 0
+            },
             "DistributionConfig": {
-                "CallerReference": "6441605581961",
+                "CallerReference": "1371ecb7-664d-44f8-9eb4-3ffd904561b9",
+                "Aliases": {
+                    "Quantity": 0
+                },
+                "DefaultRootObject": "",
+                "Origins": {
+                    "Quantity": 1,
+                    "Items": [
+                        {
+                            "Id": "c7n-test-bucket.s3.us-east-1",
+                            "DomainName": "c7n-test-bucket.s3.us-east-1.amazonaws.com",
+                            "OriginPath": "",
+                            "CustomHeaders": {
+                                "Quantity": 0
+                            },
+                            "S3OriginConfig": {
+                                "OriginAccessIdentity": ""
+                            },
+                            "ConnectionAttempts": 3,
+                            "ConnectionTimeout": 10,
+                            "OriginShield": {
+                                "Enabled": false
+                            },
+                            "OriginAccessControlId": ""
+                        }
+                    ]
+                },
+                "OriginGroups": {
+                    "Quantity": 0
+                },
+                "DefaultCacheBehavior": {
+                    "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                    "TrustedSigners": {
+                        "Enabled": false,
+                        "Quantity": 0
+                    },
+                    "TrustedKeyGroups": {
+                        "Enabled": false,
+                        "Quantity": 0
+                    },
+                    "ViewerProtocolPolicy": "allow-all",
+                    "AllowedMethods": {
+                        "Quantity": 2,
+                        "Items": [
+                            "HEAD",
+                            "GET"
+                        ],
+                        "CachedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ]
+                        }
+                    },
+                    "SmoothStreaming": false,
+                    "Compress": true,
+                    "LambdaFunctionAssociations": {
+                        "Quantity": 0
+                    },
+                    "FunctionAssociations": {
+                        "Quantity": 0
+                    },
+                    "FieldLevelEncryptionId": "",
+                    "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                },
+                "CacheBehaviors": {
+                    "Quantity": 2,
+                    "Items": [
+                        {
+                            "PathPattern": "/beta/hello",
+                            "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                            "TrustedSigners": {
+                                "Enabled": false,
+                                "Quantity": 0
+                            },
+                            "TrustedKeyGroups": {
+                                "Enabled": false,
+                                "Quantity": 0
+                            },
+                            "ViewerProtocolPolicy": "redirect-to-https",
+                            "AllowedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ],
+                                "CachedMethods": {
+                                    "Quantity": 2,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ]
+                                }
+                            },
+                            "SmoothStreaming": false,
+                            "Compress": true,
+                            "LambdaFunctionAssociations": {
+                                "Quantity": 1,
+                                "Items": [
+                                    {
+                                        "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:c7n-lambda-edge-new:1",
+                                        "EventType": "origin-request",
+                                        "IncludeBody": false
+                                    }
+                                ]
+                            },
+                            "FunctionAssociations": {
+                                "Quantity": 0
+                            },
+                            "FieldLevelEncryptionId": "",
+                            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                        },
+                        {
+                            "PathPattern": "/beta/world",
+                            "TargetOriginId": "c7n-test-bucket.s3.us-east-1",
+                            "TrustedSigners": {
+                                "Enabled": false,
+                                "Quantity": 0
+                            },
+                            "TrustedKeyGroups": {
+                                "Enabled": false,
+                                "Quantity": 0
+                            },
+                            "ViewerProtocolPolicy": "redirect-to-https",
+                            "AllowedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ],
+                                "CachedMethods": {
+                                    "Quantity": 2,
+                                    "Items": [
+                                        "HEAD",
+                                        "GET"
+                                    ]
+                                }
+                            },
+                            "SmoothStreaming": false,
+                            "Compress": true,
+                            "LambdaFunctionAssociations": {
+                                "Quantity": 1,
+                                "Items": [
+                                    {
+                                        "LambdaFunctionARN": "arn:aws:lambda:us-east-1:644160558196:function:test-lambda-edge:4",
+                                        "EventType": "viewer-response",
+                                        "IncludeBody": false
+                                    }
+                                ]
+                            },
+                            "FunctionAssociations": {
+                                "Quantity": 0
+                            },
+                            "FieldLevelEncryptionId": "",
+                            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                        }
+                    ]
+                },
+                "CustomErrorResponses": {
+                    "Quantity": 0
+                },
                 "Comment": "",
                 "Logging": {
                     "Enabled": true,
                     "IncludeCookies": false,
-                    "Bucket": "test-logging.s3.amazonaws.com",
+                    "Bucket": "e3q5uc7sqll7mn-cloudfront-log-test.s3.amazonaws.com",
                     "Prefix": ""
                 },
-                "Enabled": true
+                "PriceClass": "PriceClass_All",
+                "Enabled": true,
+                "ViewerCertificate": {
+                    "CloudFrontDefaultCertificate": true,
+                    "SSLSupportMethod": "vip",
+                    "MinimumProtocolVersion": "TLSv1",
+                    "CertificateSource": "cloudfront"
+                },
+                "Restrictions": {
+                    "GeoRestriction": {
+                        "RestrictionType": "none",
+                        "Quantity": 0
+                    }
+                },
+                "WebACLId": "",
+                "HttpVersion": "http2",
+                "IsIPV6Enabled": true,
+                "ContinuousDeploymentPolicyId": "",
+                "Staging": false
             }
         }
     }

--- a/tests/data/placebo/test_distribution_update_distribution/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_distribution_update_distribution/tagging.GetResources_1.json
@@ -2,7 +2,17 @@
     "status_code": 200,
     "data": {
         "PaginationToken": "",
-        "ResourceTagMappingList": [],
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudfront::644160558196:distribution/E3Q5UC7SQLL7MN",
+                "Tags": [
+                    {
+                        "Key": "test",
+                        "Value": "c7n"
+                    }
+                ]
+            }
+        ],
         "ResponseMetadata": {}
     }
 }

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -693,7 +693,7 @@ class CloudFront(BaseTest):
                             "Logging": {
                                 "Enabled": True,
                                 "IncludeCookies": False,
-                                "Bucket": 'test-logging.s3.amazonaws.com',
+                                "Bucket": 'e3q5uc7sqll7mn-cloudfront-log-test.s3.amazonaws.com',
                                 "Prefix": '',
                             }
                         }


### PR DESCRIPTION
With the update of `merge_dict`, the behavior changed how this function was used. 
Although the comments had previously mentioned that it would use the value from A, it would use the value from B instead.

