### PR TITLE
feat: aws - apigwv2 - add route resource for authorization type filtering

### DIFF
--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -1414,14 +1414,9 @@ class ApiGatewayV2Route(query.ChildResourceManager):
         arn_type = "/apis"
         id = "RouteId"
         name = "RouteKey"
-        cfn_type = config_type = "AWS::ApiGatewayV2::Route"
+        cfn_type = "AWS::ApiGatewayV2::Route"
         permission_prefix = 'apigateway'
         permissions_enum = ('apigateway:GET',)
-
-    source_mapping = {
-        "describe-child": query.ChildDescribeSource,
-        "config": query.ConfigSource
-    }
 
     def get_arns(self, resources):
         partition = get_partition(self.config.region)

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -11,6 +11,7 @@ ResourceMap = {
   "aws.ami": "c7n.resources.ami.AMI",
   "aws.apigw-domain-name": "c7n.resources.apigw.CustomDomainName",
   "aws.apigwv2": "c7n.resources.apigw.ApiGwV2",
+  "aws.apigwv2-route": "c7n.resources.apigw.ApiGatewayV2Route",
   "aws.apigwv2-stage": "c7n.resources.apigw.ApiGatewayV2Stage",
   "aws.appmesh-mesh": "c7n.resources.appmesh.AppmeshMesh",
   "aws.appmesh-virtualgateway": "c7n.resources.appmesh.AppmeshVirtualGateway",

--- a/tests/data/placebo/test_apigwv2_route_filter_no_auth/apigateway.GetApis_1.json
+++ b/tests/data/placebo/test_apigwv2_route_filter_no_auth/apigateway.GetApis_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Items": [
+            {
+                "ApiEndpoint": "https://svr07q9wvj.execute-api.us-east-1.amazonaws.com",
+                "ApiId": "svr07q9wvj",
+                "ApiKeySelectionExpression": "$request.header.x-api-key",
+                "CreatedDate": {
+                    "__class__": "datetime",
+                    "year": 2025,
+                    "month": 12,
+                    "day": 12,
+                    "hour": 23,
+                    "minute": 8,
+                    "second": 1,
+                    "microsecond": 0
+                },
+                "DisableExecuteApiEndpoint": false,
+                "IpAddressType": "ipv4",
+                "Name": "example-api-amazing-kiwi",
+                "ProtocolType": "HTTP",
+                "RouteSelectionExpression": "$request.method $request.path",
+                "Tags": {}
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_apigwv2_route_filter_no_auth/apigateway.GetRoutes_1.json
+++ b/tests/data/placebo/test_apigwv2_route_filter_no_auth/apigateway.GetRoutes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Items": [
+            {
+                "ApiKeyRequired": false,
+                "AuthorizationType": "AWS_IAM",
+                "RouteId": "ck2ui4k",
+                "RouteKey": "GET /iam-auth",
+                "Target": "integrations/ipp55qs"
+            },
+            {
+                "ApiKeyRequired": false,
+                "AuthorizationType": "NONE",
+                "RouteId": "jxtjrzi",
+                "RouteKey": "GET /no-auth",
+                "Target": "integrations/ipp55qs"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_apigwv2_route_query/apigateway.GetApis_1.json
+++ b/tests/data/placebo/test_apigwv2_route_query/apigateway.GetApis_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Items": [
+            {
+                "ApiEndpoint": "https://sozi1cborg.execute-api.us-east-1.amazonaws.com",
+                "ApiId": "sozi1cborg",
+                "ApiKeySelectionExpression": "$request.header.x-api-key",
+                "CreatedDate": {
+                    "__class__": "datetime",
+                    "year": 2025,
+                    "month": 12,
+                    "day": 12,
+                    "hour": 23,
+                    "minute": 7,
+                    "second": 48,
+                    "microsecond": 0
+                },
+                "DisableExecuteApiEndpoint": false,
+                "IpAddressType": "ipv4",
+                "Name": "example-api-sharing-duck",
+                "ProtocolType": "HTTP",
+                "RouteSelectionExpression": "$request.method $request.path",
+                "Tags": {}
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_apigwv2_route_query/apigateway.GetRoutes_1.json
+++ b/tests/data/placebo/test_apigwv2_route_query/apigateway.GetRoutes_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Items": [
+            {
+                "ApiKeyRequired": false,
+                "AuthorizationType": "NONE",
+                "RouteId": "ms6wuq0",
+                "RouteKey": "GET /no-auth",
+                "Target": "integrations/ev8tgnj"
+            },
+            {
+                "ApiKeyRequired": false,
+                "AuthorizationType": "AWS_IAM",
+                "RouteId": "v7guotm",
+                "RouteKey": "GET /iam-auth",
+                "Target": "integrations/ev8tgnj"
+            }
+        ]
+    }
+}

--- a/tests/terraform/apigatewayv2_route/main.tf
+++ b/tests/terraform/apigatewayv2_route/main.tf
@@ -1,0 +1,33 @@
+resource "random_pet" "api" {
+  prefix = "example-api"
+}
+
+resource "aws_apigatewayv2_api" "example" {
+  name                       = random_pet.api.id
+  protocol_type              = "HTTP"
+  route_selection_expression = "$request.method $request.path"
+}
+
+resource "aws_apigatewayv2_integration" "example" {
+  api_id           = aws_apigatewayv2_api.example.id
+  integration_type = "HTTP_PROXY"
+  integration_uri  = "https://example.com"
+  integration_method = "ANY"
+}
+
+# Route with no authorization (should be flagged by policy)
+resource "aws_apigatewayv2_route" "no_auth" {
+  api_id    = aws_apigatewayv2_api.example.id
+  route_key = "GET /no-auth"
+  target    = "integrations/${aws_apigatewayv2_integration.example.id}"
+  authorization_type = "NONE"
+}
+
+# Route with IAM authorization (should pass policy)
+resource "aws_apigatewayv2_route" "iam_auth" {
+  api_id    = aws_apigatewayv2_api.example.id
+  route_key = "GET /iam-auth"
+  target    = "integrations/${aws_apigatewayv2_integration.example.id}"
+  authorization_type = "AWS_IAM"
+}
+

--- a/tests/terraform/apigatewayv2_route/main.tf
+++ b/tests/terraform/apigatewayv2_route/main.tf
@@ -9,25 +9,25 @@ resource "aws_apigatewayv2_api" "example" {
 }
 
 resource "aws_apigatewayv2_integration" "example" {
-  api_id           = aws_apigatewayv2_api.example.id
-  integration_type = "HTTP_PROXY"
-  integration_uri  = "https://example.com"
+  api_id             = aws_apigatewayv2_api.example.id
+  integration_type   = "HTTP_PROXY"
+  integration_uri    = "https://example.com"
   integration_method = "ANY"
 }
 
 # Route with no authorization (should be flagged by policy)
 resource "aws_apigatewayv2_route" "no_auth" {
-  api_id    = aws_apigatewayv2_api.example.id
-  route_key = "GET /no-auth"
-  target    = "integrations/${aws_apigatewayv2_integration.example.id}"
+  api_id             = aws_apigatewayv2_api.example.id
+  route_key          = "GET /no-auth"
+  target             = "integrations/${aws_apigatewayv2_integration.example.id}"
   authorization_type = "NONE"
 }
 
 # Route with IAM authorization (should pass policy)
 resource "aws_apigatewayv2_route" "iam_auth" {
-  api_id    = aws_apigatewayv2_api.example.id
-  route_key = "GET /iam-auth"
-  target    = "integrations/${aws_apigatewayv2_integration.example.id}"
+  api_id             = aws_apigatewayv2_api.example.id
+  route_key          = "GET /iam-auth"
+  target             = "integrations/${aws_apigatewayv2_integration.example.id}"
   authorization_type = "AWS_IAM"
 }
 

--- a/tests/terraform/apigatewayv2_route/tf_resources.json
+++ b/tests/terraform/apigatewayv2_route/tf_resources.json
@@ -1,0 +1,99 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_apigatewayv2_api": {
+            "example": {
+                "api_endpoint": "https://svr07q9wvj.execute-api.us-east-1.amazonaws.com",
+                "api_key_selection_expression": "$request.header.x-api-key",
+                "arn": "arn:aws:apigateway:us-east-1::/apis/svr07q9wvj",
+                "body": null,
+                "cors_configuration": [],
+                "credentials_arn": null,
+                "description": "",
+                "disable_execute_api_endpoint": false,
+                "execution_arn": "arn:aws:execute-api:us-east-1:644160558196:svr07q9wvj",
+                "fail_on_warnings": null,
+                "id": "svr07q9wvj",
+                "ip_address_type": "ipv4",
+                "name": "example-api-amazing-kiwi",
+                "protocol_type": "HTTP",
+                "region": "us-east-1",
+                "route_key": null,
+                "route_selection_expression": "$request.method $request.path",
+                "tags": null,
+                "tags_all": {},
+                "target": null,
+                "version": ""
+            }
+        },
+        "aws_apigatewayv2_integration": {
+            "example": {
+                "api_id": "svr07q9wvj",
+                "connection_id": "",
+                "connection_type": "INTERNET",
+                "content_handling_strategy": "",
+                "credentials_arn": "",
+                "description": "",
+                "id": "ipp55qs",
+                "integration_method": "ANY",
+                "integration_response_selection_expression": "",
+                "integration_subtype": "",
+                "integration_type": "HTTP_PROXY",
+                "integration_uri": "https://example.com",
+                "passthrough_behavior": "",
+                "payload_format_version": "1.0",
+                "region": "us-east-1",
+                "request_parameters": null,
+                "request_templates": null,
+                "response_parameters": [],
+                "template_selection_expression": "",
+                "timeout_milliseconds": 30000,
+                "tls_config": []
+            }
+        },
+        "aws_apigatewayv2_route": {
+            "iam_auth": {
+                "api_id": "svr07q9wvj",
+                "api_key_required": false,
+                "authorization_scopes": null,
+                "authorization_type": "AWS_IAM",
+                "authorizer_id": "",
+                "id": "ck2ui4k",
+                "model_selection_expression": "",
+                "operation_name": "",
+                "region": "us-east-1",
+                "request_models": null,
+                "request_parameter": [],
+                "route_key": "GET /iam-auth",
+                "route_response_selection_expression": "",
+                "target": "integrations/ipp55qs"
+            },
+            "no_auth": {
+                "api_id": "svr07q9wvj",
+                "api_key_required": false,
+                "authorization_scopes": null,
+                "authorization_type": "NONE",
+                "authorizer_id": "",
+                "id": "jxtjrzi",
+                "model_selection_expression": "",
+                "operation_name": "",
+                "region": "us-east-1",
+                "request_models": null,
+                "request_parameter": [],
+                "route_key": "GET /no-auth",
+                "route_response_selection_expression": "",
+                "target": "integrations/ipp55qs"
+            }
+        },
+        "random_pet": {
+            "api": {
+                "id": "example-api-amazing-kiwi",
+                "keepers": null,
+                "length": 2,
+                "prefix": "example-api",
+                "separator": "-"
+            }
+        }
+    }
+}

