### PR TITLE
aws - artifact-domain - fix cross account filter

### DIFF
--- a/c7n/resources/artifact.py
+++ b/c7n/resources/artifact.py
@@ -30,7 +30,7 @@ class CrossAccountDomain(CrossAccountAccessFilter):
         for r in resources:
             result = self.manager.retry(
                 client.get_domain_permissions_policy,
-                domain=r['domainName'],
+                domain=r['name'],
                 ignore_err_codes=('ResourceNotFoundException',))
             r[self.policy_attribute] = result['policy']['document']
         return super().process(resources)

--- a/tests/data/placebo/test_artifact_domain_cross_account/codeartifact.DescribeDomain_1.json
+++ b/tests/data/placebo/test_artifact_domain_cross_account/codeartifact.DescribeDomain_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "domain": {
+            "name": "c7n-test",
+            "owner": "644160558196",
+            "arn": "arn:aws:codeartifact:us-east-2:644160558196:domain/c7n-test",
+            "status": "Active",
+            "createdTime": {
+                "__class__": "datetime",
+                "year": 2025,
+                "month": 11,
+                "day": 24,
+                "hour": 10,
+                "minute": 38,
+                "second": 11,
+                "microsecond": 494000
+            },
+            "encryptionKey": "arn:aws:kms:us-east-2:644160558196:key/da619881-9cb1-42ce-9c6a-9bc6d87cdf8e",
+            "repositoryCount": 0,
+            "assetSizeBytes": 0,
+            "s3BucketArn": "arn:aws:s3:::assets-644160558196-us-east-2"
+        }
+    }
+}

--- a/tests/data/placebo/test_artifact_domain_cross_account/codeartifact.GetDomainPermissionsPolicy_1.json
+++ b/tests/data/placebo/test_artifact_domain_cross_account/codeartifact.GetDomainPermissionsPolicy_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "policy": {
+            "resourceArn": "arn:aws:codeartifact:us-east-2:644160558196:domain/c7n-test",
+            "revision": "pmQ3XEZ8pSPYvFpTn0mHKthtxxDIjp7CnivtwIKJz+U=",
+            "document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"ContributorPolicy\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"codeartifact:DescribeDomain\",\"Resource\":\"*\"}]}"
+        }
+    }
+}

--- a/tests/data/placebo/test_artifact_domain_cross_account/codeartifact.ListDomains_1.json
+++ b/tests/data/placebo/test_artifact_domain_cross_account/codeartifact.ListDomains_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "domains": [
+            {
+                "name": "c7n-test",
+                "owner": "644160558196",
+                "arn": "arn:aws:codeartifact:us-east-2:644160558196:domain/c7n-test",
+                "status": "Active",
+                "createdTime": {
+                    "__class__": "datetime",
+                    "year": 2025,
+                    "month": 11,
+                    "day": 24,
+                    "hour": 10,
+                    "minute": 38,
+                    "second": 11,
+                    "microsecond": 494000
+                },
+                "encryptionKey": "arn:aws:kms:us-east-2:644160558196:key/da619881-9cb1-42ce-9c6a-9bc6d87cdf8e"
+            }
+        ]
+    }
+}

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -23,6 +23,21 @@ class CodeArtifact(BaseTest):
             time.sleep(3)
         assert factory().client('codeartifact').list_domains().get('domains') == []
 
+    def test_artifact_domain_cross_account(self):
+        factory = self.replay_flight_data('test_artifact_domain_cross_account', region='us-east-2')
+        p = self.load_policy(
+            {
+                'name': 'artifact-domain-no-xaccount',
+                'resource': 'aws.artifact-domain',
+                'filters': ['cross-account'],
+            },
+            session_factory=factory,
+            config={'region': 'us-east-2'},
+        )
+        resources = p.run()
+        assert len(resources) == 1
+        assert resources[0]['name'] == 'c7n-test'
+
     def test_cross_account_and_delete_repo(self):
         factory = self.replay_flight_data('test_artifact_repo_cross_account')
         p = self.load_policy({


### PR DESCRIPTION
Update the cross-account filter to pull a domain's name out of a `name` key rather than `domainName` when evaluating the `cross-account` filter.

(The key is accurately `domainName` for the `aws.artifact-repository` resource.)

Closes #10445 