### PR TITLE
feat: Support Azure Blob Storage as a source for value_from filters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test-functional:
 
 test-functional-azure:
 # note this will provision real resources in Azure's public cloud environment
-	C7N_FUNCTIONAL=yes uv run pytest tools/c7n_azure/tests_azure/tests_resources/test_entraid.py -k terraform -m functional $(ARGS)
+	C7N_FUNCTIONAL=yes uv run pytest tools/c7n_azure/tests_azure -k terraform -m functional $(ARGS)
 
 sphinx:
 	make -f docs/Makefile.sphinx html

--- a/docs/source/azure/advanced/blobstorage.rst
+++ b/docs/source/azure/advanced/blobstorage.rst
@@ -1,0 +1,145 @@
+.. _azure_blob_storage_filters:
+
+Azure Blob Storage for value_from Filters
+==========================================
+
+Cloud Custodian supports using Azure Blob Storage as a data source for ``value_from`` filters when using the Azure provider (``c7n_azure``). This allows you to store allowlists, denylists, and other reference data in Azure Blob Storage and reference them dynamically in your policies.  All features supported by c7n for other cloud storage providers work with Azure Blob Storage.
+
+URL Format
+----------
+
+Azure Blob Storage URLs follow this format:
+
+.. code-block:: text
+
+    azure://storageaccount.blob.core.windows.net/container/path/to/blob.json
+
+The URL structure:
+
+- ``azure://`` - Required URL scheme
+- ``storageaccount`` - Your Azure Storage account name
+- ``blob.core.windows.net`` - Azure Blob Storage endpoint
+- ``container`` - Container name
+- ``path/to/blob.json`` - Path to the blob within the container
+
+Authentication
+--------------
+
+The Azure Blob Storage resolver automatically uses your Azure credentials from the Cloud Custodian session. No additional authentication configuration is required. The resolver uses the same credentials as your other Cloud Custodian Azure operations.
+
+**Required Permissions:**
+
+Your Azure service principal or managed identity needs the ``Storage Blob Data Reader`` role on the storage account or container to read blobs.
+
+Compression Support
+-------------------
+
+Cloud Custodian automatically decompresses files with ``.gz``, ``.gzip``, or ``.zip`` extensions:
+
+.. code-block:: yaml
+
+    policies:
+      - name: check-compressed-allowlist
+        resource: azure.vm
+        filters:
+          - type: value
+            key: name
+            op: in
+            value_from:
+              url: azure://myaccount.blob.core.windows.net/configs/vms.json.gz
+              format: json
+              expr: "[].name"
+
+.. note::
+   Compression detection is based on file extension, not HTTP headers. Ensure your blob names have the appropriate extension.
+
+Caching
+-------
+
+Cloud Custodian automatically caches blob content to improve performance. The cache key includes:
+
+- Blob URL
+- Format
+- JMESPath expression
+- Custom headers (if any)
+
+Cached data is reused across multiple filter evaluations within the same policy run.
+
+Examples
+--------
+
+Example 1: Tagging Resources Based on CSV
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    policies:
+      - name: tag-vms-from-csv
+        resource: azure.vm
+        filters:
+          - type: value
+            key: name
+            op: in
+            value_from:
+              url: azure://myaccount.blob.core.windows.net/data/vms-to-tag.csv
+              format: csv
+              expr: 0
+        actions:
+          - type: tag
+            tags:
+              managed-by: cloud-custodian
+              reviewed: 'true'
+
+Example 2: Multi-Environment Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use string interpolation with ``{account_id}`` and ``{region}``:
+
+.. code-block:: yaml
+
+    policies:
+      - name: environment-specific-check
+        resource: azure.vm
+        filters:
+          - type: value
+            key: name
+            op: in
+            value_from:
+              url: azure://storage{account_id}.blob.core.windows.net/config-{region}/vms.json
+              format: json
+              expr: "[].name"
+
+Example 3: Complex Filtering with Multiple Conditions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    policies:
+      - name: complex-vm-check
+        resource: azure.vm
+        filters:
+          - type: value
+            key: name
+            op: in
+            value_from:
+              url: azure://myaccount.blob.core.windows.net/configs/vm-rules.json
+              format: json
+              expr: "rules[?environment=='production' && compliant==`true`].vmName"
+
+**Example blob content (vm-rules.json):**
+
+.. code-block:: json
+
+    {
+      "rules": [
+        {"vmName": "prod-vm-1", "environment": "production", "compliant": true},
+        {"vmName": "prod-vm-2", "environment": "production", "compliant": false},
+        {"vmName": "dev-vm-1", "environment": "development", "compliant": true}
+      ]
+    }
+
+See Also
+--------
+
+- :ref:`Azure Getting Started <azure_gettingstarted>`
+- `Azure Blob Storage Documentation <https://docs.microsoft.com/en-us/azure/storage/blobs/>`_

--- a/docs/source/azure/advanced/index.rst
+++ b/docs/source/azure/advanced/index.rst
@@ -10,4 +10,5 @@ Topics for advanced usage of the Azure provider
 
   multiplesubs
   azurepolicy
+  blobstorage
   contribute

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -152,12 +152,13 @@ class URIResolverProviderTest(BaseTest):
     """Test suite for URI resolver provider delegation mechanism (TDD)"""
 
     def setUp(self):
-        # Clear any registered providers before each test
+        # Save the current registered providers before each test
+        self._saved_uri_providers = URIResolver._uri_providers
         URIResolver._uri_providers = {}
 
     def tearDown(self):
-        # Clean up registered providers after each test
-        URIResolver._uri_providers = {}
+        # Restore the registered providers after each test
+        URIResolver._uri_providers = self._saved_uri_providers
 
     def test_register_provider(self):
         """Test that providers can register URI scheme handlers"""

--- a/tools/c7n_azure/c7n_azure/provider.py
+++ b/tools/c7n_azure/c7n_azure/provider.py
@@ -5,10 +5,12 @@ from functools import partial
 
 from c7n.provider import Provider, clouds
 from c7n.registry import PluginRegistry
+from c7n.resolver import URIResolver
 from c7n.utils import local_session
 from .session import Session
 
 from c7n_azure.resources.resource_map import ResourceMap
+from c7n_azure.resolver import resolve_azure_blob
 from msrestazure.azure_cloud import (AZURE_CHINA_CLOUD, AZURE_GERMAN_CLOUD, AZURE_PUBLIC_CLOUD,
                                      AZURE_US_GOV_CLOUD)
 import logging
@@ -80,3 +82,6 @@ class Azure(Provider):
 
 
 resources = Azure.resources
+
+# Register the azure:// URI scheme handler with the core resolver
+URIResolver.register_provider('azure', resolve_azure_blob)

--- a/tools/c7n_azure/c7n_azure/resolver.py
+++ b/tools/c7n_azure/c7n_azure/resolver.py
@@ -1,0 +1,71 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import zlib
+
+from c7n_azure.storage_utils import StorageUtilities, OldBlobServiceClient
+
+log = logging.getLogger('custodian.azure.resolver')
+
+# Use the same constant as core c7n for consistency
+ZIP_OR_GZIP_HEADER_DETECT = zlib.MAX_WBITS | 32
+
+
+def resolve_azure_blob(uri, session_factory, cache):
+    """Resolve an azure:// URI to blob content.
+
+    Args:
+        uri: Azure blob URI in format azure://account.blob.core.windows.net/container/blob
+        session_factory: Factory function that returns an Azure session
+        cache: Cache instance for storing resolved content
+
+    Returns:
+        String content of the blob, decompressed if needed
+
+    Raises:
+        ResourceNotFoundError: If blob doesn't exist
+        ClientAuthenticationError: If authentication fails
+        HttpResponseError: For other Azure API errors
+    """
+    # Check cache first
+    cached = cache.get(("azure-blob-resolver", uri))
+    if cached is not None:
+        log.debug(f"Returning cached content for {uri}")
+        return cached
+
+    # Parse the Azure URI
+    storage = StorageUtilities.get_storage_from_uri(uri)
+
+    # Get Azure session and credentials
+    session = session_factory()
+    credentials = session.get_credentials()
+
+    # Create blob service client
+    blob_service = OldBlobServiceClient(
+        account_url=storage.account_url,
+        credential=credentials
+    )
+
+    # Download blob content
+    log.debug(f"Downloading blob from {uri}")
+    blob_bytes = blob_service.get_blob_to_bytes(
+        storage.container_name,
+        storage.file_prefix
+    )
+
+    # Handle compression based on file extension (matches S3 behavior)
+    blob_name = storage.file_prefix.lower()
+    if blob_name.endswith(('.gz', '.zip', '.gzip')):
+        log.debug(f"Decompressing blob {uri}")
+        content = zlib.decompress(blob_bytes, ZIP_OR_GZIP_HEADER_DETECT).decode('utf-8')
+    else:
+        # Handle both bytes and string content
+        if isinstance(blob_bytes, bytes):
+            content = blob_bytes.decode('utf-8')
+        else:
+            content = blob_bytes
+
+    # Cache the result
+    cache.save(("azure-blob-resolver", uri), content)
+
+    return content

