### PR TITLE
GCP: Big Query + Big Table Label Actions

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/bigquery.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/bigquery.py
@@ -29,6 +29,8 @@ class DataSet(QueryResourceManager):
         permissions = ('bigquery.datasets.get',)
         urn_component = "dataset"
         urn_id_path = "datasetReference.datasetId"
+        labels = True
+        labels_op = 'patch'
 
         @staticmethod
         def get(client, event):
@@ -43,6 +45,10 @@ class DataSet(QueryResourceManager):
             else:
                 ref = event
             return client.execute_query('get', verb_arguments=ref)
+
+        @staticmethod
+        def get_label_params(resource, all_labels):
+            return {**resource['datasetReference'], 'body': {'labels': all_labels}}
 
     def augment(self, resources):
         client = self.get_client()
@@ -71,6 +77,7 @@ class BigQueryJob(QueryResourceManager):
         name = id = 'id'
         default_report_fields = ["id", "user_email", "status.state"]
         urn_component = "job"
+        # Jobs have labels but no update method, so no labels action
 
         @staticmethod
         def get(client, event):
@@ -115,6 +122,8 @@ class BigQueryTable(ChildResourceManager):
         asset_type = "bigquery.googleapis.com/Table"
         urn_component = "table"
         urn_id_path = "tableReference.tableId"
+        labels = True
+        labels_op = 'patch'
 
         @classmethod
         def _get_urn_id(cls, resource):
@@ -128,6 +137,10 @@ class BigQueryTable(ChildResourceManager):
                 'datasetId': event['dataset_id'],
                 'tableId': event['resourceName'].rsplit('/', 1)[-1]
             })
+
+        @staticmethod
+        def get_label_params(resource, all_labels):
+            return {**resource['tableReference'], 'body': {'labels': all_labels}}
 
     def augment(self, resources):
         client = self.get_client()

--- a/tools/c7n_gcp/c7n_gcp/resources/bigtable.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/bigtable.py
@@ -22,8 +22,19 @@ class BigTableInstance(QueryResourceManager):
         name = id = 'id'
         scope_template = "projects/{}"
         permissions = ('bigtable.instances.list',)
+        perm_service = 'bigtable'
         asset_type = "bigtableadmin.googleapis.com/Instance"
         default_report_fields = ['displayName', 'expireTime']
+        labels = True
+        labels_op = 'partialUpdateInstance'
+
+        @staticmethod
+        def get_label_params(resource, all_labels):
+            return {
+                'name': resource['name'],
+                'updateMask': 'labels',
+                'body': {'labels': all_labels},
+            }
 
 
 @resources.register('bigtable-instance-cluster')

