### PR TITLE
feat: Add the "validate" command to c7n-org.

### DIFF
--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -243,20 +243,31 @@ don't require quoting, i.e., "my_{charge_code}".
 
 ## Validating Policies
 
-c7n-org supports validating policy files without requiring cloud credentials:
+c7n-org supports validating policy files without requiring cloud credentials.
+This is useful for pre-commit checks and CI/CD pipelines.
 
 ```shell
 c7n-org validate -c accounts.yml -u policies.yml
 ```
 
-This performs schema validation, checks policy structure, and detects common
-errors. It's useful for pre-commit checks and CI/CD pipelines. The command
-supports the same policy filtering options as `run` (`-p`, `-l`, `--resource`)
-and includes optional deprecation checking with `--check-deprecations`.
+By default, validation performs schema checks, policy structure validation,
+and detects common errors. The `--per-account` flag enables deeper validation
+with account-specific variable expansion:
 
-Note that validation is account-agnostic and doesn't expand variables or
-require cloud access. For full validation with account context, use
-`c7n-org run --dryrun`.
+```shell
+c7n-org validate -c accounts.yml -u policies.yml --per-account
+```
+
+In per-account mode, c7n-org validates that policy variables can be expanded
+correctly for each account, catching issues like missing variable definitions
+that would only appear at runtime.
+
+You can filter which policies and accounts to validate using the same flags
+as the `run` command:
+
+- Filter policies with `-p`, `-l`, or `--resource`
+- Filter accounts with `-a`, `--tags`, or `--not-accounts` (when using `--per-account`)
+- Check for deprecated features with `--check-deprecations`
 
 See `c7n-org validate --help` for more information.
 

--- a/tools/c7n_org/README.md
+++ b/tools/c7n_org/README.md
@@ -28,6 +28,7 @@ Commands:
   report        report on an AWS cross account policy execution
   run           run a custodian policy across accounts (AWS, Azure, GCP, OCI)
   run-script    run a script across AWS accounts