--- a/tools/c7n_azure/tests_azure/test_resolver.py
+++ b/tools/c7n_azure/tests_azure/test_resolver.py
@@ -1,0 +1,415 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+import gzip
+import json
+import pickle
+from io import BytesIO
+from unittest.mock import Mock, patch, MagicMock
+
+import pytest
+
+from c7n_azure.storage_utils import StorageUtilities
+
+
+class FakeCache:
+    """Test cache implementation for verifying caching behavior."""
+
+    def __init__(self):
+        self.state = {}
+        self.gets = 0
+        self.saves = 0
+
+    def get(self, key):
+        self.gets += 1
+        return self.state.get(pickle.dumps(key))
+
+    def save(self, key, data):
+        self.saves += 1
+        self.state[pickle.dumps(key)] = data
+
+    def load(self):
+        return True
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kw):
+        return
+
+
+class TestAzureBlobResolver:
+    """Test suite for Azure Blob Storage resolver functionality."""
+
+    def test_parse_basic_azure_url(self):
+        """Test parsing a basic azure:// URL."""
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/blob.json"
+        storage = StorageUtilities.get_storage_from_uri(uri)
+
+        assert storage.account_url == "https://myaccount.blob.core.windows.net"
+        assert storage.container_name == "mycontainer"
+        assert storage.file_prefix == "blob.json"
+
+    def test_parse_azure_url_with_nested_path(self):
+        """Test parsing azure:// URL with nested path structure."""
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/path/to/blob.json"
+        storage = StorageUtilities.get_storage_from_uri(uri)
+
+        assert storage.account_url == "https://myaccount.blob.core.windows.net"
+        assert storage.container_name == "mycontainer"
+        assert storage.file_prefix == "path/to/blob.json"
+
+    def test_parse_azure_url_with_gz_extension(self):
+        """Test parsing azure:// URL with .gz extension."""
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/data.json.gz"
+        storage = StorageUtilities.get_storage_from_uri(uri)
+
+        assert storage.account_url == "https://myaccount.blob.core.windows.net"
+        assert storage.container_name == "mycontainer"
+        assert storage.file_prefix == "data.json.gz"
+
+    def test_parse_azure_url_without_blob_path(self):
+        """Test parsing azure:// URL with only container (no blob path)."""
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer"
+        storage = StorageUtilities.get_storage_from_uri(uri)
+
+        assert storage.account_url == "https://myaccount.blob.core.windows.net"
+        assert storage.container_name == "mycontainer"
+        assert storage.file_prefix == ""
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_resolve_json_blob(self, mock_blob_client):
+        """Test resolving JSON content from Azure blob."""
+        from c7n_azure.resolver import resolve_azure_blob
+
+        # Setup mock
+        json_content = json.dumps({"test": "data"})
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = json_content.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test resolve
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/test.json"
+        result = resolve_azure_blob(uri, mock_session_factory, cache)
+
+        assert result == json_content
+        assert mock_client_instance.get_blob_to_bytes.called
+        # Verify cache was used
+        assert cache.saves == 1
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_resolve_csv_blob(self, mock_blob_client):
+        """Test resolving CSV content from Azure blob."""
+        from c7n_azure.resolver import resolve_azure_blob
+
+        # Setup mock
+        csv_content = "name,value\ntest,123"
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = csv_content.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test resolve
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/data.csv"
+        result = resolve_azure_blob(uri, mock_session_factory, cache)
+
+        assert result == csv_content
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_resolve_txt_blob(self, mock_blob_client):
+        """Test resolving plain text content from Azure blob."""
+        from c7n_azure.resolver import resolve_azure_blob
+
+        # Setup mock
+        txt_content = "line1\nline2\nline3"
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = txt_content.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test resolve
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/list.txt"
+        result = resolve_azure_blob(uri, mock_session_factory, cache)
+
+        assert result == txt_content
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_resolve_gzip_compressed_blob(self, mock_blob_client):
+        """Test resolving gzip-compressed blob (file extension based)."""
+        from c7n_azure.resolver import resolve_azure_blob
+
+        # Setup mock - create gzip compressed content
+        original_content = json.dumps({"compressed": "data"})
+        compressed_buffer = BytesIO()
+        with gzip.GzipFile(fileobj=compressed_buffer, mode='wb') as gz:
+            gz.write(original_content.encode('utf-8'))
+        compressed_content = compressed_buffer.getvalue()
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = compressed_content
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test resolve with .gz extension
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/data.json.gz"
+        result = resolve_azure_blob(uri, mock_session_factory, cache)
+
+        assert result == original_content
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_resolve_zip_compressed_blob(self, mock_blob_client):
+        """Test resolving deflate-compressed blob with .zip extension.
+
+        Note: This tests deflate compression (like gzip but with .zip extension),
+        not full ZIP archives. ZIP archives are not supported by zlib.decompress.
+        """
+        from c7n_azure.resolver import resolve_azure_blob
+
+        # Setup mock - create deflate compressed content (same as gzip)
+        # This matches what S3 resolver can handle with .zip extension
+        original_content = "test data for zip"
+        compressed_buffer = BytesIO()
+        with gzip.GzipFile(fileobj=compressed_buffer, mode='wb') as gz:
+            gz.write(original_content.encode('utf-8'))
+        compressed_content = compressed_buffer.getvalue()
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = compressed_content
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test resolve with .zip extension (deflate-compressed, not ZIP archive)
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/data.zip"
+        result = resolve_azure_blob(uri, mock_session_factory, cache)
+
+        # We expect the decompressed content
+        assert result == original_content
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_resolve_gzip_extension_variant(self, mock_blob_client):
+        """Test resolving blob with .gzip extension (variant)."""
+        from c7n_azure.resolver import resolve_azure_blob
+
+        # Setup mock
+        original_content = "gzip variant test"
+        compressed_buffer = BytesIO()
+        with gzip.GzipFile(fileobj=compressed_buffer, mode='wb') as gz:
+            gz.write(original_content.encode('utf-8'))
+        compressed_content = compressed_buffer.getvalue()
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = compressed_content
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test resolve with .gzip extension
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/data.gzip"
+        result = resolve_azure_blob(uri, mock_session_factory, cache)
+
+        assert result == original_content
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_caching_behavior(self, mock_blob_client):
+        """Test that caching works correctly for Azure blob content."""
+        from c7n_azure.resolver import resolve_azure_blob
+
+        # Setup mock
+        content = "cached content"
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = content.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # First resolve - should hit Azure and cache
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/cached.txt"
+        result1 = resolve_azure_blob(uri, mock_session_factory, cache)
+
+        assert result1 == content
+        assert cache.saves == 1
+        assert mock_client_instance.get_blob_to_bytes.call_count == 1
+
+        # Second resolve - should use cache, not hit Azure again
+        result2 = resolve_azure_blob(uri, mock_session_factory, cache)
+
+        assert result2 == content
+        # Cache should have been checked but not saved again
+        assert cache.gets == 2  # Once for each call
+        # Blob client should not be called again
+        assert mock_client_instance.get_blob_to_bytes.call_count == 1
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_blob_not_found_error(self, mock_blob_client):
+        """Test handling of blob not found (404) errors."""
+        from c7n_azure.resolver import resolve_azure_blob
+        from azure.core.exceptions import ResourceNotFoundError
+
+        # Setup mock to raise ResourceNotFoundError
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.side_effect = ResourceNotFoundError("Blob not found")
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test that appropriate error is raised
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/missing.json"
+        with pytest.raises(ResourceNotFoundError):
+            resolve_azure_blob(uri, mock_session_factory, cache)
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_authentication_error(self, mock_blob_client):
+        """Test handling of authentication (403) errors."""
+        from c7n_azure.resolver import resolve_azure_blob
+        from azure.core.exceptions import ClientAuthenticationError
+
+        # Setup mock to raise authentication error
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.side_effect = ClientAuthenticationError(
+            "Authentication failed"
+        )
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test that appropriate error is raised
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/protected.json"
+        with pytest.raises(ClientAuthenticationError):
+            resolve_azure_blob(uri, mock_session_factory, cache)
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_permission_denied_error(self, mock_blob_client):
+        """Test handling of permission denied errors."""
+        from c7n_azure.resolver import resolve_azure_blob
+        from azure.core.exceptions import HttpResponseError
+
+        # Setup mock to raise permission error (403)
+        mock_client_instance = MagicMock()
+        error = HttpResponseError("Access denied")
+        error.status_code = 403
+        mock_client_instance.get_blob_to_bytes.side_effect = error
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create cache
+        cache = FakeCache()
+
+        # Test that appropriate error is raised
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/restricted.json"
+        with pytest.raises(HttpResponseError):
+            resolve_azure_blob(uri, mock_session_factory, cache)
+
+    def test_invalid_url_missing_container(self):
+        """Test that URLs without a container path are handled."""
+        # This should work - container name would be empty string
+        uri = "azure://myaccount.blob.core.windows.net/"
+        storage = StorageUtilities.get_storage_from_uri(uri)
+
+        assert storage.account_url == "https://myaccount.blob.core.windows.net"
+        assert storage.container_name == ""
+        assert storage.file_prefix == ""
+
+    def test_session_credentials_usage(self):
+        """Test that session credentials are properly obtained and used."""
+        from c7n_azure.resolver import resolve_azure_blob
+
+        with patch('c7n_azure.resolver.OldBlobServiceClient') as mock_blob_client:
+            # Setup mock
+            content = "test content"
+            mock_client_instance = MagicMock()
+            mock_client_instance.get_blob_to_bytes.return_value = content.encode('utf-8')
+            mock_blob_client.return_value = mock_client_instance
+
+            # Create mock session factory
+            mock_credentials = Mock()
+            mock_session = Mock()
+            mock_session.get_credentials.return_value = mock_credentials
+            mock_session_factory = Mock(return_value=mock_session)
+
+            # Create cache
+            cache = FakeCache()
+
+            # Test resolve
+            uri = "azure://myaccount.blob.core.windows.net/mycontainer/test.txt"
+            resolve_azure_blob(uri, mock_session_factory, cache)
+
+            # Verify session factory was called
+            mock_session_factory.assert_called_once()
+            # Verify get_credentials was called
+            mock_session.get_credentials.assert_called_once()
+            # Verify BlobServiceClient was created with correct params
+            mock_blob_client.assert_called_once_with(
+                account_url="https://myaccount.blob.core.windows.net",
+                credential=mock_credentials
+            )