--- a/tests/test_apigw.py
+++ b/tests/test_apigw.py
@@ -32,6 +32,48 @@ def test_apigwv2_stage_query(test, apigatewayv2_stage):
     ]
 
 
+@terraform("apigatewayv2_route")
+def test_apigwv2_route_query(test, apigatewayv2_route):
+    factory = test.replay_flight_data("test_apigwv2_route_query")
+
+    policy = test.load_policy({
+        "name": "test-aws-apigwv2-route",
+        "resource": "aws.apigwv2-route"
+    }, session_factory=factory)
+
+    resources = policy.run()
+
+    assert len(resources) > 0
+    # Verify we get routes with expected fields
+    assert 'RouteId' in resources[0]
+    assert 'RouteKey' in resources[0]
+    assert 'AuthorizationType' in resources[0]
+    assert 'c7n:parent-id' in resources[0]
+
+
+@terraform("apigatewayv2_route")
+def test_apigwv2_route_filter_no_auth(test, apigatewayv2_route):
+    factory = test.replay_flight_data("test_apigwv2_route_filter_no_auth")
+
+    policy = test.load_policy({
+        "name": "test-aws-apigwv2-route-no-auth",
+        "resource": "aws.apigwv2-route",
+        "filters": [
+            {
+                "type": "value",
+                "key": "AuthorizationType",
+                "value": "NONE"
+            }
+        ]
+    }, session_factory=factory)
+
+    resources = policy.run()
+
+    assert len(resources) >= 1
+    for r in resources:
+        assert r['AuthorizationType'] == 'NONE'
+
+
 class TestRestAccount(BaseTest):
 
     def test_missing_rest_account(self):