+  validate    validate policy files without requiring cloud credentials
 ```
 
 In order to run c7n-org against multiple accounts, a config file must
@@ -239,6 +240,25 @@ i.e., `{ charge_code }` would be invalid due to the extra white space. Additiona
 yaml parsing can transform a value like `{charge_code}` to null, unless it's quoted
 in strings like the above example. Values that do interpolation into other content
 don't require quoting, i.e., "my_{charge_code}".
+
+## Validating Policies
+
+c7n-org supports validating policy files without requiring cloud credentials:
+
+```shell
+c7n-org validate -c accounts.yml -u policies.yml
+```
+
+This performs schema validation, checks policy structure, and detects common
+errors. It's useful for pre-commit checks and CI/CD pipelines. The command
+supports the same policy filtering options as `run` (`-p`, `-l`, `--resource`)
+and includes optional deprecation checking with `--check-deprecations`.
+
+Note that validation is account-agnostic and doesn't expand variables or
+require cloud access. For full validation with account context, use
+`c7n-org run --dryrun`.
+
+See `c7n-org validate --help` for more information.
 
 ## Other commands
 

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -459,6 +459,222 @@ def report(config, output, use, output_dir, accounts,
     writer.writerows(rows)
 
 
+@cli.command()
+@click.option('-c', '--config', required=True, help="Accounts config file")
+@click.option('-u', '--use', required=True, help="Policy config file(s)")
+@click.option('-p', '--policy', multiple=True, help="Policy name filter")
+@click.option('-l', '--policytags', 'policy_tags',
+              multiple=True, default=None, help="Policy tag filter")
+@click.option('--resource', default=None, help="Resource type filter")
+@click.option('--check-deprecations',
+              type=click.Choice(['skip', 'warn', 'strict']),
+              default='warn',
+              help="Check for deprecated features")
+@click.option('--debug', default=False, is_flag=True, help="Enable debug logging")
+@click.option('-v', '--verbose', default=False, help="Verbose output", is_flag=True)
+def validate(config, use, policy, policy_tags, resource,
+             check_deprecations, debug, verbose):
+    """Validate policy files for c7n-org execution.
+
+    This command validates Cloud Custodian policy files without requiring
+    cloud credentials or account-specific context. It performs:
+
+    - JSON/YAML schema validation
+    - Policy structure validation
+    - Resource type validation
+    - Policy object validation
+    - Duplicate policy name detection
+    - Optional deprecation checking
+
+    Exit codes:
+      0 - All policies are valid
+      1 - Validation errors found
+
+    Example:
+      c7n-org validate -c accounts.yml -u policies.yml
+    """
+    # Setup logging
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s: %(name)s:%(levelname)s %(message)s"
+    )
+    logging.getLogger('botocore').setLevel(logging.ERROR)
+    logging.getLogger('urllib3').setLevel(logging.ERROR)
+
+    log.info("Starting policy validation")
+    log.debug(f"Config file: {config}")
+    log.debug(f"Policy file: {use}")
+
+    # Import validation utilities from c7n.commands
+    from c7n.commands import DuplicateKeyCheckLoader
+    from c7n import schema, deprecated
+    from c7n.schema import StructureParser
+    from c7n.policy import Policy, PolicyValidationError
+    from c7n.config import Config, Bag
+    from c7n.resources import load_resources, load_available
+    from c7n.loader import SourceLocator
+
+    # Load available resources
+    load_available()
+
+    # Load account config (for filtering, minimal validation in Phase 1)
+    # Note: accounts_config loaded but not used in Phase 1 - reserved for future phases
+    log.debug("Loading account config")
+    try:
+        with open(config, 'rb') as fh:
+            _ = yaml.safe_load(fh.read())  # noqa: F841
+    except IOError:
+        log.error(f"Account config file not found: {config}")
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        log.error(f"Invalid YAML in account config: {e}")
+        sys.exit(1)
+
+    # Load policy config
+    log.debug("Loading policy config")
+    use = os.path.expanduser(use)
+    if not os.path.exists(use):
+        log.error(f"Policy config file not found: {use}")
+        sys.exit(1)
+
+    fmt = use.rsplit('.', 1)[-1]
+    if fmt not in ('yml', 'yaml', 'json'):
+        log.error("The policy file must end in .json, .yml or .yaml.")
+        sys.exit(1)
+
+    try:
+        with open(use) as fh:
+            custodian_config = yaml.load(fh.read(), Loader=DuplicateKeyCheckLoader)  # nosec nosemgrep
+    except IOError:
+        log.error(f"Policy config file not found: {use}")
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        log.error(f"Invalid YAML in policy config: {e}")
+        sys.exit(1)
+
+    # Apply policy filters
+    log.debug("Applying policy filters")
+    policies = custodian_config.get('policies', [])
+    original_count = len(policies)
+
+    if policy:
+        log.debug(f"Filtering by policy names: {policy}")
+        policies = [p for p in policies if p.get('name') in policy]
+
+    if resource:
+        log.debug(f"Filtering by resource type: {resource}")
+        policies = [p for p in policies if p.get('resource') == resource]
+
+    if policy_tags:
+        log.debug(f"Filtering by policy tags: {policy_tags}")
+        policies = [p for p in policies if set(policy_tags).issubset(
+            set(p.get('tags', [])))]
+
+    custodian_config['policies'] = policies
+    log.info(f"Validating {len(policies)} policies (filtered from {original_count})")
+
+    if len(policies) == 0:
+        log.warning("No policies to validate after filtering")
+        sys.exit(0)
+
+    # Core validation logic
+    structure = StructureParser()
+    errors = []
+    used_policy_names = set()
+    found_deprecations = False
+    footnotes = deprecated.Footnotes()
+
+    # Structure validation
+    log.debug("Running structure validation")
+    try:
+        structure.validate(custodian_config)
+    except PolicyValidationError as e:
+        log.error(f"Configuration invalid: {use}")
+        log.error(str(e))
+        sys.exit(1)
+
+    # Load resources for schema validation
+    log.debug("Loading resources for schema validation")
+    resource_types = structure.get_resource_types(custodian_config)
+    log.debug(f"Resource types found: {resource_types}")
+    load_resources(resource_types)
+
+    # Schema validation
+    log.debug("Running schema validation")
+    schm = schema.generate()
+    errors = schema.validate(custodian_config, schm)
+
+    # Check for duplicate policy names
+    log.debug("Checking for duplicate policy names")
+    conf_policy_names = {
+        p.get('name', 'unknown') for p in custodian_config.get('policies', ())}
+    dupes = conf_policy_names.intersection(used_policy_names)
+    if len(dupes) >= 1:
+        errors.append(ValueError(
+            f"Only one policy with a given name allowed, duplicates: {', '.join(dupes)}"
+        ))
+    used_policy_names = used_policy_names.union(conf_policy_names)
+
+    # Determine deprecation check mode
+    if check_deprecations == 'skip':
+        check_mode = deprecated.SKIP
+    elif check_deprecations == 'strict':
+        check_mode = deprecated.STRICT
+    else:
+        check_mode = None  # 'warn' mode - check but don't exit
+
+    # Policy-level validation
+    if not errors:
+        log.debug("Running policy-level validation")
+        null_config = Config.empty(dryrun=True, account_id='na', region='na')
+        source_locator = None
+        if fmt in ('yml', 'yaml'):
+            source_locator = SourceLocator(use)
+
+        for p in custodian_config.get('policies', ()):
+            policy_name = p.get('name', 'unknown')
+            log.debug(f"Validating policy: {policy_name}")
+            try:
+                policy = Policy(p, null_config, Bag())
+                policy.validate()
+
+                # Check deprecations
+                if check_mode != deprecated.SKIP:
+                    report = deprecated.report(policy)
+                    if report:
+                        found_deprecations = True
+                        log.warning(
+                            "deprecated usage found in policy\n" +
+                            report.format(
+                                source_locator=source_locator,
+                                footnotes=footnotes))
+            except Exception as e:
+                msg = f"Policy: {policy_name} is invalid: {e}"
+                errors.append(msg)
+
+    # Report results
+    if errors:
+        log.error(f"Configuration invalid: {use}")
+        for e in errors:
+            log.error(str(e))
+        sys.exit(1)
+
+    log.info(f"Configuration valid: {use}")
+
+    # Handle deprecations
+    if found_deprecations:
+        notes = footnotes()
+        if notes:
+            log.warning("deprecation footnotes:\n" + notes)
+        if check_mode == deprecated.STRICT:
+            log.error("Deprecations found with --check-deprecations=strict")
+            sys.exit(1)
+
+    log.info("Validation complete - all policies are valid!")
+    sys.exit(0)
+
+
 def _get_env_creds(account, session, region, env=None):
     env = env or {}
     if account["provider"] == 'aws':

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -873,7 +873,8 @@ def validate_per_account(custodian_config, accounts_config, policy_file,
             return False
         return True
     else:
-        log.error("Validation failed for one or more accounts")
+        log.error(f"Validation failed for {len(accounts_with_errors)} account(s): "
+                  f"{', '.join(accounts_with_errors)}")
         return False
 
 
@@ -1013,6 +1014,15 @@ def validate(config, use, policy, policy_tags, resource,
 
     if len(policies) == 0:
         log.warning("No policies to validate after filtering")
+        if policy or resource or policy_tags:
+            filters_applied = []
+            if policy:
+                filters_applied.append(f"policy names: {', '.join(policy)}")
+            if resource:
+                filters_applied.append(f"resource type: {resource}")
+            if policy_tags:
+                filters_applied.append(f"policy tags: {', '.join(policy_tags)}")
+            log.warning(f"Filters applied: {'; '.join(filters_applied)}")
         sys.exit(0)
 
     # Determine deprecation check mode

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -459,6 +459,360 @@ def report(config, output, use, output_dir, accounts,
     writer.writerows(rows)
 
 
+def validate_basic(custodian_config, policy_file, fmt, check_mode, verbose):
+    """Run basic account-agnostic validation (Phase 1 logic).
+
+    Args:
+        custodian_config: Parsed policy configuration
+        policy_file: Path to policy file (for error reporting)
+        fmt: File format ('yml', 'yaml', 'json')
+        check_mode: Deprecation check mode (deprecated.SKIP, deprecated.STRICT, or None)
+        verbose: Verbose logging flag
+
+    Returns:
+        bool: True if validation passes, False otherwise
+    """
+    from c7n import schema, deprecated
+    from c7n.schema import StructureParser
+    from c7n.policy import Policy, PolicyValidationError
+    from c7n.config import Config, Bag
+    from c7n.resources import load_resources
+    from c7n.loader import SourceLocator
+
+    # Core validation logic
+    structure = StructureParser()
+    errors = []
+    used_policy_names = set()
+    found_deprecations = False
+    footnotes = deprecated.Footnotes()
+
+    # Structure validation
+    log.debug("Running structure validation")
+    try:
+        structure.validate(custodian_config)
+    except PolicyValidationError as e:
+        log.error(f"Configuration invalid: {policy_file}")
+        log.error(str(e))
+        return False
+
+    # Load resources for schema validation
+    log.debug("Loading resources for schema validation")
+    resource_types = structure.get_resource_types(custodian_config)
+    log.debug(f"Resource types found: {resource_types}")
+    load_resources(resource_types)
+
+    # Schema validation
+    log.debug("Running schema validation")
+    schm = schema.generate()
+    errors = schema.validate(custodian_config, schm)
+
+    # Check for duplicate policy names
+    log.debug("Checking for duplicate policy names")
+    conf_policy_names = {
+        p.get('name', 'unknown') for p in custodian_config.get('policies', ())}
+    dupes = conf_policy_names.intersection(used_policy_names)
+    if len(dupes) >= 1:
+        errors.append(ValueError(
+            f"Only one policy with a given name allowed, duplicates: {', '.join(dupes)}"
+        ))
+    used_policy_names = used_policy_names.union(conf_policy_names)
+
+    # Policy-level validation
+    if not errors:
+        log.debug("Running policy-level validation")
+        null_config = Config.empty(dryrun=True, account_id='na', region='na')
+        source_locator = None
+        if fmt in ('yml', 'yaml'):
+            source_locator = SourceLocator(policy_file)
+
+        for p in custodian_config.get('policies', ()):
+            policy_name = p.get('name', 'unknown')
+            log.debug(f"Validating policy: {policy_name}")
+            try:
+                policy = Policy(p, null_config, Bag())
+                policy.validate()
+
+                # Check deprecations
+                if check_mode != deprecated.SKIP:
+                    report = deprecated.report(policy)
+                    if report:
+                        found_deprecations = True
+                        log.warning(
+                            "deprecated usage found in policy\n" +
+                            report.format(
+                                source_locator=source_locator,
+                                footnotes=footnotes))
+            except Exception as e:
+                msg = f"Policy: {policy_name} is invalid: {e}"
+                errors.append(msg)
+
+    # Report results
+    if errors:
+        log.error(f"Configuration invalid: {policy_file}")
+        for e in errors:
+            log.error(str(e))
+        return False
+
+    log.info(f"Configuration valid: {policy_file}")
+
+    # Handle deprecations
+    if found_deprecations:
+        notes = footnotes()
+        if notes:
+            log.warning("deprecation footnotes:\n" + notes)
+        if check_mode == deprecated.STRICT:
+            log.error("Deprecations found with --check-deprecations=strict")
+            return False
+
+    log.info("Validation complete - all policies are valid!")
+    return True
+
+
+def find_unexpanded_variables(obj, path=""):
+    """Recursively find unexpanded variable references in policy data.
+
+    Args:
+        obj: Policy data object (dict, list, str, or other)
+        path: Current path in the object tree (for error reporting)
+
+    Returns:
+        list: List of tuples (path, unexpanded_string) for each unexpanded variable
+    """
+    import re
+
+    unexpanded = []
+    var_pattern = re.compile(r'\{[^}]+\}')
+
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            new_path = f"{path}.{key}" if path else key
+            unexpanded.extend(find_unexpanded_variables(value, new_path))
+    elif isinstance(obj, list):
+        for idx, item in enumerate(obj):
+            new_path = f"{path}[{idx}]"
+            unexpanded.extend(find_unexpanded_variables(item, new_path))
+    elif isinstance(obj, str):
+        # Check if string contains variable placeholders
+        if var_pattern.search(obj):
+            # Extract variable names from the string
+            matches = var_pattern.findall(obj)
+            for match in matches:
+                # Skip known runtime variables that are intentionally not expanded
+                runtime_vars = [
+                    '{account}', '{event}', '{op}', '{action_date}',
+                    '{service}', '{bucket_region}', '{bucket_name}',
+                    '{source_bucket_name}', '{source_bucket_region}',
+                    '{target_bucket_name}', '{target_prefix}', '{LoadBalancerName}'
+                ]
+                if match in runtime_vars:
+                    continue
+                unexpanded.append((path, match))
+
+    return unexpanded
+
+
+def validate_per_account(custodian_config, accounts_config, policy_file,
+                        fmt, check_mode, verbose):
+    """Run per-account validation with variable expansion.
+
+    Validates policies for each account, expanding account-specific variables
+    and checking for missing or invalid variable references.
+
+    This function validates that policies work correctly with each account's
+    specific configuration and variables. It handles multi-cloud scenarios by
+    matching policy providers with account providers.
+
+    Args:
+        custodian_config: Parsed policy configuration
+        accounts_config: Parsed account configuration
+        policy_file: Path to policy file (for error reporting)
+        fmt: File format ('yml', 'yaml', 'json')
+        check_mode: Deprecation check mode
+        verbose: Verbose logging flag
+
+    Returns:
+        bool: True if validation passes for all accounts, False otherwise
+    """
+    import copy
+    from c7n import deprecated
+    from c7n.policy import Policy
+    from c7n.config import Config, Bag
+    from c7n.loader import SourceLocator
+
+    accounts = accounts_config['accounts']
+    policies = custodian_config.get('policies', [])
+
+    log.info(f"Validating {len(policies)} policies across {len(accounts)} accounts")
+
+    # First, run basic validation to catch structural issues
+    log.debug("Running initial basic validation")
+    if not validate_basic(custodian_config, policy_file, fmt, check_mode, verbose):
+        return False
+
+    # Track results per account
+    account_results = {}
+    overall_success = True
+
+    # Validate for each account
+    for account in accounts:
+        account_name = account.get('name', account.get('account_id', 'unknown'))
+        log.info(f"Validating for account: {account_name}")
+
+        account_errors = []
+        account_warnings = []
+
+        # Get account-specific variables
+        account_vars = account.get('vars', {})
+        if verbose and account_vars:
+            log.debug(f"  Account variables: {list(account_vars.keys())}")
+
+        # Get account info (already normalized by accounts_iterator)
+        account_id = account.get('account_id', 'na')
+        account_provider = account.get('provider', 'aws')
+
+        # Use region from account config
+        # accounts_iterator() has already set appropriate region defaults per provider
+        regions = account.get('regions', ['na'])
+        region = regions[0] if regions else 'na'
+
+        if verbose:
+            log.debug(f"  Account provider: {account_provider}, region: {region}")
+
+        # Create config for this account
+        account_config = Config.empty(
+            dryrun=True,
+            account_id=account_id,
+            region=region
+        )
+
+        source_locator = None
+        if fmt in ('yml', 'yaml'):
+            source_locator = SourceLocator(policy_file)
+
+        # Validate each policy with account context
+        for policy_data in policies:
+            policy_name = policy_data.get('name', 'unknown')
+
+            # Determine policy provider from resource type
+            resource_type = policy_data.get('resource', '')
+            if '.' in resource_type:
+                policy_provider = resource_type.split('.')[0]
+            else:
+                # Default to aws for unqualified resource types
+                policy_provider = 'aws'
+
+            # Skip if policy provider doesn't match account provider
+            if policy_provider != account_provider:
+                if verbose:
+                    log.debug(
+                        f"  Skipping policy '{policy_name}' for account '{account_name}' "
+                        f"(provider mismatch: policy={policy_provider}, "
+                        f"account={account_provider})"
+                    )
+                continue
+
+            if verbose:
+                log.debug(f"  Validating policy: {policy_name}")
+
+            try:
+                # Make a deep copy to avoid modifying original
+                policy_data_copy = copy.deepcopy(policy_data)
+
+                # Create policy object
+                policy = Policy(policy_data_copy, account_config, Bag())
+
+                # Get variables (this adds runtime variables)
+                variables = policy.get_variables(account_vars)
+
+                # Expand variables (modifies policy.data in place)
+                policy.expand_variables(variables)
+
+                # Check for unexpanded variables (those that couldn't be resolved)
+                unexpanded = find_unexpanded_variables(policy.data, f"policy.{policy_name}")
+                if unexpanded:
+                    for path, var in unexpanded:
+                        var_name = var.strip('{}')
+                        msg = (f"Policy '{policy_name}' references undefined "
+                               f"variable '{var_name}' at {path}")
+                        account_errors.append(msg)
+                    continue
+
+                # Validate expanded policy
+                try:
+                    policy.validate()
+                except Exception as e:
+                    msg = f"Policy '{policy_name}' validation failed after variable expansion: {e}"
+                    account_errors.append(msg)
+                    continue
+
+                # Check deprecations
+                if check_mode != deprecated.SKIP:
+                    report = deprecated.report(policy)
+                    if report:
+                        warning = f"Policy '{policy_name}' uses deprecated features"
+                        account_warnings.append(warning)
+                        if verbose:
+                            log.warning(f"  {warning}\n" +
+                                      report.format(source_locator=source_locator))
+
+            except Exception as e:
+                msg = f"Policy '{policy_name}' unexpected error: {e}"
+                account_errors.append(msg)
+
+        # Store results for this account
+        account_results[account_name] = {
+            'errors': account_errors,
+            'warnings': account_warnings,
+            'success': len(account_errors) == 0
+        }
+
+        if not account_results[account_name]['success']:
+            overall_success = False
+
+    # Report results
+    log.info("=" * 60)
+    log.info("Per-Account Validation Summary")
+    log.info("=" * 60)
+
+    accounts_with_errors = []
+    accounts_with_warnings = []
+    accounts_valid = []
+
+    for account_name, result in account_results.items():
+        if result['errors']:
+            accounts_with_errors.append(account_name)
+            log.error(f"Account validation FAILED: {account_name}")
+            for error in result['errors']:
+                log.error(f"  {error}")
+        elif result['warnings']:
+            accounts_with_warnings.append(account_name)
+            log.warning(f"Account validation PASSED with warnings: {account_name}")
+            for warning in result['warnings']:
+                log.warning(f"  {warning}")
+        else:
+            accounts_valid.append(account_name)
+            log.info(f"Account validation PASSED: {account_name}")
+
+    # Final summary
+    log.info("=" * 60)
+    log.info(f"Total Accounts: {len(account_results)}")
+    log.info(f"  Valid: {len(accounts_valid)}")
+    log.info(f"  With Warnings: {len(accounts_with_warnings)}")
+    log.info(f"  With Errors: {len(accounts_with_errors)}")
+    log.info("=" * 60)
+
+    if overall_success:
+        log.info("All accounts validated successfully")
+        # Check if deprecations should fail in strict mode
+        if check_mode == deprecated.STRICT and accounts_with_warnings:
+            log.error("Deprecations found with --check-deprecations=strict")
+            return False
+        return True
+    else:
+        log.error("Validation failed for one or more accounts")
+        return False
+
+
 @cli.command()
 @click.option('-c', '--config', required=True, help="Accounts config file")
 @click.option('-u', '--use', required=True, help="Policy config file(s)")
@@ -466,6 +820,14 @@ def report(config, output, use, output_dir, accounts,
 @click.option('-l', '--policytags', 'policy_tags',
               multiple=True, default=None, help="Policy tag filter")
 @click.option('--resource', default=None, help="Resource type filter")
+@click.option('-a', '--accounts', multiple=True, default=None,
+              help="Account name or id filter")
+@click.option('--tags', multiple=True, default=None,
+              help="Account tag filter")
+@click.option('--not-accounts', multiple=True, default=None,
+              help="Exclude accounts")
+@click.option('--per-account', default=False, is_flag=True,
+              help="Validate per account with variable expansion")
 @click.option('--check-deprecations',
               type=click.Choice(['skip', 'warn', 'strict']),
               default='warn',
@@ -473,26 +835,9 @@ def report(config, output, use, output_dir, accounts,
 @click.option('--debug', default=False, is_flag=True, help="Enable debug logging")
 @click.option('-v', '--verbose', default=False, help="Verbose output", is_flag=True)
 def validate(config, use, policy, policy_tags, resource,
+             accounts, tags, not_accounts, per_account,
              check_deprecations, debug, verbose):
-    """Validate policy files for c7n-org execution.
-
-    This command validates Cloud Custodian policy files without requiring
-    cloud credentials or account-specific context. It performs:
-
-    - JSON/YAML schema validation
-    - Policy structure validation
-    - Resource type validation
-    - Policy object validation
-    - Duplicate policy name detection
-    - Optional deprecation checking
-
-    Exit codes:
-      0 - All policies are valid
-      1 - Validation errors found
-
-    Example:
-      c7n-org validate -c accounts.yml -u policies.yml
-    """
+    """validate policy files for c7n-org execution."""
     # Setup logging
     level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(
@@ -512,28 +857,52 @@ def validate(config, use, policy, policy_tags, resource,
 
     # Import validation utilities from c7n.commands
     from c7n.commands import DuplicateKeyCheckLoader
-    from c7n import schema, deprecated
-    from c7n.schema import StructureParser
-    from c7n.policy import Policy, PolicyValidationError
-    from c7n.config import Config, Bag
-    from c7n.resources import load_resources, load_available
-    from c7n.loader import SourceLocator
+    from c7n import deprecated
+    from c7n.resources import load_available
 
     # Load available resources
     load_available()
 
-    # Load account config (for filtering, minimal validation in Phase 1)
-    # Note: accounts_config loaded but not used in Phase 1 - reserved for future phases
-    log.debug("Loading account config")
+    # Load and validate account config
+    log.debug("Loading and validating account config")
     try:
         with open(config, 'rb') as fh:
-            _ = yaml.safe_load(fh.read())  # noqa: F841
+            accounts_config = yaml.safe_load(fh.read())
     except IOError:
         log.error(f"Account config file not found: {config}")
         sys.exit(1)
     except yaml.YAMLError as e:
         log.error(f"Invalid YAML in account config: {e}")
         sys.exit(1)
+
+    # Validate account config against schema
+    log.debug("Validating account config schema")
+    try:
+        jsonschema.validate(accounts_config, CONFIG_SCHEMA)
+    except jsonschema.ValidationError as e:
+        log.error(f"Account config validation failed: {e.message}")
+        if e.path:
+            log.error(f"Path: {' -> '.join(str(p) for p in e.path)}")
+        sys.exit(1)
+
+    # Normalize accounts using accounts_iterator
+    log.debug("Normalizing account configurations")
+    accounts_config['accounts'] = list(accounts_iterator(accounts_config))
+
+    # Apply account filters if provided
+    if accounts or tags or not_accounts:
+        log.debug(
+            f"Applying account filters: accounts={accounts}, "
+            f"tags={tags}, not_accounts={not_accounts}"
+        )
+        filter_accounts(accounts_config, tags, accounts, not_accounts)
+        log.info(f"Filtered to {len(accounts_config['accounts'])} accounts")
+    else:
+        log.info(f"Loaded {len(accounts_config['accounts'])} accounts")
+
+    if len(accounts_config['accounts']) == 0:
+        log.warning("No accounts selected after filtering")
+        sys.exit(0)
 
     # Load policy config
     log.debug("Loading policy config")
@@ -582,44 +951,6 @@ def validate(config, use, policy, policy_tags, resource,
         log.warning("No policies to validate after filtering")
         sys.exit(0)
 
-    # Core validation logic
-    structure = StructureParser()
-    errors = []
-    used_policy_names = set()
-    found_deprecations = False
-    footnotes = deprecated.Footnotes()
-
-    # Structure validation
-    log.debug("Running structure validation")
-    try:
-        structure.validate(custodian_config)
-    except PolicyValidationError as e:
-        log.error(f"Configuration invalid: {use}")
-        log.error(str(e))
-        sys.exit(1)
-
-    # Load resources for schema validation
-    log.debug("Loading resources for schema validation")
-    resource_types = structure.get_resource_types(custodian_config)
-    log.debug(f"Resource types found: {resource_types}")
-    load_resources(resource_types)
-
-    # Schema validation
-    log.debug("Running schema validation")
-    schm = schema.generate()
-    errors = schema.validate(custodian_config, schm)
-
-    # Check for duplicate policy names
-    log.debug("Checking for duplicate policy names")
-    conf_policy_names = {
-        p.get('name', 'unknown') for p in custodian_config.get('policies', ())}
-    dupes = conf_policy_names.intersection(used_policy_names)
-    if len(dupes) >= 1:
-        errors.append(ValueError(
-            f"Only one policy with a given name allowed, duplicates: {', '.join(dupes)}"
-        ))
-    used_policy_names = used_policy_names.union(conf_policy_names)
-
     # Determine deprecation check mode
     if check_deprecations == 'skip':
         check_mode = deprecated.SKIP
@@ -628,55 +959,23 @@ def validate(config, use, policy, policy_tags, resource,
     else:
         check_mode = None  # 'warn' mode - check but don't exit
 
-    # Policy-level validation
-    if not errors:
-        log.debug("Running policy-level validation")
-        null_config = Config.empty(dryrun=True, account_id='na', region='na')
-        source_locator = None
-        if fmt in ('yml', 'yaml'):
-            source_locator = SourceLocator(use)
+    # Decide validation mode
+    if per_account:
+        log.info("Running per-account validation mode")
+        success = validate_per_account(
+            custodian_config,
+            accounts_config,
+            use,
+            fmt,
+            check_mode,
+            verbose
+        )
+    else:
+        log.info("Running basic validation mode (account-agnostic)")
+        success = validate_basic(custodian_config, use, fmt, check_mode, verbose)
 
-        for p in custodian_config.get('policies', ()):
-            policy_name = p.get('name', 'unknown')
-            log.debug(f"Validating policy: {policy_name}")
-            try:
-                policy = Policy(p, null_config, Bag())
-                policy.validate()
-
-                # Check deprecations
-                if check_mode != deprecated.SKIP:
-                    report = deprecated.report(policy)
-                    if report:
-                        found_deprecations = True
-                        log.warning(
-                            "deprecated usage found in policy\n" +
-                            report.format(
-                                source_locator=source_locator,
-                                footnotes=footnotes))
-            except Exception as e:
-                msg = f"Policy: {policy_name} is invalid: {e}"
-                errors.append(msg)
-
-    # Report results
-    if errors:
-        log.error(f"Configuration invalid: {use}")
-        for e in errors:
-            log.error(str(e))
-        sys.exit(1)
-
-    log.info(f"Configuration valid: {use}")
-
-    # Handle deprecations
-    if found_deprecations:
-        notes = footnotes()
-        if notes:
-            log.warning("deprecation footnotes:\n" + notes)
-        if check_mode == deprecated.STRICT:
-            log.error("Deprecations found with --check-deprecations=strict")
-            sys.exit(1)
-
-    log.info("Validation complete - all policies are valid!")
-    sys.exit(0)
+    # Exit based on results
+    sys.exit(0 if success else 1)
 
 
 def _get_env_creds(account, session, region, env=None):

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -12,6 +12,8 @@ import time
 import subprocess  # nosec
 import sys
 import shlex
+import re
+import copy
 
 import multiprocessing
 from concurrent.futures import (
@@ -24,14 +26,17 @@ from botocore.exceptions import ClientError
 import click
 import jsonschema
 
+from c7n import schema, deprecated
 from c7n.credentials import assumed_session, SessionFactory
 from c7n.executor import MainThreadExecutor
 from c7n.exceptions import InvalidOutputConfig
-from c7n.config import Config
-from c7n.policy import PolicyCollection
+from c7n.config import Config, Bag
+from c7n.loader import SourceLocator
+from c7n.policy import PolicyCollection, Policy, PolicyValidationError
 from c7n.provider import get_resource_class, clouds as cloud_providers
 from c7n.reports.csvout import Formatter, fs_record_set, record_set, strip_output_path
-from c7n.resources import load_available
+from c7n.resources import load_available, load_resources
+from c7n.schema import StructureParser
 from c7n.utils import (
     CONN_CACHE, dumps, filter_empty, format_string_values, get_policy_provider, join_output_path)
 
@@ -472,12 +477,6 @@ def validate_basic(custodian_config, policy_file, fmt, check_mode, verbose):
     Returns:
         bool: True if validation passes, False otherwise
     """
-    from c7n import schema, deprecated
-    from c7n.schema import StructureParser
-    from c7n.policy import Policy, PolicyValidationError
-    from c7n.config import Config, Bag
-    from c7n.resources import load_resources
-    from c7n.loader import SourceLocator
 
     # Core validation logic
     structure = StructureParser()
@@ -595,8 +594,6 @@ def find_unexpanded_variables(obj, path="", allowed_placeholders=None):
         framework_vars = extract_framework_runtime_variables(variables)
         errors = find_unexpanded_variables(policy_data, allowed_placeholders=framework_vars)
     """
-    import re
-
     unexpanded = []
     var_pattern = re.compile(r'\{[^}]+\}')
 
@@ -649,8 +646,6 @@ def extract_framework_runtime_variables(variables):
         }
         Returns: {'{event}', '{op}'}
     """
-    import re
-
     runtime_placeholders = set()
     # Match strings that are EXACTLY a placeholder: {something}
     # This excludes partial matches like "arn:aws:iam::{account_id}::role/name"
@@ -686,12 +681,6 @@ def validate_per_account(custodian_config, accounts_config, policy_file,
     Returns:
         bool: True if validation passes for all accounts, False otherwise
     """
-    import copy
-    from c7n import deprecated
-    from c7n.policy import Policy
-    from c7n.config import Config, Bag
-    from c7n.loader import SourceLocator
-
     accounts = accounts_config['accounts']
     policies = custodian_config.get('policies', [])
 

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -578,9 +578,9 @@ def find_unexpanded_variables(obj, path="", allowed_placeholders=None):
         obj: Policy data object (dict, list, str, or other)
         path: Current path in the object tree (for error reporting)
         allowed_placeholders: Optional set of placeholder strings (e.g., {'{event}', '{op}'})
-                            that should NOT be flagged as errors. These represent framework
-                            runtime variables that are intentionally not expanded during
-                            validation. If None (default), no placeholders are allowed.
+                              that should NOT be flagged as errors. These represent framework
+                              runtime variables that are intentionally not expanded during
+                              validation. If None (default), no placeholders are allowed.
 
     Returns:
         list: List of tuples (path, unexpanded_string) for each unexpanded variable
@@ -640,9 +640,9 @@ def extract_framework_runtime_variables(variables):
     Example:
         variables = {
             'account_id': '123456789012',  # Expanded value
-            'region': 'us-east-1',          # Expanded value
-            'event': '{event}',              # Runtime placeholder
-            'op': '{op}'                     # Runtime placeholder
+            'region': 'us-east-1',         # Expanded value
+            'event': '{event}',            # Runtime placeholder
+            'op': '{op}'                   # Runtime placeholder
         }
         Returns: {'{event}', '{op}'}
     """

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -728,7 +728,7 @@ def validate_per_account(custodian_config, accounts_config, policy_file,
         )
 
         source_locator = None
-        if fmt in ('yml', 'yaml'):
+        if fmt.lower() in ('yml', 'yaml'):
             source_locator = SourceLocator(policy_file)
 
         # Validate each policy with account context

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -568,15 +568,32 @@ def validate_basic(custodian_config, policy_file, fmt, check_mode, verbose):
     return True
 
 
-def find_unexpanded_variables(obj, path=""):
+def find_unexpanded_variables(obj, path="", allowed_placeholders=None):
     """Recursively find unexpanded variable references in policy data.
+
+    This function identifies variable placeholders (e.g., {variable_name}) that remain
+    unexpanded in policy data. Framework runtime variables can be explicitly allowed
+    by passing them in the allowed_placeholders parameter.
 
     Args:
         obj: Policy data object (dict, list, str, or other)
         path: Current path in the object tree (for error reporting)
+        allowed_placeholders: Optional set of placeholder strings (e.g., {'{event}', '{op}'})
+                            that should NOT be flagged as errors. These represent framework
+                            runtime variables that are intentionally not expanded during
+                            validation. If None (default), no placeholders are allowed.
 
     Returns:
         list: List of tuples (path, unexpanded_string) for each unexpanded variable
+              that is not in the allowed_placeholders set
+
+    Example:
+        # Flag all unexpanded variables (default behavior)
+        errors = find_unexpanded_variables(policy_data)
+
+        # Allow framework runtime variables
+        framework_vars = extract_framework_runtime_variables(variables)
+        errors = find_unexpanded_variables(policy_data, allowed_placeholders=framework_vars)
     """
     import re
 
@@ -586,29 +603,65 @@ def find_unexpanded_variables(obj, path=""):
     if isinstance(obj, dict):
         for key, value in obj.items():
             new_path = f"{path}.{key}" if path else key
-            unexpanded.extend(find_unexpanded_variables(value, new_path))
+            unexpanded.extend(find_unexpanded_variables(value, new_path, allowed_placeholders))
     elif isinstance(obj, list):
         for idx, item in enumerate(obj):
             new_path = f"{path}[{idx}]"
-            unexpanded.extend(find_unexpanded_variables(item, new_path))
+            unexpanded.extend(find_unexpanded_variables(item, new_path, allowed_placeholders))
     elif isinstance(obj, str):
         # Check if string contains variable placeholders
         if var_pattern.search(obj):
             # Extract variable names from the string
             matches = var_pattern.findall(obj)
             for match in matches:
-                # Skip known runtime variables that are intentionally not expanded
-                runtime_vars = [
-                    '{account}', '{event}', '{op}', '{action_date}',
-                    '{service}', '{bucket_region}', '{bucket_name}',
-                    '{source_bucket_name}', '{source_bucket_region}',
-                    '{target_bucket_name}', '{target_prefix}', '{LoadBalancerName}'
-                ]
-                if match in runtime_vars:
+                # Skip framework runtime variables that are intentionally not expanded
+                if allowed_placeholders and match in allowed_placeholders:
                     continue
                 unexpanded.append((path, match))
 
     return unexpanded
+
+
+def extract_framework_runtime_variables(variables):
+    """Extract framework runtime variables that should remain unexpanded.
+
+    Cloud Custodian's Policy.get_variables() returns a dict where some values
+    are placeholder strings like '{event}', '{op}', etc. These are intentionally
+    NOT expanded during validation because they're only available at runtime.
+
+    This function identifies those placeholders by looking for string values
+    that match the pattern {variable_name}. This approach is provider-agnostic
+    and works across AWS, Azure, and GCP by querying the actual Policy object's
+    variable definitions rather than using hardcoded lists.
+
+    Args:
+        variables: Dictionary returned by Policy.get_variables()
+
+    Returns:
+        set: Set of placeholder strings like '{event}', '{op}', etc.
+
+    Example:
+        variables = {
+            'account_id': '123456789012',  # Expanded value
+            'region': 'us-east-1',          # Expanded value
+            'event': '{event}',              # Runtime placeholder
+            'op': '{op}'                     # Runtime placeholder
+        }
+        Returns: {'{event}', '{op}'}
+    """
+    import re
+
+    runtime_placeholders = set()
+    # Match strings that are EXACTLY a placeholder: {something}
+    # This excludes partial matches like "arn:aws:iam::{account_id}::role/name"
+    placeholder_pattern = re.compile(r'^\{[^}]+\}$')
+
+    for key, value in variables.items():
+        # Only consider string values that match the exact placeholder pattern
+        if isinstance(value, str) and placeholder_pattern.match(value):
+            runtime_placeholders.add(value)
+
+    return runtime_placeholders
 
 
 def validate_per_account(custodian_config, accounts_config, policy_file,
@@ -724,11 +777,22 @@ def validate_per_account(custodian_config, accounts_config, policy_file,
                 # Get variables (this adds runtime variables)
                 variables = policy.get_variables(account_vars)
 
+                # Extract framework runtime variables BEFORE expansion
+                # These are placeholders like {event}, {op} that remain unexpanded
+                # because they're only available at policy execution time, not validation time
+                framework_runtime_vars = extract_framework_runtime_variables(variables)
+
                 # Expand variables (modifies policy.data in place)
+                # This expands user-defined variables from account config
                 policy.expand_variables(variables)
 
-                # Check for unexpanded variables (those that couldn't be resolved)
-                unexpanded = find_unexpanded_variables(policy.data, f"policy.{policy_name}")
+                # Check for unexpanded variables, but allow framework runtime placeholders
+                # User-defined variables that couldn't be resolved will still be flagged
+                unexpanded = find_unexpanded_variables(
+                    policy.data,
+                    f"policy.{policy_name}",
+                    allowed_placeholders=framework_runtime_vars
+                )
                 if unexpanded:
                     for path, var in unexpanded:
                         var_name = var.strip('{}')

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -499,12 +499,16 @@ def validate(config, use, policy, policy_tags, resource,
         level=level,
         format="%(asctime)s: %(name)s:%(levelname)s %(message)s"
     )
+    # Suppress noisy third-party loggers
     logging.getLogger('botocore').setLevel(logging.ERROR)
     logging.getLogger('urllib3').setLevel(logging.ERROR)
+    logging.getLogger('oci').setLevel(logging.ERROR)
+    logging.getLogger('oci.circuit_breaker').setLevel(logging.ERROR)
 
     log.info("Starting policy validation")
-    log.debug(f"Config file: {config}")
-    log.debug(f"Policy file: {use}")
+    if verbose:
+        log.debug(f"Config file: {config}")
+        log.debug(f"Policy file: {use}")
 
     # Import validation utilities from c7n.commands
     from c7n.commands import DuplicateKeyCheckLoader

--- a/tools/c7n_org/tests/fixtures/accounts-with-vars.yml
+++ b/tools/c7n_org/tests/fixtures/accounts-with-vars.yml
@@ -1,0 +1,33 @@
+accounts:
+  - name: dev-account
+    account_id: '123456789012'
+    role: 'arn:aws:iam::123456789012:role/CloudCustodian'
+    regions:
+      - us-east-1
+    tags:
+      - dev
+      - testing
+    vars:
+      environment: development
+      cost_center: dev-ops
+
+  - name: prod-account
+    account_id: '987654321098'
+    role: 'arn:aws:iam::987654321098:role/CloudCustodian'
+    regions:
+      - us-east-1
+      - us-west-2
+    tags:
+      - prod
+    vars:
+      environment: production
+      cost_center: finance
+
+  - name: staging-account
+    account_id: '555555555555'
+    role: 'arn:aws:iam::555555555555:role/CloudCustodian'
+    regions:
+      - us-east-1
+    tags:
+      - staging
+    # No vars defined - should trigger errors if policy needs them

--- a/tools/c7n_org/tests/fixtures/deprecated-policy.yml
+++ b/tools/c7n_org/tests/fixtures/deprecated-policy.yml
@@ -1,0 +1,10 @@
+policies:
+  - name: policy-with-deprecated-feature
+    resource: aws.ec2
+    filters:
+      # Using old-style tag filter syntax (deprecated)
+      - "tag:Name": present
+    actions:
+      - type: mark-for-op
+        op: stop
+        days: 7

--- a/tools/c7n_org/tests/fixtures/duplicate-names-policy.yml
+++ b/tools/c7n_org/tests/fixtures/duplicate-names-policy.yml
@@ -1,0 +1,11 @@
+policies:
+  - name: duplicate-name
+    resource: aws.ec2
+    filters:
+      - tag:Name: present
+
+  - name: duplicate-name
+    resource: aws.s3
+    filters:
+      - type: bucket-encryption
+        state: false

--- a/tools/c7n_org/tests/fixtures/flow-logs-deprecated-policy.yml
+++ b/tools/c7n_org/tests/fixtures/flow-logs-deprecated-policy.yml
@@ -1,0 +1,9 @@
+policies:
+  - name: vpc-with-deprecated-flow-logs-filter
+    resource: aws.vpc
+    description: Uses deprecated flow-logs filter fields
+    filters:
+      - type: flow-logs
+        enabled: true              # DEPRECATED: use list-item style attrs
+        status: active             # DEPRECATED: use list-item style attrs
+        destination-type: s3       # DEPRECATED: use list-item style attrs

--- a/tools/c7n_org/tests/fixtures/invalid-schema-policy.yml
+++ b/tools/c7n_org/tests/fixtures/invalid-schema-policy.yml
@@ -1,0 +1,9 @@
+policies:
+  - name: invalid-schema-policy
+    resource: aws.ec2
+    filters:
+      - type: invalid-filter-type-that-does-not-exist
+        key: SomeKey
+        value: SomeValue
+    actions:
+      - type: invalid-action-type

--- a/tools/c7n_org/tests/fixtures/invalid-structure-policy.yml
+++ b/tools/c7n_org/tests/fixtures/invalid-structure-policy.yml
@@ -1,0 +1,2 @@
+This is not valid YAML or JSON
+Just some random text: [{ that doesn't parse

--- a/tools/c7n_org/tests/fixtures/multicloud-policy.yml
+++ b/tools/c7n_org/tests/fixtures/multicloud-policy.yml
@@ -1,0 +1,65 @@
+policies:
+  - name: aws-ec2-tag-compliance
+    resource: aws.ec2
+    description: Ensure EC2 instances have required tags
+    filters:
+      - tag:Environment: absent
+    actions:
+      - type: tag
+        key: Environment
+        value: production
+
+  - name: azure-vm-tag-compliance
+    resource: azure.vm
+    description: Ensure Azure VMs have required tags
+    filters:
+      - type: value
+        key: tags.Environment
+        value: absent
+    actions:
+      - type: tag
+        tags:
+          Environment: production
+
+  - name: gcp-instance-tag-compliance
+    resource: gcp.instance
+    description: Ensure GCP instances have required labels
+    filters:
+      - type: value
+        key: labels.environment
+        value: absent
+    actions:
+      - type: set-labels
+        labels:
+          environment: production
+
+  - name: aws-s3-encryption
+    resource: aws.s3
+    description: Ensure S3 buckets have encryption enabled
+    filters:
+      - type: bucket-encryption
+        state: False
+    actions:
+      - type: set-bucket-encryption
+
+  - name: azure-storage-https
+    resource: azure.storage
+    description: Ensure Azure storage accounts require HTTPS
+    filters:
+      - type: value
+        key: properties.supportsHttpsTrafficOnly
+        value: false
+    actions:
+      - type: require-secure-transfer
+        value: true
+
+  - name: gcp-storage-uniform-access
+    resource: gcp.bucket
+    description: Ensure GCP storage buckets have uniform access control
+    filters:
+      - type: value
+        key: iamConfiguration.uniformBucketLevelAccess.enabled
+        value: false
+    actions:
+      - type: set-uniform-access
+        state: true

--- a/tools/c7n_org/tests/fixtures/policy-missing-vars.yml
+++ b/tools/c7n_org/tests/fixtures/policy-missing-vars.yml
@@ -1,0 +1,9 @@
+policies:
+  - name: needs-undefined-var
+    resource: ec2
+    filters:
+      - tag:Owner: absent
+    actions:
+      - type: tag
+        key: Owner
+        value: "{undefined_variable}"

--- a/tools/c7n_org/tests/fixtures/policy-with-runtime-vars.yml
+++ b/tools/c7n_org/tests/fixtures/policy-with-runtime-vars.yml
@@ -1,0 +1,31 @@
+policies:
+  - name: lambda-with-event-var
+    resource: aws.lambda
+    description: Policy using runtime {event} variable in description
+    comment: "Event variable: {event}"
+    filters:
+      - type: value
+        key: Runtime
+        value: python3.9
+
+  - name: ec2-with-op-var
+    resource: aws.ec2
+    description: Policy using {op} variable for operations
+    comment: "Operation: {op}"
+    filters:
+      - State.Name: running
+
+  - name: s3-with-action-date
+    resource: aws.s3
+    description: Policy using {action_date} for scheduling
+    comment: "Scheduled for: {action_date}"
+    filters:
+      - type: bucket-logging
+        op: disabled
+
+  - name: mixed-variables-policy
+    resource: aws.ec2
+    description: Mix of user vars and runtime vars
+    comment: "Environment {environment} event {event} at {action_date}"
+    filters:
+      - tag:Environment: "{environment}"

--- a/tools/c7n_org/tests/fixtures/policy-with-vars.yml
+++ b/tools/c7n_org/tests/fixtures/policy-with-vars.yml
@@ -1,0 +1,27 @@
+policies:
+  - name: tag-enforcement
+    resource: ec2
+    description: Enforce {environment} tagging
+    filters:
+      - tag:Environment: absent
+    actions:
+      - type: tag
+        key: Environment
+        value: "{environment}"
+      
+  - name: cost-tracking
+    resource: ec2
+    description: Tag with cost center
+    filters:
+      - tag:CostCenter: absent
+    actions:
+      - type: tag
+        key: CostCenter
+        value: "{cost_center}"
+
+  - name: no-variables-policy
+    resource: s3
+    description: Policy without variables
+    filters:
+      - type: bucket-encryption
+        state: false

--- a/tools/c7n_org/tests/fixtures/simple-valid-policy.yml
+++ b/tools/c7n_org/tests/fixtures/simple-valid-policy.yml
@@ -1,0 +1,6 @@
+policies:
+  - name: tag-compliance-simple
+    resource: ec2
+    description: Simple policy without actions for testing
+    filters:
+      - tag:Environment: absent

--- a/tools/c7n_org/tests/fixtures/test-accounts.yml
+++ b/tools/c7n_org/tests/fixtures/test-accounts.yml
@@ -1,0 +1,13 @@
+accounts:
+  - name: dev
+    account_id: '112233445566'
+    tags:
+      - red
+      - black
+    role: 'arn:aws:iam::{account_id}:role/CloudCustodian'
+  - name: prod
+    account_id: '998877665544'
+    tags:
+      - blue
+      - production
+    role: 'arn:aws:iam::{account_id}:role/CloudCustodian'

--- a/tools/c7n_org/tests/fixtures/valid-policy.yml
+++ b/tools/c7n_org/tests/fixtures/valid-policy.yml
@@ -1,0 +1,39 @@
+policies:
+  - name: ec2-tag-compliance
+    resource: aws.ec2
+    description: Check EC2 instances for required tags
+    tags:
+      - compliance
+      - tagging
+    filters:
+      - tag:Environment: absent
+    actions:
+      - type: notify
+        subject: Missing Environment tag on EC2 instance
+
+  - name: s3-encryption-check
+    resource: aws.s3
+    description: Ensure S3 buckets have encryption enabled
+    tags:
+      - security
+      - encryption
+    filters:
+      - type: bucket-encryption
+        state: false
+    actions:
+      - type: set-bucket-encryption
+
+  - name: lambda-old-runtimes
+    resource: aws.lambda
+    description: Find Lambda functions with old runtimes
+    tags:
+      - compliance
+      - security
+    filters:
+      - type: value
+        key: Runtime
+        op: in
+        value:
+          - python2.7
+          - python3.6
+          - nodejs8.10

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -382,14 +382,8 @@ class OrgTest(TestUtils):
 
     def test_validate_command_invalid_schema(self):
         """Test validate command with schema errors - should exit 1."""
-        run_dir = self.get_temp_dir()
-
-        # Create accounts file
-        with open(os.path.join(run_dir, 'accounts.yml'), 'w') as fh:
-            fh.write(ACCOUNTS_AWS_DEFAULT)
-
         # Create invalid policy file with schema violation
-        invalid_policy = yaml.safe_dump({
+        invalid_policy = {
             'policies': [{
                 'name': 'invalid-schema',
                 'resource': 'aws.ec2',
@@ -397,9 +391,8 @@ class OrgTest(TestUtils):
                     {'type': 'nonexistent-filter-type-xyz123'}
                 ]
             }]
-        })
-        with open(os.path.join(run_dir, 'policies.yml'), 'w') as fh:
-            fh.write(invalid_policy)
+        }
+        run_dir = self.setup_run_dir(policies=invalid_policy)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -411,21 +404,14 @@ class OrgTest(TestUtils):
 
     def test_validate_command_invalid_structure(self):
         """Test validate command with structural errors - should exit 1."""
-        run_dir = self.get_temp_dir()
-
-        # Create accounts file
-        with open(os.path.join(run_dir, 'accounts.yml'), 'w') as fh:
-            fh.write(ACCOUNTS_AWS_DEFAULT)
-
         # Create structurally invalid policy (missing required fields)
-        invalid_policy = yaml.safe_dump({
+        invalid_policy = {
             'policies': [{
                 'name': 'missing-resource'
                 # Missing 'resource' field which is required
             }]
-        })
-        with open(os.path.join(run_dir, 'policies.yml'), 'w') as fh:
-            fh.write(invalid_policy)
+        }
+        run_dir = self.setup_run_dir(policies=invalid_policy)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -437,21 +423,14 @@ class OrgTest(TestUtils):
 
     def test_validate_command_duplicate_policy_names(self):
         """Test validate command with duplicate policy names - should exit 1."""
-        run_dir = self.get_temp_dir()
-
-        # Create accounts file
-        with open(os.path.join(run_dir, 'accounts.yml'), 'w') as fh:
-            fh.write(ACCOUNTS_AWS_DEFAULT)
-
         # Create policy file with duplicate names
-        duplicate_policy = yaml.safe_dump({
+        duplicate_policy = {
             'policies': [
                 {'name': 'duplicate', 'resource': 'aws.ec2'},
                 {'name': 'duplicate', 'resource': 'aws.s3'}
             ]
-        })
-        with open(os.path.join(run_dir, 'policies.yml'), 'w') as fh:
-            fh.write(duplicate_policy)
+        }
+        run_dir = self.setup_run_dir(policies=duplicate_policy)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -499,14 +478,8 @@ class OrgTest(TestUtils):
 
     def test_validate_command_check_deprecations_warn(self):
         """Test validate command with deprecated features in warn mode - should exit 0."""
-        run_dir = self.get_temp_dir()
-
-        # Create accounts file
-        with open(os.path.join(run_dir, 'accounts.yml'), 'w') as fh:
-            fh.write(ACCOUNTS_AWS_DEFAULT)
-
         # Create policy with mark-for-op (commonly deprecated)
-        policy = yaml.safe_dump({
+        policy = {
             'policies': [{
                 'name': 'with-mark-for-op',
                 'resource': 'aws.ec2',
@@ -517,9 +490,8 @@ class OrgTest(TestUtils):
                     'days': 7
                 }]
             }]
-        })
-        with open(os.path.join(run_dir, 'policies.yml'), 'w') as fh:
-            fh.write(policy)
+        }
+        run_dir = self.setup_run_dir(policies=policy)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -533,14 +505,8 @@ class OrgTest(TestUtils):
 
     def test_validate_command_check_deprecations_strict(self):
         """Test validate command with deprecated features in strict mode - should exit 1."""
-        run_dir = self.get_temp_dir()
-
-        # Create accounts file
-        with open(os.path.join(run_dir, 'accounts.yml'), 'w') as fh:
-            fh.write(ACCOUNTS_AWS_DEFAULT)
-
         # Create policy with mark-for-op (commonly deprecated)
-        policy = yaml.safe_dump({
+        policy = {
             'policies': [{
                 'name': 'with-mark-for-op',
                 'resource': 'aws.ec2',
@@ -551,9 +517,8 @@ class OrgTest(TestUtils):
                     'days': 7
                 }]
             }]
-        })
-        with open(os.path.join(run_dir, 'policies.yml'), 'w') as fh:
-            fh.write(policy)
+        }
+        run_dir = self.setup_run_dir(policies=policy)
 
         runner = CliRunner()
         result = runner.invoke(

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -597,3 +597,43 @@ class OrgTest(TestUtils):
              '-u', os.path.join(run_dir, 'policies.txt')],
             catch_exceptions=False)
         self.assertEqual(result.exit_code, 1)
+
+    def test_validate_command_multicloud_policies(self):
+        """Test validate command with multicloud policies (AWS, Azure, GCP) - should exit 0."""
+        run_dir = self.setup_run_dir()
+        fixtures_dir = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+        runner = CliRunner()
+        result = runner.invoke(
+            org.cli,
+            ['validate', '-c', os.path.join(run_dir, 'accounts.yml'),
+             '-u', os.path.join(fixtures_dir, 'multicloud-policy.yml')],
+            catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+
+        # Test filtering by AWS resources
+        result = runner.invoke(
+            org.cli,
+            ['validate', '-c', os.path.join(run_dir, 'accounts.yml'),
+             '-u', os.path.join(fixtures_dir, 'multicloud-policy.yml'),
+             '--resource', 'aws.ec2'],
+            catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+
+        # Test filtering by Azure resources
+        result = runner.invoke(
+            org.cli,
+            ['validate', '-c', os.path.join(run_dir, 'accounts.yml'),
+             '-u', os.path.join(fixtures_dir, 'multicloud-policy.yml'),
+             '--resource', 'azure.storage'],
+            catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+
+        # Test filtering by GCP resources
+        result = runner.invoke(
+            org.cli,
+            ['validate', '-c', os.path.join(run_dir, 'accounts.yml'),
+             '-u', os.path.join(fixtures_dir, 'multicloud-policy.yml'),
+             '--resource', 'gcp.bucket'],
+            catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
This PR adds the command `c7n-org validate`, allowing the validation of multi-cloud policy suites and policies with variables.  It can do basic variable-aware validation without checking that the variables make sense, or per-account validation with full variable substitution.  It can also optionally check and either warn or fail for the use of deprecated features (as understood by c7n or a provider plugin).

Fixes #4085.