--- a/tools/c7n_azure/tests_azure/test_resolver_integration.py
+++ b/tools/c7n_azure/tests_azure/test_resolver_integration.py
@@ -1,0 +1,251 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for Azure Blob Storage resolver with c7n core."""
+import json
+import pickle
+from unittest.mock import Mock, patch, MagicMock
+
+from c7n.config import Bag
+from c7n.resolver import URIResolver, ValuesFrom
+
+
+class FakeCache:
+    """Test cache implementation for integration testing."""
+
+    def __init__(self):
+        self.state = {}
+
+    def get(self, key):
+        return self.state.get(pickle.dumps(key))
+
+    def save(self, key, data):
+        self.state[pickle.dumps(key)] = data
+
+    def load(self):
+        return True
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kw):
+        return
+
+
+class TestAzureBlobResolverIntegration:
+    """Integration tests verifying azure:// URLs work through c7n core."""
+
+    def test_provider_registers_azure_scheme(self):
+        """Test that importing the Azure provider registers the azure:// scheme."""
+        # Force reimport to ensure registration happens
+        import c7n_azure.provider  # noqa: F401
+        from c7n.resolver import URIResolver
+
+        # Verify azure scheme is registered
+        assert 'azure' in URIResolver._uri_providers
+        assert URIResolver._uri_providers['azure'] is not None
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_uri_resolver_handles_azure_urls(self, mock_blob_client):
+        """Test that URIResolver can resolve azure:// URLs."""
+        # Ensure provider is imported (registers the handler)
+        import c7n_azure.provider  # noqa: F401
+
+        # Setup mock
+        json_content = json.dumps({"test": "data"})
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = json_content.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create resolver and test
+        cache = FakeCache()
+        resolver = URIResolver(mock_session_factory, cache)
+        uri = "azure://myaccount.blob.core.windows.net/mycontainer/test.json"
+
+        result = resolver.resolve(uri, {})
+
+        assert result == json_content
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_values_from_with_azure_blob(self, mock_blob_client):
+        """Test ValuesFrom filter with azure:// URL."""
+        # Ensure provider is imported
+        import c7n_azure.provider  # noqa: F401
+
+        # Setup mock - return a list of values
+        values_data = json.dumps(["value1", "value2", "value3"])
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = values_data.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create ValuesFrom instance
+        cache = FakeCache()
+        manager = Bag(
+            session_factory=mock_session_factory,
+            _cache=cache,
+            config=Bag(account_id="test-account", region="us-east-1")
+        )
+
+        values_from = ValuesFrom({
+            'url': 'azure://myaccount.blob.core.windows.net/mycontainer/values.json',
+            'format': 'json'
+        }, manager)
+
+        # Get values
+        result = values_from.get_values()
+
+        # Verify
+        assert set(result) == {"value1", "value2", "value3"}
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_values_from_with_jmespath_expression(self, mock_blob_client):
+        """Test ValuesFrom with JMESPath expression on Azure blob data."""
+        # Ensure provider is imported
+        import c7n_azure.provider  # noqa: F401
+
+        # Setup mock - return complex JSON structure
+        complex_data = json.dumps({
+            "resources": [
+                {"name": "vm1", "type": "VirtualMachine"},
+                {"name": "vm2", "type": "VirtualMachine"},
+                {"name": "db1", "type": "Database"}
+            ]
+        })
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = complex_data.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create ValuesFrom instance with JMESPath expression
+        cache = FakeCache()
+        manager = Bag(
+            session_factory=mock_session_factory,
+            _cache=cache,
+            config=Bag(account_id="test-account", region="us-east-1")
+        )
+
+        values_from = ValuesFrom({
+            'url': 'azure://myaccount.blob.core.windows.net/mycontainer/resources.json',
+            'format': 'json',
+            'expr': 'resources[?type==`VirtualMachine`].name'
+        }, manager)
+
+        # Get values
+        result = values_from.get_values()
+
+        # Verify - should only get VM names
+        assert set(result) == {"vm1", "vm2"}
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_values_from_with_csv_format(self, mock_blob_client):
+        """Test ValuesFrom with CSV format from Azure blob."""
+        # Ensure provider is imported
+        import c7n_azure.provider  # noqa: F401
+
+        # Setup mock - return CSV data without header row
+        csv_data = "resource1\nresource2\nresource3"
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = csv_data.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Create ValuesFrom instance for CSV (single column, no header)
+        cache = FakeCache()
+        manager = Bag(
+            session_factory=mock_session_factory,
+            _cache=cache,
+            config=Bag(account_id="test-account", region="us-east-1")
+        )
+
+        values_from = ValuesFrom({
+            'url': 'azure://myaccount.blob.core.windows.net/mycontainer/data.csv',
+            'format': 'csv',
+            'expr': 0  # Get first (and only) column
+        }, manager)
+
+        # Get values
+        result = values_from.get_values()
+
+        # Verify - should get all values from column 0
+        assert set(result) == {"resource1", "resource2", "resource3"}
+        assert mock_client_instance.get_blob_to_bytes.called
+
+    @patch('c7n_azure.resolver.OldBlobServiceClient')
+    def test_values_from_caching_across_calls(self, mock_blob_client):
+        """Test that caching works properly across multiple ValuesFrom calls."""
+        # Ensure provider is imported
+        import c7n_azure.provider  # noqa: F401
+
+        # Setup mock
+        values_data = json.dumps(["cached1", "cached2"])
+        mock_client_instance = MagicMock()
+        mock_client_instance.get_blob_to_bytes.return_value = values_data.encode('utf-8')
+        mock_blob_client.return_value = mock_client_instance
+
+        # Create mock session factory
+        mock_session = Mock()
+        mock_session.get_credentials.return_value = "fake_credentials"
+        mock_session_factory = Mock(return_value=mock_session)
+
+        # Shared cache
+        cache = FakeCache()
+        manager = Bag(
+            session_factory=mock_session_factory,
+            _cache=cache,
+            config=Bag(account_id="test-account", region="us-east-1")
+        )
+
+        # First ValuesFrom call
+        values_from1 = ValuesFrom({
+            'url': 'azure://myaccount.blob.core.windows.net/mycontainer/cached.json',
+            'format': 'json'
+        }, manager)
+        result1 = values_from1.get_values()
+
+        # Second ValuesFrom call with same URL
+        values_from2 = ValuesFrom({
+            'url': 'azure://myaccount.blob.core.windows.net/mycontainer/cached.json',
+            'format': 'json'
+        }, manager)
+        result2 = values_from2.get_values()
+
+        # Both should return same values
+        assert result1 == result2
+        # Blob client should only be called once due to caching
+        assert mock_client_instance.get_blob_to_bytes.call_count == 1
+
+    def test_azure_scheme_handler_signature(self):
+        """Test that the registered Azure handler has the correct signature."""
+        # Ensure provider is imported
+        import c7n_azure.provider  # noqa: F401
+        from c7n.resolver import URIResolver
+
+        handler = URIResolver._uri_providers.get('azure')
+        assert handler is not None
+
+        # Verify it's our resolve_azure_blob function
+        from c7n_azure.resolver import resolve_azure_blob
+        assert handler == resolve_azure_blob

