### PR TITLE
feat: Implement the 'elasticache-reserved' resource in ElastiCache.

### DIFF
--- a/c7n/resources/elasticache.py
+++ b/c7n/resources/elasticache.py
@@ -719,3 +719,36 @@ class ModifyUser(BaseAction):
         for r in resources:
             retry(client.modify_user, UserId=r['UserId'], **self.data["attributes"],
                 ignore_err_codes=('UserNotFoundFault',))
+
+
+@resources.register('elasticache-reserved')
+class ReservedCacheNodes(QueryResourceManager):
+    """Lists all the reserved cache nodes
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: reserved-cache-nodes-expiring
+            resource: aws.elasticache-reserved
+            filters:
+              - type: value
+                key: State
+                value: active
+
+    """
+
+    class resource_type(TypeInfo):
+        service = 'elasticache'
+        name = id = 'ReservedCacheNodeId'
+        date = 'StartTime'
+        enum_spec = (
+            'describe_reserved_cache_nodes',
+            'ReservedCacheNodes',
+            None,
+        )
+        filter_name = 'ReservedCacheNodeId'
+        filter_type = 'scalar'
+        arn_type = "reserved-instance"
+        permissions_enum = ('elasticache:DescribeReservedCacheNodes',)

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -125,6 +125,7 @@ ResourceMap = {
   "aws.eks-nodegroup": "c7n.resources.eks.NodeGroup",
   "aws.elastic-ip": "c7n.resources.vpc.NetworkAddress",
   "aws.elasticache-group": "c7n.resources.elasticache.ElastiCacheReplicationGroup",
+  "aws.elasticache-reserved": "c7n.resources.elasticache.ReservedCacheNodes",
   "aws.elasticache-user": "c7n.resources.elasticache.ElastiCacheUser",
   "aws.elasticbeanstalk": "c7n.resources.elasticbeanstalk.ElasticBeanstalk",
   "aws.elasticbeanstalk-environment": "c7n.resources.elasticbeanstalk.ElasticBeanstalkEnvironment",

--- a/tests/data/placebo/test_reserved_cache_nodes/elasticache.DescribeReservedCacheNodes_1.json
+++ b/tests/data/placebo/test_reserved_cache_nodes/elasticache.DescribeReservedCacheNodes_1.json
@@ -1,0 +1,29 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "ReservedCacheNodes": [
+        {
+            "ReservedCacheNodeId": "test-reservation",
+            "ReservedCacheNodesOfferingId": "649fd0c8-cf6d-47a0-bfa6-060f8e75e95f",
+            "CacheNodeType": "cache.t2.small",
+            "StartTime": "2025-10-09T19:52:28Z",
+            "Duration": 2592000,
+            "FixedPrice": 27.5,
+            "UsagePrice": 0.005,
+            "CacheNodeCount": 1,
+            "ProductDescription": "Test description here",
+            "OfferingType": "Light Utilization",
+            "State": "active",
+            "RecurringCharges": [
+                {
+                    "RecurringChargeAmount": 1.30,
+                    "RecurringChargeFrequency": "weekly"
+                }
+            ],
+            "ReservationARN": "arn:aws:elasticache:us-east-1:123456789012:reserved-instance:ri-2017-03-27-08-33-25-582"
+        }
+    ],
+    "NextToken": ""
+  }
+}

--- a/tests/data/placebo/test_reserved_cache_nodes_filtered/elasticache.DescribeReservedCacheNodes_1.json
+++ b/tests/data/placebo/test_reserved_cache_nodes_filtered/elasticache.DescribeReservedCacheNodes_1.json
@@ -1,0 +1,29 @@
+{
+  "status_code": 200,
+  "data": {
+    "ResponseMetadata": {},
+    "ReservedCacheNodes": [
+      {
+        "ReservedCacheNodeId": "test-reservation",
+        "ReservedCacheNodesOfferingId": "649fd0c8-cf6d-47a0-bfa6-060f8e75e95f",
+        "CacheNodeType": "cache.t2.small",
+        "StartTime": "2025-10-09T19:52:28Z",
+        "Duration": 2592000,
+        "FixedPrice": 27.5,
+        "UsagePrice": 0.005,
+        "CacheNodeCount": 1,
+        "ProductDescription": "Test description here",
+        "OfferingType": "Light Utilization",
+        "State": "active",
+        "RecurringCharges": [
+          {
+            "RecurringChargeAmount": 1.3,
+            "RecurringChargeFrequency": "weekly"
+          }
+        ],
+        "ReservationARN": "arn:aws:elasticache:us-east-1:123456789012:reserved-instance:ri-2017-03-27-08-33-25-582"
+      }
+    ],
+    "NextToken": ""
+  }
+}

--- a/tests/test_elasticache.py
+++ b/tests/test_elasticache.py
@@ -683,3 +683,34 @@ class TestElastiCacheUser(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+
+class TestReservedCacheNodes(BaseTest):
+
+    def test_reserved_cache_nodes(self):
+        session_factory = self.replay_flight_data("test_reserved_cache_nodes")
+        p = self.load_policy(
+            {
+                "name": "reserved-cache-nodes",
+                "resource": "aws.elasticache-reserved",
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['ReservedCacheNodeId'], 'test-reservation')
+        self.assertEqual(resources[0]['State'], 'active')
+
+    def test_reserved_cache_nodes_filter(self):
+        session_factory = self.replay_flight_data("test_reserved_cache_nodes_filtered")
+        p = self.load_policy(
+            {
+                "name": "reserved-cache-nodes-active",
+                "resource": "aws.elasticache-reserved",
+                "filters": [{"type": "value", "key": "State", "value": "active"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['State'], 'active')


### PR DESCRIPTION
## :dart: What needed to be done and why?

Resolves https://github.com/cloud-custodian/cloud-custodian/issues/8451

*Quick summary of the issue*

This adds support for the `elasticache-reserved` resource on AWS ElastiCache.

## :new: What is changed by this PR?

* Adds a new resource class to `c7n/resources/elasticache.py`
* Adds tests covering the resource

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
