### PR TITLE
fix: broken GCP Secret Manager resource documentation link

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/secret.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/secret.py
@@ -6,7 +6,7 @@ from c7n_gcp.query import (QueryResourceManager, TypeInfo)
 
 @resources.register('secret')
 class Secret(QueryResourceManager):
-    """GCP resource: https://cloud.google.com/secret-manager/docs/reference/rest/v1
+    """GCP resource: https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets
     """
     class resource_type(TypeInfo):
         service = 'secretmanager'


### PR DESCRIPTION
## Why

The existing link is broken and it'll return 404.