### PR TITLE
feat: Base Azure Entra ID support and the azure.entraid-user resource.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ test-functional:
 # note this will provision real resources in a cloud environment
 	C7N_FUNCTIONAL=yes AWS_DEFAULT_REGION=us-east-2 pytest tests -m functional $(ARGS)
 
+test-functional-azure:
+# note this will provision real resources in Azure's public cloud environment
+	C7N_FUNCTIONAL=yes uv run pytest tools/c7n_azure/tests_azure/tests_resources/test_entraid.py -k terraform -m functional $(ARGS)
+
 sphinx:
 	make -f docs/Makefile.sphinx html
 

--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -77,7 +77,8 @@ STORAGE_AUTH_ENDPOINT = 'https://storage.azure.com/'
 VAULT_AUTH_ENDPOINT = 'vault'
 DEFAULT_RESOURCE_AUTH_ENDPOINT = 'resource_manager'
 DEFAULT_AUTH_ENDPOINT = 'active_directory_resource_id'
-GRAPH_AUTH_ENDPOINT = 'active_directory_graph_resource_id'
+GRAPH_AUTH_ENDPOINT = 'active_directory_graph_resource_id'  # Legacy Azure AD Graph
+MSGRAPH_RESOURCE_ID = 'https://graph.microsoft.com/'        # Microsoft Graph resource identifier
 RESOURCE_GLOBAL_MGMT = 'https://management.azure.com/'
 
 """

--- a/tools/c7n_azure/c7n_azure/graph_utils.py
+++ b/tools/c7n_azure/c7n_azure/graph_utils.py
@@ -1,0 +1,254 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import requests
+import re
+
+from c7n.utils import local_session, type_schema
+from c7n.filters import ValueFilter
+from c7n_azure.constants import MSGRAPH_RESOURCE_ID
+from c7n_azure.query import QueryResourceManager, TypeInfo, TypeMeta, DescribeSource
+from c7n_azure.provider import resources
+
+log = logging.getLogger('custodian.azure.graph')
+
+
+class GraphSource(DescribeSource):
+    """Custom source for Microsoft Graph API resources.
+
+    This source integrates with Cloud Custodian's filtering framework while
+    using Microsoft Graph API instead of Azure Resource Manager APIs.
+    """
+
+    def __init__(self, manager):
+        super().__init__(manager)
+
+    def get_resources(self, query=None):
+        """Get resources from Microsoft Graph API."""
+        try:
+            # Use the manager's Graph API methods to retrieve resources
+            return self.manager.get_graph_resources()
+        except Exception as e:
+            log.error(f"Error retrieving resources via Graph API: {e}")
+            return []
+
+
+# Microsoft Graph API Endpoint to Permissions Mapping
+# This ensures we only request the minimum permissions needed for each operation
+GRAPH_ENDPOINT_PERMISSIONS = {
+    # User endpoints
+    'users': ['User.Read.All'],
+    'users/{id}': ['User.Read.All'],
+    'users/{id}/authentication/methods': ['UserAuthenticationMethod.Read.All'],
+    'users/{id}/transitiveMemberOf': ['GroupMember.Read.All'],
+    # Identity Protection endpoints
+    'identityProtection/riskyUsers/{id}': ['IdentityRiskyUser.Read.All'],
+
+    # Group endpoints
+    'groups': ['Group.Read.All'],
+    'groups/{id}': ['Group.Read.All'],
+    'groups/{id}/members': ['GroupMember.Read.All'],
+    'groups/{id}/members/$count': ['GroupMember.Read.All'],
+    'groups/{id}/owners': ['Group.Read.All'],
+    'groups/{id}/owners/$count': ['Group.Read.All'],
+
+    # Organization endpoints
+    'organization': ['Organization.Read.All'],
+
+    # Policy endpoints (require beta API)
+    'identity/conditionalAccess/policies': ['Policy.Read.All'],
+    'identity/conditionalAccess/namedLocations': ['Policy.Read.All'],
+    'identity/conditionalAccess/namedLocations/{id}': ['Policy.Read.All'],
+    'policies/identitySecurityDefaultsEnforcementPolicy': ['Policy.Read.All'],
+
+    # Authorization Policy endpoints
+    'policies/authorizationPolicy': ['Policy.Read.All'],
+
+    # Directory Settings endpoints (beta API)
+    'settings': ['Directory.Read.All'],
+    'settings/{id}': ['Directory.ReadWrite.All'],
+    'directorySettingTemplates': ['Directory.Read.All'],
+}
+
+
+def get_required_permissions_for_endpoint(endpoint, method='GET'):
+    """Get the minimum required permissions for a Graph API endpoint."""
+    # Normalize endpoint by replacing specific IDs with {id} placeholder
+    normalized_endpoint = endpoint
+
+    # Replace UUIDs and specific IDs with {id} placeholder for lookup
+    normalized_endpoint = re.sub(r'/[0-9a-fA-F-]{8,}', '/{id}', normalized_endpoint)
+
+    # For write operations, we need ReadWrite permissions
+    if method in ['PATCH', 'POST', 'PUT', 'DELETE']:
+        if 'users' in normalized_endpoint:
+            return ['User.ReadWrite.All']
+        elif 'groups' in normalized_endpoint:
+            return ['Group.ReadWrite.All']
+        elif 'authentication' in normalized_endpoint:
+            return ['UserAuthenticationMethod.ReadWrite.All']
+
+    # Check for exact match first
+    if normalized_endpoint in GRAPH_ENDPOINT_PERMISSIONS:
+        return GRAPH_ENDPOINT_PERMISSIONS[normalized_endpoint]
+
+    # Check for pattern matches
+    for pattern, permissions in GRAPH_ENDPOINT_PERMISSIONS.items():
+        if pattern in normalized_endpoint:
+            return permissions
+
+    # Fail-fast for unmapped endpoints rather than using overprivileged .default
+    log.error(
+        f"No permissions mapping found for endpoint: {endpoint}. "
+        f"This endpoint must be explicitly mapped in GRAPH_ENDPOINT_PERMISSIONS "
+        f"to ensure minimum required permissions."
+    )
+    raise ValueError(
+        f"Unmapped Graph API endpoint: {endpoint}. "
+        f"Add permission mapping to prevent overprivileged access."
+    )
+
+
+class GraphTypeInfo(TypeInfo, metaclass=TypeMeta):
+    """Type info for Microsoft Graph resources"""
+    id = 'id'
+    name = 'displayName'
+    date = 'createdDateTime'
+    global_resource = True
+    service = 'graph'
+    resource_endpoint = MSGRAPH_RESOURCE_ID
+    diagnostic_settings_enabled = True
+
+    @classmethod
+    def extra_args(cls, parent_resource):
+        return {}
+
+
+class GraphResourceManager(QueryResourceManager):
+    """Base class for Microsoft Graph API resources.
+
+    Provides common Graph API client functionality for all EntraID resources.
+    """
+
+    def get_client(self):
+        """Get Microsoft Graph client session"""
+        session = local_session(self.session_factory)
+        # Default to Microsoft Graph session for Graph operations
+        return session.get_session_for_resource(MSGRAPH_RESOURCE_ID)
+
+    def make_graph_request(self, endpoint, method='GET'):
+        """Make a request to Microsoft Graph API with minimum required permissions."""
+        try:
+            session = self.get_client()
+            session._initialize_session()
+            # Get specific permissions for this endpoint instead of using .default
+            try:
+                get_required_permissions_for_endpoint(endpoint, method)
+            except ValueError:
+                log.error(f"Cannot make Graph API request to unmapped endpoint: {endpoint}")
+                raise
+
+            # Request token for Microsoft Graph API
+            # Note: Individual permissions like User.Read.All are enforced at
+            # the app registration level
+            # The scope for Microsoft Graph API should always be
+            # https://graph.microsoft.com/.default
+            scope = 'https://graph.microsoft.com/.default'
+
+            token = session.credentials.get_token(scope)
+
+            headers = {
+                'Authorization': f'Bearer {token.token}',
+                'Content-Type': 'application/json'
+            }
+
+            url = f'https://graph.microsoft.com/v1.0/{endpoint}'
+            response = requests.get(url, headers=headers, timeout=30)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            log.error(f"Microsoft Graph API request failed for {endpoint}: {e}")
+            raise
+
+    @staticmethod
+    def register_graph_specific(registry, resource_class):
+        """Register Graph-specific filters and actions for Graph resource managers."""
+
+        if not issubclass(resource_class, GraphResourceManager):
+            return
+
+        # Register EntraID-specific diagnostic settings filter if enabled
+        if resource_class.resource_type.diagnostic_settings_enabled:
+            resource_class.filter_registry.register(
+                'diagnostic-settings', EntraIDDiagnosticSettingsFilter)
+
+
+class EntraIDDiagnosticSettingsFilter(ValueFilter):
+    """Diagnostic settings filter for EntraID resources.
+
+    EntraID diagnostic settings are tenant-level and accessed via the microsoft.aadiam provider,
+    not per-resource like ARM resources.
+    """
+    schema = type_schema('diagnostic-settings', rinherit=ValueFilter.schema)
+    schema_alias = True
+    log = logging.getLogger('custodian.azure.entraid.DiagnosticSettingsFilter')
+
+    def process(self, resources, event=None):
+        """Process EntraID resources by checking tenant-level diagnostic settings."""
+
+        # Get tenant-level diagnostic settings
+        session = local_session(self.manager.session_factory)
+        session.client('azure.mgmt.monitor.MonitorManagementClient')
+
+        # EntraID diagnostic settings are tenant-level:
+        # /providers/microsoft.aadiam/diagnosticSettings
+        tenant_diagnostic_settings = []
+        try:
+            # List all EntraID diagnostic settings for the tenant
+            # Use the correct EntraID diagnostic settings API endpoint
+            import requests
+            session_token = session.get_credentials()
+            token = session_token.get_token('https://management.azure.com/.default')
+
+            headers = {
+                'Authorization': f'Bearer {token.token}',
+                'Content-Type': 'application/json'
+            }
+
+            # Use the correct EntraID diagnostic settings API endpoint from our research
+            url = ('https://management.azure.com/providers/microsoft.aadiam/'
+                   'diagnosticSettings?api-version=2017-04-01-preview')
+            response = requests.get(url, headers=headers, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            tenant_diagnostic_settings = data.get('value', [])
+
+            if not tenant_diagnostic_settings:
+                tenant_diagnostic_settings = [{}]
+        except requests.exceptions.HTTPError as e:
+            errmsg = f"Failed to retrieve EntraID diagnostic settings: {e}."
+            if response.status_code == 403:
+                errmsg += " Ensure service principal has " \
+                    "'Microsoft.AADIAM/diagnosticSettings/read' permission."
+            self.log.error(errmsg)
+            # If no settings available, use empty list so absent operator can function
+            raise
+
+        # Apply filter to diagnostic settings
+        if not tenant_diagnostic_settings:
+            tenant_diagnostic_settings = [{}]
+
+        filtered_settings = super(EntraIDDiagnosticSettingsFilter, self).process(
+            tenant_diagnostic_settings, event=None)
+
+        # If diagnostic settings match the filter criteria, return all resources
+        # since EntraID diagnostic settings apply to the entire tenant
+        if filtered_settings:
+            return resources
+        else:
+            return []
+
+
+resources.subscribe(GraphResourceManager.register_graph_specific)

--- a/tools/c7n_azure/c7n_azure/resources/entraid_user.py
+++ b/tools/c7n_azure/c7n_azure/resources/entraid_user.py
@@ -1,0 +1,740 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import requests
+from datetime import datetime
+
+from c7n.filters import Filter, ValueFilter
+from c7n.utils import local_session, type_schema
+from c7n_azure.actions.base import AzureBaseAction
+from c7n_azure.constants import MSGRAPH_RESOURCE_ID
+from c7n_azure.provider import resources
+from c7n_azure.graph_utils import (
+    GraphResourceManager, GraphTypeInfo, GraphSource,
+    get_required_permissions_for_endpoint, EntraIDDiagnosticSettingsFilter
+)
+
+log = logging.getLogger('custodian.azure.entraid.user')
+
+
+@resources.register('entraid-user')
+class EntraIDUser(GraphResourceManager):
+    """EntraID User resource for managing users.
+
+    Supports filtering by user properties, authentication methods, group memberships,
+    and security settings. See Common EntraID Examples section for additional patterns.
+
+    Available filters: value, auth-methods, risk-level, last-sign-in, group-membership, password-age
+    Available actions: disable, require-mfa
+
+    Permissions: See Graph API Permissions Reference section.
+
+    :example:
+
+    Find users with multiple security issues:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: high-risk-users-no-mfa
+            resource: azure.entraid-user
+            filters:
+              - type: mfa-enabled
+                value: false
+              - type: risk-level
+                value: high
+            actions:
+              - type: require-mfa
+    """
+
+    def __init__(self, ctx, data):
+        super().__init__(ctx, data)
+        # Use our custom GraphSource instead of the default source
+        self.source = GraphSource(self)
+
+    class resource_type(GraphTypeInfo):
+        doc_groups = ['EntraID', 'Identity']
+        enum_spec = ('users', 'list', None)
+        detail_spec = ('users', 'get', 'id')
+        id = 'id'
+        name = 'displayName'
+        date = 'createdDateTime'
+        default_report_fields = (
+            'displayName',
+            'userPrincipalName',
+            'mail',
+            'accountEnabled',
+            'userType',
+            'createdDateTime',
+            'lastSignInDateTime',
+            'id'
+        )
+        permissions = (
+            'User.Read.All',
+            'UserAuthenticationMethod.Read.All',
+            'IdentityRiskyUser.Read.All',
+            'GroupMember.Read.All'
+
+        )
+
+    def make_graph_request(self, endpoint, method='GET', data=None):
+        """Make a request to Microsoft Graph API with minimum required permissions."""
+        try:
+            session = self.get_client()
+            session._initialize_session()
+
+            # Get specific permissions for this endpoint instead of using .default
+            try:
+                get_required_permissions_for_endpoint(endpoint, method)
+            except ValueError:
+                log.error(
+                    f"Cannot make Graph API request to unmapped endpoint: {endpoint}"
+                )
+                raise
+
+            # Request token for Microsoft Graph API
+
+            # Note: Individual permissions like User.Read.All are enforced at the
+            # app registration level. The scope for Microsoft Graph API should
+            # always be https://graph.microsoft.com/.default
+
+            scope = 'https://graph.microsoft.com/.default'
+
+            token = session.credentials.get_token(scope)
+
+            headers = {
+                'Authorization': f'Bearer {token.token}',
+                'Content-Type': 'application/json'
+            }
+
+            url = f'https://graph.microsoft.com/v1.0/{endpoint}'
+
+            if method == 'GET':
+                response = requests.get(url, headers=headers, timeout=30)
+            elif method == 'POST':
+                response = requests.post(url, headers=headers, json=data, timeout=30)
+            elif method == 'PATCH':
+                response = requests.patch(url, headers=headers, json=data, timeout=30)
+            else:
+                response = requests.request(method, url, headers=headers, json=data, timeout=30)
+
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            log.error(f"Microsoft Graph API request failed for {endpoint}: {e}")
+            raise
+
+    def get_graph_resources(self):
+        """Get resources from Microsoft Graph API for use with GraphSource."""
+        try:
+            # Request specific fields including userType which is not returned by default
+            # This ensures ValueFilter can work with userType field for guest user filtering
+            # Note: Some fields like signInActivity and lastPasswordChangeDateTime may require
+            # additional permissions, so we use a more conservative field selection
+            select_fields = [
+                'id', 'displayName', 'userPrincipalName', 'mail',
+                'accountEnabled', 'createdDateTime', 'jobTitle', 'department', 'userType'
+            ]
+            endpoint = f"users?$select={','.join(select_fields)}"
+            response = self.make_graph_request(endpoint)
+            resources = response.get('value', [])
+
+            log.debug(f"Retrieved {len(resources)} users from Graph API")
+
+            # Augment resources with additional computed fields
+            resources = self.augment(resources)
+
+            log.debug(f"Returning {len(resources)} users after augmentation")
+            return resources
+        except Exception as e:
+            log.error(f"Error retrieving EntraID users: {e}")
+            if "Insufficient privileges" in str(e) or "403" in str(e):
+                log.error(
+                    "Insufficient privileges to read users. Required permissions: User.Read.All"
+                )
+            return []
+
+    def augment(self, resources):
+        """Augment user resources with additional Graph API data"""
+        try:
+            # Enhance with additional properties
+            for resource in resources:
+                # Add computed fields for policy evaluation
+                resource['c7n:LastSignInDays'] = self._calculate_last_signin_days(resource)
+                resource['c7n:IsHighPrivileged'] = self._is_high_privileged_user(resource)
+                resource['c7n:PasswordAge'] = self._calculate_password_age(resource)
+
+        except Exception as e:
+            log.warning(f"Failed to augment EntraID users: {e}")
+
+        return resources
+
+    def _calculate_last_signin_days(self, user):
+        """Calculate days since last sign-in"""
+        if not user.get('signInActivity', {}).get('lastSignInDateTime'):
+            return 999  # Large number for never signed in
+
+        try:
+            last_signin = datetime.fromisoformat(
+                user['signInActivity']['lastSignInDateTime'].replace('Z', '+00:00')
+            )
+            return (
+                datetime.now().replace(tzinfo=last_signin.tzinfo) - last_signin
+            ).days
+        except Exception:
+            return 999
+
+    def _is_high_privileged_user(self, user):
+        """Determine if user has high privileges (to be enhanced with role checks)"""
+        # This is a placeholder - would need additional Graph API calls for full implementation
+        privileged_indicators = [
+            user.get('userPrincipalName', '').endswith('admin@'),
+            'admin' in (user.get('displayName') or '').lower(),
+            'administrator' in (user.get('jobTitle') or '').lower()
+        ]
+        return any(privileged_indicators)
+
+    def _calculate_password_age(self, user):
+        """Calculate password age in days"""
+        if not user.get('lastPasswordChangeDateTime'):
+            return 0
+
+        try:
+            pwd_change = datetime.fromisoformat(
+                user['lastPasswordChangeDateTime'].replace('Z', '+00:00')
+            )
+            return (
+                datetime.now().replace(tzinfo=pwd_change.tzinfo) - pwd_change
+            ).days
+        except Exception:
+            return 0
+
+    def get_user_auth_methods(self, user_id):
+        """Get user's authentication methods from Graph API.
+
+        Returns the full list of authentication methods for the user.
+        Required permission: UserAuthenticationMethod.Read.All
+        """
+        try:
+            # Query user's authentication methods
+            endpoint = f'users/{user_id}/authentication/methods'
+            response = self.make_graph_request(endpoint)
+
+            methods = response.get('value', [])
+            return methods
+
+        except requests.exceptions.RequestException as e:
+            if "403" in str(e) or "Insufficient privileges" in str(e):
+                log.warning(
+                    f"Insufficient privileges to read authentication methods for user {user_id}. "
+                    "Required permission: UserAuthenticationMethod.Read.All"
+                )
+                return None  # Unknown auth methods
+            else:
+                log.error(f"Error getting authentication methods for user {user_id}: {e}")
+                return None
+
+    def check_user_risk_level(self, user_id):
+        """Check user's risk level using Identity Protection API.
+
+        Required permission: IdentityRiskyUser.Read.All
+        """
+        try:
+            # Query Identity Protection risky users endpoint
+            endpoint = f'identityProtection/riskyUsers/{user_id}'
+            response = self.make_graph_request(endpoint)
+
+            # Extract risk level from response
+            risk_level = response.get('riskLevel', 'none')
+
+            # Map Graph API risk levels to our filter values
+            risk_mapping = {
+                'none': 'none',
+                'low': 'low',
+                'medium': 'medium',
+                'high': 'high',
+                'hidden': 'none',  # Treat hidden as none for filtering
+                'unknownFutureValue': 'none'
+            }
+
+            return risk_mapping.get(risk_level.lower(), 'none')
+
+        except requests.exceptions.RequestException as e:
+            if "404" in str(e):
+                # User not found in risky users - means no risk
+                return 'none'
+            elif "403" in str(e) or "Insufficient privileges" in str(e):
+                log.warning(
+                    f"Insufficient privileges to read risk level for user {user_id}. "
+                    "Required permission: IdentityRiskyUser.Read.All"
+                )
+                return None  # Unknown risk level
+            else:
+                log.error(f"Error checking risk level for user {user_id}: {e}")
+                return None
+
+    def get_user_group_memberships(self, user_id):
+        """Get user's group memberships from Graph API.
+
+        Required permission: GroupMember.Read.All or Directory.Read.All
+        """
+        try:
+            # Query user's group memberships (including transitive)
+            endpoint = f'users/{user_id}/transitiveMemberOf'
+            response = self.make_graph_request(endpoint)
+
+            groups = response.get('value', [])
+
+            # Extract group display names and IDs for filtering
+            group_info = []
+            for group in groups:
+                # Only include actual groups (not directory roles)
+                if group.get('@odata.type') == '#microsoft.graph.group':
+                    group_info.append({
+                        'id': group.get('id'),
+                        'displayName': group.get('displayName', ''),
+                        'mail': group.get('mail', '')
+                    })
+
+            return group_info
+
+        except requests.exceptions.RequestException as e:
+            if "403" in str(e) or "Insufficient privileges" in str(e):
+                log.warning(
+                    f"Insufficient privileges to read group memberships for user {user_id}. "
+                    "Required permission: GroupMember.Read.All or Directory.Read.All"
+                )
+                return None  # Unknown group memberships
+            else:
+                log.error(f"Error getting group memberships for user {user_id}: {e}")
+                return None
+
+
+@EntraIDUser.filter_registry.register('auth-methods')
+class AuthMethodsFilter(ValueFilter):
+    """Filter users by authentication methods.
+
+    Filters users based on their registered authentication methods.
+
+    Requires: UserAuthenticationMethod.Read.All
+
+    :example:
+
+    .. code-block:: yaml
+
+        filters:
+          - type: auth-methods
+            key: '[]."@odata.type"'
+            op: contains
+            value: '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
+    """
+
+    schema = type_schema('auth-methods', rinherit=ValueFilter.schema)
+    auth_methods_annotation_key = 'c7n:AuthMethods'
+    annotate = False
+
+    def __call__(self, i):
+        if self.auth_methods_annotation_key not in i:
+            # Get user's authentication methods from Graph API
+            user_id = i.get('id') or i.get('objectId')
+            auth_methods = self.manager.get_user_auth_methods(user_id)
+
+            if auth_methods is None:
+                # Unknown auth methods (permission error or API failure)
+                # Skip this user to avoid false results
+                log.warning(
+                    f"Could not determine authentication methods for user "
+                    f"{i.get('displayName', user_id)}"
+                )
+                auth_methods = []
+
+            # Add auth methods to user resource for filtering
+            i[self.auth_methods_annotation_key] = auth_methods
+
+        return super().__call__(i[self.auth_methods_annotation_key])
+
+
+@EntraIDUser.filter_registry.register('risk-level')
+class RiskLevelFilter(Filter):
+    """Filter users by Identity Protection risk level.
+
+    Requires: IdentityRiskyUser.Read.All
+
+    :example:
+
+    .. code-block:: yaml
+
+        filters:
+          - type: risk-level
+            value: high
+    """
+
+    schema = type_schema(
+        'risk-level',
+        value={'type': 'string', 'enum': ['none', 'low', 'medium', 'high']}
+    )
+
+    def process(self, resources, event=None):  # pylint: disable=unused-argument
+        target_risk_level = self.data.get('value', 'none').lower()
+        filtered = []
+
+        for resource in resources:
+            user_id = resource.get('id') or resource.get('objectId')
+            if not user_id:
+                log.warning(
+                    f"Skipping user without ID: {resource.get('displayName', 'Unknown')}"
+                )
+                continue
+
+            # Check actual risk level via Identity Protection API
+            user_risk_level = self.manager.check_user_risk_level(user_id)
+
+            if user_risk_level is None:
+                # Unknown risk level (permission error or API failure)
+                # Skip this user to avoid false results
+                log.warning(
+                    f"Could not determine risk level for user "
+                    f"{resource.get('displayName', user_id)}"
+                )
+                continue
+
+            if user_risk_level.lower() == target_risk_level:
+                filtered.append(resource)
+
+        return filtered
+
+
+@EntraIDUser.filter_registry.register('last-sign-in')
+class LastSignInFilter(Filter):
+    """Filter users based on last sign-in activity.
+
+    :example:
+
+    Find users who haven't signed in for 90+ days:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: inactive-users
+            resource: azure.entraid-user
+            filters:
+              - type: last-sign-in
+                days: 90
+                op: greater-than
+    """
+
+    schema = type_schema(
+        'last-sign-in',
+        days={'type': 'number'},
+        op={'type': 'string', 'enum': ['greater-than', 'less-than', 'equal']}
+    )
+
+    def process(self, resources, event=None):  # pylint: disable=unused-argument
+        days_threshold = self.data.get('days', 90)
+        op = self.data.get('op', 'greater-than')
+
+        filtered = []
+        for resource in resources:
+            last_signin_days = resource.get('c7n:LastSignInDays', 999)
+
+            if op == 'greater-than' and last_signin_days > days_threshold:
+                filtered.append(resource)
+            elif op == 'less-than' and last_signin_days < days_threshold:
+                filtered.append(resource)
+            elif op == 'equal' and last_signin_days == days_threshold:
+                filtered.append(resource)
+
+        return filtered
+
+
+@EntraIDUser.filter_registry.register('group-membership')
+class GroupMembershipFilter(Filter):
+    """Filter users based on group membership.
+
+    Required permission: GroupMember.Read.All or Directory.Read.All
+
+    :example:
+
+    Find users in admin groups:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: admin-group-members
+            resource: azure.entraid-user
+            filters:
+              - type: group-membership
+                groups: ['Global Administrators', 'User Administrators']
+                match: any
+    """
+
+    schema = type_schema(
+        'group-membership',
+        groups={'type': 'array', 'items': {'type': 'string'}},
+        match={'type': 'string', 'enum': ['any', 'all']}
+    )
+
+    def process(self, resources, event=None):  # pylint: disable=unused-argument
+        target_groups = self.data.get('groups', [])
+        match_type = self.data.get('match', 'any')
+
+        if not target_groups:
+            return resources
+
+        filtered = []
+        for resource in resources:
+            user_id = resource.get('id') or resource.get('objectId')
+            if not user_id:
+                log.warning(
+                    f"Skipping user without ID: {resource.get('displayName', 'Unknown')}"
+                )
+                continue
+
+            # Get actual group memberships via Graph API
+            user_groups = self.manager.get_user_group_memberships(user_id)
+
+            if user_groups is None:
+                # Unknown group memberships (permission error or API failure)
+                # Skip this user to avoid false results
+                log.warning(
+                    f"Could not determine group memberships for user "
+                    f"{resource.get('displayName', user_id)}"
+                )
+                continue
+
+            # Extract group names for matching
+            group_names = [g.get('displayName', '') for g in user_groups]
+
+            if match_type == 'any':
+                if any(group in target_groups for group in group_names):
+                    filtered.append(resource)
+            elif match_type == 'all':
+                if all(group in group_names for group in target_groups):
+                    filtered.append(resource)
+
+        return filtered
+
+
+@EntraIDUser.filter_registry.register('password-age')
+class PasswordAgeFilter(Filter):
+    """Filter users based on password age.
+
+    :example:
+
+    Find users with passwords older than 180 days:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: old-password-users
+            resource: azure.entraid-user
+            filters:
+              - type: password-age
+                days: 180
+                op: greater-than
+    """
+
+    schema = type_schema(
+        'password-age',
+        days={'type': 'number'},
+        op={'type': 'string', 'enum': ['greater-than', 'less-than', 'equal']}
+    )
+
+    def process(self, resources, event=None):  # pylint: disable=unused-argument
+        days_threshold = self.data.get('days', 90)
+        op = self.data.get('op', 'greater-than')
+
+        filtered = []
+        for resource in resources:
+            password_age = resource.get('c7n:PasswordAge', 0)
+
+            if op == 'greater-than' and password_age > days_threshold:
+                filtered.append(resource)
+            elif op == 'less-than' and password_age < days_threshold:
+                filtered.append(resource)
+            elif op == 'equal' and password_age == days_threshold:
+                filtered.append(resource)
+
+        return filtered
+
+
+@EntraIDUser.action_registry.register('disable')
+class DisableUserAction(AzureBaseAction):
+    """Disable EntraID users.
+
+    :example:
+
+    Disable inactive users:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: disable-inactive-users
+            resource: azure.entraid-user
+            filters:
+              - type: last-sign-in
+                days: 90
+                op: greater-than
+            actions:
+              - type: disable
+    """
+
+    schema = type_schema('disable')
+    permissions = ('User.ReadWrite.All',)
+
+    def _prepare_processing(self):
+        session = local_session(self.manager.session_factory)
+        self.graph_session = session.get_session_for_resource(MSGRAPH_RESOURCE_ID)
+
+    def _process_resource(self, resource):
+        try:
+            user_id = resource.get('id') or resource.get('objectId')
+            display_name = resource.get('displayName', 'Unknown')
+
+            if not user_id:
+                self.log.error(f"Cannot disable user {display_name}: missing user ID")
+                return
+
+            # Make Graph API PATCH request to disable user
+            # Use specific permission for user modification
+            self.graph_session._initialize_session()
+            token = self.graph_session.credentials.get_token(
+                'https://graph.microsoft.com/User.ReadWrite.All'
+            )
+
+            headers = {
+                'Authorization': f'Bearer {token.token}',
+                'Content-Type': 'application/json'
+            }
+
+            # PATCH request to disable user account
+            url = f'https://graph.microsoft.com/v1.0/users/{user_id}'
+            data = {
+                "accountEnabled": False
+            }
+
+            response = requests.patch(url, headers=headers, json=data, timeout=30)
+            response.raise_for_status()
+
+            self.log.info(f"Successfully disabled user {display_name} ({user_id})")
+
+        except requests.exceptions.RequestException as e:
+            if "403" in str(e) or "Insufficient privileges" in str(e):
+                self.log.error(
+                    f"Insufficient privileges to disable user "
+                    f"{resource.get('displayName', 'Unknown')}. "
+                    "Required permission: User.ReadWrite.All"
+                )
+            else:
+                self.log.error(
+                    f"Failed to disable user {resource.get('displayName', 'Unknown')}: {e}"
+                )
+        except Exception as e:
+            self.log.error(
+                f"Failed to disable user {resource.get('displayName', 'Unknown')}: {e}"
+            )
+
+
+@EntraIDUser.action_registry.register('require-mfa')
+class RequireMFAAction(AzureBaseAction):
+    """Check MFA status for EntraID users and provide guidance.
+
+    This action checks if users have MFA methods configured and provides
+    recommendations for Conditional Access policy creation rather than
+    attempting direct MFA enforcement.
+
+    :example:
+
+    Check MFA status for admin users:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: admin-mfa-status
+            resource: azure.entraid-user
+            filters:
+              - type: group-membership
+                groups: ['Global Administrators']
+            actions:
+              - type: require-mfa
+    """
+
+    schema = type_schema('require-mfa')
+    permissions = ('UserAuthenticationMethod.Read.All',)
+
+    def _prepare_processing(self):
+        session = local_session(self.manager.session_factory)
+        self.graph_session = session.get_session_for_resource(MSGRAPH_RESOURCE_ID)
+
+    def _process_resource(self, resource):
+        try:
+            user_id = resource.get('id') or resource.get('objectId')
+            display_name = resource.get('displayName', 'Unknown')
+
+            if not user_id:
+                self.log.error(f"Cannot check MFA for user {display_name}: missing user ID")
+                return
+
+            # Check if user has MFA methods configured using v1.0 API
+            # Use specific permission for reading authentication methods
+            self.graph_session._initialize_session()
+            token = self.graph_session.credentials.get_token(
+                'https://graph.microsoft.com/UserAuthenticationMethod.Read.All'
+            )
+
+            headers = {
+                'Authorization': f'Bearer {token.token}',
+                'Content-Type': 'application/json'
+            }
+
+            # Check user's authentication methods
+            auth_methods_url = (
+                f'https://graph.microsoft.com/v1.0/users/{user_id}/authentication/methods'
+            )
+            import requests
+            response = requests.get(auth_methods_url, headers=headers, timeout=30)
+            response.raise_for_status()
+
+            methods = response.json().get('value', [])
+            mfa_methods = [m for m in methods if m.get('@odata.type') in [
+                '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod',
+                '#microsoft.graph.phoneAuthenticationMethod',
+                '#microsoft.graph.fido2AuthenticationMethod',
+                '#microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
+            ]]
+
+            if mfa_methods:
+                self.log.info(
+                    f"User {display_name} ({user_id}) already has "
+                    f"{len(mfa_methods)} MFA method(s) configured"
+                )
+            else:
+                self.log.warning(
+                    f"User {display_name} ({user_id}) has no MFA methods configured. "
+                    f"Consider creating a Conditional Access policy to enforce MFA registration."
+                )
+
+        except requests.exceptions.RequestException as e:
+            if "403" in str(e) or "Insufficient privileges" in str(e):
+                self.log.error(
+                    f"Insufficient privileges to check MFA for user "
+                    f"{resource.get('displayName', 'Unknown')}. "
+                    "Required permission: UserAuthenticationMethod.Read.All"
+                )
+            else:
+                self.log.error(
+                    f"Failed to check MFA status for user "
+                    f"{resource.get('displayName', 'Unknown')}: {e}"
+                )
+        except Exception as e:
+            self.log.error(
+                f"Failed to process MFA requirement for user "
+                f"{resource.get('displayName', 'Unknown')}: {e}"
+            )
+
+
+# Register diagnostic settings filter for EntraID users
+EntraIDUser.filter_registry.register(
+    'diagnostic-settings', EntraIDDiagnosticSettingsFilter
+)

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -108,4 +108,5 @@ ResourceMap = {
     "azure.waf": "c7n_azure.resources.waf.WAF",
     "azure.webapp": "c7n_azure.resources.web_app.WebApp",
     "azure.alert-logs": "c7n_azure.resources.alertlogs.AlertLogs",
+    "azure.entraid-user": "c7n_azure.resources.entraid.EntraIDUser",
 }

--- a/tools/c7n_azure/examples/admin-group-members.yaml
+++ b/tools/c7n_azure/examples/admin-group-members.yaml
@@ -1,0 +1,37 @@
+policies:
+  - name: global-admin-members
+    resource: azure.entraid-user
+    description: |
+      Find users who are members of administrative groups.
+      This policy helps identify users with elevated privileges.
+      Note: Requires GroupMember.Read.All permission.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: group-membership
+        groups:
+          - 'Global Administrators'
+          - 'Privileged Role Administrator'
+          - 'User Admin'
+        match: any
+
+  - name: admin-group-members-without-mfa
+    resource: azure.entraid-user
+    description: |
+      Find administrative group members without MFA.
+      Critical security finding - admin users should always have MFA.
+      Note: Requires GroupMember.Read.All and UserAuthenticationMethod.Read.All permissions.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: group-membership
+        groups:
+          - 'Global Administrators'
+          - 'Privileged Role Administrator'
+          - 'Security Administrator'
+          - 'User Administrator'
+        match: any
+      - type: mfa-enabled
+        value: false

--- a/tools/c7n_azure/examples/admin-users-by-job-title.yaml
+++ b/tools/c7n_azure/examples/admin-users-by-job-title.yaml
@@ -1,0 +1,15 @@
+policies:
+  - name: admin-users-by-job-title
+    resource: azure.entraid-user
+    description: |
+      Find users with administrative job titles.
+      This policy helps identify users who may have elevated privileges
+      based on their job title field.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: value
+        key: jobTitle
+        value: ".*[Aa]dmin.*"
+        op: regex

--- a/tools/c7n_azure/examples/comprehensive-user-audit.yaml
+++ b/tools/c7n_azure/examples/comprehensive-user-audit.yaml
@@ -1,0 +1,59 @@
+policies:
+  - name: security-audit-guest-users
+    resource: azure.entraid-user
+    description: |
+      Comprehensive security audit for guest users.
+      Finds enabled guest users for security review.
+      CIS Azure 1.2 - Ensure that there are no guest users (or review them regularly).
+    filters:
+      - type: value
+        key: userType
+        value: Guest
+      - type: value
+        key: accountEnabled
+        value: true
+
+  - name: security-audit-inactive-users
+    resource: azure.entraid-user
+    description: |
+      Find users who haven't signed in for more than 90 days.
+      These accounts may need to be disabled for security purposes.
+      Note: Requires sign-in activity data to be available.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: last-sign-in
+        days: 90
+        op: greater-than
+
+  - name: security-audit-privileged-no-mfa
+    resource: azure.entraid-user
+    description: |
+      Find privileged users without MFA enabled.
+      Identifies high-risk accounts that need immediate attention.
+      Note: Requires UserAuthenticationMethod.Read.All permission.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: value
+        key: jobTitle
+        value: ".*[Aa]dmin.*"
+        op: regex
+      - type: mfa-enabled
+        value: false
+
+  - name: security-audit-old-passwords
+    resource: azure.entraid-user
+    description: |
+      Find users with passwords older than 180 days.
+      These accounts may need password rotation.
+      Note: Requires password change date information.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: password-age
+        days: 180
+        op: greater-than

--- a/tools/c7n_azure/examples/disabled-users.yaml
+++ b/tools/c7n_azure/examples/disabled-users.yaml
@@ -1,0 +1,10 @@
+policies:
+  - name: disabled-users
+    resource: azure.entraid-user
+    description: |
+      Find all disabled user accounts in the directory.
+      This policy helps identify inactive accounts that may need cleanup.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: false

--- a/tools/c7n_azure/examples/enabled-guest-users.yaml
+++ b/tools/c7n_azure/examples/enabled-guest-users.yaml
@@ -1,0 +1,14 @@
+policies:
+  - name: enabled-guest-users
+    resource: azure.entraid-user
+    description: |
+      Find users who are both enabled AND guest users.
+      This policy demonstrates multiple filter conditions (AND logic).
+      This typically returns fewer results since most guests are managed differently.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: value
+        key: userType
+        value: Guest

--- a/tools/c7n_azure/examples/enabled-member-users.yaml
+++ b/tools/c7n_azure/examples/enabled-member-users.yaml
@@ -1,0 +1,14 @@
+policies:
+  - name: enabled-member-users
+    resource: azure.entraid-user
+    description: |
+      Find users who are both enabled AND internal members.
+      This policy demonstrates multiple filter conditions (AND logic).
+      Useful for identifying active internal users.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: value
+        key: userType
+        value: Member

--- a/tools/c7n_azure/examples/enabled-users.yaml
+++ b/tools/c7n_azure/examples/enabled-users.yaml
@@ -1,0 +1,10 @@
+policies:
+  - name: enabled-users
+    resource: azure.entraid-user
+    description: |
+      Find all enabled user accounts in the directory.
+      This policy helps identify active user accounts for auditing purposes.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true

--- a/tools/c7n_azure/examples/member-users.yaml
+++ b/tools/c7n_azure/examples/member-users.yaml
@@ -1,0 +1,10 @@
+policies:
+  - name: member-users
+    resource: azure.entraid-user
+    description: |
+      Find all member users (internal users) in the directory.
+      This policy helps distinguish between internal and external users.
+    filters:
+      - type: value
+        key: userType
+        value: Member

--- a/tools/c7n_azure/examples/users-by-department.yaml
+++ b/tools/c7n_azure/examples/users-by-department.yaml
@@ -1,0 +1,14 @@
+policies:
+  - name: it-department-users
+    resource: azure.entraid-user
+    description: |
+      Find users in the IT department.
+      This policy demonstrates filtering by department field.
+      Modify the department value to match your organization's structure.
+    filters:
+      - type: value
+        key: accountEnabled
+        value: true
+      - type: value
+        key: department
+        value: IT

--- a/tools/c7n_azure/examples/users-with-mfa.yaml
+++ b/tools/c7n_azure/examples/users-with-mfa.yaml
@@ -1,0 +1,10 @@
+policies:
+  - name: users-with-mfa
+    resource: azure.entraid-user
+    description: |
+      Find users who have multi-factor authentication enabled.
+      This policy helps identify users with proper security measures in place.
+      Note: Requires UserAuthenticationMethod.Read.All permission.
+    filters:
+      - type: mfa-enabled
+        value: true

--- a/tools/c7n_azure/tests_azure/conftest.py
+++ b/tools/c7n_azure/tests_azure/conftest.py
@@ -1,0 +1,77 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import re
+import pytest
+
+from c7n.vendored.distutils.util import strtobool
+
+try:
+    from pytest_terraform.tf import LazyPluginCacheDir, LazyReplay
+    from c7n.testing import TestUtils
+    from c7n.config import Bag, Config
+    from c7n.policy import ExecutionContext
+    from c7n_azure.session import Session
+except ImportError:
+    # Fallback if pytest-terraform is not available
+    class LazyReplay:
+        pass
+
+    class LazyPluginCacheDir:
+        pass
+
+    class TestUtils:
+        pass
+
+
+# If we have C7N_FUNCTIONAL make sure Replay is False otherwise enable Replay
+LazyReplay.value = not strtobool(os.environ.get('C7N_FUNCTIONAL', 'no'))
+LazyPluginCacheDir.value = '../.tfcache'
+
+
+class TerraformAzureRewriteHooks:
+    """Local pytest plugin for Azure terraform tests
+
+    Work around to allow for dynamic registration of hooks based on plugin availability
+    """
+    def pytest_terraform_modify_state(self, tfstate):
+        """Sanitize functional testing account data for Azure"""
+        # Azure-specific sanitization - replace Azure GUIDs with placeholder
+        # Azure GUID pattern
+        azure_guid_pattern = (
+            r'\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            r'[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b'
+        )
+        tfstate.update(
+            re.sub(
+                azure_guid_pattern,
+                '00000000-0000-0000-0000-000000000000',
+                str(tfstate)
+            )
+        )
+
+
+def pytest_configure(config):
+    # Only register pytest-terraform hooks if the plugin is available
+    if config.pluginmanager.hasplugin("terraform"):
+        config.pluginmanager.register(TerraformAzureRewriteHooks())
+
+
+class AzureTerraformTesting(TestUtils):
+    """Pytest Azure Testing Fixture for Terraform tests"""
+
+    def __init__(self, request):
+        self.request = request
+        # Set up Azure test context similar to BaseTest
+        self.test_context = ExecutionContext(
+            Session,
+            Bag(name="terraform-test", provider_name='azure'),
+            Config.empty()
+        )
+
+
+@pytest.fixture(scope='function')
+def test(request):
+    """Azure test fixture that provides Cloud Custodian testing utilities"""
+    test_utils = AzureTerraformTesting(request)
+    return test_utils

--- a/tools/c7n_azure/tests_azure/test_diagnostic_settings.py
+++ b/tools/c7n_azure/tests_azure/test_diagnostic_settings.py
@@ -143,3 +143,26 @@ class DiagnosticSettingsFilterTest(BaseTest):
         }
         self.assertRaises(
             PolicyValidationError, self.load_policy, policy, validate=True)
+
+
+class EntraIDDiagnosticSettingsFilterTest(BaseTest):
+    """Test diagnostic settings filter for EntraID resources."""
+
+    def test_entraid_diagnostic_settings_schema_validate(self):
+        """Test that EntraID resources support diagnostic-settings filter schema validation."""
+
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-entraid-diagnostic-settings',
+                'resource': 'azure.entraid-user',
+                'filters': [
+                    {
+                        'type': 'diagnostic-settings',
+                        'key': "logs[?category == 'AuditLogs'][].enabled",
+                        'op': 'in',
+                        'value_type': 'swap',
+                        'value': True
+                    }
+                ]
+            }, validate=False)
+            self.assertTrue(p)

--- a/tools/c7n_azure/tests_azure/tests_resources/terraform/entraid_user/main.tf
+++ b/tools/c7n_azure/tests_azure/tests_resources/terraform/entraid_user/main.tf
@@ -1,0 +1,175 @@
+# Terraform configuration for EntraID User testing
+# Creates test users with various configurations for Cloud Custodian policy testing
+
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+  }
+}
+
+# Generate random suffix for unique naming
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+# Get current client configuration for tenant info
+data "azuread_client_config" "current" {}
+
+# Get available domains
+data "azuread_domains" "current" {
+  only_initial = false
+}
+
+# Use the first available domain for user principal names
+locals {
+  domain_name = data.azuread_domains.current.domains[0].domain_name
+}
+
+# Test User 1: Enabled user with admin role (for testing high-privilege detection)
+resource "azuread_user" "test_admin_user" {
+  user_principal_name   = "c7n-test-admin-${random_string.suffix.result}@${local.domain_name}"
+  display_name          = "C7N Test Admin User"
+  mail_nickname         = "c7n-test-admin-${random_string.suffix.result}"
+  password              = "P@ssw0rd123!"
+  force_password_change = false
+  account_enabled       = true
+  job_title             = "Administrator"
+  department            = "IT"
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}
+
+# Test User 2: Disabled user (for testing disabled account cleanup)
+resource "azuread_user" "test_disabled_user" {
+  user_principal_name   = "c7n-test-disabled-${random_string.suffix.result}@${local.domain_name}"
+  display_name          = "C7N Test Disabled User"
+  mail_nickname         = "c7n-test-disabled-${random_string.suffix.result}"
+  password              = "P@ssw0rd123!"
+  force_password_change = false
+  account_enabled       = false
+  job_title             = "User"
+  department            = "HR"
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}
+
+# Test User 3: Regular enabled user (for baseline testing)
+resource "azuread_user" "test_regular_user" {
+  user_principal_name   = "c7n-test-regular-${random_string.suffix.result}@${local.domain_name}"
+  display_name          = "C7N Test Regular User"
+  mail_nickname         = "c7n-test-regular-${random_string.suffix.result}"
+  password              = "P@ssw0rd123!"
+  force_password_change = false
+  account_enabled       = true
+  job_title             = "Developer"
+  department            = "Engineering"
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}
+
+# Test User 4: User with old password (simulate password age testing)
+resource "azuread_user" "test_old_password_user" {
+  user_principal_name   = "c7n-test-oldpwd-${random_string.suffix.result}@${local.domain_name}"
+  display_name          = "C7N Test Old Password User"
+  mail_nickname         = "c7n-test-oldpwd-${random_string.suffix.result}"
+  password              = "OldP@ssw0rd123!"
+  force_password_change = false
+  account_enabled       = true
+  job_title             = "Analyst"
+  department            = "Finance"
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+}
+
+# Create a security group for testing group membership filters
+resource "azuread_group" "test_security_group" {
+  display_name     = "C7N Test Security Group ${random_string.suffix.result}"
+  mail_enabled     = false
+  security_enabled = true
+  description      = "Test security group for Cloud Custodian EntraID testing"
+}
+
+# Add admin user to the security group
+resource "azuread_group_member" "admin_member" {
+  group_object_id  = azuread_group.test_security_group.object_id
+  member_object_id = azuread_user.test_admin_user.object_id
+}
+
+# Outputs for pytest-terraform to use
+output "test_admin_user" {
+  value = {
+    id                  = azuread_user.test_admin_user.id
+    object_id           = azuread_user.test_admin_user.object_id
+    user_principal_name = azuread_user.test_admin_user.user_principal_name
+    display_name        = azuread_user.test_admin_user.display_name
+    account_enabled     = azuread_user.test_admin_user.account_enabled
+    job_title           = azuread_user.test_admin_user.job_title
+    department          = azuread_user.test_admin_user.department
+  }
+}
+
+output "test_disabled_user" {
+  value = {
+    id                  = azuread_user.test_disabled_user.id
+    object_id           = azuread_user.test_disabled_user.object_id
+    user_principal_name = azuread_user.test_disabled_user.user_principal_name
+    display_name        = azuread_user.test_disabled_user.display_name
+    account_enabled     = azuread_user.test_disabled_user.account_enabled
+    job_title           = azuread_user.test_disabled_user.job_title
+    department          = azuread_user.test_disabled_user.department
+  }
+}
+
+output "test_regular_user" {
+  value = {
+    id                  = azuread_user.test_regular_user.id
+    object_id           = azuread_user.test_regular_user.object_id
+    user_principal_name = azuread_user.test_regular_user.user_principal_name
+    display_name        = azuread_user.test_regular_user.display_name
+    account_enabled     = azuread_user.test_regular_user.account_enabled
+    job_title           = azuread_user.test_regular_user.job_title
+    department          = azuread_user.test_regular_user.department
+  }
+}
+
+output "test_old_password_user" {
+  value = {
+    id                  = azuread_user.test_old_password_user.id
+    object_id           = azuread_user.test_old_password_user.object_id
+    user_principal_name = azuread_user.test_old_password_user.user_principal_name
+    display_name        = azuread_user.test_old_password_user.display_name
+    account_enabled     = azuread_user.test_old_password_user.account_enabled
+    job_title           = azuread_user.test_old_password_user.job_title
+    department          = azuread_user.test_old_password_user.department
+  }
+}
+
+output "test_security_group" {
+  value = {
+    id           = azuread_group.test_security_group.id
+    object_id    = azuread_group.test_security_group.object_id
+    display_name = azuread_group.test_security_group.display_name
+    description  = azuread_group.test_security_group.description
+  }
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/terraform/entraid_user/tf_resources.json
+++ b/tools/c7n_azure/tests_azure/tests_resources/terraform/entraid_user/tf_resources.json
@@ -1,0 +1,569 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {
+        "test_admin_user": {
+            "value": {
+                "account_enabled": true,
+                "department": "IT",
+                "display_name": "C7N Test Admin User",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "job_title": "Administrator",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "user_principal_name": "c7n-test-admin-dw2t83rv@example.com"
+            },
+            "type": [
+                "object",
+                {
+                    "account_enabled": "bool",
+                    "department": "string",
+                    "display_name": "string",
+                    "id": "string",
+                    "job_title": "string",
+                    "object_id": "string",
+                    "user_principal_name": "string"
+                }
+            ]
+        },
+        "test_disabled_user": {
+            "value": {
+                "account_enabled": false,
+                "department": "HR",
+                "display_name": "C7N Test Disabled User",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "job_title": "User",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "user_principal_name": "c7n-test-disabled-dw2t83rv@example.com"
+            },
+            "type": [
+                "object",
+                {
+                    "account_enabled": "bool",
+                    "department": "string",
+                    "display_name": "string",
+                    "id": "string",
+                    "job_title": "string",
+                    "object_id": "string",
+                    "user_principal_name": "string"
+                }
+            ]
+        },
+        "test_old_password_user": {
+            "value": {
+                "account_enabled": true,
+                "department": "Finance",
+                "display_name": "C7N Test Old Password User",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "job_title": "Analyst",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "user_principal_name": "c7n-test-oldpwd-dw2t83rv@example.com"
+            },
+            "type": [
+                "object",
+                {
+                    "account_enabled": "bool",
+                    "department": "string",
+                    "display_name": "string",
+                    "id": "string",
+                    "job_title": "string",
+                    "object_id": "string",
+                    "user_principal_name": "string"
+                }
+            ]
+        },
+        "test_regular_user": {
+            "value": {
+                "account_enabled": true,
+                "department": "Engineering",
+                "display_name": "C7N Test Regular User",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "job_title": "Developer",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "user_principal_name": "c7n-test-regular-dw2t83rv@example.com"
+            },
+            "type": [
+                "object",
+                {
+                    "account_enabled": "bool",
+                    "department": "string",
+                    "display_name": "string",
+                    "id": "string",
+                    "job_title": "string",
+                    "object_id": "string",
+                    "user_principal_name": "string"
+                }
+            ]
+        },
+        "test_security_group": {
+            "value": {
+                "description": "Test security group for Cloud Custodian EntraID testing",
+                "display_name": "C7N Test Security Group dw2t83rv",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "object_id": "00000000-0000-0000-0000-000000000000"
+            },
+            "type": [
+                "object",
+                {
+                    "description": "string",
+                    "display_name": "string",
+                    "id": "string",
+                    "object_id": "string"
+                }
+            ]
+        }
+    },
+    "resources": {
+        "azuread_client_config": {
+            "current": {
+                "client_id": "00000000-0000-0000-0000-000000000000",
+                "id": "00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "tenant_id": "00000000-0000-0000-0000-000000000000",
+                "timeouts": null
+            }
+        },
+        "azuread_domains": {
+            "current": {
+                "admin_managed": false,
+                "domains": [
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "example.com",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain1.com",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain2.com",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain3.org",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain4.com",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain5.org",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain6.org",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain7.com",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "mockorg.onmicrosoft.com",
+                        "initial": true,
+                        "root": true,
+                        "supported_services": [
+                            "Email",
+                            "OfficeCommunicationsOnline"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": true,
+                        "domain_name": "mockorg.com",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain8.com",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "MOCKTESTDOMAIN123456789.example.cloud",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [],
+                        "verified": true
+                    },
+                    {
+                        "admin_managed": true,
+                        "authentication_type": "Managed",
+                        "default": false,
+                        "domain_name": "testdomain9.com",
+                        "initial": false,
+                        "root": true,
+                        "supported_services": [
+                            "Email"
+                        ],
+                        "verified": true
+                    }
+                ],
+                "id": "domains#00000000-0000-0000-0000-000000000000#MockHashForTestingPurposes123=",
+                "include_unverified": false,
+                "only_default": false,
+                "only_initial": false,
+                "only_root": false,
+                "supports_services": [],
+                "timeouts": null
+            }
+        },
+        "azuread_group": {
+            "test_security_group": {
+                "administrative_unit_ids": null,
+                "assignable_to_role": false,
+                "auto_subscribe_new_members": false,
+                "behaviors": null,
+                "description": "Test security group for Cloud Custodian EntraID testing",
+                "display_name": "C7N Test Security Group dw2t83rv",
+                "dynamic_membership": [],
+                "external_senders_allowed": false,
+                "hide_from_address_lists": false,
+                "hide_from_outlook_clients": false,
+                "id": "00000000-0000-0000-0000-000000000000",
+                "mail": "",
+                "mail_enabled": false,
+                "mail_nickname": "mock-group-1",
+                "members": [],
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "onpremises_domain_name": "",
+                "onpremises_group_type": "",
+                "onpremises_netbios_name": "",
+                "onpremises_sam_account_name": "",
+                "onpremises_security_identifier": "",
+                "onpremises_sync_enabled": false,
+                "owners": [
+                    "00000000-0000-0000-0000-000000000000"
+                ],
+                "preferred_language": "",
+                "prevent_duplicate_names": false,
+                "provisioning_options": null,
+                "proxy_addresses": [],
+                "security_enabled": true,
+                "theme": "",
+                "timeouts": null,
+                "types": null,
+                "visibility": "",
+                "writeback_enabled": false
+            }
+        },
+        "azuread_group_member": {
+            "admin_member": {
+                "group_object_id": "00000000-0000-0000-0000-000000000000",
+                "id": "00000000-0000-0000-0000-000000000000/member/00000000-0000-0000-0000-000000000000",
+                "member_object_id": "00000000-0000-0000-0000-000000000000",
+                "timeouts": null
+            }
+        },
+        "azuread_user": {
+            "test_admin_user": {
+                "about_me": "",
+                "account_enabled": true,
+                "age_group": "",
+                "business_phones": [],
+                "city": "",
+                "company_name": "",
+                "consent_provided_for_minor": "",
+                "cost_center": "",
+                "country": "",
+                "creation_type": "",
+                "department": "IT",
+                "disable_password_expiration": false,
+                "disable_strong_password": false,
+                "display_name": "C7N Test Admin User",
+                "division": "",
+                "employee_id": "",
+                "employee_type": "",
+                "external_user_state": "",
+                "fax_number": "",
+                "force_password_change": false,
+                "given_name": "",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "im_addresses": [],
+                "job_title": "Administrator",
+                "mail": "",
+                "mail_nickname": "c7n-test-admin-dw2t83rv",
+                "manager_id": "",
+                "mobile_phone": "",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "office_location": "",
+                "onpremises_distinguished_name": "",
+                "onpremises_domain_name": "",
+                "onpremises_immutable_id": "",
+                "onpremises_sam_account_name": "",
+                "onpremises_security_identifier": "",
+                "onpremises_sync_enabled": false,
+                "onpremises_user_principal_name": "",
+                "other_mails": null,
+                "password": "P@ssw0rd123!",
+                "postal_code": "",
+                "preferred_language": "",
+                "proxy_addresses": [],
+                "show_in_address_list": true,
+                "state": "",
+                "street_address": "",
+                "surname": "",
+                "timeouts": null,
+                "usage_location": "",
+                "user_principal_name": "c7n-test-admin-dw2t83rv@example.com",
+                "user_type": "Member"
+            },
+            "test_disabled_user": {
+                "about_me": "",
+                "account_enabled": false,
+                "age_group": "",
+                "business_phones": [],
+                "city": "",
+                "company_name": "",
+                "consent_provided_for_minor": "",
+                "cost_center": "",
+                "country": "",
+                "creation_type": "",
+                "department": "HR",
+                "disable_password_expiration": false,
+                "disable_strong_password": false,
+                "display_name": "C7N Test Disabled User",
+                "division": "",
+                "employee_id": "",
+                "employee_type": "",
+                "external_user_state": "",
+                "fax_number": "",
+                "force_password_change": false,
+                "given_name": "",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "im_addresses": [],
+                "job_title": "User",
+                "mail": "",
+                "mail_nickname": "c7n-test-disabled-dw2t83rv",
+                "manager_id": "",
+                "mobile_phone": "",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "office_location": "",
+                "onpremises_distinguished_name": "",
+                "onpremises_domain_name": "",
+                "onpremises_immutable_id": "",
+                "onpremises_sam_account_name": "",
+                "onpremises_security_identifier": "",
+                "onpremises_sync_enabled": false,
+                "onpremises_user_principal_name": "",
+                "other_mails": null,
+                "password": "P@ssw0rd123!",
+                "postal_code": "",
+                "preferred_language": "",
+                "proxy_addresses": [],
+                "show_in_address_list": true,
+                "state": "",
+                "street_address": "",
+                "surname": "",
+                "timeouts": null,
+                "usage_location": "",
+                "user_principal_name": "c7n-test-disabled-dw2t83rv@example.com",
+                "user_type": "Member"
+            },
+            "test_old_password_user": {
+                "about_me": "",
+                "account_enabled": true,
+                "age_group": "",
+                "business_phones": [],
+                "city": "",
+                "company_name": "",
+                "consent_provided_for_minor": "",
+                "cost_center": "",
+                "country": "",
+                "creation_type": "",
+                "department": "Finance",
+                "disable_password_expiration": false,
+                "disable_strong_password": false,
+                "display_name": "C7N Test Old Password User",
+                "division": "",
+                "employee_id": "",
+                "employee_type": "",
+                "external_user_state": "",
+                "fax_number": "",
+                "force_password_change": false,
+                "given_name": "",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "im_addresses": [],
+                "job_title": "Analyst",
+                "mail": "",
+                "mail_nickname": "c7n-test-oldpwd-dw2t83rv",
+                "manager_id": "",
+                "mobile_phone": "",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "office_location": "",
+                "onpremises_distinguished_name": "",
+                "onpremises_domain_name": "",
+                "onpremises_immutable_id": "",
+                "onpremises_sam_account_name": "",
+                "onpremises_security_identifier": "",
+                "onpremises_sync_enabled": false,
+                "onpremises_user_principal_name": "",
+                "other_mails": null,
+                "password": "OldP@ssw0rd123!",
+                "postal_code": "",
+                "preferred_language": "",
+                "proxy_addresses": [],
+                "show_in_address_list": true,
+                "state": "",
+                "street_address": "",
+                "surname": "",
+                "timeouts": null,
+                "usage_location": "",
+                "user_principal_name": "c7n-test-oldpwd-dw2t83rv@example.com",
+                "user_type": "Member"
+            },
+            "test_regular_user": {
+                "about_me": "",
+                "account_enabled": true,
+                "age_group": "",
+                "business_phones": [],
+                "city": "",
+                "company_name": "",
+                "consent_provided_for_minor": "",
+                "cost_center": "",
+                "country": "",
+                "creation_type": "",
+                "department": "Engineering",
+                "disable_password_expiration": false,
+                "disable_strong_password": false,
+                "display_name": "C7N Test Regular User",
+                "division": "",
+                "employee_id": "",
+                "employee_type": "",
+                "external_user_state": "",
+                "fax_number": "",
+                "force_password_change": false,
+                "given_name": "",
+                "id": "00000000-0000-0000-0000-000000000000",
+                "im_addresses": [],
+                "job_title": "Developer",
+                "mail": "",
+                "mail_nickname": "c7n-test-regular-dw2t83rv",
+                "manager_id": "",
+                "mobile_phone": "",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+                "office_location": "",
+                "onpremises_distinguished_name": "",
+                "onpremises_domain_name": "",
+                "onpremises_immutable_id": "",
+                "onpremises_sam_account_name": "",
+                "onpremises_security_identifier": "",
+                "onpremises_sync_enabled": false,
+                "onpremises_user_principal_name": "",
+                "other_mails": null,
+                "password": "P@ssw0rd123!",
+                "postal_code": "",
+                "preferred_language": "",
+                "proxy_addresses": [],
+                "show_in_address_list": true,
+                "state": "",
+                "street_address": "",
+                "surname": "",
+                "timeouts": null,
+                "usage_location": "",
+                "user_principal_name": "c7n-test-regular-dw2t83rv@example.com",
+                "user_type": "Member"
+            }
+        },
+        "random_string": {
+            "suffix": {
+                "id": "dw2t83rv",
+                "keepers": null,
+                "length": 8,
+                "lower": true,
+                "min_lower": 0,
+                "min_numeric": 0,
+                "min_special": 0,
+                "min_upper": 0,
+                "number": true,
+                "numeric": true,
+                "override_special": null,
+                "result": "dw2t83rv",
+                "special": false,
+                "upper": false
+            }
+        }
+    }
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_entraid.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_entraid.py
@@ -1,0 +1,517 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock, patch
+import pytest
+from pytest_terraform import terraform
+
+from c7n_azure.resources.entraid_user import EntraIDUser
+from tests_azure.azure_common import BaseTest
+
+
+class EntraIDUserTest(BaseTest):
+    """Test EntraID User resource functionality"""
+
+    def test_entraid_user_schema_validate(self):
+        """Test that the EntraID user resource schema validates correctly"""
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-entraid-user',
+                'resource': 'azure.entraid-user',
+                'filters': [
+                    {'type': 'value', 'key': 'accountEnabled', 'value': True}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_entraid_user_resource_type(self):
+        """Test EntraID user resource type configuration"""
+        resource_type = EntraIDUser.resource_type
+        self.assertEqual(resource_type.service, 'graph')
+        self.assertEqual(resource_type.id, 'id')
+        self.assertEqual(resource_type.name, 'displayName')
+        self.assertTrue(resource_type.global_resource)
+        self.assertIn('User.Read.All', resource_type.permissions)
+
+    @patch('c7n_azure.resources.entraid_user.local_session')
+    def test_entraid_user_augment(self, mock_session):
+        """Test user resource augmentation with computed fields"""
+        mock_client = Mock()
+        mock_session.return_value.get_session_for_resource.return_value.\
+client.return_value = mock_client
+
+        # Sample user data
+        users = [
+            {
+                'objectId': 'user1-id',
+                'displayName': 'Test User',
+                'userPrincipalName': 'test.user@example.com',
+                'accountEnabled': True,
+                'lastSignInDateTime': '2023-01-01T12:00:00Z',
+                'lastPasswordChangeDateTime': '2022-01-01T12:00:00Z',
+                'jobTitle': 'Administrator'
+            },
+            {
+                'objectId': 'user2-id',
+                'displayName': 'Regular User',
+                'userPrincipalName': 'regular@example.com',
+                'accountEnabled': False,
+                'lastSignInDateTime': None,
+                'lastPasswordChangeDateTime': None,
+                'jobTitle': 'User'
+            }
+        ]
+
+        policy = self.load_policy({
+            'name': 'test-augment',
+            'resource': 'azure.entraid-user'
+        })
+
+        resource_mgr = policy.resource_manager
+        augmented = resource_mgr.augment(users)
+
+        # Check augmented fields
+        self.assertIn('c7n:LastSignInDays', augmented[0])
+        self.assertIn('c7n:IsHighPrivileged', augmented[0])
+        self.assertIn('c7n:PasswordAge', augmented[0])
+
+        # Admin user should be flagged as high privileged
+        self.assertTrue(augmented[0]['c7n:IsHighPrivileged'])
+        self.assertFalse(augmented[1]['c7n:IsHighPrivileged'])
+
+    @patch('c7n_azure.resources.entraid_user.EntraIDUser.get_user_auth_methods')
+    def test_auth_methods_filter(self, mock_auth_methods):
+        """Test authentication methods filter with real Graph API implementation"""
+        users = [
+            {
+                'id': 'user1',
+                'objectId': 'user1',
+                'displayName': 'User 1'
+            },
+            {
+                'id': 'user2',
+                'objectId': 'user2',
+                'displayName': 'User 2'
+            },
+            {
+                'id': 'user3',
+                'objectId': 'user3',
+                'displayName': 'User 3'
+            }
+        ]
+
+        # Mock authentication methods: user1 has multiple methods, user2 has one, user3 has none
+        def mock_auth_methods_side_effect(user_id):
+            if user_id == 'user1':
+                return [
+                    {
+                        '@odata.type': (
+                            '#microsoft.graph.'
+                            'microsoftAuthenticatorAuthenticationMethod'
+                        ),
+                        'id': 'method1-id',
+                        'displayName': 'Microsoft Authenticator'
+                    },
+                    {
+                        '@odata.type': '#microsoft.graph.phoneAuthenticationMethod',
+                        'id': 'method2-id',
+                        'phoneNumber': '+1555XXXX123',
+                        'phoneType': 'mobile'
+                    }
+                ]
+            elif user_id == 'user2':
+                return [
+                    {
+                        '@odata.type': '#microsoft.graph.phoneAuthenticationMethod',
+                        'id': 'method3-id',
+                        'phoneNumber': '+1555XXXX456',
+                        'phoneType': 'mobile'
+                    }
+                ]
+            else:
+                return []  # No authentication methods
+
+        mock_auth_methods.side_effect = mock_auth_methods_side_effect
+
+        policy = self.load_policy({
+            'name': 'test-auth-methods-filter',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {'type': 'auth-methods', 'key': '[]."@odata.type"', 'value': 'not-null'}
+            ]
+        })
+
+        resource_mgr = policy.resource_manager
+        filtered = resource_mgr.filter_resources(users)
+
+        # Should have 3 users with auth methods data enriched (including user with empty list)
+        self.assertEqual(len(filtered), 2)
+
+        # Check that users are enriched with auth methods data
+        for user in filtered:
+            self.assertIn('c7n:AuthMethods', user)
+
+        # Check actual auth methods content
+        user1 = next(u for u in filtered if u['id'] == 'user1')
+        user2 = next(u for u in filtered if u['id'] == 'user2')
+
+        self.assertEqual(len(user1['c7n:AuthMethods']), 2)  # User1 has 2 methods
+        self.assertEqual(len(user2['c7n:AuthMethods']), 1)  # User2 has 1 method
+
+        # Verify the auth methods check was called for each user
+        self.assertEqual(mock_auth_methods.call_count, 3)
+
+    def test_last_signin_filter(self):
+        """Test last sign-in filter"""
+        users = [
+            {
+                'objectId': 'user1',
+                'c7n:LastSignInDays': 120  # Old sign-in
+            },
+            {
+                'objectId': 'user2',
+                'c7n:LastSignInDays': 30   # Recent sign-in
+            },
+            {
+                'objectId': 'user3',
+                'c7n:LastSignInDays': 999  # Never signed in
+            }
+        ]
+
+        policy = self.load_policy({
+            'name': 'test-signin-filter',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {'type': 'last-sign-in', 'days': 90, 'op': 'greater-than'}
+            ]
+        })
+
+        resource_mgr = policy.resource_manager
+        filtered = resource_mgr.filter_resources(users)
+
+        # Should match user1 and user3 (>90 days)
+        self.assertEqual(len(filtered), 2)
+        self.assertEqual(set(u['objectId'] for u in filtered), {'user1', 'user3'})
+
+    @patch('c7n_azure.resources.entraid_user.EntraIDUser.get_user_group_memberships')
+    def test_group_membership_filter(self, mock_group_memberships):
+        """Test group membership filter with real Graph API implementation"""
+        users = [
+            {
+                'id': 'user1',
+                'objectId': 'user1',
+                'displayName': 'User 1'
+            },
+            {
+                'id': 'user2',
+                'objectId': 'user2',
+                'displayName': 'User 2'
+            },
+            {
+                'id': 'user3',
+                'objectId': 'user3',
+                'displayName': 'User 3'
+            }
+        ]
+
+        # Mock group memberships: user1 in admin groups, user2 in regular, user3 unknown
+        def mock_group_side_effect(user_id):
+            if user_id == 'user1':
+                return [
+                    {'id': 'group1', 'displayName': 'Global Administrators'},
+                    {'id': 'group2', 'displayName': 'Regular Users'}
+                ]
+            elif user_id == 'user2':
+                return [
+                    {'id': 'group2', 'displayName': 'Regular Users'}
+                ]
+            else:
+                return None  # Unknown group memberships
+
+        mock_group_memberships.side_effect = mock_group_side_effect
+
+        policy = self.load_policy({
+            'name': 'test-group-filter',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {
+                    'type': 'group-membership',
+                    'groups': ['Global Administrators'],
+                    'match': 'any'
+                }
+            ]
+        })
+
+        resource_mgr = policy.resource_manager
+        filtered = resource_mgr.filter_resources(users)
+
+        # Only user1 is in admin group (user3 skipped due to unknown status)
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]['id'], 'user1')
+
+        # Verify the group membership check was called
+        self.assertEqual(mock_group_memberships.call_count, 3)
+
+    @patch('c7n_azure.resources.entraid_user.EntraIDUser.make_graph_request')
+    def test_user_type_field_requested(self, mock_graph_request):
+        """Test that userType field is explicitly requested from Graph API"""
+        # Mock the Graph API response with userType field
+        mock_graph_request.return_value = {
+            'value': [
+                {
+                    'id': 'user1',
+                    'objectId': 'user1',
+                    'displayName': 'Guest User',
+                    'userPrincipalName': 'guest@external.com',
+                    'userType': 'Guest',
+                    'accountEnabled': True
+                },
+                {
+                    'id': 'user2',
+                    'objectId': 'user2',
+                    'displayName': 'Member User',
+                    'userPrincipalName': 'member@internal.com',
+                    'userType': 'Member',
+                    'accountEnabled': True
+                }
+            ]
+        }
+
+        policy = self.load_policy({
+            'name': 'test-usertype-field',
+            'resource': 'azure.entraid-user'
+        })
+
+        resource_mgr = policy.resource_manager
+        resources = resource_mgr.resources()
+
+        # Verify the API was called with $select parameter including userType
+        mock_graph_request.assert_called_once()
+        call_args = mock_graph_request.call_args[0]
+        endpoint = call_args[0]
+        self.assertIn('$select=', endpoint)
+        self.assertIn('userType', endpoint)
+
+        # Verify userType field is present in returned resources
+        self.assertEqual(len(resources), 2)
+        self.assertEqual(resources[0]['userType'], 'Guest')
+        self.assertEqual(resources[1]['userType'], 'Member')
+
+    def test_guest_user_filter(self):
+        """Test that ValueFilter works correctly with userType field for guest users"""
+        users = [
+            {
+                'id': 'user1',
+                'objectId': 'user1',
+                'displayName': 'Guest User',
+                'userPrincipalName': 'guest@external.com',
+                'userType': 'Guest',
+                'accountEnabled': True
+            },
+            {
+                'id': 'user2',
+                'objectId': 'user2',
+                'displayName': 'Member User',
+                'userPrincipalName': 'member@internal.com',
+                'userType': 'Member',
+                'accountEnabled': True
+            },
+            {
+                'id': 'user3',
+                'objectId': 'user3',
+                'displayName': 'Another Member',
+                'userPrincipalName': 'member2@internal.com',
+                'userType': 'Member',
+                'accountEnabled': True
+            }
+        ]
+
+        # Test filtering for guest users (like the guest-users.yaml policy)
+        policy = self.load_policy({
+            'name': 'test-guest-filter',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {'type': 'value', 'key': 'userType', 'value': 'Guest'},
+                {'type': 'value', 'key': 'accountEnabled', 'value': True}
+            ]
+        })
+
+        resource_mgr = policy.resource_manager
+        filtered = resource_mgr.filter_resources(users)
+
+        # Should only return the guest user
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]['userType'], 'Guest')
+        self.assertEqual(filtered[0]['displayName'], 'Guest User')
+
+        # Test filtering for member users
+        policy_members = self.load_policy({
+            'name': 'test-member-filter',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {'type': 'value', 'key': 'userType', 'value': 'Member'}
+            ]
+        })
+
+        resource_mgr_members = policy_members.resource_manager
+        filtered_members = resource_mgr_members.filter_resources(users)
+
+        # Should return both member users
+        self.assertEqual(len(filtered_members), 2)
+        self.assertTrue(all(u['userType'] == 'Member' for u in filtered_members))
+
+    def test_password_age_filter(self):
+        """Test password age filter"""
+        users = [
+            {
+                'objectId': 'user1',
+                'c7n:PasswordAge': 200  # Old password
+            },
+            {
+                'objectId': 'user2',
+                'c7n:PasswordAge': 30   # Recent password change
+            }
+        ]
+
+        policy = self.load_policy({
+            'name': 'test-password-age',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {'type': 'password-age', 'days': 180, 'op': 'greater-than'}
+            ]
+        })
+
+        resource_mgr = policy.resource_manager
+        filtered = resource_mgr.filter_resources(users)
+
+        # Only user1 has old password
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]['objectId'], 'user1')
+
+    def test_disable_user_action(self):
+        """Test disable user action"""
+
+        policy = self.load_policy({
+            'name': 'test-disable-action',
+            'resource': 'azure.entraid-user',
+            'actions': [{'type': 'disable'}]
+        })
+
+        # Validate action schema
+        resource_mgr = policy.resource_manager
+        action = resource_mgr.actions[0]
+        self.assertEqual(action.type, 'disable')
+        self.assertIn('User.ReadWrite.All', action.permissions)
+
+
+# Terraform-based integration tests
+# These tests use real Azure EntraID resources provisioned via Terraform
+# Following the same pattern as AWS tests
+
+
+@terraform('entraid_user')
+@pytest.mark.functional
+def test_entraid_user_discovery_terraform(test, entraid_user):
+    """Test that Cloud Custodian can discover users provisioned by Terraform"""
+    # Verify terraform fixtures loaded successfully
+    assert len(entraid_user.outputs) == 5, (
+        f"Expected 5 total outputs (4 users + 1 group), got {len(entraid_user.outputs)}"
+    )
+    assert 'azuread_user' in entraid_user.resources, "azuread_user resources not found"
+
+    # Get terraform-provisioned user data
+    admin_user = entraid_user.outputs['test_admin_user']['value']
+    disabled_user = entraid_user.outputs['test_disabled_user']['value']
+    regular_user = entraid_user.outputs['test_regular_user']['value']
+    old_password_user = entraid_user.outputs['test_old_password_user']['value']
+
+    # Verify test data integrity
+
+    assert admin_user['account_enabled'] is True
+    assert admin_user['job_title'] == 'Administrator'
+    assert admin_user['department'] == 'IT'
+
+    assert disabled_user['account_enabled'] is False
+    assert disabled_user['job_title'] == 'User'
+    assert disabled_user['department'] == 'HR'
+
+    assert regular_user['account_enabled'] is True
+    assert regular_user['job_title'] == 'Developer'
+    assert regular_user['department'] == 'Engineering'
+
+    assert old_password_user['account_enabled'] is True
+
+    assert old_password_user['job_title'] == 'Analyst'
+    assert old_password_user['department'] == 'Finance'
+
+    # Test Cloud Custodian policy creation and validation
+    policy = test.load_policy({
+        'name': 'terraform-enabled-users',
+        'resource': 'azure.entraid-user',
+        'filters': [
+            {'type': 'value', 'key': 'accountEnabled', 'value': True}
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy.resource_manager.type == 'entraid-user'
+
+    # Test job title filter policy
+    admin_policy = test.load_policy({
+        'name': 'terraform-admin-users',
+        'resource': 'azure.entraid-user',
+        'filters': [
+            {'type': 'value', 'key': 'jobTitle', 'value': 'Administrator'}
+        ]
+    })
+
+    assert admin_policy.resource_manager.type == 'entraid-user'
+
+    print(f"SUCCESS: Terraform fixtures loaded {len(entraid_user.outputs)} users successfully")
+
+
+@terraform('entraid_user')
+@pytest.mark.functional
+def test_entraid_user_job_title_filter_terraform(test, entraid_user):
+    """Test job title filter against Terraform-provisioned users"""
+    admin_user = entraid_user.outputs['test_admin_user']['value']
+    regular_user = entraid_user.outputs['test_regular_user']['value']
+
+    # Test policy for admin job titles
+    policy = test.load_policy({
+        'name': 'terraform-admin-users',
+        'resource': 'azure.entraid-user',
+        'filters': [
+            {'type': 'value', 'key': 'jobTitle', 'value': 'Administrator'}
+        ]
+    })
+
+    # Verify test data has expected job titles
+    assert admin_user['job_title'] == 'Administrator'
+    assert regular_user['job_title'] == 'Developer'
+
+    # Verify policy validates correctly
+    assert policy is not None
+
+
+@terraform('entraid_user')
+@pytest.mark.functional
+def test_entraid_user_department_filter_terraform(test, entraid_user):
+    """Test department filter against Terraform-provisioned users"""
+    admin_user = entraid_user.outputs['test_admin_user']['value']
+    old_password_user = entraid_user.outputs['test_old_password_user']['value']
+
+    # Test policy for IT department users
+    policy = test.load_policy({
+        'name': 'terraform-it-users',
+        'resource': 'azure.entraid-user',
+        'filters': [
+            {'type': 'value', 'key': 'department', 'value': 'IT'}
+        ]
+    })
+
+    # Verify test data has expected departments
+    assert admin_user['department'] == 'IT'
+    assert old_password_user['department'] == 'Finance'
+
+    assert policy is not None

--- a/tools/c7n_azure/tests_azure/tests_resources/test_entraid_simple.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_entraid_simple.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+import sys
+from unittest.mock import Mock, patch
+
+try:
+    from c7n_azure.resources.entraid_user import EntraIDUser
+    from c7n.config import Config
+    from c7n.policy import Policy
+except ImportError as e:
+    print(f"Import error: {e}")
+    sys.exit(1)
+
+
+class EntraIDUserTest(unittest.TestCase):
+    """Test EntraID User resource functionality"""
+
+    def load_policy(self, policy_data, validate=False):
+        """Helper method to load a policy"""
+        config = Config.empty()
+        policy = Policy(policy_data, config, session_factory=None)
+        return policy
+
+    def test_entraid_user_schema_validate(self):
+        """Test that the EntraID user resource schema validates correctly"""
+        policy_data = {
+            'name': 'test-entraid-user',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {'type': 'value', 'key': 'accountEnabled', 'value': True}
+            ]
+        }
+        p = self.load_policy(policy_data, validate=True)
+        self.assertIsNotNone(p)
+        self.assertEqual(p.name, 'test-entraid-user')
+
+    def test_entraid_user_resource_type(self):
+        """Test EntraID user resource type configuration"""
+        resource_type = EntraIDUser.resource_type
+        self.assertEqual(resource_type.service, 'graph')
+        self.assertEqual(resource_type.id, 'id')
+        self.assertEqual(resource_type.name, 'displayName')
+        self.assertTrue(resource_type.global_resource)
+        self.assertIn('User.Read.All', resource_type.permissions)
+
+    @patch('c7n_azure.resources.entraid_user.local_session')
+    def test_entraid_user_augment(self, mock_session):
+        """Test user resource augmentation with computed fields"""
+        mock_client = Mock()
+        mock_session.return_value.get_session_for_resource.return_value = mock_client
+
+        # Sample user data
+        users = [
+            {
+                'objectId': 'user1-id',
+                'displayName': 'Test User',
+                'userPrincipalName': 'test.user@example.com',
+                'accountEnabled': True,
+                'signInActivity': {'lastSignInDateTime': '2023-01-01T12:00:00Z'},
+                'lastPasswordChangeDateTime': '2022-01-01T12:00:00Z',
+                'jobTitle': 'Administrator'
+            },
+            {
+                'objectId': 'user2-id',
+                'displayName': 'Regular User',
+                'userPrincipalName': 'regular@example.com',
+                'accountEnabled': False,
+                'signInActivity': {},
+                'lastPasswordChangeDateTime': None,
+                'jobTitle': 'User'
+            }
+        ]
+
+        policy_data = {
+            'name': 'test-augment',
+            'resource': 'azure.entraid-user'
+        }
+        policy = self.load_policy(policy_data)
+
+        resource_mgr = policy.resource_manager
+        augmented = resource_mgr.augment(users)
+
+        # Check augmented fields
+        self.assertIn('c7n:LastSignInDays', augmented[0])
+        self.assertIn('c7n:IsHighPrivileged', augmented[0])
+        self.assertIn('c7n:PasswordAge', augmented[0])
+
+        # Admin user should be flagged as high privileged
+        self.assertTrue(augmented[0]['c7n:IsHighPrivileged'])
+        self.assertFalse(augmented[1]['c7n:IsHighPrivileged'])
+
+    @patch('c7n_azure.resources.entraid_user.local_session')
+    def test_auth_methods_filter(self, mock_session):
+        """Test authentication methods filter"""
+        # Mock the session and Graph API responses
+        mock_client = Mock()
+        mock_session.return_value.get_session_for_resource.return_value = mock_client
+
+        users = [
+            {
+                'objectId': 'user1',
+                'id': 'user1'
+            },
+            {
+                'objectId': 'user2',
+                'id': 'user2'
+            },
+            {
+                'objectId': 'user3',
+                'id': 'user3'
+            }
+        ]
+
+        policy_data = {
+            'name': 'test-auth-methods-filter',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {'type': 'auth-methods', 'key': '[]."@odata.type"', 'value': 'not-null'}
+            ]
+        }
+
+        policy = self.load_policy(policy_data)
+        resource_mgr = policy.resource_manager
+
+        # Mock the Graph API responses for authentication methods
+        def mock_make_graph_request(endpoint):
+            if 'user1/authentication/methods' in endpoint:
+                return {
+                    'value': [
+                        {
+                            '@odata.type': (
+                                '#microsoft.graph.'
+                                'microsoftAuthenticatorAuthenticationMethod'
+                            ),
+                            'id': 'method1-id',
+                            'displayName': 'Microsoft Authenticator'
+                        },
+                        {
+                            '@odata.type': (
+                                '#microsoft.graph.phoneAuthenticationMethod'
+                            ),
+                            'id': 'method2-id',
+                            'phoneNumber': '+1555XXXX123',
+                            'phoneType': 'mobile'
+                        }
+                    ]
+                }
+            elif 'user2/authentication/methods' in endpoint:
+                return {
+                    'value': [
+                        {
+                            '@odata.type': '#microsoft.graph.phoneAuthenticationMethod',
+                            'id': 'method3-id',
+                            'phoneNumber': '+1555XXXX456',
+                            'phoneType': 'mobile'
+                        }
+                    ]
+                }
+            else:
+                return {'value': []}
+
+        resource_mgr.make_graph_request = mock_make_graph_request
+
+        filtered = resource_mgr.filter_resources(users)
+
+        # Should have all 3 users - the filter enriches all users with auth methods data
+        self.assertEqual(len(filtered), 2)
+        self.assertIn('c7n:AuthMethods', filtered[0])
+        self.assertIn('c7n:AuthMethods', filtered[1])
+
+        # Check that auth methods data is properly enriched
+        user1_methods = next(u for u in filtered if u['objectId'] == 'user1')['c7n:AuthMethods']
+        user2_methods = next(u for u in filtered if u['objectId'] == 'user2')['c7n:AuthMethods']
+
+        self.assertEqual(len(user1_methods), 2)  # User1 has 2 auth methods
+        self.assertEqual(len(user2_methods), 1)  # User2 has 1 auth method
+
+    def test_last_signin_filter(self):
+        """Test last sign-in filter"""
+        users = [
+            {
+                'objectId': 'user1',
+                'c7n:LastSignInDays': 120  # Old sign-in
+            },
+            {
+                'objectId': 'user2',
+                'c7n:LastSignInDays': 30   # Recent sign-in
+            },
+            {
+                'objectId': 'user3',
+                'c7n:LastSignInDays': 999  # Never signed in
+            }
+        ]
+
+        policy_data = {
+            'name': 'test-signin-filter',
+            'resource': 'azure.entraid-user',
+            'filters': [
+                {'type': 'last-sign-in', 'days': 90, 'op': 'greater-than'}
+            ]
+        }
+
+        policy = self.load_policy(policy_data)
+        resource_mgr = policy.resource_manager
+        filtered = resource_mgr.filter_resources(users)
+
+        # Should match user1 and user3 (>90 days)
+        self.assertEqual(len(filtered), 2)
+        self.assertEqual(
+            set(u['objectId'] for u in filtered), {'user1', 'user3'}
+        )
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
We introduce base support for accessing resources behind the Microsoft Graph API, as well as the azure.entraid-user resource; the auth-methods, risk-level, last-sign-in, group-membership, and password-age filters; and the disable and require-mfa actions.  We also support the standard diagnostic-settings filter on this resource.

Fixes #10157.