### PR TITLE
releng - exclude bandit's hardcoded password check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,11 @@ data-update:
 ###
 # Static analyzers
 
+# For context around skipping the B105 (hardcoded password)
+# rule, see:
+# https://github.com/PyCQA/bandit/issues/1350
 analyzer-bandit:
-	uvx bandit -i -s B101,B311 \
+	uvx bandit -i -s B101,B105,B311 \
 	-r tools/c7n_azure/c7n_azure \
 	 tools/c7n_gcp/c7n_gcp \
 	 tools/c7n_oci/c7n_oci \


### PR DESCRIPTION
Bandit 1.9.3 includes an enhancement that causes the hardcoded password check to look inside dictionaries. That's potentially valuable but also noisy - that change triggered 10 false positives in the c7n codebase and 0 "real" findings.

We also run semgrep during CI which has some more fine-grained checks such as:

https://semgrep.dev/r?q=python.boto3.security.hardcoded-token.hardcoded-token

We've got an [issue](https://github.com/PyCQA/bandit/issues/1350) open on the bandit repo as well, because we could certainly re-include the B105 rule in the future if there was a knob that would let us explicitly allow the value `NextToken`. But as the B105 rule description makes it pretty clear that it can be noisy, it's possible that it's working as intended. In that case, it's up to us to either exclude the check entirely or flag each false positive with `# nosec B105`.

Landing this change should get CI turning green again for other PRs that are currently failing on the Bandit step, notably #10462 where the issue first showed up.