### PR TITLE
feat: Upgraded azure-mgmt-sql to latest.

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqldatabase.py
@@ -18,9 +18,12 @@ import enum
 import logging
 
 from azure.core.exceptions import AzureError, ResourceNotFoundError
-from azure.mgmt.sql.models import (BackupLongTermRetentionPolicy,
-                                   BackupShortTermRetentionPolicy,
-                                   DatabaseUpdate, Sku)
+from azure.mgmt.sql.models import (
+    LongTermRetentionPolicy,
+    BackupShortTermRetentionPolicy,
+    DatabaseUpdate,
+    Sku,
+)
 from c7n.filters import Filter
 from c7n.filters.core import PolicyValidationError
 from c7n.utils import get_annotation_prefix, type_schema
@@ -233,7 +236,7 @@ class DataMaskingPolicyFilter(Filter):
 class BackupRetentionPolicyHelper:
 
     SHORT_TERM_SQL_OPERATIONS = 'backup_short_term_retention_policies'
-    LONG_TERM_SQL_OPERATIONS = 'backup_long_term_retention_policies'
+    LONG_TERM_SQL_OPERATIONS = 'long_term_retention_policies'
 
     WEEK_OF_YEAR = 'week_of_year'
 
@@ -619,15 +622,15 @@ class LongTermBackupRetentionPolicyAction(BackupRetentionPolicyBaseAction):
             # If there is a yearly retention, and the week is not specified, default to week 1
             new_retention_policy[BackupRetentionPolicyHelper.WEEK_OF_YEAR] = 1
 
