### PR TITLE
gcp - fix panic in Cloud Logging client initialization

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/output.py
+++ b/tools/c7n_gcp/c7n_gcp/output.py
@@ -155,10 +155,10 @@ class StackDriverLogging(LogOutput):
 
         log_group = self.get_log_group()
         project_id = local_session(self.ctx.session_factory).get_default_project()
-        client = LogClient(project_id)
+        client = LogClient(project=project_id)
         return CloudLoggingHandler(
             client,
-            log_group,
+            name=log_group,
             labels={
                 'policy': self.ctx.policy.name,
                 'resource': self.ctx.policy.resource_type},
@@ -167,8 +167,9 @@ class StackDriverLogging(LogOutput):
     def leave_log(self):
         super(StackDriverLogging, self).leave_log()
         # Flush and stop the background thread
-        self.handler.transport.flush()
-        self.handler.transport.worker.stop()
+        if self.handler.transport:
+            self.handler.transport.flush()
+            self.handler.transport.worker.stop()
 
 
 @blob_outputs.register('gs', condition=bool(StorageClient))


### PR DESCRIPTION
## Summary

Resolves: https://github.com/cloud-custodian/cloud-custodian/issues/10442

Fix panic that occurred when sending logs to Google Cloud Logging due to incorrect argument passing in client initialization.

After applying these changes, I'm now able to send logs to Google Cloud:

```console
$ uv run custodian run -s . policy.yml --log-group gcp://xxx
2025-11-24 03:56:54,207: custodian.policy:INFO policy:cloud-run-service-deletion-protection resource:gcp.cloud-run-service region: count:2 time:0.65
Waiting up to 5 seconds.
Sent all pending logs.
```