### PR TITLE
azure - fix metrics start-of-day test

### DIFF
--- a/tools/c7n_azure/tests_azure/tests_resources/test_armresource.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_armresource.py
@@ -1,10 +1,14 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+import datetime
+
 from ..azure_common import BaseTest, arm_template, cassette_name
 from unittest.mock import patch
 from c7n_azure.resources.generic_arm_resource import GenericArmResource
 from c7n_azure.resources.arm import arm_tags_unsupported
 from c7n.exceptions import PolicyValidationError
+from c7n.testing import mock_datetime_now
+from dateutil.parser import parse as date_parse
 
 
 class ArmResourceTest(BaseTest):
@@ -62,7 +66,9 @@ class ArmResourceTest(BaseTest):
                  'threshold': 0,
                  'period_start': 'start-of-day'}],
         })
-        resources = p.run()
+
+        with mock_datetime_now(date_parse("2026-02-21T12:00:00+00:00"), datetime):
+            resources = p.run()
         self.assertEqual(len(resources), 1)
 
     @arm_template('vm.json')


### PR DESCRIPTION
Freeze time for the start-of-day test in #10573

Extracting this from #10599 just to get CI green