### PR TITLE
added for suspended firehose stream too

### DIFF
--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -210,7 +210,7 @@ class FirehoseDelete(Action):
                 "These delivery streams can't be deleted (wrong state): %s" % (
                     ", ".join(creating)))
         for r in resources:
-            if not r['DeliveryStreamStatus'] == 'ACTIVE':
+            if r['DeliveryStreamStatus'] not in ('ACTIVE', 'SUSPENDED'):
                 continue
             client.delete_delivery_stream(
                 DeliveryStreamName=r['DeliveryStreamName'])


### PR DESCRIPTION
Delete action for Firehose resource skips streams in SUSPENDED status
[#10384](https://github.com/cloud-custodian/cloud-custodian/issues/10384)