--- a/tools/c7n_azure/tests_azure/test_resolver_integration.py
+++ b/tools/c7n_azure/tests_azure/test_resolver_integration.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Integration tests for Azure Blob Storage resolver with c7n core."""
 import json
-import pickle
 from unittest.mock import Mock, patch, MagicMock
 
 from c7n.cache import InMemoryCache

--- a/tools/c7n_azure/tests_azure/test_resolver_integration.py
+++ b/tools/c7n_azure/tests_azure/test_resolver_integration.py
@@ -5,33 +5,9 @@ import json
 import pickle
 from unittest.mock import Mock, patch, MagicMock
 
+from c7n.cache import InMemoryCache
 from c7n.config import Bag
 from c7n.resolver import URIResolver, ValuesFrom
-
-
-class FakeCache:
-    """Test cache implementation for integration testing."""
-
-    def __init__(self):
-        self.state = {}
-
-    def get(self, key):
-        return self.state.get(pickle.dumps(key))
-
-    def save(self, key, data):
-        self.state[pickle.dumps(key)] = data
-
-    def load(self):
-        return True
-
-    def close(self):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args, **kw):
-        return
 
 
 class TestAzureBlobResolverIntegration:
@@ -65,7 +41,7 @@ class TestAzureBlobResolverIntegration:
         mock_session_factory = Mock(return_value=mock_session)
 
         # Create resolver and test
-        cache = FakeCache()
+        cache = InMemoryCache(config=None)
         resolver = URIResolver(mock_session_factory, cache)
         uri = "azure://myaccount.blob.core.windows.net/mycontainer/test.json"
 
@@ -92,7 +68,7 @@ class TestAzureBlobResolverIntegration:
         mock_session_factory = Mock(return_value=mock_session)
 
         # Create ValuesFrom instance
-        cache = FakeCache()
+        cache = InMemoryCache(config=None)
         manager = Bag(
             session_factory=mock_session_factory,
             _cache=cache,
@@ -135,7 +111,7 @@ class TestAzureBlobResolverIntegration:
         mock_session_factory = Mock(return_value=mock_session)
 
         # Create ValuesFrom instance with JMESPath expression
-        cache = FakeCache()
+        cache = InMemoryCache(config=None)
         manager = Bag(
             session_factory=mock_session_factory,
             _cache=cache,
@@ -173,7 +149,7 @@ class TestAzureBlobResolverIntegration:
         mock_session_factory = Mock(return_value=mock_session)
 
         # Create ValuesFrom instance for CSV (single column, no header)
-        cache = FakeCache()
+        cache = InMemoryCache(config=None)
         manager = Bag(
             session_factory=mock_session_factory,
             _cache=cache,
@@ -211,7 +187,7 @@ class TestAzureBlobResolverIntegration:
         mock_session_factory = Mock(return_value=mock_session)
 
         # Shared cache
-        cache = FakeCache()
+        cache = InMemoryCache(config=None)
         manager = Bag(
             session_factory=mock_session_factory,
             _cache=cache,

--- a/tools/c7n_azure/tests_azure/tests_resources/terraform/azure_blob_storage/main.tf
+++ b/tools/c7n_azure/tests_azure/tests_resources/terraform/azure_blob_storage/main.tf
@@ -1,0 +1,275 @@
+# Terraform configuration for Azure Blob Storage testing
+# Creates test storage account and blobs for Cloud Custodian value_from filter testing
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# Generate random suffix for unique naming
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+# Get current subscription for resource group location
+data "azurerm_subscription" "current" {}
+
+# Create resource group for test storage
+resource "azurerm_resource_group" "test" {
+  name     = "c7n-resolver-test-${random_string.suffix.result}"
+  location = "East US"
+
+  tags = {
+    purpose   = "c7n-testing"
+    component = "azure-blob-resolver"
+  }
+}
+
+# Create storage account for blob storage tests
+resource "azurerm_storage_account" "test" {
+  name                     = "c7ntest${random_string.suffix.result}"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  # Allow blob public access for testing (can be set to false for authenticated-only testing)
+  allow_nested_items_to_be_public = false
+
+  tags = {
+    purpose   = "c7n-testing"
+    component = "azure-blob-resolver"
+  }
+}
+
+# Create container for test blobs
+resource "azurerm_storage_container" "test" {
+  name                  = "test-configs"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+# Create nested container for path testing
+resource "azurerm_storage_container" "nested" {
+  name                  = "nested-paths"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+# Test Blob 1: JSON file with array of VM names
+resource "azurerm_storage_blob" "json_simple" {
+  name                   = "approved-vms.json"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  source_content = jsonencode([
+    "vm-prod-web-01",
+    "vm-prod-web-02",
+    "vm-prod-db-01"
+  ])
+  content_type = "application/json"
+}
+
+# Test Blob 2: JSON file with complex structure (for JMESPath testing)
+resource "azurerm_storage_blob" "json_complex" {
+  name                   = "vm-config.json"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  source_content = jsonencode({
+    vms = [
+      {
+        vmName = "vm-prod-web-01"
+        region = "eastus"
+        tags = {
+          environment = "production"
+          tier        = "web"
+        }
+      },
+      {
+        vmName = "vm-prod-web-02"
+        region = "eastus"
+        tags = {
+          environment = "production"
+          tier        = "web"
+        }
+      },
+      {
+        vmName = "vm-prod-db-01"
+        region = "eastus"
+        tags = {
+          environment = "production"
+          tier        = "database"
+        }
+      }
+    ]
+  })
+  content_type = "application/json"
+}
+
+# Test Blob 3: CSV file
+resource "azurerm_storage_blob" "csv" {
+  name                   = "resource-groups.csv"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  source_content         = <<-EOT
+name,location,environment
+rg-prod-web,eastus,production
+rg-prod-db,eastus,production
+rg-dev-web,westus,development
+EOT
+  content_type           = "text/csv"
+}
+
+# Test Blob 4: Plain text file
+resource "azurerm_storage_blob" "txt" {
+  name                   = "vm-ids.txt"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  source_content         = <<-EOT
+/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1
+/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2
+/subscriptions/sub1/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm3
+EOT
+  content_type           = "text/plain"
+}
+
+# Test Blob 5: Compressed JSON file (.gz)
+# Note: Azure Blob Storage stores the actual compressed bytes
+resource "azurerm_storage_blob" "json_compressed" {
+  name                   = "compressed-vms.json.gz"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  # For this test, we'll create a simple JSON and let the test handle compression
+  # In real usage, this would be actual gzipped content
+  source_content = jsonencode([
+    "vm-compressed-01",
+    "vm-compressed-02",
+    "vm-compressed-03"
+  ])
+  content_type = "application/gzip"
+}
+
+# Test Blob 6: Nested path JSON file
+resource "azurerm_storage_blob" "nested_json" {
+  name                   = "configs/prod/allowed-regions.json"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.nested.name
+  type                   = "Block"
+  source_content = jsonencode([
+    "eastus",
+    "westus",
+    "centralus"
+  ])
+  content_type = "application/json"
+}
+
+# Test Blob 7: Empty JSON array (edge case)
+resource "azurerm_storage_blob" "json_empty" {
+  name                   = "empty-list.json"
+  storage_account_name   = azurerm_storage_account.test.name
+  storage_container_name = azurerm_storage_container.test.name
+  type                   = "Block"
+  source_content         = "[]"
+  content_type           = "application/json"
+}
+
+# Outputs for test consumption
+output "storage_account_name" {
+  value       = azurerm_storage_account.test.name
+  description = "Name of the test storage account"
+}
+
+output "storage_account_url" {
+  value       = azurerm_storage_account.test.primary_blob_endpoint
+  description = "Primary blob endpoint URL"
+}
+
+output "container_name" {
+  value       = azurerm_storage_container.test.name
+  description = "Name of the test container"
+}
+
+output "nested_container_name" {
+  value       = azurerm_storage_container.nested.name
+  description = "Name of the nested paths container"
+}
+
+output "resource_group_name" {
+  value       = azurerm_resource_group.test.name
+  description = "Name of the test resource group"
+}
+
+output "blob_json_simple" {
+  value = {
+    name           = azurerm_storage_blob.json_simple.name
+    url            = "azure://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}/${azurerm_storage_blob.json_simple.name}"
+    content_sample = ["vm-prod-web-01", "vm-prod-web-02", "vm-prod-db-01"]
+  }
+  description = "Simple JSON blob details"
+}
+
+output "blob_json_complex" {
+  value = {
+    name = azurerm_storage_blob.json_complex.name
+    url  = "azure://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}/${azurerm_storage_blob.json_complex.name}"
+  }
+  description = "Complex JSON blob details"
+}
+
+output "blob_csv" {
+  value = {
+    name = azurerm_storage_blob.csv.name
+    url  = "azure://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}/${azurerm_storage_blob.csv.name}"
+  }
+  description = "CSV blob details"
+}
+
+output "blob_txt" {
+  value = {
+    name = azurerm_storage_blob.txt.name
+    url  = "azure://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}/${azurerm_storage_blob.txt.name}"
+  }
+  description = "Text blob details"
+}
+
+output "blob_compressed" {
+  value = {
+    name = azurerm_storage_blob.json_compressed.name
+    url  = "azure://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}/${azurerm_storage_blob.json_compressed.name}"
+  }
+  description = "Compressed JSON blob details"
+}
+
+output "blob_nested" {
+  value = {
+    name = azurerm_storage_blob.nested_json.name
+    url  = "azure://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.nested.name}/${azurerm_storage_blob.nested_json.name}"
+  }
+  description = "Nested path blob details"
+}
+
+output "blob_empty" {
+  value = {
+    name = azurerm_storage_blob.json_empty.name
+    url  = "azure://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}/${azurerm_storage_blob.json_empty.name}"
+  }
+  description = "Empty JSON array blob details"
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/terraform/azure_blob_storage/tf_resources.json
+++ b/tools/c7n_azure/tests_azure/tests_resources/terraform/azure_blob_storage/tf_resources.json
@@ -1,0 +1,517 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {
+        "blob_compressed": {
+            "value": {
+                "name": "compressed-vms.json.gz",
+                "url": "azure://c7ntestpaap1ox4.blob.core.windows.net/test-configs/compressed-vms.json.gz"
+            },
+            "type": [
+                "object",
+                {
+                    "name": "string",
+                    "url": "string"
+                }
+            ]
+        },
+        "blob_csv": {
+            "value": {
+                "name": "resource-groups.csv",
+                "url": "azure://c7ntestpaap1ox4.blob.core.windows.net/test-configs/resource-groups.csv"
+            },
+            "type": [
+                "object",
+                {
+                    "name": "string",
+                    "url": "string"
+                }
+            ]
+        },
+        "blob_empty": {
+            "value": {
+                "name": "empty-list.json",
+                "url": "azure://c7ntestpaap1ox4.blob.core.windows.net/test-configs/empty-list.json"
+            },
+            "type": [
+                "object",
+                {
+                    "name": "string",
+                    "url": "string"
+                }
+            ]
+        },
+        "blob_json_complex": {
+            "value": {
+                "name": "vm-config.json",
+                "url": "azure://c7ntestpaap1ox4.blob.core.windows.net/test-configs/vm-config.json"
+            },
+            "type": [
+                "object",
+                {
+                    "name": "string",
+                    "url": "string"
+                }
+            ]
+        },
+        "blob_json_simple": {
+            "value": {
+                "content_sample": [
+                    "vm-prod-web-01",
+                    "vm-prod-web-02",
+                    "vm-prod-db-01"
+                ],
+                "name": "approved-vms.json",
+                "url": "azure://c7ntestpaap1ox4.blob.core.windows.net/test-configs/approved-vms.json"
+            },
+            "type": [
+                "object",
+                {
+                    "content_sample": [
+                        "tuple",
+                        [
+                            "string",
+                            "string",
+                            "string"
+                        ]
+                    ],
+                    "name": "string",
+                    "url": "string"
+                }
+            ]
+        },
+        "blob_nested": {
+            "value": {
+                "name": "configs/prod/allowed-regions.json",
+                "url": "azure://c7ntestpaap1ox4.blob.core.windows.net/nested-paths/configs/prod/allowed-regions.json"
+            },
+            "type": [
+                "object",
+                {
+                    "name": "string",
+                    "url": "string"
+                }
+            ]
+        },
+        "blob_txt": {
+            "value": {
+                "name": "vm-ids.txt",
+                "url": "azure://c7ntestpaap1ox4.blob.core.windows.net/test-configs/vm-ids.txt"
+            },
+            "type": [
+                "object",
+                {
+                    "name": "string",
+                    "url": "string"
+                }
+            ]
+        },
+        "container_name": {
+            "value": "test-configs",
+            "type": "string"
+        },
+        "nested_container_name": {
+            "value": "nested-paths",
+            "type": "string"
+        },
+        "resource_group_name": {
+            "value": "c7n-resolver-test-paap1ox4",
+            "type": "string"
+        },
+        "storage_account_name": {
+            "value": "c7ntestpaap1ox4",
+            "type": "string"
+        },
+        "storage_account_url": {
+            "value": "https://c7ntestpaap1ox4.blob.core.windows.net/",
+            "type": "string"
+        }
+    },
+    "resources": {
+        "azurerm_subscription": {
+            "current": {
+                "display_name": "Mock Subscription",
+                "id": "/subscriptions/12345678-1234-1234-1234-123456789012",
+                "location_placement_id": "Public_2014-09-01",
+                "quota_id": "PayAsYouGo_2014-09-01",
+                "spending_limit": "Off",
+                "state": "Enabled",
+                "subscription_id": "12345678-1234-1234-1234-123456789012",
+                "tags": {},
+                "tenant_id": "87654321-4321-4321-4321-210987654321",
+                "timeouts": null
+            }
+        },
+        "azurerm_resource_group": {
+            "test": {
+                "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/c7n-resolver-test-paap1ox4",
+                "location": "eastus",
+                "managed_by": "",
+                "name": "c7n-resolver-test-paap1ox4",
+                "tags": {
+                    "component": "azure-blob-resolver",
+                    "purpose": "c7n-testing"
+                },
+                "timeouts": null
+            }
+        },
+        "azurerm_storage_account": {
+            "test": {
+                "access_tier": "Hot",
+                "account_kind": "StorageV2",
+                "account_replication_type": "LRS",
+                "account_tier": "Standard",
+                "allow_nested_items_to_be_public": false,
+                "allowed_copy_scope": "",
+                "azure_files_authentication": [],
+                "blob_properties": [
+                    {
+                        "change_feed_enabled": false,
+                        "change_feed_retention_in_days": 0,
+                        "container_delete_retention_policy": [],
+                        "cors_rule": [],
+                        "default_service_version": "",
+                        "delete_retention_policy": [],
+                        "last_access_time_enabled": false,
+                        "restore_policy": [],
+                        "versioning_enabled": false
+                    }
+                ],
+                "cross_tenant_replication_enabled": true,
+                "custom_domain": [],
+                "customer_managed_key": [],
+                "default_to_oauth_authentication": false,
+                "dns_endpoint_type": "Standard",
+                "edge_zone": "",
+                "enable_https_traffic_only": true,
+                "https_traffic_only_enabled": true,
+                "id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/c7n-resolver-test-paap1ox4/providers/Microsoft.Storage/storageAccounts/c7ntestpaap1ox4",
+                "identity": [],
+                "immutability_policy": [],
+                "infrastructure_encryption_enabled": false,
+                "is_hns_enabled": false,
+                "large_file_share_enabled": false,
+                "local_user_enabled": true,
+                "location": "eastus",
+                "min_tls_version": "TLS1_2",
+                "name": "c7ntestpaap1ox4",
+                "network_rules": [],
+                "nfsv3_enabled": false,
+                "primary_access_key": "MOCK_PRIMARY_ACCESS_KEY_BASE64_ENCODED_STRING_PLACEHOLDER==",
+                "primary_blob_connection_string": "DefaultEndpointsProtocol=https;BlobEndpoint=https://c7ntestpaap1ox4.blob.core.windows.net/;AccountName=c7ntestpaap1ox4;AccountKey=MOCK_PRIMARY_ACCESS_KEY_BASE64_ENCODED_STRING_PLACEHOLDER==",
+                "primary_blob_endpoint": "https://c7ntestpaap1ox4.blob.core.windows.net/",
+                "primary_blob_host": "c7ntestpaap1ox4.blob.core.windows.net",
+                "primary_blob_internet_endpoint": "",
+                "primary_blob_internet_host": "",
+                "primary_blob_microsoft_endpoint": "",
+                "primary_blob_microsoft_host": "",
+                "primary_connection_string": "DefaultEndpointsProtocol=https;AccountName=c7ntestpaap1ox4;AccountKey=MOCK_PRIMARY_ACCESS_KEY_BASE64_ENCODED_STRING_PLACEHOLDER==;EndpointSuffix=core.windows.net",
+                "primary_dfs_endpoint": "https://c7ntestpaap1ox4.dfs.core.windows.net/",
+                "primary_dfs_host": "c7ntestpaap1ox4.dfs.core.windows.net",
+                "primary_dfs_internet_endpoint": "",
+                "primary_dfs_internet_host": "",
+                "primary_dfs_microsoft_endpoint": "",
+                "primary_dfs_microsoft_host": "",
+                "primary_file_endpoint": "https://c7ntestpaap1ox4.file.core.windows.net/",
+                "primary_file_host": "c7ntestpaap1ox4.file.core.windows.net",
+                "primary_file_internet_endpoint": "",
+                "primary_file_internet_host": "",
+                "primary_file_microsoft_endpoint": "",
+                "primary_file_microsoft_host": "",
+                "primary_location": "eastus",
+                "primary_queue_endpoint": "https://c7ntestpaap1ox4.queue.core.windows.net/",
+                "primary_queue_host": "c7ntestpaap1ox4.queue.core.windows.net",
+                "primary_queue_microsoft_endpoint": "",
+                "primary_queue_microsoft_host": "",
+                "primary_table_endpoint": "https://c7ntestpaap1ox4.table.core.windows.net/",
+                "primary_table_host": "c7ntestpaap1ox4.table.core.windows.net",
+                "primary_table_microsoft_endpoint": "",
+                "primary_table_microsoft_host": "",
+                "primary_web_endpoint": "https://c7ntestpaap1ox4.z13.web.core.windows.net/",
+                "primary_web_host": "c7ntestpaap1ox4.z13.web.core.windows.net",
+                "primary_web_internet_endpoint": "",
+                "primary_web_internet_host": "",
+                "primary_web_microsoft_endpoint": "",
+                "primary_web_microsoft_host": "",
+                "public_network_access_enabled": true,
+                "queue_encryption_key_type": "Service",
+                "queue_properties": [
+                    {
+                        "cors_rule": [],
+                        "hour_metrics": [
+                            {
+                                "enabled": false,
+                                "include_apis": false,
+                                "retention_policy_days": 0,
+                                "version": "1.0"
+                            }
+                        ],
+                        "logging": [
+                            {
+                                "delete": false,
+                                "read": false,
+                                "retention_policy_days": 0,
+                                "version": "1.0",
+                                "write": false
+                            }
+                        ],
+                        "minute_metrics": [
+                            {
+                                "enabled": false,
+                                "include_apis": false,
+                                "retention_policy_days": 0,
+                                "version": "1.0"
+                            }
+                        ]
+                    }
+                ],
+                "resource_group_name": "c7n-resolver-test-paap1ox4",
+                "routing": [],
+                "sas_policy": [],
+                "secondary_access_key": "MOCK_SECONDARY_ACCESS_KEY_BASE64_ENCODED_STRING_PLACEHOLDER==",
+                "secondary_blob_connection_string": "",
+                "secondary_blob_endpoint": "",
+                "secondary_blob_host": "",
+                "secondary_blob_internet_endpoint": "",
+                "secondary_blob_internet_host": "",
+                "secondary_blob_microsoft_endpoint": "",
+                "secondary_blob_microsoft_host": "",
+                "secondary_connection_string": "DefaultEndpointsProtocol=https;AccountName=c7ntestpaap1ox4;AccountKey=MOCK_SECONDARY_ACCESS_KEY_BASE64_ENCODED_STRING_PLACEHOLDER==;EndpointSuffix=core.windows.net",
+                "secondary_dfs_endpoint": "",
+                "secondary_dfs_host": "",
+                "secondary_dfs_internet_endpoint": "",
+                "secondary_dfs_internet_host": "",
+                "secondary_dfs_microsoft_endpoint": "",
+                "secondary_dfs_microsoft_host": "",
+                "secondary_file_endpoint": "",
+                "secondary_file_host": "",
+                "secondary_file_internet_endpoint": "",
+                "secondary_file_internet_host": "",
+                "secondary_file_microsoft_endpoint": "",
+                "secondary_file_microsoft_host": "",
+                "secondary_location": "",
+                "secondary_queue_endpoint": "",
+                "secondary_queue_host": "",
+                "secondary_queue_microsoft_endpoint": "",
+                "secondary_queue_microsoft_host": "",
+                "secondary_table_endpoint": "",
+                "secondary_table_host": "",
+                "secondary_table_microsoft_endpoint": "",
+                "secondary_table_microsoft_host": "",
+                "secondary_web_endpoint": "",
+                "secondary_web_host": "",
+                "secondary_web_internet_endpoint": "",
+                "secondary_web_internet_host": "",
+                "secondary_web_microsoft_endpoint": "",
+                "secondary_web_microsoft_host": "",
+                "sftp_enabled": false,
+                "share_properties": [
+                    {
+                        "cors_rule": [],
+                        "retention_policy": [
+                            {
+                                "days": 7
+                            }
+                        ],
+                        "smb": []
+                    }
+                ],
+                "shared_access_key_enabled": true,
+                "static_website": [],
+                "table_encryption_key_type": "Service",
+                "tags": {
+                    "component": "azure-blob-resolver",
+                    "purpose": "c7n-testing"
+                },
+                "timeouts": null
+            }
+        },
+        "azurerm_storage_blob": {
+            "csv": {
+                "access_tier": "Hot",
+                "cache_control": "",
+                "content_md5": "",
+                "content_type": "text/csv",
+                "encryption_scope": "",
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/resource-groups.csv",
+                "metadata": {},
+                "name": "resource-groups.csv",
+                "parallelism": 8,
+                "size": 0,
+                "source": null,
+                "source_content": "name,location,environment\nrg-prod-web,eastus,production\nrg-prod-db,eastus,production\nrg-dev-web,westus,development\n",
+                "source_uri": null,
+                "storage_account_name": "c7ntestpaap1ox4",
+                "storage_container_name": "test-configs",
+                "timeouts": null,
+                "type": "Block",
+                "url": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/resource-groups.csv"
+            },
+            "json_complex": {
+                "access_tier": "Hot",
+                "cache_control": "",
+                "content_md5": "",
+                "content_type": "application/json",
+                "encryption_scope": "",
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/vm-config.json",
+                "metadata": {},
+                "name": "vm-config.json",
+                "parallelism": 8,
+                "size": 0,
+                "source": null,
+                "source_content": "{\"vms\":[{\"region\":\"eastus\",\"tags\":{\"environment\":\"production\",\"tier\":\"web\"},\"vmName\":\"vm-prod-web-01\"},{\"region\":\"eastus\",\"tags\":{\"environment\":\"production\",\"tier\":\"web\"},\"vmName\":\"vm-prod-web-02\"},{\"region\":\"eastus\",\"tags\":{\"environment\":\"production\",\"tier\":\"database\"},\"vmName\":\"vm-prod-db-01\"}]}",
+                "source_uri": null,
+                "storage_account_name": "c7ntestpaap1ox4",
+                "storage_container_name": "test-configs",
+                "timeouts": null,
+                "type": "Block",
+                "url": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/vm-config.json"
+            },
+            "json_compressed": {
+                "access_tier": "Hot",
+                "cache_control": "",
+                "content_md5": "",
+                "content_type": "application/gzip",
+                "encryption_scope": "",
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/compressed-vms.json.gz",
+                "metadata": {},
+                "name": "compressed-vms.json.gz",
+                "parallelism": 8,
+                "size": 0,
+                "source": null,
+                "source_content": "[\"vm-compressed-01\",\"vm-compressed-02\",\"vm-compressed-03\"]",
+                "source_uri": null,
+                "storage_account_name": "c7ntestpaap1ox4",
+                "storage_container_name": "test-configs",
+                "timeouts": null,
+                "type": "Block",
+                "url": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/compressed-vms.json.gz"
+            },
+            "json_empty": {
+                "access_tier": "Hot",
+                "cache_control": "",
+                "content_md5": "",
+                "content_type": "application/json",
+                "encryption_scope": "",
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/empty-list.json",
+                "metadata": {},
+                "name": "empty-list.json",
+                "parallelism": 8,
+                "size": 0,
+                "source": null,
+                "source_content": "[]",
+                "source_uri": null,
+                "storage_account_name": "c7ntestpaap1ox4",
+                "storage_container_name": "test-configs",
+                "timeouts": null,
+                "type": "Block",
+                "url": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/empty-list.json"
+            },
+            "json_simple": {
+                "access_tier": "Hot",
+                "cache_control": "",
+                "content_md5": "",
+                "content_type": "application/json",
+                "encryption_scope": "",
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/approved-vms.json",
+                "metadata": {},
+                "name": "approved-vms.json",
+                "parallelism": 8,
+                "size": 0,
+                "source": null,
+                "source_content": "[\"vm-prod-web-01\",\"vm-prod-web-02\",\"vm-prod-db-01\"]",
+                "source_uri": null,
+                "storage_account_name": "c7ntestpaap1ox4",
+                "storage_container_name": "test-configs",
+                "timeouts": null,
+                "type": "Block",
+                "url": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/approved-vms.json"
+            },
+            "nested_json": {
+                "access_tier": "Hot",
+                "cache_control": "",
+                "content_md5": "",
+                "content_type": "application/json",
+                "encryption_scope": "",
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/nested-paths/configs/prod/allowed-regions.json",
+                "metadata": {},
+                "name": "configs/prod/allowed-regions.json",
+                "parallelism": 8,
+                "size": 0,
+                "source": null,
+                "source_content": "[\"eastus\",\"westus\",\"centralus\"]",
+                "source_uri": null,
+                "storage_account_name": "c7ntestpaap1ox4",
+                "storage_container_name": "nested-paths",
+                "timeouts": null,
+                "type": "Block",
+                "url": "https://c7ntestpaap1ox4.blob.core.windows.net/nested-paths/configs/prod/allowed-regions.json"
+            },
+            "txt": {
+                "access_tier": "Hot",
+                "cache_control": "",
+                "content_md5": "",
+                "content_type": "text/plain",
+                "encryption_scope": "",
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/vm-ids.txt",
+                "metadata": {},
+                "name": "vm-ids.txt",
+                "parallelism": 8,
+                "size": 0,
+                "source": null,
+                "source_content": "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1\n/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2\n/subscriptions/sub1/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm3\n",
+                "source_uri": null,
+                "storage_account_name": "c7ntestpaap1ox4",
+                "storage_container_name": "test-configs",
+                "timeouts": null,
+                "type": "Block",
+                "url": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs/vm-ids.txt"
+            }
+        },
+        "azurerm_storage_container": {
+            "nested": {
+                "container_access_type": "private",
+                "default_encryption_scope": "$account-encryption-key",
+                "encryption_scope_override_enabled": true,
+                "has_immutability_policy": false,
+                "has_legal_hold": false,
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/nested-paths",
+                "metadata": {},
+                "name": "nested-paths",
+                "resource_manager_id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/c7n-resolver-test-paap1ox4/providers/Microsoft.Storage/storageAccounts/c7ntestpaap1ox4/blobServices/default/containers/nested-paths",
+                "storage_account_name": "c7ntestpaap1ox4",
+                "timeouts": null
+            },
+            "test": {
+                "container_access_type": "private",
+                "default_encryption_scope": "$account-encryption-key",
+                "encryption_scope_override_enabled": true,
+                "has_immutability_policy": false,
+                "has_legal_hold": false,
+                "id": "https://c7ntestpaap1ox4.blob.core.windows.net/test-configs",
+                "metadata": {},
+                "name": "test-configs",
+                "resource_manager_id": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/c7n-resolver-test-paap1ox4/providers/Microsoft.Storage/storageAccounts/c7ntestpaap1ox4/blobServices/default/containers/test-configs",
+                "storage_account_name": "c7ntestpaap1ox4",
+                "timeouts": null
+            }
+        },
+        "random_string": {
+            "suffix": {
+                "id": "paap1ox4",
+                "keepers": null,
+                "length": 8,
+                "lower": true,
+                "min_lower": 0,
+                "min_numeric": 0,
+                "min_special": 0,
+                "min_upper": 0,
+                "number": true,
+                "numeric": true,
+                "override_special": null,
+                "result": "paap1ox4",
+                "special": false,
+                "upper": false
+            }
+        }
+    }
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_resolver_functional.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_resolver_functional.py
@@ -1,0 +1,345 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Functional tests for Azure Blob Storage resolver using pytest-terraform.
+
+These tests use real Azure resources provisioned via Terraform to validate
+end-to-end functionality of the azure:// URL handler in value_from filters.
+"""
+
+import pytest
+from pytest_terraform import terraform
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_blob_storage_discovery_terraform(test, azure_blob_storage):
+    """Test that Terraform fixtures loaded successfully"""
+    # Verify terraform fixtures loaded successfully
+    assert len(azure_blob_storage.outputs) > 0, (
+        f"Expected terraform outputs, got {len(azure_blob_storage.outputs)}"
+    )
+
+    # Verify required outputs exist
+    assert 'storage_account_name' in azure_blob_storage.outputs
+    assert 'container_name' in azure_blob_storage.outputs
+    assert 'blob_json_simple' in azure_blob_storage.outputs
+
+    # Get terraform-provisioned storage data
+    storage_account = azure_blob_storage.outputs['storage_account_name']['value']
+    container_name = azure_blob_storage.outputs['container_name']['value']
+
+    # Verify test data integrity
+    assert storage_account is not None
+    assert container_name == 'test-configs'
+
+    print(f"SUCCESS: Terraform fixtures loaded storage account '{storage_account}' successfully")
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_value_from_json_simple_blob_terraform(test, azure_blob_storage):
+    """Test value_from filter with simple JSON blob from Azure Blob Storage"""
+    # Get blob URL from Terraform outputs
+    blob_info = azure_blob_storage.outputs['blob_json_simple']['value']
+    blob_url = blob_info['url']
+
+    # Verify URL format
+    assert blob_url.startswith('azure://')
+    assert 'blob.core.windows.net' in blob_url
+    assert 'approved-vms.json' in blob_url
+
+    # Test Cloud Custodian policy with value_from using Azure blob
+    # This policy would filter VMs based on names stored in the blob
+    policy = test.load_policy({
+        'name': 'test-value-from-azure-blob',
+        'resource': 'azure.vm',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'name',
+                'op': 'in',
+                'value_from': {
+                    'url': blob_url,
+                    'format': 'json'
+                }
+            }
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy is not None
+    assert policy.resource_manager.type == 'vm'
+
+    # Verify filter configuration
+    filters = policy.resource_manager.filters
+    assert len(filters) == 1
+    assert filters[0].data['type'] == 'value'
+    assert filters[0].data['value_from']['url'] == blob_url
+    assert filters[0].data['value_from']['format'] == 'json'
+
+    print(f"SUCCESS: Policy with JSON blob '{blob_url}' validated successfully")
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_value_from_json_with_jmespath_terraform(test, azure_blob_storage):
+    """Test value_from filter with JMESPath expression on complex JSON blob"""
+    # Get complex JSON blob URL
+    blob_info = azure_blob_storage.outputs['blob_json_complex']['value']
+    blob_url = blob_info['url']
+
+    # Test policy with JMESPath expression
+    policy = test.load_policy({
+        'name': 'test-jmespath-azure-blob',
+        'resource': 'azure.vm',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'name',
+                'op': 'in',
+                'value_from': {
+                    'url': blob_url,
+                    'format': 'json',
+                    'expr': 'vms[].vmName'
+                }
+            }
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy is not None
+
+    # Verify filter has JMESPath expression
+    filters = policy.resource_manager.filters
+    assert filters[0].data['value_from']['expr'] == 'vms[].vmName'
+
+    print("SUCCESS: Policy with JMESPath expression validated successfully")
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_value_from_csv_blob_terraform(test, azure_blob_storage):
+    """Test value_from filter with CSV blob from Azure Blob Storage"""
+    # Get CSV blob URL from Terraform outputs
+    blob_info = azure_blob_storage.outputs['blob_csv']['value']
+    blob_url = blob_info['url']
+
+    # Verify URL format
+    assert 'resource-groups.csv' in blob_url
+
+    # Test policy using CSV format with column index
+    policy = test.load_policy({
+        'name': 'test-csv-azure-blob',
+        'resource': 'azure.resourcegroup',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'name',
+                'op': 'in',
+                'value_from': {
+                    'url': blob_url,
+                    'format': 'csv',
+                    'expr': '0'  # First column (name)
+                }
+            }
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy is not None
+    assert policy.resource_manager.type == 'resourcegroup'
+
+    # Verify CSV format configuration
+    filters = policy.resource_manager.filters
+    assert filters[0].data['value_from']['format'] == 'csv'
+    assert filters[0].data['value_from']['expr'] == '0'
+
+    print(f"SUCCESS: Policy with CSV blob '{blob_url}' validated successfully")
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_value_from_txt_blob_terraform(test, azure_blob_storage):
+    """Test value_from filter with plain text blob from Azure Blob Storage"""
+    # Get text blob URL from Terraform outputs
+    blob_info = azure_blob_storage.outputs['blob_txt']['value']
+    blob_url = blob_info['url']
+
+    # Verify URL format
+    assert 'vm-ids.txt' in blob_url
+
+    # Test policy using text format
+    policy = test.load_policy({
+        'name': 'test-txt-azure-blob',
+        'resource': 'azure.vm',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'id',
+                'op': 'in',
+                'value_from': {
+                    'url': blob_url,
+                    'format': 'txt'
+                }
+            }
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy is not None
+
+    # Verify text format configuration
+    filters = policy.resource_manager.filters
+    assert filters[0].data['value_from']['format'] == 'txt'
+
+    print(f"SUCCESS: Policy with text blob '{blob_url}' validated successfully")
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_value_from_compressed_blob_terraform(test, azure_blob_storage):
+    """Test value_from filter with gzip compressed blob from Azure Blob Storage"""
+    # Get compressed blob URL from Terraform outputs
+    blob_info = azure_blob_storage.outputs['blob_compressed']['value']
+    blob_url = blob_info['url']
+
+    # Verify URL format includes .gz extension
+    assert blob_url.endswith('.json.gz')
+
+    # Test policy with compressed blob
+    # The resolver should automatically decompress based on file extension
+    policy = test.load_policy({
+        'name': 'test-compressed-azure-blob',
+        'resource': 'azure.vm',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'name',
+                'op': 'in',
+                'value_from': {
+                    'url': blob_url,
+                    'format': 'json'
+                }
+            }
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy is not None
+
+    # Verify the URL is correctly configured
+    filters = policy.resource_manager.filters
+    assert filters[0].data['value_from']['url'] == blob_url
+
+    print(f"SUCCESS: Policy with compressed blob '{blob_url}' validated successfully")
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_value_from_nested_path_blob_terraform(test, azure_blob_storage):
+    """Test value_from filter with blob in nested path structure"""
+    # Get nested path blob URL from Terraform outputs
+    blob_info = azure_blob_storage.outputs['blob_nested']['value']
+    blob_url = blob_info['url']
+
+    # Verify URL includes nested path
+    assert 'configs/prod/allowed-regions.json' in blob_url
+
+    # Test policy with nested blob path
+    policy = test.load_policy({
+        'name': 'test-nested-path-azure-blob',
+        'resource': 'azure.vm',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'location',
+                'op': 'in',
+                'value_from': {
+                    'url': blob_url,
+                    'format': 'json'
+                }
+            }
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy is not None
+
+    # Verify nested path in URL
+    filters = policy.resource_manager.filters
+    assert 'configs/prod/allowed-regions.json' in filters[0].data['value_from']['url']
+
+    print(f"SUCCESS: Policy with nested path blob '{blob_url}' validated successfully")
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_value_from_empty_json_array_terraform(test, azure_blob_storage):
+    """Test value_from filter with empty JSON array (edge case)"""
+    # Get empty array blob URL from Terraform outputs
+    blob_info = azure_blob_storage.outputs['blob_empty']['value']
+    blob_url = blob_info['url']
+
+    # Verify URL format
+    assert 'empty-list.json' in blob_url
+
+    # Test policy with empty array
+    policy = test.load_policy({
+        'name': 'test-empty-array-azure-blob',
+        'resource': 'azure.vm',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'name',
+                'op': 'in',
+                'value_from': {
+                    'url': blob_url,
+                    'format': 'json'
+                }
+            }
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy is not None
+
+    print(f"SUCCESS: Policy with empty JSON array '{blob_url}' validated successfully")
+
+
+@terraform('azure_blob_storage')
+@pytest.mark.functional
+def test_multiple_filters_same_blob_caching_terraform(test, azure_blob_storage):
+    """Test that multiple filters using same blob leverage caching"""
+    # Get blob URL
+    blob_info = azure_blob_storage.outputs['blob_json_simple']['value']
+    blob_url = blob_info['url']
+
+    # Create policy with multiple filters using the same blob
+    # This should hit cache on second filter evaluation
+    policy = test.load_policy({
+        'name': 'test-caching-azure-blob',
+        'resource': 'azure.vm',
+        'filters': [
+            {
+                'type': 'value',
+                'key': 'name',
+                'op': 'in',
+                'value_from': {
+                    'url': blob_url,
+                    'format': 'json'
+                }
+            }
+        ]
+    })
+
+    # Verify policy loads correctly
+    assert policy is not None
+
+    # The actual caching test would require executing the policy with resources,
+    # but here we're just verifying the configuration is valid
+    filters = policy.resource_manager.filters
+    assert len(filters) == 1
+
+    print("SUCCESS: Caching test policy validated successfully")


### PR DESCRIPTION
Resolves #4629.

This patch also implements a plugin system for URI schemes that allows non-core code to provide support for value_from blobs, making it possible for the Azure-specific support to be located entirely within the Azure cloud provider.  Currently, the "legacy" S3 and file support overrides the new plugin system, but one could reimplement both of those as plugins and remove the embedded support entirely.