### PR TITLE
GCP - Add set-iam-policy action for gcp.bucket

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/storage.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/storage.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from c7n.utils import type_schema
 from c7n_gcp.actions import MethodAction
+from c7n_gcp.actions.iampolicy import SetIamPolicy
 from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo
 from c7n_gcp.filters import IamPolicyFilter
@@ -96,3 +97,79 @@ class BucketLevelAccess(MethodAction):
                 'fields': 'iamConfiguration',
                 'projection': 'noAcl',  # not documented but
                 'body': {'iamConfiguration': {'uniformBucketLevelAccess': {'enabled': enabled}}}}
+
+
+@Bucket.action_registry.register('set-iam-policy')
+class BucketSetIamPolicy(SetIamPolicy):
+    """Manage GCP bucket IAM policy bindings.
+
+    This action supports ``add-bindings`` and ``remove-bindings`` to manage
+    bucket-level IAM policies. A common use case is removing ``allUsers`` and
+    ``allAuthenticatedUsers`` from buckets that have been misconfigured with
+    public access.
+
+    The ``remove-bindings`` list specifies which members to remove from which
+    roles. If removing a member leaves a role binding with no members, that
+    binding is dropped entirely. Use ``members: '*'`` as a wildcard to remove
+    all members from a role.
+
+    Example policy to detect and remediate publicly accessible buckets.
+    To fully remove anonymous and public access, all predefined storage roles
+    must be covered:
+
+    .. code-block:: yaml
+
+      policies:
+        - name: gcp-bucket-remove-public-access
+          resource: gcp.bucket
+          filters:
+            - type: iam-policy
+              doc:
+                key: 'bindings[*].members[]'
+                op: intersect
+                value:
+                  - allUsers
+                  - allAuthenticatedUsers
+          actions:
+            - type: set-iam-policy
+              remove-bindings:
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.admin
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.objectAdmin
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.objectCreator
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.objectUser
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.objectViewer
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.bucketViewer
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.folderAdmin
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.legacyBucketOwner
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.legacyBucketReader
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.legacyBucketWriter
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.legacyObjectOwner
+                - members: [allUsers, allAuthenticatedUsers]
+                  role: roles/storage.legacyObjectReader
+    """
+
+    permissions = ('storage.buckets.getIamPolicy', 'storage.buckets.setIamPolicy')
+
+    def _verb_arguments(self, resource):
+        return {'bucket': resource['name']}
+
+    def get_resource_params(self, model, resource):
+        params = self._verb_arguments(resource)
+        existing_bindings = self._get_existing_bindings(model, resource)
+        add_bindings = self.data.get('add-bindings', [])
+        remove_bindings = self.data.get('remove-bindings', [])
+        bindings_to_set = self._add_bindings(existing_bindings, add_bindings)
+        bindings_to_set = self._remove_bindings(bindings_to_set, remove_bindings)
+        params['body'] = {'bindings': bindings_to_set} if bindings_to_set else {}
+        return params

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-and-remove/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-and-remove/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWwLCp6O1jhburp6oA-n4P28tcz7zKWZeisvSRuWkhfofYKh76daG0OOq5wW6CBQ2ieb",
+    "etag": "CAQ=",
+    "date": "Fri, 27 Feb 2026 13:24:00 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 13:24:00 GMT",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAQ=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-and-remove/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-and-remove/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWzJUAXIQAroa_U0Kl80l-vE69Z6gxhcgWApMig3hUbXlGzEnfYaau8XYvSm594vu37X",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 13:24:01 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 13:24:01 GMT",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-and-remove/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-and-remove/get-storage-v1-b_1.json
@@ -1,0 +1,138 @@
+{
+ "headers": {
+  "content-type": "application/json; charset=UTF-8",
+  "x-guploader-uploadid": "AGQBYWxAg931eQ9UPZB9SmAelsnCotq7Zh-kqFsHT2_7LrPIa0N4kEOS_K21Oa44RNOE-bol0w-y5w",
+  "date": "Fri, 27 Feb 2026 13:23:59 GMT",
+  "vary": "Origin, X-Origin",
+  "cache-control": "private, max-age=0, must-revalidate, no-transform",
+  "expires": "Fri, 27 Feb 2026 13:23:59 GMT",
+  "content-length": "35185",
+  "server": "UploadServer",
+  "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+  "status": "200",
+  "content-location": "https://storage.googleapis.com/storage/v1/b?project=stacklet-test-policies&projection=full&alt=json"
+ },
+ "body": {
+  "kind": "storage#buckets",
+  "items": [
+   {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok",
+    "id": "iam-test-bucket-wuc48fhtok",
+    "name": "iam-test-bucket-wuc48fhtok",
+    "projectNumber": "859150599087",
+    "generation": "1772198616332255829",
+    "metageneration": "4",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAQ=",
+    "timeCreated": "2026-02-27T13:23:36.605Z",
+    "updated": "2026-02-27T13:23:52.715Z",
+    "acl": [
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-editors-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-editors-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-owners-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-owners-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/allAuthenticatedUsers",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/allAuthenticatedUsers",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "allAuthenticatedUsers",
+      "role": "READER",
+      "etag": "CAQ="
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-viewers-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-viewers-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "defaultObjectAcl": [
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "owner": {
+     "entity": "project-owners-859150599087"
+    },
+    "labels": {
+     "env": "default",
+     "goog-terraform-provisioned": "true"
+    },
+    "softDeletePolicy": {
+     "retentionDurationSeconds": "604800",
+     "effectiveTime": "2026-02-27T13:23:36.605Z"
+    },
+    "iamConfiguration": {
+     "bucketPolicyOnly": {
+      "enabled": false
+     },
+     "uniformBucketLevelAccess": {
+      "enabled": false
+     },
+     "publicAccessPrevention": "inherited"
+    },
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
+   }
+  ]
+ }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-and-remove/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-and-remove/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWx62_B_Fay8nhVvttFFZs2kgKwMxuGTkB--cgo_8nNk7sQkw0AJeJ9woHWMJMLppxov",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 13:24:01 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+    "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+    "pragma": "no-cache",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-bindings/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-bindings/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxBqqI5nkMEHqQUut_N68RK3P3YgwUmQHcmScmYN11qRWRuLKb1oYzCYm-eBgnyK_G-",
+    "etag": "CAQ=",
+    "date": "Fri, 27 Feb 2026 13:13:56 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 13:13:56 GMT",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAQ=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-bindings/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-bindings/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
@@ -1,0 +1,46 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWy_rBi-NVVlwBG4V11xhZk2OUjWQGFbDZyGHJNfGXVDcgesqq_PjFyhc30oTzQ4ftPd",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 13:13:58 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 13:13:58 GMT",
+    "content-length": "798",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-bindings/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-bindings/get-storage-v1-b_1.json
@@ -1,0 +1,138 @@
+{
+ "headers": {
+  "content-type": "application/json; charset=UTF-8",
+  "x-guploader-uploadid": "AGQBYWyOeloEMvYBC1zxc88sO23lUrkmhK_28XMITboYrm89L6MB0XFtDlHS_QWxEKSOjycd",
+  "date": "Fri, 27 Feb 2026 13:13:56 GMT",
+  "vary": "Origin, X-Origin",
+  "cache-control": "private, max-age=0, must-revalidate, no-transform",
+  "expires": "Fri, 27 Feb 2026 13:13:56 GMT",
+  "content-length": "35185",
+  "server": "UploadServer",
+  "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+  "status": "200",
+  "content-location": "https://storage.googleapis.com/storage/v1/b?project=stacklet-test-policies&projection=full&alt=json"
+ },
+ "body": {
+  "kind": "storage#buckets",
+  "items": [
+   {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok",
+    "id": "iam-test-bucket-wuc48fhtok",
+    "name": "iam-test-bucket-wuc48fhtok",
+    "projectNumber": "859150599087",
+    "generation": "1772198011033678480",
+    "metageneration": "4",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAQ=",
+    "timeCreated": "2026-02-27T13:13:31.439Z",
+    "updated": "2026-02-27T13:13:48.910Z",
+    "acl": [
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-editors-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-editors-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-owners-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-owners-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/allAuthenticatedUsers",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/allAuthenticatedUsers",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "allAuthenticatedUsers",
+      "role": "READER",
+      "etag": "CAQ="
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-viewers-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-viewers-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "defaultObjectAcl": [
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "owner": {
+     "entity": "project-owners-859150599087"
+    },
+    "labels": {
+     "goog-terraform-provisioned": "true",
+     "env": "default"
+    },
+    "softDeletePolicy": {
+     "retentionDurationSeconds": "604800",
+     "effectiveTime": "2026-02-27T13:13:31.439Z"
+    },
+    "iamConfiguration": {
+     "bucketPolicyOnly": {
+      "enabled": false
+     },
+     "uniformBucketLevelAccess": {
+      "enabled": false
+     },
+     "publicAccessPrevention": "inherited"
+    },
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
+   }
+  ]
+ }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-bindings/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-add-bindings/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,46 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWyvnf7knKhjQMj2WHK0tHjlVKKEHrJji57rAlEUrtA3qAJZfeY3z_WATD3_CRR4q12_",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 13:13:58 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+    "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+    "pragma": "no-cache",
+    "content-length": "798",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-idempotent/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-idempotent/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWzzwO8qTm8uOeRdIoJNKrC8BTHuPzkIaWxD3cb6pF01OsWgpLTFlYVvd-DeET0n8jlz",
+    "etag": "CAQ=",
+    "date": "Fri, 27 Feb 2026 13:26:41 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 13:26:41 GMT",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAQ=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-idempotent/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-idempotent/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxkoYtkFWYr1GJSCMfR4dVOC3E98bLkJyANExkXCfOJYaAO7hNQg3qrVy4v4sSzLm7y",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 13:26:42 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 13:26:42 GMT",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-idempotent/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-idempotent/get-storage-v1-b_1.json
@@ -1,0 +1,138 @@
+{
+ "headers": {
+  "content-type": "application/json; charset=UTF-8",
+  "x-guploader-uploadid": "AGQBYWzmHlbU9V3jTvNj6Z_Wkb_JsudhLe50QrtpF1_xo0Z5LX5SmfqiZCyZd-9WMkzGEvIpLSo3-Yth7U59",
+  "date": "Fri, 27 Feb 2026 13:26:40 GMT",
+  "vary": "Origin, X-Origin",
+  "cache-control": "private, max-age=0, must-revalidate, no-transform",
+  "expires": "Fri, 27 Feb 2026 13:26:40 GMT",
+  "content-length": "35185",
+  "server": "UploadServer",
+  "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+  "status": "200",
+  "content-location": "https://storage.googleapis.com/storage/v1/b?project=stacklet-test-policies&projection=full&alt=json"
+ },
+ "body": {
+  "kind": "storage#buckets",
+  "items": [
+   {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok",
+    "id": "iam-test-bucket-wuc48fhtok",
+    "name": "iam-test-bucket-wuc48fhtok",
+    "projectNumber": "859150599087",
+    "generation": "1772198776334054575",
+    "metageneration": "4",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAQ=",
+    "timeCreated": "2026-02-27T13:26:16.587Z",
+    "updated": "2026-02-27T13:26:33.451Z",
+    "acl": [
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-editors-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-editors-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-owners-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-owners-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/allAuthenticatedUsers",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/allAuthenticatedUsers",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "allAuthenticatedUsers",
+      "role": "READER",
+      "etag": "CAQ="
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-viewers-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-viewers-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "defaultObjectAcl": [
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "owner": {
+     "entity": "project-owners-859150599087"
+    },
+    "labels": {
+     "goog-terraform-provisioned": "true",
+     "env": "default"
+    },
+    "softDeletePolicy": {
+     "retentionDurationSeconds": "604800",
+     "effectiveTime": "2026-02-27T13:26:16.587Z"
+    },
+    "iamConfiguration": {
+     "bucketPolicyOnly": {
+      "enabled": false
+     },
+     "uniformBucketLevelAccess": {
+      "enabled": false
+     },
+     "publicAccessPrevention": "inherited"
+    },
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
+   }
+  ]
+ }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-idempotent/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-idempotent/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxJnGMlHeCqIKogfwULu_5jzJ3575yEtwy0yjWUabeeYDmD35VeXyRVU-Mj4P1QobXT",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 13:26:42 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+    "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+    "pragma": "no-cache",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-wildcard/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-wildcard/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWyt307d7Z2dLhKfESZYNhtTAwJ9kwIH9oI2IcS_W4oNK-u9T-5Y41laxbsBMn2ofJtq",
+    "etag": "CAQ=",
+    "date": "Fri, 27 Feb 2026 13:17:27 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 13:17:27 GMT",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAQ=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-wildcard/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-wildcard/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
@@ -1,0 +1,38 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxr9Bb0tSeissyL3_4uVk5hsyTHs9fm7bS38ED-MWj58vti7SdPsBYIKduFeWS03Q0s",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 13:17:29 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 13:17:29 GMT",
+    "content-length": "503",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-wildcard/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-wildcard/get-storage-v1-b_1.json
@@ -1,0 +1,138 @@
+{
+ "headers": {
+  "content-type": "application/json; charset=UTF-8",
+  "x-guploader-uploadid": "AGQBYWzvlcecQP9XvQtQKm47MPhp0RYLhQ_1R0qdxzgR-iukIw3AawNdGuGnBPhB5CNoUPmO",
+  "date": "Fri, 27 Feb 2026 13:17:27 GMT",
+  "vary": "Origin, X-Origin",
+  "cache-control": "private, max-age=0, must-revalidate, no-transform",
+  "expires": "Fri, 27 Feb 2026 13:17:27 GMT",
+  "content-length": "35185",
+  "server": "UploadServer",
+  "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+  "status": "200",
+  "content-location": "https://storage.googleapis.com/storage/v1/b?project=stacklet-test-policies&projection=full&alt=json"
+ },
+ "body": {
+  "kind": "storage#buckets",
+  "items": [
+   {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok",
+    "id": "iam-test-bucket-wuc48fhtok",
+    "name": "iam-test-bucket-wuc48fhtok",
+    "projectNumber": "859150599087",
+    "generation": "1772198209451490740",
+    "metageneration": "4",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAQ=",
+    "timeCreated": "2026-02-27T13:16:49.897Z",
+    "updated": "2026-02-27T13:17:20.055Z",
+    "acl": [
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-editors-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-editors-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-owners-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-owners-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/allAuthenticatedUsers",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/allAuthenticatedUsers",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "allAuthenticatedUsers",
+      "role": "READER",
+      "etag": "CAQ="
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-viewers-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-viewers-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "defaultObjectAcl": [
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "owner": {
+     "entity": "project-owners-859150599087"
+    },
+    "labels": {
+     "env": "default",
+     "goog-terraform-provisioned": "true"
+    },
+    "softDeletePolicy": {
+     "retentionDurationSeconds": "604800",
+     "effectiveTime": "2026-02-27T13:16:49.897Z"
+    },
+    "iamConfiguration": {
+     "bucketPolicyOnly": {
+      "enabled": false
+     },
+     "uniformBucketLevelAccess": {
+      "enabled": false
+     },
+     "publicAccessPrevention": "inherited"
+    },
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
+   }
+  ]
+ }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-wildcard/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy-wildcard/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,38 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWyNXG2-6UVYVwRzUcGzdRfBkPNl3i8juKNLopwCIqei_w9tLadWibavgOF0JX2TAFGo",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 13:17:28 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+    "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+    "pragma": "no-cache",
+    "content-length": "503",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWwB-zNqi-SFHz--yIP2KtfTs_qaDQJWcbicE7gnmY-fE775YUplC9OEHMpgCDSUblJi",
+    "etag": "CAQ=",
+    "date": "Fri, 27 Feb 2026 12:48:03 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 12:48:03 GMT",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAQ=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_2.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWyY1Tg__k5KpUyX8DAWWE_JsxmaEVLh8ePA_ehoDIo-eiUbD-glmebP6DKlR6lQMuFs",
+    "etag": "CAQ=",
+    "date": "Fri, 27 Feb 2026 12:48:03 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 12:48:03 GMT",
+    "content-length": "702",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAQ=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "allAuthenticatedUsers",
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "allUsers",
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_3.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/get-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_3.json
@@ -1,0 +1,43 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxs46eI2LK-SLn6jBakIopbg1h3tckkXvmX5EaswXaufxPuCirnWowW2JaqKPcWjRsK",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 12:48:26 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Fri, 27 Feb 2026 12:48:26 GMT",
+    "content-length": "649",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/get-storage-v1-b_1.json
@@ -1,0 +1,138 @@
+{
+ "headers": {
+  "content-type": "application/json; charset=UTF-8",
+  "x-guploader-uploadid": "AGQBYWzQoUrsydtneOGQLNpGKNOVBrPtieo70zvxoeEg9I1Hq-ahLfwK9egJKPs35-HLp2i3wMnhdOHsEejM",
+  "date": "Fri, 27 Feb 2026 12:48:00 GMT",
+  "vary": "Origin, X-Origin",
+  "cache-control": "private, max-age=0, must-revalidate, no-transform",
+  "expires": "Fri, 27 Feb 2026 12:48:00 GMT",
+  "content-length": "35185",
+  "server": "UploadServer",
+  "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+  "status": "200",
+  "content-location": "https://storage.googleapis.com/storage/v1/b?project=stacklet-test-policies&projection=full&alt=json"
+ },
+ "body": {
+  "kind": "storage#buckets",
+  "items": [
+   {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok",
+    "id": "iam-test-bucket-wuc48fhtok",
+    "name": "iam-test-bucket-wuc48fhtok",
+    "projectNumber": "859150599087",
+    "generation": "1772196291935270982",
+    "metageneration": "4",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAQ=",
+    "timeCreated": "2026-02-27T12:44:52.273Z",
+    "updated": "2026-02-27T12:45:07.369Z",
+    "acl": [
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-editors-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-editors-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-owners-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-owners-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/allAuthenticatedUsers",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/allAuthenticatedUsers",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "allAuthenticatedUsers",
+      "role": "READER",
+      "etag": "CAQ="
+     },
+     {
+      "kind": "storage#bucketAccessControl",
+      "id": "iam-test-bucket-wuc48fhtok/project-viewers-859150599087",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok/acl/project-viewers-859150599087",
+      "bucket": "iam-test-bucket-wuc48fhtok",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "defaultObjectAcl": [
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-owners-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "owners"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-editors-859150599087",
+      "role": "OWNER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "editors"
+      }
+     },
+     {
+      "kind": "storage#objectAccessControl",
+      "entity": "project-viewers-859150599087",
+      "role": "READER",
+      "etag": "CAQ=",
+      "projectTeam": {
+       "projectNumber": "859150599087",
+       "team": "viewers"
+      }
+     }
+    ],
+    "owner": {
+     "entity": "project-owners-859150599087"
+    },
+    "labels": {
+     "env": "default",
+     "goog-terraform-provisioned": "true"
+    },
+    "softDeletePolicy": {
+     "retentionDurationSeconds": "604800",
+     "effectiveTime": "2026-02-27T12:44:52.273Z"
+    },
+    "iamConfiguration": {
+     "bucketPolicyOnly": {
+      "enabled": false
+     },
+     "uniformBucketLevelAccess": {
+      "enabled": false
+     },
+     "publicAccessPrevention": "inherited"
+    },
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
+   }
+  ]
+ }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-set-iam-policy/put-storage-v1-b-iam-test-bucket-wuc48fhtok-iam_1.json
@@ -1,0 +1,43 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxdSvO8Fk4UP14NH77Qih5x7nLHVn-XWdWM9-NW16MagWqMLRqtnx1PlWjM1RNCICTT",
+    "etag": "CAU=",
+    "date": "Fri, 27 Feb 2026 12:48:04 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+    "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+    "pragma": "no-cache",
+    "content-length": "649",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/iam-test-bucket-wuc48fhtok",
+    "version": 1,
+    "etag": "CAU=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/bucket_set_iam_policy/main.tf
+++ b/tools/c7n_gcp/tests/terraform/bucket_set_iam_policy/main.tf
@@ -1,0 +1,40 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project = var.google_project_id
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "iam-test-bucket-wuc48fhtok"
+  location = "US"
+
+  labels = {
+    env = "default"
+  }
+}
+
+resource "google_service_account" "legitimate_member" {
+  account_id   = "iam-test-sa-wuc48fhtok"
+  display_name = "Legitimate IAM Test Service Account"
+  project      = var.google_project_id
+}
+
+resource "google_storage_bucket_iam_member" "sa_viewer" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.legitimate_member.email}"
+}
+
+resource "google_storage_bucket_iam_member" "public_viewer" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+resource "google_storage_bucket_iam_member" "authenticated_legacy_reader" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.legacyBucketReader"
+  member = "allAuthenticatedUsers"
+}

--- a/tools/c7n_gcp/tests/terraform/bucket_set_iam_policy/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/bucket_set_iam_policy/tf_resources.json
@@ -1,0 +1,105 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_service_account": {
+            "legitimate_member": {
+                "account_id": "iam-test-sa-wuc48fhtok",
+                "create_ignore_already_exists": null,
+                "description": "",
+                "disabled": false,
+                "display_name": "Legitimate IAM Test Service Account",
+                "email": "iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com",
+                "id": "projects/cloud-custodian/serviceAccounts/iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com",
+                "name": "projects/cloud-custodian/serviceAccounts/iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com",
+                "project": "stacklet-test-policies",
+                "timeouts": null,
+                "unique_id": "100187559211596008082"
+            }
+        },
+        "google_storage_bucket": {
+            "bucket": {
+                "autoclass": [],
+                "cors": [],
+                "custom_placement_config": [],
+                "default_event_based_hold": false,
+                "effective_labels": {
+                    "env": "default",
+                    "goog-terraform-provisioned": "true"
+                },
+                "enable_object_retention": false,
+                "encryption": [],
+                "force_destroy": false,
+                "hierarchical_namespace": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "id": "iam-test-bucket-wuc48fhtok",
+                "ip_filter": [],
+                "labels": {
+                    "env": "default"
+                },
+                "lifecycle_rule": [],
+                "location": "US",
+                "logging": [],
+                "name": "iam-test-bucket-wuc48fhtok",
+                "project": "stacklet-test-policies",
+                "project_number": 859150599087,
+                "public_access_prevention": "inherited",
+                "requester_pays": false,
+                "retention_policy": [],
+                "rpo": "DEFAULT",
+                "self_link": "https://www.googleapis.com/storage/v1/b/iam-test-bucket-wuc48fhtok",
+                "soft_delete_policy": [
+                    {
+                        "effective_time": "2026-02-27T13:26:16.587Z",
+                        "retention_duration_seconds": 604800
+                    }
+                ],
+                "storage_class": "STANDARD",
+                "terraform_labels": {
+                    "env": "default",
+                    "goog-terraform-provisioned": "true"
+                },
+                "time_created": "2026-02-27T13:26:16.587Z",
+                "timeouts": null,
+                "uniform_bucket_level_access": false,
+                "updated": "2026-02-27T13:26:16.587Z",
+                "url": "gs://iam-test-bucket-wuc48fhtok",
+                "versioning": [],
+                "website": []
+            }
+        },
+        "google_storage_bucket_iam_member": {
+            "authenticated_legacy_reader": {
+                "bucket": "b/iam-test-bucket-wuc48fhtok",
+                "condition": [],
+                "etag": "CAM=",
+                "id": "b/iam-test-bucket-wuc48fhtok/roles/storage.legacyBucketReader/allAuthenticatedUsers",
+                "member": "allAuthenticatedUsers",
+                "role": "roles/storage.legacyBucketReader",
+                "timeouts": null
+            },
+            "public_viewer": {
+                "bucket": "b/iam-test-bucket-wuc48fhtok",
+                "condition": [],
+                "etag": "CAM=",
+                "id": "b/iam-test-bucket-wuc48fhtok/roles/storage.objectViewer/allUsers",
+                "member": "allUsers",
+                "role": "roles/storage.objectViewer",
+                "timeouts": null
+            },
+            "sa_viewer": {
+                "bucket": "b/iam-test-bucket-wuc48fhtok",
+                "condition": [],
+                "etag": "CAQ=",
+                "id": "b/iam-test-bucket-wuc48fhtok/roles/storage.objectViewer/serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:iam-test-sa-wuc48fhtok@stacklet-test-policies.iam.gserviceaccount.com",
+                "role": "roles/storage.objectViewer",
+                "timeouts": null
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/test_gcp_storage.py
+++ b/tools/c7n_gcp/tests/test_gcp_storage.py
@@ -4,6 +4,187 @@
 import time
 
 from gcp_common import BaseTest
+from pytest_terraform import terraform
+
+
+@terraform("bucket_set_iam_policy")
+def test_bucket_set_iam_policy_remove_public_access(test, bucket_set_iam_policy):
+    bucket_name = bucket_set_iam_policy.resources['google_storage_bucket']['bucket']['name']
+    sa_email = (
+        "serviceAccount:"
+        + bucket_set_iam_policy.resources['google_service_account']['legitimate_member']['email']
+    )
+    factory = test.replay_flight_data('bucket-set-iam-policy')
+
+    policy = test.load_policy(
+        {'name': 'bucket-set-iam-policy',
+            'resource': 'gcp.bucket',
+            'filters': [{
+                'type': 'iam-policy',
+                'doc': {
+                    'key': 'bindings[*].members[]',
+                    'op': 'intersect',
+                    'value': ['allUsers', 'allAuthenticatedUsers'],
+                }
+            }],
+            'actions': [{
+                'type': 'set-iam-policy',
+                'remove-bindings': [
+                    {
+                        'members': ['allUsers', 'allAuthenticatedUsers'],
+                        'role': 'roles/storage.objectViewer'
+                    },
+                    {
+                        'members': ['allUsers', 'allAuthenticatedUsers'],
+                        'role': 'roles/storage.legacyBucketReader'
+                    },
+                ]
+            }]},
+        session_factory=factory)
+    resources = policy.run()
+    assert len(resources) == 1
+    assert resources[0]['name'] == bucket_name
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'bucket': bucket_name})
+    all_members = [
+        member
+        for binding in updated_policy.get('bindings', [])
+        for member in binding['members']
+    ]
+    assert 'allUsers' not in all_members
+    assert 'allAuthenticatedUsers' not in all_members
+    assert sa_email in all_members
+
+
+@terraform("bucket_set_iam_policy")
+def test_bucket_set_iam_policy_add_bindings(test, bucket_set_iam_policy):
+    bucket_name = bucket_set_iam_policy.resources['google_storage_bucket']['bucket']['name']
+    sa_email = (
+        "serviceAccount:"
+        + bucket_set_iam_policy.resources['google_service_account']['legitimate_member']['email']
+    )
+    factory = test.replay_flight_data('bucket-set-iam-policy-add-bindings')
+    policy = test.load_policy(
+        {'name': 'bucket-set-iam-policy-add-bindings',
+         'resource': 'gcp.bucket',
+         'filters': [{'type': 'value', 'key': 'name', 'value': bucket_name}],
+         'actions': [{
+             'type': 'set-iam-policy',
+             'add-bindings': [{
+                 'members': [sa_email],
+                 'role': 'roles/storage.legacyBucketReader'
+             }]
+         }]},
+        session_factory=factory)
+
+    resources = policy.run()
+    assert len(resources) == 1
+    assert resources[0]['name'] == bucket_name
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'bucket': bucket_name})
+    legacy_reader_binding = next(
+        (b for b in updated_policy.get('bindings', [])
+         if b['role'] == 'roles/storage.legacyBucketReader'),
+        None
+    )
+    assert legacy_reader_binding is not None
+    assert sa_email in legacy_reader_binding['members']
+
+
+@terraform("bucket_set_iam_policy")
+def test_bucket_set_iam_policy_remove_wildcard(test, bucket_set_iam_policy):
+    bucket_name = bucket_set_iam_policy.resources['google_storage_bucket']['bucket']['name']
+    factory = test.replay_flight_data('bucket-set-iam-policy-wildcard')
+    policy = test.load_policy(
+        {'name': 'bucket-set-iam-policy-wildcard',
+         'resource': 'gcp.bucket',
+         'filters': [{'type': 'value', 'key': 'name', 'value': bucket_name}],
+         'actions': [{
+             'type': 'set-iam-policy',
+             'remove-bindings': [{
+                 'members': '*',
+                 'role': 'roles/storage.objectViewer'
+             }]
+         }]},
+        session_factory=factory)
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'bucket': bucket_name})
+    roles = [b['role'] for b in updated_policy.get('bindings', [])]
+    assert 'roles/storage.objectViewer' not in roles
+
+
+@terraform("bucket_set_iam_policy")
+def test_bucket_set_iam_policy_add_and_remove_remove_wins(test, bucket_set_iam_policy):
+    bucket_name = bucket_set_iam_policy.resources['google_storage_bucket']['bucket']['name']
+    sa_email = (
+        "serviceAccount:"
+        + bucket_set_iam_policy.resources['google_service_account']['legitimate_member']['email']
+    )
+    factory = test.replay_flight_data('bucket-set-iam-policy-add-and-remove')
+    policy = test.load_policy(
+        {'name': 'bucket-set-iam-policy-add-and-remove',
+         'resource': 'gcp.bucket',
+         'filters': [{'type': 'value', 'key': 'name', 'value': bucket_name}],
+         'actions': [{
+             'type': 'set-iam-policy',
+             'add-bindings': [
+                 {'members': [sa_email], 'role': 'roles/storage.objectAdmin'},
+             ],
+             'remove-bindings': [
+                 {'members': [sa_email], 'role': 'roles/storage.objectAdmin'},
+             ]
+         }]},
+        session_factory=factory)
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'bucket': bucket_name})
+    roles = [b['role'] for b in updated_policy.get('bindings', [])]
+    assert 'roles/storage.objectAdmin' not in roles
+
+
+@terraform("bucket_set_iam_policy")
+def test_bucket_set_iam_policy_remove_nonexistent_is_noop(test, bucket_set_iam_policy):
+    bucket_name = bucket_set_iam_policy.resources['google_storage_bucket']['bucket']['name']
+    sa_email = (
+        "serviceAccount:"
+        + bucket_set_iam_policy.resources['google_service_account']['legitimate_member']['email']
+    )
+    factory = test.replay_flight_data('bucket-set-iam-policy-idempotent')
+    policy = test.load_policy(
+        {'name': 'bucket-set-iam-policy-idempotent',
+         'resource': 'gcp.bucket',
+         'filters': [{'type': 'value', 'key': 'name', 'value': bucket_name}],
+         'actions': [{
+             'type': 'set-iam-policy',
+             'remove-bindings': [{
+                 'members': ['allUsers', 'allAuthenticatedUsers'],
+                 'role': 'roles/storage.objectAdmin'
+             }]
+         }]},
+        session_factory=factory)
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'bucket': bucket_name})
+    roles = [b['role'] for b in updated_policy.get('bindings', [])]
+    assert 'roles/storage.objectAdmin' not in roles
+    all_members = [
+        member
+        for binding in updated_policy.get('bindings', [])
+        for member in binding['members']
+    ]
+    assert sa_email in all_members
 
 
 class BucketTest(BaseTest):


### PR DESCRIPTION
This PR resolves https://github.com/cloud-custodian/cloud-custodian/issues/10502

It adds a set-iam-policy action for gcp.bucket resources, allowing bucket-level IAM bindings to be added or removed via policies. The primary use case is automated remediation of publicly accessible buckets by removing allUsers and allAuthenticatedUsers from storage roles.                                                                                                                
