### PR TITLE
releng - ensure dependabot scans reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,11 @@ version: 2
 updates:
 
 - package-ecosystem: "github-actions"
-  directory: "/"
+  directories:
+    - "/"
+    - ".github/composites/docker-build-push"
+    - ".github/composites/docs-publish"
+    - ".github/composites/install"
   schedule:
       interval: "monthly"
   commit-message:


### PR DESCRIPTION

while looking at a dependabot pr, it became apparent that it wasn't scanning our reusable workflows to update them as well.
it looks like it should be supported per the docs as references to reusable within the same repo from default location actions
should be followed, but let's go ahead and be explicit by listing out the reusable workflow in dependabot configuration.

