### PR TITLE
aws - service-quota - updated `account-service-limits` example usage policy

### DIFF
--- a/docs/source/aws/examples/accountservicelimit.rst
+++ b/docs/source/aws/examples/accountservicelimit.rst
@@ -49,14 +49,14 @@ Global Services
   .. code-block:: yaml
 
      policies:
-      - name: iam-service-quotas
-        resource: aws.service-quota
-        conditions:
-          - region: us-east-1
-        query:
-          - include_service_codes:
-              - iam
-        filters:
-          - UsageMetric: present
-          - type: usage-metric
-            limit: 50
+       - name: iam-service-quotas
+         resource: aws.service-quota
+         conditions:
+           - region: us-east-1
+         query:
+           - include_service_codes:
+               - iam
+         filters:
+           - UsageMetric: present
+           - type: usage-metric
+             limit: 50


### PR DESCRIPTION
AWS rejects most service limit increase support cases now and forces users to go through service quotas. This PR updates the existing guidance by providing an up to date example by providing an idempotent policy that utilizes service quotas.