### PR TITLE
doc: add output to GCS example command

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -250,13 +250,16 @@ To enable logging to CloudWatch logs, Stackdriver, or Azure AppInsights, use the
   custodian run -s output -l gcp://cloud-custodian/policies policy.yml
 
 You can also store the output of your Custodian logs in a cloud provider's blob storage like S3
-or Azure Storage accounts::
+, Azure Storage accounts or Google Cloud Storage::
 
   # AWS S3
   custodian run -s s3://my-custodian-bucket policy.yml
 
   # Azure Storage Accounts
   custodian run -s azure://my-custodian-storage-account policy.yml
+
+  # Google Cloud Storage
+  custodian run -s gs://my-custodian-bucket policy.yml
 
 .. _mailer_and_notifications_deployment:
 


### PR DESCRIPTION
## Why

Because it’s beneficial for readers to know that GCS is also supported as an output destination.

Here: 

https://github.com/cloud-custodian/cloud-custodian/blob/87b272686b0885c79c9a061d849cf9fe248d884e/tools/c7n_gcp/c7n_gcp/output.py#L174-L183