--- a/tools/c7n_gcp/tests/data/flights/bigtable-instance-label/get-v2-projects-cloud-custodian-instances-c7n-bigtable-instance_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bigtable-instance-label/get-v2-projects-cloud-custodian-instances-c7n-bigtable-instance_1.json
@@ -1,0 +1,28 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:48:29 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "303",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigtableadmin.googleapis.com/v2/projects/cloud-custodian/instances/c7n-bigtable-instance?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/instances/c7n-bigtable-instance",
+    "displayName": "c7n-bigtable-instance",
+    "state": "READY",
+    "type": "PRODUCTION",
+    "labels": {
+      "goog-terraform-provisioned": "true",
+      "env": "not-the-default"
+    },
+    "createTime": "2026-02-05T20:36:16.382739Z"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bigtable-instance-label/get-v2-projects-cloud-custodian-instances_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bigtable-instance-label/get-v2-projects-cloud-custodian-instances_1.json
@@ -1,0 +1,32 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:48:28 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "364",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigtableadmin.googleapis.com/v2/projects/cloud-custodian/instances?alt=json"
+  },
+  "body": {
+    "instances": [
+      {
+        "name": "projects/cloud-custodian/instances/c7n-bigtable-instance",
+        "displayName": "c7n-bigtable-instance",
+        "state": "READY",
+        "type": "PRODUCTION",
+        "labels": {
+          "env": "default",
+          "goog-terraform-provisioned": "true"
+        },
+        "createTime": "2026-02-05T20:36:16.382739Z"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bigtable-instance-label/patch-v2-projects-cloud-custodian-instances-c7n-bigtable-instance_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bigtable-instance-label/patch-v2-projects-cloud-custodian-instances-c7n-bigtable-instance_1.json
@@ -1,0 +1,47 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:48:29 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1067",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "operations/projects/cloud-custodian/instances/c7n-bigtable-instance/locations/us-central1-a/operations/9099284083680298882",
+    "metadata": {
+      "@type": "type.googleapis.com/google.bigtable.admin.v2.UpdateInstanceMetadata",
+      "originalRequest": {
+        "instance": {
+          "name": "projects/cloud-custodian/instances/c7n-bigtable-instance",
+          "type": "PRODUCTION",
+          "labels": {
+            "env": "not-the-default",
+            "goog-terraform-provisioned": "true"
+          }
+        },
+        "updateMask": "labels"
+      },
+      "requestTime": "2026-02-05T20:48:28.886782Z",
+      "finishTime": "2026-02-05T20:48:28.886782Z"
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.bigtable.admin.v2.Instance",
+      "name": "projects/cloud-custodian/instances/c7n-bigtable-instance",
+      "displayName": "c7n-bigtable-instance",
+      "type": "PRODUCTION",
+      "labels": {
+        "env": "not-the-default",
+        "goog-terraform-provisioned": "true"
+      },
+      "createTime": "2026-02-05T20:36:16.382739Z"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-dataset-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-dataset-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset_1.json
@@ -1,0 +1,56 @@
+{
+  "headers": {
+    "etag": "BcSPpcmHZ6gearVKuw3cyQ==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 19:50:31 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "922",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#dataset",
+    "etag": "BcSPpcmHZ6gearVKuw3cyQ==",
+    "id": "cloud-custodian:c7n_bq_dataset",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset",
+    "datasetReference": {
+      "datasetId": "c7n_bq_dataset",
+      "projectId": "cloud-custodian"
+    },
+    "description": "",
+    "labels": {
+      "env": "default",
+      "goog-terraform-provisioned": "true"
+    },
+    "access": [
+      {
+        "role": "WRITER",
+        "specialGroup": "projectWriters"
+      },
+      {
+        "role": "OWNER",
+        "specialGroup": "projectOwners"
+      },
+      {
+        "role": "OWNER",
+        "userByEmail": "caleb.syring@sixfeetup.com"
+      },
+      {
+        "role": "READER",
+        "specialGroup": "projectReaders"
+      }
+    ],
+    "creationTime": "1770318608386",
+    "lastModifiedTime": "1770321024616",
+    "location": "US",
+    "type": "DEFAULT",
+    "maxTimeTravelHours": "168"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-dataset-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-dataset-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset_2.json
@@ -1,0 +1,56 @@
+{
+  "headers": {
+    "etag": "4Q2lbcCq0izhTYeRC3d96Q==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 19:50:32 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "930",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#dataset",
+    "etag": "4Q2lbcCq0izhTYeRC3d96Q==",
+    "id": "cloud-custodian:c7n_bq_dataset",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset",
+    "datasetReference": {
+      "datasetId": "c7n_bq_dataset",
+      "projectId": "cloud-custodian"
+    },
+    "description": "",
+    "labels": {
+      "env": "not-the-default",
+      "goog-terraform-provisioned": "true"
+    },
+    "access": [
+      {
+        "role": "WRITER",
+        "specialGroup": "projectWriters"
+      },
+      {
+        "role": "OWNER",
+        "specialGroup": "projectOwners"
+      },
+      {
+        "role": "OWNER",
+        "userByEmail": "caleb.syring@sixfeetup.com"
+      },
+      {
+        "role": "READER",
+        "specialGroup": "projectReaders"
+      }
+    ],
+    "creationTime": "1770318608386",
+    "lastModifiedTime": "1770321032211",
+    "location": "US",
+    "type": "DEFAULT",
+    "maxTimeTravelHours": "168"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-dataset-label/get-bigquery-v2-projects-cloud-custodian-datasets_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-dataset-label/get-bigquery-v2-projects-cloud-custodian-datasets_1.json
@@ -1,0 +1,37 @@
+{
+  "headers": {
+    "etag": "xEqm9agvhG/BGgg+W9ijRA==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 19:50:31 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "438",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#datasetList",
+    "etag": "xEqm9agvhG/BGgg+W9ijRA==",
+    "datasets": [
+      {
+        "kind": "bigquery#dataset",
+        "id": "cloud-custodian:c7n_bq_dataset",
+        "datasetReference": {
+          "datasetId": "c7n_bq_dataset",
+          "projectId": "cloud-custodian"
+        },
+        "labels": {
+          "env": "default",
+          "goog-terraform-provisioned": "true"
+        },
+        "location": "US"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-dataset-label/patch-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-dataset-label/patch-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset_1.json
@@ -1,0 +1,55 @@
+{
+  "headers": {
+    "etag": "4Q2lbcCq0izhTYeRC3d96Q==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 19:50:32 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "930",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "kind": "bigquery#dataset",
+    "etag": "4Q2lbcCq0izhTYeRC3d96Q==",
+    "id": "cloud-custodian:c7n_bq_dataset",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset",
+    "datasetReference": {
+      "datasetId": "c7n_bq_dataset",
+      "projectId": "cloud-custodian"
+    },
+    "description": "",
+    "labels": {
+      "env": "not-the-default",
+      "goog-terraform-provisioned": "true"
+    },
+    "access": [
+      {
+        "role": "WRITER",
+        "specialGroup": "projectWriters"
+      },
+      {
+        "role": "OWNER",
+        "specialGroup": "projectOwners"
+      },
+      {
+        "role": "OWNER",
+        "userByEmail": "caleb.syring@sixfeetup.com"
+      },
+      {
+        "role": "READER",
+        "specialGroup": "projectReaders"
+      }
+    ],
+    "creationTime": "1770318608386",
+    "lastModifiedTime": "1770321032211",
+    "location": "US",
+    "type": "DEFAULT",
+    "maxTimeTravelHours": "168"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset-tables-c7n_bq_table_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset-tables-c7n_bq_table_1.json
@@ -1,0 +1,52 @@
+{
+  "headers": {
+    "etag": "EzW0gyEQBbcUpMJA3JwQPg==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:14:55 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "892",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset/tables/c7n_bq_table?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#table",
+    "etag": "EzW0gyEQBbcUpMJA3JwQPg==",
+    "id": "cloud-custodian:c7n_bq_dataset.c7n_bq_table",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset/tables/c7n_bq_table",
+    "tableReference": {
+      "projectId": "cloud-custodian",
+      "datasetId": "c7n_bq_dataset",
+      "tableId": "c7n_bq_table"
+    },
+    "labels": {
+      "goog-terraform-provisioned": "true",
+      "env": "default"
+    },
+    "schema": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "mode": "REQUIRED"
+        }
+      ]
+    },
+    "numBytes": "0",
+    "numLongTermBytes": "0",
+    "numRows": "0",
+    "creationTime": "1770321954878",
+    "lastModifiedTime": "1770321954937",
+    "type": "TABLE",
+    "location": "US",
+    "numTotalLogicalBytes": "0",
+    "numActiveLogicalBytes": "0",
+    "numLongTermLogicalBytes": "0"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset-tables-c7n_bq_table_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset-tables-c7n_bq_table_2.json
@@ -1,0 +1,52 @@
+{
+  "headers": {
+    "etag": "SFNbezEQlKIaiKBn9pvbPA==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:14:56 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "900",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset/tables/c7n_bq_table?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#table",
+    "etag": "SFNbezEQlKIaiKBn9pvbPA==",
+    "id": "cloud-custodian:c7n_bq_dataset.c7n_bq_table",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset/tables/c7n_bq_table",
+    "tableReference": {
+      "projectId": "cloud-custodian",
+      "datasetId": "c7n_bq_dataset",
+      "tableId": "c7n_bq_table"
+    },
+    "labels": {
+      "goog-terraform-provisioned": "true",
+      "env": "not-the-default"
+    },
+    "schema": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "mode": "REQUIRED"
+        }
+      ]
+    },
+    "numBytes": "0",
+    "numLongTermBytes": "0",
+    "numRows": "0",
+    "creationTime": "1770321954878",
+    "lastModifiedTime": "1770322496067",
+    "type": "TABLE",
+    "location": "US",
+    "numTotalLogicalBytes": "0",
+    "numActiveLogicalBytes": "0",
+    "numLongTermLogicalBytes": "0"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset-tables_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset-tables_1.json
@@ -1,0 +1,40 @@
+{
+  "headers": {
+    "etag": "g2eNXLEiAdkTD66ehaw9gA==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:14:55 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "535",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset/tables?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#tableList",
+    "etag": "g2eNXLEiAdkTD66ehaw9gA==",
+    "tables": [
+      {
+        "kind": "bigquery#table",
+        "id": "cloud-custodian:c7n_bq_dataset.c7n_bq_table",
+        "tableReference": {
+          "projectId": "cloud-custodian",
+          "datasetId": "c7n_bq_dataset",
+          "tableId": "c7n_bq_table"
+        },
+        "type": "TABLE",
+        "labels": {
+          "goog-terraform-provisioned": "true",
+          "env": "default"
+        },
+        "creationTime": "1770321954878"
+      }
+    ],
+    "totalItems": 1
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset_1.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "etag": "2o6HatXYGCWNy+fD95x0zg==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:14:55 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "944",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#dataset",
+    "etag": "2o6HatXYGCWNy+fD95x0zg==",
+    "id": "cloud-custodian:c7n_bq_dataset",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset",
+    "datasetReference": {
+      "datasetId": "c7n_bq_dataset",
+      "projectId": "cloud-custodian"
+    },
+    "friendlyName": "",
+    "description": "",
+    "labels": {
+      "env": "default",
+      "goog-terraform-provisioned": "true"
+    },
+    "access": [
+      {
+        "role": "WRITER",
+        "specialGroup": "projectWriters"
+      },
+      {
+        "role": "OWNER",
+        "specialGroup": "projectOwners"
+      },
+      {
+        "role": "OWNER",
+        "userByEmail": "caleb.syring@sixfeetup.com"
+      },
+      {
+        "role": "READER",
+        "specialGroup": "projectReaders"
+      }
+    ],
+    "creationTime": "1770318608386",
+    "lastModifiedTime": "1770321954110",
+    "location": "US",
+    "type": "DEFAULT",
+    "maxTimeTravelHours": "168"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-table-label/get-bigquery-v2-projects-cloud-custodian-datasets_1.json
@@ -1,0 +1,38 @@
+{
+  "headers": {
+    "etag": "yCcsJ/pchp6zM5JNbQEXGA==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:14:55 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "464",
+    "-content-encoding": "gzip",
+    "content-location": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets?alt=json"
+  },
+  "body": {
+    "kind": "bigquery#datasetList",
+    "etag": "yCcsJ/pchp6zM5JNbQEXGA==",
+    "datasets": [
+      {
+        "kind": "bigquery#dataset",
+        "id": "cloud-custodian:c7n_bq_dataset",
+        "datasetReference": {
+          "datasetId": "c7n_bq_dataset",
+          "projectId": "cloud-custodian"
+        },
+        "labels": {
+          "env": "default",
+          "goog-terraform-provisioned": "true"
+        },
+        "friendlyName": "",
+        "location": "US"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bq-table-label/patch-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset-tables-c7n_bq_table_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bq-table-label/patch-bigquery-v2-projects-cloud-custodian-datasets-c7n_bq_dataset-tables-c7n_bq_table_1.json
@@ -1,0 +1,51 @@
+{
+  "headers": {
+    "etag": "SFNbezEQlKIaiKBn9pvbPA==",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Feb 2026 20:14:56 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "900",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "kind": "bigquery#table",
+    "etag": "SFNbezEQlKIaiKBn9pvbPA==",
+    "id": "cloud-custodian:c7n_bq_dataset.c7n_bq_table",
+    "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/cloud-custodian/datasets/c7n_bq_dataset/tables/c7n_bq_table",
+    "tableReference": {
+      "projectId": "cloud-custodian",
+      "datasetId": "c7n_bq_dataset",
+      "tableId": "c7n_bq_table"
+    },
+    "labels": {
+      "goog-terraform-provisioned": "true",
+      "env": "not-the-default"
+    },
+    "schema": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "mode": "REQUIRED"
+        }
+      ]
+    },
+    "numBytes": "0",
+    "numLongTermBytes": "0",
+    "numRows": "0",
+    "creationTime": "1770321954878",
+    "lastModifiedTime": "1770322496067",
+    "type": "TABLE",
+    "location": "US",
+    "numTotalLogicalBytes": "0",
+    "numActiveLogicalBytes": "0",
+    "numLongTermLogicalBytes": "0"
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/bigquery/main.tf
+++ b/tools/c7n_gcp/tests/terraform/bigquery/main.tf
@@ -1,0 +1,33 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project = var.google_project_id
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "c7n_bq_dataset"
+
+  labels = {
+    env = "default"
+  }
+}
+
+resource "google_bigquery_table" "table" {
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
+  table_id   = "c7n_bq_table"
+  schema     = <<SCHEMA
+  [
+    {
+      "name": "id",
+      "type": "INTEGER",
+      "mode": "REQUIRED"
+    }
+  ]
+  SCHEMA
+
+  labels = {
+    env = "default"
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/bigtable/main.tf
+++ b/tools/c7n_gcp/tests/terraform/bigtable/main.tf
@@ -1,0 +1,23 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project = var.google_project_id
+}
+
+resource "google_bigtable_instance" "instance" {
+  name                = "c7n-bigtable-instance"
+  deletion_protection = false
+
+  cluster {
+    cluster_id   = "c7n-bigtable-cluster"
+    zone         = "us-central1-a"
+    num_nodes    = 1
+    storage_type = "HDD"
+  }
+
+  labels = {
+    env = "default"
+  }
+}

--- a/tools/c7n_gcp/tests/test_bigquery.py
+++ b/tools/c7n_gcp/tests/test_bigquery.py
@@ -45,6 +45,35 @@ class BigQueryDataSetTest(BaseTest):
             time.sleep(1)
         self.assertEqual(len(resources), 1)
 
+    def test_dataset_label(self):
+        # Set the "env" label to not the default
+        factory = self.replay_flight_data('bq-dataset-label')
+        p = self.load_policy(
+            {
+                'name': 'bq-dataset-label',
+                'resource': 'gcp.bq-dataset',
+                'filters': [{
+                    'type': 'value',
+                    'key': 'id',
+                    'op': 'contains',
+                    'value': 'c7n_bq_dataset',
+                }],
+                'actions': [
+                    {'type': 'set-labels',
+                     'labels': {'env': 'not-the-default'}}
+                ]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['labels']['env'], 'default')
+
+        # Fetch the dataset manually to confirm the label was changed
+        client = p.resource_manager.get_client()
+        result = client.execute_query('get', resources[0]['datasetReference'])
+        self.assertEqual(result['labels']['env'], 'not-the-default')
+
 
 class BigQueryJobTest(BaseTest):
 
@@ -149,3 +178,32 @@ class BigQueryTableTest(BaseTest):
         if self.recording:
             time.sleep(1)
         self.assertEqual(len(resources), 1)
+
+    def test_table_label(self):
+        # Set the "env" label to not the default
+        factory = self.replay_flight_data('bq-table-label')
+        p = self.load_policy(
+            {
+                'name': 'bq-table-label',
+                'resource': 'gcp.bq-table',
+                'filters': [{
+                    'type': 'value',
+                    'key': 'id',
+                    'op': 'contains',
+                    'value': 'c7n_bq_table',
+                }],
+                'actions': [
+                    {'type': 'set-labels',
+                     'labels': {'env': 'not-the-default'}}
+                ]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['labels']['env'], 'default')
+
+        # Fetch the table manually to confirm the label was changed
+        client = p.resource_manager.get_client()
+        result = client.execute_query('get', resources[0]['tableReference'])
+        self.assertEqual(result['labels']['env'], 'not-the-default')


### PR DESCRIPTION
resolves #10524 

Enables the `set-label` action for the following resources:
- Big Query
  - `gcp.bq-dataset`
  - `gcp.bq-table`
  - 
- Big Table
  - `gcp.bigtable-instance`

There are other Big Query/Big Table resources, but they either don't support labels at all or don't support updating them after creation (such as `gcp.bq-job`)