-        return BackupLongTermRetentionPolicy(**new_retention_policy)
+        return LongTermRetentionPolicy(**new_retention_policy)
 
     def _copy_retention_policy(self, retention_policy):
         """
         Create a copy of a retention policy object with only the required parameters for the
-        BackupLongTermRetentionPolicy class.
+        LongTermRetentionPolicy class.
 
         more info:
-          https://docs.microsoft.com/en-us/python/api/azure-mgmt-sql/azure.mgmt.sql.models.backuplongtermretentionpolicy?view=azure-python
+          https://docs.microsoft.com/en-us/python/api/azure-mgmt-sql/azure.mgmt.sql.models.longtermretentionpolicy?view=azure-python
         """
 
         keys = [backup_type.retention_property for backup_type in

--- a/tools/c7n_azure/pyproject.toml
+++ b/tools/c7n_azure/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "azure-mgmt-servicebus<9.0.0,>=8.2.0",
     "azure-mgmt-servicefabric<2.0.0,>=1.0.0",
     "azure-mgmt-signalr==0.4.0",
-    "azure-mgmt-sql<2.0.0,>=1.0.0",
+    "azure-mgmt-sql<4.0.0,>=3.0.0",
     "azure-mgmt-storage<23.0.0,>=22.1.1",
     "azure-mgmt-streamanalytics<2.0.0,>=1.0.0rc1",
     "azure-mgmt-subscription<2.0.0,>=1.0.0",

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py
@@ -448,7 +448,7 @@ class LongTermBackupRetentionPolicyActionTest(BaseTest):
     def setUpClass(cls, *args, **kwargs):
         super(LongTermBackupRetentionPolicyActionTest, cls).setUpClass(*args, **kwargs)
         cls.client = local_session(Session).client('azure.mgmt.sql.SqlManagementClient') \
-            .backup_long_term_retention_policies
+            .long_term_retention_policies
 
     def tearDown(self, *args, **kwargs):
         default_long_term_policy = {

--- a/uv.lock
+++ b/uv.lock
@@ -1022,16 +1022,16 @@ wheels = [
 
 [[package]]
 name = "azure-mgmt-sql"
-version = "1.0.0"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-common" },
     { name = "azure-mgmt-core" },
     { name = "msrest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/40af724de7a0b00f9a8986ec3554adf1c1cbc5f65c6401d3b0d7b86fc169/azure-mgmt-sql-1.0.0.zip", hash = "sha256:c7904f8798fbb285a2160c41c8bd7a416c6bd987f5d36a9b98c16f41e24e9f47", size = 938942, upload-time = "2020-11-25T04:37:31.156Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/af/398c57d15064ea23475076cd087b1a143b66d33a029e6e47c4688ca32310/azure-mgmt-sql-3.0.1.zip", hash = "sha256:129042cc011225e27aee6ef2697d585fa5722e5d1aeb0038af6ad2451a285457", size = 996625, upload-time = "2021-07-16T02:07:56.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/e9/6dd75c0e54b19fd1dca986aae06b853551c9631c3e2e50c94e7d3391e0be/azure_mgmt_sql-1.0.0-py2.py3-none-any.whl", hash = "sha256:8fae38fc88ba3388b15854f3a8a2c3f8aaeb9cb609ad37b6545abb8d3ae540e6", size = 711094, upload-time = "2020-11-25T04:37:29.419Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/46/db6dd21a237c32eb747c4a1790a6b0aafe1f52c55e07b90f732231027d47/azure_mgmt_sql-3.0.1-py2.py3-none-any.whl", hash = "sha256:1d1dd940d4d41be4ee319aad626341251572a5bf4a2addec71779432d9a1381f", size = 912881, upload-time = "2021-07-16T02:07:53.079Z" },
 ]
 
 [[package]]
@@ -1548,7 +1548,7 @@ requires-dist = [
     { name = "azure-mgmt-servicebus", specifier = ">=8.2.0,<9.0.0" },
     { name = "azure-mgmt-servicefabric", specifier = ">=1.0.0,<2.0.0" },
     { name = "azure-mgmt-signalr", specifier = "==0.4.0" },
-    { name = "azure-mgmt-sql", specifier = ">=1.0.0,<2.0.0" },
+    { name = "azure-mgmt-sql", specifier = ">=3.0.0,<4.0.0" },
     { name = "azure-mgmt-storage", specifier = ">=22.1.1,<23.0.0" },
     { name = "azure-mgmt-streamanalytics", specifier = ">=1.0.0rc1,<2.0.0" },
     { name = "azure-mgmt-subscription", specifier = ">=1.0.0,<2.0.0" },
@@ -2415,7 +2415,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
Resolves #10349 .

## Summary

This updates the `tools/c7n_azure` portion of the codebase to use the latest version of `azure-mgmt-sql` (`3.0.1`).

## Migration

Previously, C7N was relying on an old version of `azure-mgmt-sql` (`1.0.0`, from 2020). This depends on APIs that are deprecated, & going away mid-2026.

In the transition to `2.0.0`, there were a large number of breaking changes:

* Operation ReplicationLinksOperations.get has a new signature
* Operation RestorableDroppedDatabasesOperations.get has a new signature
* Operation ReplicationLinksOperations.get has a new signature
* Parameter old_server_dns_alias_id of model ServerDnsAliasAcquisition is now required
* Operation SensitivityLabelsOperations.list_recommended_by_database has a new signature
* Operation ManagedDatabaseSensitivityLabelsOperations.list_recommended_by_database has a new signature
* Operation DatabasesOperations.begin_import_method has a new signature
* Operation DatabasesOperations.list_by_server has a new signature
* Operation ManagedDatabaseSensitivityLabelsOperations.list_current_by_database has a new signature
* Operation ManagedDatabaseSensitivityLabelsOperations.list_current_by_database has a new signature
* Operation ManagedDatabaseSensitivityLabelsOperations.list_recommended_by_database has a new signature
* Operation ManagedInstanceAdministratorsOperations.begin_create_or_update has a new signature
* Operation ManagedInstanceAdministratorsOperations.begin_delete has a new signature
* Operation ManagedInstanceAdministratorsOperations.get has a new signature
* Operation ManagedInstancesOperations.get has a new signature
* Operation ManagedInstancesOperations.list has a new signature
* Operation ManagedInstancesOperations.list_by_instance_pool has a new signature
* Operation ManagedInstancesOperations.list_by_resource_group has a new signature
* Operation SensitivityLabelsOperations.list_current_by_database has a new signature
* Operation SensitivityLabelsOperations.list_current_by_database has a new signature
* Operation SensitivityLabelsOperations.list_recommended_by_database has a new signature
* Operation ServersOperations.get has a new signature
* Operation ServersOperations.list has a new signature
* Operation ServersOperations.list_by_resource_group has a new signature
* Model BackupShortTermRetentionPolicy no longer has parameter diff_backup_interval_in_hours
* Model Database no longer has parameter read_replica_count
* Model ReplicationLink no longer has parameter location
* Model DatabaseUpdate no longer has parameter read_replica_count
* Model FirewallRule no longer has parameter kind
* Model FirewallRule no longer has parameter location
* Model RestorableDroppedDatabase no longer has parameter service_level_objective
* Model RestorableDroppedDatabase no longer has parameter edition
* Model RestorableDroppedDatabase no longer has parameter elastic_pool_name
* Model DatabaseSecurityAlertPolicy no longer has parameter use_server_default
* Model DatabaseSecurityAlertPolicy no longer has parameter kind
* Model DatabaseSecurityAlertPolicy no longer has parameter location
* Model DatabaseUsage no longer has parameter resource_name
* Model DatabaseUsage no longer has parameter next_reset_time
* Removed operation DatabasesOperations.begin_create_import_operation
* Model DatabaseUsageListResult has a new signature
* Model RestorableDroppedDatabaseListResult has a new signature
* Removed operation group RecommendedElasticPoolsOperations
* Removed operation group BackupLongTermRetentionPoliciesOperations
* Removed operation group DatabaseThreatDetectionPoliciesOperations
* Removed operation group ServiceTierAdvisorsOperations

I've confirmed that the `c7n_azure` codebase is unaffected by all of the above. However, as noted by @hiteshmck in the #10349 thread, there were a couple additional undocumented breaking changes (quoting here):

* BackupLongTermRetentionPolicy class was renamed to LongTermRetentionPolicy
* SqlManagementClient.backup_long_term_retention_policies property was renamed to long_term_retention_policies

...which **DO** affect the `c7n_azure` codebase.

## Changes

* Updated `tools/c7n_azure/pyproject.toml` (& `uv.lock`) to pull latest `azure-mgmt-sql`.
* Updated `tools/c7n_azure/c7n_azure/resources/sqldatabase.py` to correct for the found breaking changes.
* Updated `tools/c7n_azure/tests_azure/tests_resources/test_sqldatabase.py` to correct for the found breaking changes.

~With these changes (& the changes to make `mock` work), the test suite for `c7n_azure` is fully passing locally.~

## Notes

* Since `BackupLongTermRetentionPolicy` changed to just `LongTermRetentionPolicy`, I double-checked on `BackupShortTermRetentionPolicy` (thinking it might also have been renamed). It has not, nor have any of the methods referencing short-term retention policies.