### PR TITLE
GCP - Add override for permission component naming mismatch.

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/actions/core.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/core.py
@@ -103,7 +103,7 @@ class MethodAction(Action):
             return ()
         if not method:
             method = self.method_spec['op']
-        component = m.component
+        component = getattr(m, 'perm_component', m.component)
         if '.' in component:
             component = component.split('.')[-1]
         return ("{}.{}.{}".format(

--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -82,7 +82,7 @@ class DescribeSource:
         method = m.enum_spec[0]
         if method == 'aggregatedList':
             method = 'list'
-        component = m.component
+        component = getattr(m, 'perm_component', m.component)
         if '.' in component:
             component = component.split('.')[-1]
         return ("%s.%s.%s" % (

--- a/tools/c7n_gcp/c7n_gcp/resources/certificatemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/certificatemanager.py
@@ -20,6 +20,7 @@ class CertificateManagerCertificate(QueryResourceManager):
         service = 'certificatemanager'
         version = 'v1'
         component = 'projects.locations.certificates'
+        perm_component = 'certs'  # Permission component differs from API component
         enum_spec = ('list', 'certificates[]', None)
         scope = 'project'
         scope_template = 'projects/{}/locations/-'


### PR DESCRIPTION

## Problem

Test `test_resource.py::ResourceMetaTest::test_check_permissions` was failing because
Certificate Manager's API component name (`certificates`) differs from its IAM permission
component name (`certs`), causing auto-generated permissions like
`certificatemanager.certificates.update` instead of the valid `certificatemanager.certs.update`.

## Solution

Added `perm_component` attribute to TypeInfo, following the existing `perm_service` pattern
for permission overrides. Updated permission generation in `actions/core.py` and `query.py`
to check for `perm_component` before extracting from the API component path.

Set `perm_component = 'certs'` in CertificateManagerCertificate.resource_type.
