### PR TITLE
Fix GuardDuty administrator account key and rename variables from Master → Administrator

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -407,8 +407,8 @@ class GuardDutyEnabled(MultiAttrFilter):
                 filters:
                   - type: guard-duty
                     Detector.Status: ENABLED
-                    Master.AccountId: "00011001"
-                    Master.RelationshipStatus: "Enabled"
+                    Administrator.AccountId: "00011001"
+                    Administrator.RelationshipStatus: "Enabled"
     """
 
     schema = {
@@ -419,7 +419,7 @@ class GuardDutyEnabled(MultiAttrFilter):
             'match-operator': {'enum': ['or', 'and']}},
         'patternProperties': {
             '^Detector': {'oneOf': [{'type': 'object'}, {'type': 'string'}]},
-            '^Master': {'oneOf': [{'type': 'object'}, {'type': 'string'}]}},
+            '^Administrator': {'oneOf': [{'type': 'object'}, {'type': 'string'}]}},
     }
 
     annotation = "c7n:guard-duty"
@@ -451,8 +451,8 @@ class GuardDutyEnabled(MultiAttrFilter):
 
         detector = client.get_detector(DetectorId=detector_id)
         detector.pop('ResponseMetadata', None)
-        master = client.get_administrator_account(DetectorId=detector_id).get('Master')
-        resource[self.annotation] = r = {'Detector': detector, 'Master': master}
+        admin = client.get_administrator_account(DetectorId=detector_id).get('Administrator')
+        resource[self.annotation] = r = {'Detector': detector, 'Administrator': admin}
         return r
 
 


### PR DESCRIPTION
This PR fixes an incorrect key reference in the GuardDuty resource handler.

The `get_administrator_account` API returns an `Administrator` key, not `Master`. The code previously relied on the deprecated `get_master_account` API structure.
Current schema from [aws docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/securityhub/client/get_administrator_account.html):
```
{
    'Administrator': {
        'AccountId': 'string',
        'InvitationId': 'string',
        'InvitedAt': datetime(2015, 1, 1),
        'MemberStatus': 'string'
    }
}
```

Closes #10375 

**PS:** I have the feeling that `RelationshipStatus` should be update to `MemberStatus` but I'm not sure about that. Happy to fix it too if someones confirms it.