--- a/tests/test_apigw.py
+++ b/tests/test_apigw.py
@@ -44,11 +44,15 @@ def test_apigwv2_route_query(test, apigatewayv2_route):
     resources = policy.run()
 
     assert len(resources) > 0
-    # Verify we get routes with expected fields
     assert 'RouteId' in resources[0]
     assert 'RouteKey' in resources[0]
     assert 'AuthorizationType' in resources[0]
     assert 'c7n:parent-id' in resources[0]
+
+    assert policy.resource_manager.get_arns(resources) == [
+        'arn:aws:apigateway:us-east-1::/apis/sozi1cborg/routes/ms6wuq0',
+        'arn:aws:apigateway:us-east-1::/apis/sozi1cborg/routes/v7guotm'
+    ]
 
 
 @terraform("apigatewayv2_route")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -205,8 +205,9 @@ class PolicyMetaLint(BaseTest):
         overrides = overrides.difference(
             {'account', 's3', 'hostedzone', 'log-group', 'rest-api', 'redshift-snapshot',
              'rest-stage', 'codedeploy-app', 'codedeploy-group', 'fis-template', 'dlm-policy',
-             'apigwv2', 'apigwv2-stage', 'lexv2-bot-alias', 'apigw-domain-name', 'fis-experiment',
-             'launch-template-version', 'glue-table', 'glue-catalog', 'cloudwatch-synthetics'})
+             'apigwv2', 'apigwv2-route', 'apigwv2-stage', 'lexv2-bot-alias', 'apigw-domain-name',
+             'fis-experiment', 'launch-template-version', 'glue-table', 'glue-catalog',
+             'cloudwatch-synthetics'})
         if overrides:
             raise ValueError("unknown arn overrides in %s" % (", ".join(overrides)))
 


### PR DESCRIPTION
resolves #9643

Add new `apigwv2-route` child resource to enable filtering API Gateway V2 routes by authorization type. The new resource:
- Enumerates routes from parent HTTP/WebSocket APIs
- Supports filtering by AuthorizationType field
- Includes AWS Config as a data source
- Generates proper ARNs for route resources

Example policy to find routes without authorization:

```yaml
policies:
  - name: apigwv2-routes-without-authorization
     resource: aws.apigwv2-route
     filters:
       - type: value
          key: AuthorizationType
          value: NONE
```