### PR TITLE
feat: gcp - iam-policy filter - add value filter semantics and remove-bindings: matched

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/actions/iampolicy.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/iampolicy.py
@@ -3,6 +3,7 @@
 
 from c7n.utils import local_session, type_schema
 from c7n_gcp.actions import MethodAction
+from c7n_gcp.filters.iampolicy import IamPolicyFilter
 
 
 class SetIamPolicy(MethodAction):
@@ -30,7 +31,7 @@ class SetIamPolicy(MethodAction):
         Note the `resource` field in the example that could be changed to another resource that has
         both `setIamPolicy` and `getIamPolicy` methods (such as gcp.spanner-database-instance).
 
-        Example:
+        Example using exact values:
 
         .. code-block:: yaml
 
@@ -55,6 +56,28 @@ class SetIamPolicy(MethodAction):
                           - user:user5@gmail.com
                           - user:user6@gmail.com
                         role: roles/viewer
+
+        Example using the ``iam-policy`` filter with value filter semantics and
+        ``remove-bindings: matched`` for dry-run-safe pattern matching:
+
+        .. code-block:: yaml
+
+            policies:
+              - name: remove-service-account-admin-permissions
+                resource: gcp.project
+                filters:
+                  - type: iam-policy
+                    user-role:
+                      role:
+                        op: glob
+                        value: 'roles/*admin'
+                        value_type: normalize
+                      user:
+                        op: glob
+                        value: 'serviceAccount:*'
+                actions:
+                  - type: set-iam-policy
+                    remove-bindings: matched
         """
     schema = type_schema('set-iam-policy',
                          **{
@@ -70,14 +93,20 @@ class SetIamPolicy(MethodAction):
                                                        'minItems': 1}}
                              },
                              'remove-bindings': {
-                                 'type': 'array',
-                                 'minItems': 1,
-                                 'items': {'role': {'type': 'string'},
-                                           'members': {'oneOf': [
-                                               {'type': 'array',
-                                                'items': {'type': 'string'},
-                                                'minItems': 1},
-                                               {'enum': ['*']}]}}},
+                                 'oneOf': [
+                                     {'enum': ['matched']},
+                                     {
+                                         'type': 'array',
+                                         'minItems': 1,
+                                         'items': {
+                                             'role': {'type': 'string'},
+                                             'members': {'oneOf': [
+                                                 {'type': 'array',
+                                                  'items': {'type': 'string'},
+                                                  'minItems': 1},
+                                                 {'enum': ['*']}]}}}
+                                 ]
+                             },
                          })
     method_spec = {'op': 'setIamPolicy'}
     schema_alias = True
@@ -85,8 +114,9 @@ class SetIamPolicy(MethodAction):
     def get_resource_params(self, model, resource):
         """
         Collects `existing_bindings` with the `_get_existing_bindings` method, `add_bindings` and
-        `remove_bindings` from a policy, then calls `_remove_bindings` with the result of
-        `_add_bindings` being applied to the `existing_bindings`, and finally sets the resulting
+        `remove_bindings` from a policy, applies `_add_bindings` to the `existing_bindings`, then
+        removes bindings either via `_remove_matched_bindings` (when ``remove-bindings: matched``)
+        or `_remove_bindings` (when an explicit list is provided), and finally sets the resulting
         list at the 'bindings' key if there is at least a single record there, or assigns an empty
         object to the 'policy' key in order to avoid errors produced by the API.
 
@@ -95,10 +125,16 @@ class SetIamPolicy(MethodAction):
         """
         params = self._verb_arguments(resource)
         existing_bindings = self._get_existing_bindings(model, resource)
-        add_bindings = self.data['add-bindings'] if 'add-bindings' in self.data else []
-        remove_bindings = self.data['remove-bindings'] if 'remove-bindings' in self.data else []
+        add_bindings = self.data.get('add-bindings', [])
+        remove_bindings = self.data.get('remove-bindings', [])
         bindings_to_set = self._add_bindings(existing_bindings, add_bindings)
-        bindings_to_set = self._remove_bindings(bindings_to_set, remove_bindings)
+
+        if remove_bindings == 'matched':
+            matched_pairs = resource.get(IamPolicyFilter.annotation_key, [])
+            bindings_to_set = self._remove_matched_bindings(bindings_to_set, matched_pairs)
+        else:
+            bindings_to_set = self._remove_bindings(bindings_to_set, remove_bindings)
+
         params['body'] = {
             'policy': {'bindings': bindings_to_set} if len(bindings_to_set) > 0 else {}}
         return params
@@ -206,6 +242,27 @@ class SetIamPolicy(MethodAction):
         for role in roles_to_existing_bindings:
             if role not in roles_to_bindings_to_remove:
                 bindings.append(roles_to_existing_bindings[role])
+        return bindings
+
+    def _remove_matched_bindings(self, existing_bindings, matched_pairs):
+        """Remove specific (role, member) pairs annotated by the iam-policy filter.
+
+        Reads the list of ``{role, member}`` dicts stored by the ``iam-policy`` filter
+        under ``c7n:matched-iam-bindings`` and removes exactly those pairs from
+        ``existing_bindings``, leaving everything else intact.
+
+        :param existing_bindings: list of ``{role, members}`` dicts from the resource
+        :param matched_pairs: list of ``{role, member}`` dicts from the filter annotation
+        """
+        pairs_to_remove = {(p['role'], p['member']) for p in matched_pairs}
+        bindings = []
+        for binding in existing_bindings:
+            updated_members = [
+                m for m in binding['members']
+                if (binding['role'], m) not in pairs_to_remove
+            ]
+            if updated_members:
+                bindings.append({**binding, 'members': updated_members})
         return bindings
 
     def _get_roles_to_bindings_dict(self, bindings_list):

--- a/tools/c7n_gcp/c7n_gcp/filters/iampolicy.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/iampolicy.py
@@ -11,6 +11,8 @@ class IamPolicyFilter(Filter):
     Filters resources based on their IAM policy
     """
 
+    annotation_key = 'c7n:matched-iam-bindings'
+
     value_filter_schema = copy.deepcopy(ValueFilter.schema)
     del value_filter_schema['required']
 
@@ -19,8 +21,18 @@ class IamPolicyFilter(Filter):
         'additionalProperties': False,
         'required': ['user', 'role'],
         'properties': {
-            'user': {'type': 'string'},
-            'role': {'type': 'string'},
+            'user': {
+                'oneOf': [
+                    {'type': 'string'},
+                    value_filter_schema,
+                ]
+            },
+            'role': {
+                'oneOf': [
+                    {'type': 'string'},
+                    value_filter_schema,
+                ]
+            },
             'has': {'type': 'boolean'}
         }
     }
@@ -34,6 +46,9 @@ class IamPolicyFilter(Filter):
         return session.client(
             model.service, model.version, model.component)
 
+    def _verb_arguments(self, resource):
+        return {'resource': resource[self.manager.resource_type.id]}
+
     def process(self, resources, event=None):
         if 'doc' in self.data:
             try:
@@ -43,15 +58,78 @@ class IamPolicyFilter(Filter):
                 resources = valueFilter.process(resources)
         if 'user-role' in self.data:
             user_role = self.data['user-role']
-            key = user_role['user']
-            val = user_role['role']
-            op = 'in' if user_role.get('has', True) else 'not-in'
-            value_type = 'swap'
-            userRolePairFilter = IamPolicyUserRolePairFilter({'key': key, 'value': val,
-            'op': op, 'value_type': value_type}, self.manager)
-            resources = userRolePairFilter.process(resources)
+            user_spec = user_role['user']
+            role_spec = user_role['role']
+            has = user_role.get('has', True)
+
+            if isinstance(user_spec, dict) or isinstance(role_spec, dict):
+                resources = self._filter_by_user_role_vf(resources, user_spec, role_spec, has)
+            else:
+                op = 'in' if has else 'not-in'
+                userRolePairFilter = IamPolicyUserRolePairFilter(
+                    {'key': user_spec, 'value': role_spec, 'op': op, 'value_type': 'swap'},
+                    self.manager)
+                resources = userRolePairFilter.process(resources)
 
         return resources
+
+    def _filter_by_user_role_vf(self, resources, user_spec, role_spec, has):
+        """Filter resources using value filter semantics on user and role.
+
+        When either ``user`` or ``role`` in the ``user-role`` block is a
+        value-filter sub-object (e.g. ``{op: glob, value: 'roles/*admin'}``),
+        this method evaluates the filters against every binding in the resource's
+        IAM policy and annotates matched resources with
+        ``c7n:matched-iam-bindings`` — a list of ``{role, member}`` dicts for
+        every binding pair that passed both filters.
+
+        Resources are included when ``has: true`` (default) and at least one
+        pair matched, or when ``has: false`` and no pairs matched.
+        """
+        model = self.manager.get_model()
+        session = local_session(self.manager.session_factory)
+        client = self.get_client(session, model)
+
+        role_vf = None
+        if isinstance(role_spec, dict):
+            role_vf = ValueFilter(dict(role_spec, key='role'), self.manager)
+            role_vf.annotate = False
+
+        user_vf = None
+        if isinstance(user_spec, dict):
+            user_vf = ValueFilter(dict(user_spec, key='member'), self.manager)
+            user_vf.annotate = False
+
+        matched_resources = []
+        for r in resources:
+            iam_policy = client.execute_command('getIamPolicy', self._verb_arguments(r))
+            matched_pairs = []
+
+            for binding in iam_policy.get('bindings', []):
+                if role_vf is not None:
+                    role_matches = role_vf({'role': binding['role']})
+                else:
+                    role_matches = binding['role'] == role_spec
+
+                if not role_matches:
+                    continue
+
+                for member in binding.get('members', []):
+                    if user_vf is not None:
+                        member_matches = user_vf({'member': member})
+                    else:
+                        member_matches = member == user_spec
+
+                    if member_matches:
+                        matched_pairs.append({'role': binding['role'], 'member': member})
+
+            if has and matched_pairs:
+                r[self.annotation_key] = r.get(self.annotation_key, []) + matched_pairs
+                matched_resources.append(r)
+            elif not has and not matched_pairs:
+                matched_resources.append(r)
+
+        return matched_resources
 
     def process_resources(self, resources):
         valueFilter = IamPolicyValueFilter(self.data['doc'], self.manager)

--- a/tools/c7n_gcp/c7n_gcp/resources/storage.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/storage.py
@@ -52,8 +52,7 @@ class BucketIamPolicyFilter(IamPolicyFilter):
     permissions = ('storage.buckets.getIamPolicy',)
 
     def _verb_arguments(self, resource):
-        verb_arguments = {{"bucket": resource["name"]}}
-        return verb_arguments
+        return {"bucket": resource["name"]}
 
 
 @Bucket.action_registry.register('set-uniform-access')
@@ -170,6 +169,10 @@ class BucketSetIamPolicy(SetIamPolicy):
         add_bindings = self.data.get('add-bindings', [])
         remove_bindings = self.data.get('remove-bindings', [])
         bindings_to_set = self._add_bindings(existing_bindings, add_bindings)
-        bindings_to_set = self._remove_bindings(bindings_to_set, remove_bindings)
+        if remove_bindings == 'matched':
+            matched_pairs = resource.get(IamPolicyFilter.annotation_key, [])
+            bindings_to_set = self._remove_matched_bindings(bindings_to_set, matched_pairs)
+        else:
+            bindings_to_set = self._remove_bindings(bindings_to_set, remove_bindings)
         params['body'] = {'bindings': bindings_to_set} if bindings_to_set else {}
         return params

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWz8SZeOV4hMc7FMm8cudgl2FnusQ396bnVOGM5ZyphUnapLTKusFaUyvElFdo4ORi8w29IS3NM",
+    "etag": "CAY=",
+    "date": "Thu, 05 Mar 2026 16:18:53 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:18:53 GMT",
+    "content-length": "1136",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAY=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_2.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxcx1_n6bG2N_0YzE2d9y7LsUgTO-7lgjZf7J6NWhYJXw8W7ZXx0iCknx_ndjukjnzT6EatBqI",
+    "etag": "CAY=",
+    "date": "Thu, 05 Mar 2026 16:18:53 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:18:53 GMT",
+    "content-length": "1136",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAY=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_3.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_3.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWzhxHiOMSvIod36ES6wBdutRtcRZPTtmVxfikYHiHUB9q2d5-MOnJkWIjEAGklFk-NEAee82iA",
+    "etag": "CAY=",
+    "date": "Thu, 05 Mar 2026 16:18:54 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:18:54 GMT",
+    "content-length": "1136",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAY=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_4.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_4.json
@@ -1,0 +1,49 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWwsj8ZWfrJCC8OA3J-MkYCyAP_l3GKhRk3YStLcH14LLBbxea7_eA677BBdTJ1XoqH1FlfDwAo",
+    "etag": "CAc=",
+    "date": "Thu, 05 Mar 2026 16:18:55 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:18:55 GMT",
+    "content-length": "766",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAc=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/get-storage-v1-b_1.json
@@ -1,0 +1,139 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWwaoN9hq0QZRFgyhLBMF9B84L3M2FfcBhaAIJX8MMbcAnR6LjVO48Ckt4nidikwOus-Um-ksm0",
+    "date": "Thu, 05 Mar 2026 16:18:53 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:18:53 GMT",
+    "content-length": "23818",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b?project=stacklet-test-policies&projection=full&alt=json"
+  },
+  "body": {
+    "kind": "storage#buckets",
+    "items": [
+      {
+        "kind": "storage#bucket",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k",
+        "id": "c7n-iam-matched-test-x7r2k",
+        "name": "c7n-iam-matched-test-x7r2k",
+        "projectNumber": "859150599087",
+        "generation": "1772727489776892643",
+        "metageneration": "6",
+        "location": "US",
+        "storageClass": "STANDARD",
+        "etag": "CAY=",
+        "timeCreated": "2026-03-05T16:18:10.042Z",
+        "updated": "2026-03-05T16:18:44.692Z",
+        "acl": [
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-editors-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-editors-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-editors-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "editors"
+            }
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-owners-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-owners-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-owners-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "owners"
+            }
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "role": "OWNER",
+            "email": "c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "etag": "CAY="
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-viewers-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-viewers-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-viewers-859150599087",
+            "role": "READER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "viewers"
+            }
+          }
+        ],
+        "defaultObjectAcl": [
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-owners-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "owners"
+            }
+          },
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-editors-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "editors"
+            }
+          },
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-viewers-859150599087",
+            "role": "READER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "viewers"
+            }
+          }
+        ],
+        "owner": {
+          "entity": "project-owners-859150599087"
+        },
+        "labels": {
+          "goog-terraform-provisioned": "true",
+          "env": "test"
+        },
+        "softDeletePolicy": {
+          "retentionDurationSeconds": "604800",
+          "effectiveTime": "2026-03-05T16:18:10.042Z"
+        },
+        "iamConfiguration": {
+          "bucketPolicyOnly": {
+            "enabled": false
+          },
+          "uniformBucketLevelAccess": {
+            "enabled": false
+          },
+          "publicAccessPrevention": "inherited"
+        },
+        "locationType": "multi-region",
+        "rpo": "DEFAULT"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/put-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-chained/put-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
@@ -1,0 +1,49 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxy_qKOxiTQua5igIIYuTODCcBjYAMHFP5fH2hbBjsv_FCdeA6lhs2VcyyDcCMHqojyQMNvBMo",
+    "etag": "CAc=",
+    "date": "Thu, 05 Mar 2026 16:18:55 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+    "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+    "pragma": "no-cache",
+    "content-length": "766",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAc=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWyXlQw_JM7LgZVHozabx-Y8KazlF3Ko83uQtgZRedO6sV04yD-mYoYNay6E5Zpbm6lc03HBui8",
+    "etag": "CAY=",
+    "date": "Thu, 05 Mar 2026 16:13:19 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:13:19 GMT",
+    "content-length": "1136",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAY=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_2.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWy3yvybs13pkgPSoRQ4kyB0XertkubUmSzTe86sLl8kR8gwHXH0so2OxMOmNRzshHnagJu07YU",
+    "etag": "CAY=",
+    "date": "Thu, 05 Mar 2026 16:13:20 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:13:20 GMT",
+    "content-length": "1136",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAY=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_3.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_3.json
@@ -1,0 +1,56 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWzmN0UnLnUaZXj602QT71gyt4PWWNfl9GjxhM1qu2IhSRfE4IBDpXmD_Q67ivi813sV81RZLMQ",
+    "etag": "CAc=",
+    "date": "Thu, 05 Mar 2026 16:13:21 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:13:21 GMT",
+    "content-length": "1038",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAc=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/get-storage-v1-b_1.json
@@ -1,0 +1,139 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWyDxVz5bj3VJj7MLG7K8-VFvI49svswWdafVyxkcbeN3C8yRhwnu1BsiBz7t7W3RzAJ0nn8rg",
+    "date": "Thu, 05 Mar 2026 16:13:19 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:13:19 GMT",
+    "content-length": "23818",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b?project=stacklet-test-policies&projection=full&alt=json"
+  },
+  "body": {
+    "kind": "storage#buckets",
+    "items": [
+      {
+        "kind": "storage#bucket",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k",
+        "id": "c7n-iam-matched-test-x7r2k",
+        "name": "c7n-iam-matched-test-x7r2k",
+        "projectNumber": "859150599087",
+        "generation": "1772727151232518954",
+        "metageneration": "6",
+        "location": "US",
+        "storageClass": "STANDARD",
+        "etag": "CAY=",
+        "timeCreated": "2026-03-05T16:12:31.725Z",
+        "updated": "2026-03-05T16:13:11.638Z",
+        "acl": [
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-editors-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-editors-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-editors-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "editors"
+            }
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-owners-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-owners-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-owners-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "owners"
+            }
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "role": "OWNER",
+            "email": "c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "etag": "CAY="
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-viewers-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-viewers-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-viewers-859150599087",
+            "role": "READER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "viewers"
+            }
+          }
+        ],
+        "defaultObjectAcl": [
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-owners-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "owners"
+            }
+          },
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-editors-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "editors"
+            }
+          },
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-viewers-859150599087",
+            "role": "READER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "viewers"
+            }
+          }
+        ],
+        "owner": {
+          "entity": "project-owners-859150599087"
+        },
+        "labels": {
+          "env": "test",
+          "goog-terraform-provisioned": "true"
+        },
+        "softDeletePolicy": {
+          "retentionDurationSeconds": "604800",
+          "effectiveTime": "2026-03-05T16:12:31.725Z"
+        },
+        "iamConfiguration": {
+          "bucketPolicyOnly": {
+            "enabled": false
+          },
+          "uniformBucketLevelAccess": {
+            "enabled": false
+          },
+          "publicAccessPrevention": "inherited"
+        },
+        "locationType": "multi-region",
+        "rpo": "DEFAULT"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/put-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-exact-role/put-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
@@ -1,0 +1,56 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWy2Z_enIWXwcu5HIWsJaQRZv9EuSmbvTi3_4183vqF7jzHepyE_uot8G17z2bV7BKmHGTgP8T0",
+    "etag": "CAc=",
+    "date": "Thu, 05 Mar 2026 16:13:21 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+    "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+    "pragma": "no-cache",
+    "content-length": "1038",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAc=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWwyML_uHb1MesxZ40HRpFzf5g6gTUA6oAl9mTIwifXlBSIUPjUO5EFgd0PtNeTz4mqHPNIpX_M",
+    "etag": "CAY=",
+    "date": "Thu, 05 Mar 2026 16:07:32 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:07:32 GMT",
+    "content-length": "1136",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAY=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_2.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_2.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxLzH95KfJt-HQM6WAzCZsIiRo4q7emfxzTQEQVk_ZGDFpWyIGwnkeucSOhWqh5M2VMHfbpHbg",
+    "etag": "CAY=",
+    "date": "Thu, 05 Mar 2026 16:07:32 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:07:32 GMT",
+    "content-length": "1136",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAY=",
+    "bindings": [
+      {
+        "role": "roles/storage.admin",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_3.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/get-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_3.json
@@ -1,0 +1,50 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxPQ_I1-3ngWc8B_LgKk5u74UJwasrn0Y_cLAXMMdFKp5woc8w1gna2o7P2NRnRtPvEe-0tt04",
+    "etag": "CAc=",
+    "date": "Thu, 05 Mar 2026 16:07:34 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:07:34 GMT",
+    "content-length": "864",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/iam?alt=json"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAc=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/get-storage-v1-b_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/get-storage-v1-b_1.json
@@ -1,0 +1,139 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWxLtY2br1JHJgVNi0AchoTTnGPLxtOf8VzD46AKuQzcFPl1qYACwvGatP6dILm42lDZkjlGeA",
+    "date": "Thu, 05 Mar 2026 16:07:32 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "expires": "Thu, 05 Mar 2026 16:07:32 GMT",
+    "content-length": "23818",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200",
+    "content-location": "https://storage.googleapis.com/storage/v1/b?project=stacklet-test-policies&projection=full&alt=json"
+  },
+  "body": {
+    "kind": "storage#buckets",
+    "items": [
+      {
+        "kind": "storage#bucket",
+        "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k",
+        "id": "c7n-iam-matched-test-x7r2k",
+        "name": "c7n-iam-matched-test-x7r2k",
+        "projectNumber": "859150599087",
+        "generation": "1772726811343937157",
+        "metageneration": "6",
+        "location": "US",
+        "storageClass": "STANDARD",
+        "etag": "CAY=",
+        "timeCreated": "2026-03-05T16:06:51.794Z",
+        "updated": "2026-03-05T16:07:23.937Z",
+        "acl": [
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-editors-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-editors-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-editors-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "editors"
+            }
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-owners-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-owners-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-owners-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "owners"
+            }
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "user-c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "role": "OWNER",
+            "email": "c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+            "etag": "CAY="
+          },
+          {
+            "kind": "storage#bucketAccessControl",
+            "id": "c7n-iam-matched-test-x7r2k/project-viewers-859150599087",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k/acl/project-viewers-859150599087",
+            "bucket": "c7n-iam-matched-test-x7r2k",
+            "entity": "project-viewers-859150599087",
+            "role": "READER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "viewers"
+            }
+          }
+        ],
+        "defaultObjectAcl": [
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-owners-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "owners"
+            }
+          },
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-editors-859150599087",
+            "role": "OWNER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "editors"
+            }
+          },
+          {
+            "kind": "storage#objectAccessControl",
+            "entity": "project-viewers-859150599087",
+            "role": "READER",
+            "etag": "CAY=",
+            "projectTeam": {
+              "projectNumber": "859150599087",
+              "team": "viewers"
+            }
+          }
+        ],
+        "owner": {
+          "entity": "project-owners-859150599087"
+        },
+        "labels": {
+          "goog-terraform-provisioned": "true",
+          "env": "test"
+        },
+        "softDeletePolicy": {
+          "retentionDurationSeconds": "604800",
+          "effectiveTime": "2026-03-05T16:06:51.794Z"
+        },
+        "iamConfiguration": {
+          "bucketPolicyOnly": {
+            "enabled": false
+          },
+          "uniformBucketLevelAccess": {
+            "enabled": false
+          },
+          "publicAccessPrevention": "inherited"
+        },
+        "locationType": "multi-region",
+        "rpo": "DEFAULT"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/put-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
+++ b/tools/c7n_gcp/tests/data/flights/bucket-iam-policy-matched-glob-admin/put-storage-v1-b-c7n-iam-matched-test-x7r2k-iam_1.json
@@ -1,0 +1,50 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "x-guploader-uploadid": "AGQBYWyVABshW-f0o6tscdetkd2_KSlV1OOVp_nCDGr9iTuTnfEYQlhwYyxBcwF8RBR_wSplgrnRruQ",
+    "etag": "CAc=",
+    "date": "Thu, 05 Mar 2026 16:07:34 GMT",
+    "vary": "Origin, X-Origin",
+    "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+    "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+    "pragma": "no-cache",
+    "content-length": "864",
+    "server": "UploadServer",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "status": "200"
+  },
+  "body": {
+    "kind": "storage#policy",
+    "resourceId": "projects/cloud-custodian/buckets/c7n-iam-matched-test-x7r2k",
+    "version": 1,
+    "etag": "CAc=",
+    "bindings": [
+      {
+        "role": "roles/storage.legacyBucketOwner",
+        "members": [
+          "projectEditor:stacklet-test-policies",
+          "projectOwner:stacklet-test-policies",
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/storage.legacyBucketReader",
+        "members": [
+          "projectViewer:stacklet-test-policies"
+        ]
+      },
+      {
+        "role": "roles/storage.objectAdmin",
+        "members": [
+          "allAuthenticatedUsers"
+        ]
+      },
+      {
+        "role": "roles/storage.objectViewer",
+        "members": [
+          "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/get-v1-projects_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/get-v1-projects_1.json
@@ -1,0 +1,36 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 15:40:23 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=350",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "21478",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v1/projects?alt=json"
+  },
+  "body": {
+    "projects": [
+      {
+        "projectNumber": "859150599087",
+        "projectId": "stacklet-test-policies",
+        "lifecycleState": "ACTIVE",
+        "name": "stacklet-test-policies",
+        "labels": {
+          "generative-language": "enabled"
+        },
+        "createTime": "2024-06-18T00:45:41.145362Z",
+        "parent": {
+          "type": "organization",
+          "id": "728386023487"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/post-v1-projects-stacklet-test-policies-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/post-v1-projects-stacklet-test-policies-getIamPolicy_1.json
@@ -1,0 +1,41 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 15:40:23 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=369",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5299",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwZMSMDIYHw=",
+    "bindings": [
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/owner",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/post-v1-projects-stacklet-test-policies-getIamPolicy_2.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/post-v1-projects-stacklet-test-policies-getIamPolicy_2.json
@@ -1,0 +1,41 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 15:40:25 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=266",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5299",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwZMSMDIYHw=",
+    "bindings": [
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/owner",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/post-v1-projects-stacklet-test-policies-getIamPolicy_3.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/post-v1-projects-stacklet-test-policies-getIamPolicy_3.json
@@ -1,0 +1,41 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 15:40:25 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=429",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5299",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwZMSMDIYHw=",
+    "bindings": [
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/owner",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/post-v1-projects-stacklet-test-policies-setIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-chained-filters/post-v1-projects-stacklet-test-policies-setIamPolicy_1.json
@@ -1,0 +1,29 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 15:40:26 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=1011",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5040",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwZMSMFsMUM=",
+    "bindings": [
+      {
+        "role": "roles/viewer",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/get-v1-projects_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/get-v1-projects_1.json
@@ -1,0 +1,36 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 16:30:25 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=281",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "21478",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudresourcemanager.googleapis.com/v1/projects?alt=json"
+  },
+  "body": {
+    "projects": [
+      {
+        "projectNumber": "859150599087",
+        "projectId": "stacklet-test-policies",
+        "lifecycleState": "ACTIVE",
+        "name": "stacklet-test-policies",
+        "labels": {
+          "generative-language": "enabled"
+        },
+        "createTime": "2024-06-18T00:45:41.145362Z",
+        "parent": {
+          "type": "organization",
+          "id": "728386023487"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/post-v1-projects-stacklet-test-policies-getIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/post-v1-projects-stacklet-test-policies-getIamPolicy_1.json
@@ -1,0 +1,41 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 16:30:26 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=418",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5299",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwZMSXO+aBg=",
+    "bindings": [
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/owner",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/post-v1-projects-stacklet-test-policies-getIamPolicy_2.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/post-v1-projects-stacklet-test-policies-getIamPolicy_2.json
@@ -1,0 +1,41 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 16:30:26 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=323",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5299",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwZMSXO+aBg=",
+    "bindings": [
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/owner",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/post-v1-projects-stacklet-test-policies-getIamPolicy_3.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/post-v1-projects-stacklet-test-policies-getIamPolicy_3.json
@@ -1,0 +1,35 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 16:30:27 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=289",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5204",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwZMSXRJaFU=",
+    "bindings": [
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/post-v1-projects-stacklet-test-policies-setIamPolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/project-iam-policy-matched-action/post-v1-projects-stacklet-test-policies-setIamPolicy_1.json
@@ -1,0 +1,35 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Thu, 05 Mar 2026 16:30:27 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "server-timing": "gfet4t7; dur=974",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5204",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "version": 1,
+    "etag": "BwZMSXRJaFU=",
+    "bindings": [
+      {
+        "role": "roles/editor",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      },
+      {
+        "role": "roles/viewer",
+        "members": [
+          "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/bucket_iam_policy_matched/main.tf
+++ b/tools/c7n_gcp/tests/terraform/bucket_iam_policy_matched/main.tf
@@ -1,0 +1,57 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project = var.google_project_id
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "c7n-iam-matched-test-x7r2k"
+  location = "US"
+
+  labels = {
+    env = "test"
+  }
+}
+
+resource "google_service_account" "sa" {
+  account_id   = "c7n-iam-matched-sa-x7r2k"
+  display_name = "C7N IAM Matched Test SA"
+  project      = var.google_project_id
+}
+
+# Matches roles/*admin via value_type: normalize (objectAdmin -> objectadmin)
+resource "google_storage_bucket_iam_member" "sa_object_admin" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+# Matches roles/*admin directly (already lowercase)
+resource "google_storage_bucket_iam_member" "sa_admin" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+# Used for exact-role-match testing (op: in); does NOT match roles/*admin
+resource "google_storage_bucket_iam_member" "sa_legacy_owner" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.legacyBucketOwner"
+  member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+# Never matches any test pattern — verifies viewer bindings are always preserved
+resource "google_storage_bucket_iam_member" "sa_viewer" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.sa.email}"
+}
+
+# Non-SA member in an admin role — verifies SA-only patterns leave other members intact
+resource "google_storage_bucket_iam_member" "non_sa_object_admin" {
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectAdmin"
+  member = "allAuthenticatedUsers"
+}

--- a/tools/c7n_gcp/tests/terraform/bucket_iam_policy_matched/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/bucket_iam_policy_matched/tf_resources.json
@@ -1,0 +1,123 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_service_account": {
+            "sa": {
+                "account_id": "c7n-iam-matched-sa-x7r2k",
+                "create_ignore_already_exists": null,
+                "description": "",
+                "disabled": false,
+                "display_name": "C7N IAM Matched Test SA",
+                "email": "c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "id": "projects/cloud-custodian/serviceAccounts/c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "name": "projects/cloud-custodian/serviceAccounts/c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "project": "stacklet-test-policies",
+                "timeouts": null,
+                "unique_id": "115290089626129128652"
+            }
+        },
+        "google_storage_bucket": {
+            "bucket": {
+                "autoclass": [],
+                "cors": [],
+                "custom_placement_config": [],
+                "default_event_based_hold": false,
+                "effective_labels": {
+                    "env": "test",
+                    "goog-terraform-provisioned": "true"
+                },
+                "enable_object_retention": false,
+                "encryption": [],
+                "force_destroy": false,
+                "hierarchical_namespace": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "id": "c7n-iam-matched-test-x7r2k",
+                "ip_filter": [],
+                "labels": {
+                    "env": "test"
+                },
+                "lifecycle_rule": [],
+                "location": "US",
+                "logging": [],
+                "name": "c7n-iam-matched-test-x7r2k",
+                "project": "stacklet-test-policies",
+                "project_number": 859150599087,
+                "public_access_prevention": "inherited",
+                "requester_pays": false,
+                "retention_policy": [],
+                "rpo": "DEFAULT",
+                "self_link": "https://www.googleapis.com/storage/v1/b/c7n-iam-matched-test-x7r2k",
+                "soft_delete_policy": [
+                    {
+                        "effective_time": "2026-03-05T16:18:10.042Z",
+                        "retention_duration_seconds": 604800
+                    }
+                ],
+                "storage_class": "STANDARD",
+                "terraform_labels": {
+                    "env": "test",
+                    "goog-terraform-provisioned": "true"
+                },
+                "time_created": "2026-03-05T16:18:10.042Z",
+                "timeouts": null,
+                "uniform_bucket_level_access": false,
+                "updated": "2026-03-05T16:18:10.042Z",
+                "url": "gs://c7n-iam-matched-test-x7r2k",
+                "versioning": [],
+                "website": []
+            }
+        },
+        "google_storage_bucket_iam_member": {
+            "non_sa_object_admin": {
+                "bucket": "b/c7n-iam-matched-test-x7r2k",
+                "condition": [],
+                "etag": "CAI=",
+                "id": "b/c7n-iam-matched-test-x7r2k/roles/storage.objectAdmin/allAuthenticatedUsers",
+                "member": "allAuthenticatedUsers",
+                "role": "roles/storage.objectAdmin",
+                "timeouts": null
+            },
+            "sa_admin": {
+                "bucket": "b/c7n-iam-matched-test-x7r2k",
+                "condition": [],
+                "etag": "CAY=",
+                "id": "b/c7n-iam-matched-test-x7r2k/roles/storage.admin/serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "role": "roles/storage.admin",
+                "timeouts": null
+            },
+            "sa_legacy_owner": {
+                "bucket": "b/c7n-iam-matched-test-x7r2k",
+                "condition": [],
+                "etag": "CAY=",
+                "id": "b/c7n-iam-matched-test-x7r2k/roles/storage.legacyBucketOwner/serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "role": "roles/storage.legacyBucketOwner",
+                "timeouts": null
+            },
+            "sa_object_admin": {
+                "bucket": "b/c7n-iam-matched-test-x7r2k",
+                "condition": [],
+                "etag": "CAM=",
+                "id": "b/c7n-iam-matched-test-x7r2k/roles/storage.objectAdmin/serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "role": "roles/storage.objectAdmin",
+                "timeouts": null
+            },
+            "sa_viewer": {
+                "bucket": "b/c7n-iam-matched-test-x7r2k",
+                "condition": [],
+                "etag": "CAY=",
+                "id": "b/c7n-iam-matched-test-x7r2k/roles/storage.objectViewer/serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-matched-sa-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "role": "roles/storage.objectViewer",
+                "timeouts": null
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/terraform/project_iam_policy_chained/main.tf
+++ b/tools/c7n_gcp/tests/terraform/project_iam_policy_chained/main.tf
@@ -1,0 +1,38 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project = var.google_project_id
+}
+
+data "google_project" "project" {
+  project_id = var.google_project_id
+}
+
+resource "google_service_account" "sa" {
+  account_id   = "c7n-iam-chained-x7r2k"
+  display_name = "C7N IAM Chained Filters Test SA"
+  project      = var.google_project_id
+}
+
+# Matched by first iam-policy filter (op: glob, value: 'roles/owner')
+resource "google_project_iam_member" "sa_owner" {
+  project = var.google_project_id
+  role    = "roles/owner"
+  member  = "serviceAccount:${google_service_account.sa.email}"
+}
+
+# Matched by second iam-policy filter (op: glob, value: 'roles/editor')
+resource "google_project_iam_member" "sa_editor" {
+  project = var.google_project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:${google_service_account.sa.email}"
+}
+
+# Never matched — verifies viewer binding is preserved
+resource "google_project_iam_member" "sa_viewer" {
+  project = var.google_project_id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.sa.email}"
+}

--- a/tools/c7n_gcp/tests/terraform/project_iam_policy_chained/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/project_iam_policy_chained/tf_resources.json
@@ -1,0 +1,71 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_project": {
+            "project": {
+                "auto_create_network": null,
+                "billing_account": "0189B3-1C2257-05D123",
+                "deletion_policy": "PREVENT",
+                "effective_labels": {
+                    "generative-language": "enabled"
+                },
+                "folder_id": "",
+                "id": "projects/stacklet-test-policies",
+                "labels": {
+                    "generative-language": "enabled"
+                },
+                "name": "stacklet-test-policies",
+                "number": "859150599087",
+                "org_id": "728386023487",
+                "project_id": "stacklet-test-policies",
+                "tags": null,
+                "terraform_labels": {
+                    "generative-language": "enabled"
+                }
+            }
+        },
+        "google_project_iam_member": {
+            "sa_editor": {
+                "condition": [],
+                "etag": "BwZMSXO+aBg=",
+                "id": "stacklet-test-policies/roles/editor/serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "project": "stacklet-test-policies",
+                "role": "roles/editor"
+            },
+            "sa_owner": {
+                "condition": [],
+                "etag": "BwZMSXO+aBg=",
+                "id": "stacklet-test-policies/roles/owner/serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "project": "stacklet-test-policies",
+                "role": "roles/owner"
+            },
+            "sa_viewer": {
+                "condition": [],
+                "etag": "BwZMSXO+aBg=",
+                "id": "stacklet-test-policies/roles/viewer/serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "project": "stacklet-test-policies",
+                "role": "roles/viewer"
+            }
+        },
+        "google_service_account": {
+            "sa": {
+                "account_id": "c7n-iam-chained-x7r2k",
+                "create_ignore_already_exists": null,
+                "description": "",
+                "disabled": false,
+                "display_name": "C7N IAM Chained Filters Test SA",
+                "email": "c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "id": "projects/cloud-custodian/serviceAccounts/c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "member": "serviceAccount:c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "name": "projects/cloud-custodian/serviceAccounts/c7n-iam-chained-x7r2k@stacklet-test-policies.iam.gserviceaccount.com",
+                "project": "stacklet-test-policies",
+                "timeouts": null,
+                "unique_id": "102203245154946241563"
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/test_iam_policy_matched.py
+++ b/tools/c7n_gcp/tests/test_iam_policy_matched.py
@@ -1,0 +1,198 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from pytest_terraform import terraform
+
+
+@terraform("bucket_iam_policy_matched")
+def test_bucket_set_iam_policy_matched_glob_admin(test, bucket_iam_policy_matched):
+    """
+    iam-policy filter with glob + value_type: normalize
+    on the role, glob on the member, then remove-bindings: matched.
+
+    Bucket has a SA in four roles:
+      - roles/storage.objectAdmin  -> matches roles/*admin (normalized to objectadmin)
+      - roles/storage.admin        -> matches roles/*admin directly
+      - roles/storage.legacyBucketOwner -> does NOT match roles/*admin
+      - roles/storage.objectViewer -> does NOT match roles/*admin
+
+    Also has allAuthenticatedUsers in roles/storage.objectAdmin to verify that
+    non-SA members in a matching role are left untouched.
+
+    Policy:
+      filters:
+        - type: iam-policy
+          user-role:
+            role: {op: glob, value_type: normalize, value: 'roles/*admin'}
+            user: {op: glob, value: 'serviceAccount:*'}
+      actions:
+        - type: set-iam-policy
+          remove-bindings: matched
+    """
+    bucket_name = bucket_iam_policy_matched.resources['google_storage_bucket']['bucket']['name']
+    sa_email = (
+        'serviceAccount:'
+        + bucket_iam_policy_matched.resources['google_service_account']['sa']['email']
+    )
+    factory = test.replay_flight_data('bucket-iam-policy-matched-glob-admin')
+
+    policy = test.load_policy(
+        {
+            'name': 'bucket-iam-policy-matched-glob-admin',
+            'resource': 'gcp.bucket',
+            'filters': [
+                {'type': 'value', 'key': 'name', 'value': bucket_name},
+                {
+                    'type': 'iam-policy',
+                    'user-role': {
+                        'role': {
+                            'op': 'glob',
+                            'value_type': 'normalize',
+                            'value': 'roles/*admin',
+                        },
+                        'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                    },
+                },
+            ],
+            'actions': [{'type': 'set-iam-policy', 'remove-bindings': 'matched'}],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'bucket': bucket_name})
+    bindings = {b['role']: b['members'] for b in updated_policy.get('bindings', [])}
+
+    assert sa_email not in bindings.get('roles/storage.objectAdmin', [])
+    assert sa_email not in bindings.get('roles/storage.admin', [])
+
+    assert 'allAuthenticatedUsers' in bindings.get('roles/storage.objectAdmin', [])
+
+    assert sa_email in bindings.get('roles/storage.legacyBucketOwner', [])
+    assert sa_email in bindings.get('roles/storage.objectViewer', [])
+
+
+@terraform("bucket_iam_policy_matched")
+def test_bucket_set_iam_policy_matched_exact_role(test, bucket_iam_policy_matched):
+    """
+    Exact role matching using op: in — equivalent to targeting roles/owner and
+    roles/editor at the project level.
+
+    Only the SA binding for roles/storage.legacyBucketOwner is removed; all
+    other bindings are untouched.
+    """
+    bucket_name = bucket_iam_policy_matched.resources['google_storage_bucket']['bucket']['name']
+    sa_email = (
+        'serviceAccount:'
+        + bucket_iam_policy_matched.resources['google_service_account']['sa']['email']
+    )
+    factory = test.replay_flight_data('bucket-iam-policy-matched-exact-role')
+
+    policy = test.load_policy(
+        {
+            'name': 'bucket-iam-policy-matched-exact-role',
+            'resource': 'gcp.bucket',
+            'filters': [
+                {'type': 'value', 'key': 'name', 'value': bucket_name},
+                {
+                    'type': 'iam-policy',
+                    'user-role': {
+                        'role': {
+                            'op': 'in',
+                            'value': ['roles/storage.legacyBucketOwner'],
+                        },
+                        'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                    },
+                },
+            ],
+            'actions': [{'type': 'set-iam-policy', 'remove-bindings': 'matched'}],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'bucket': bucket_name})
+    bindings = {b['role']: b['members'] for b in updated_policy.get('bindings', [])}
+
+    assert sa_email not in bindings.get('roles/storage.legacyBucketOwner', [])
+
+    assert sa_email in bindings.get('roles/storage.objectAdmin', [])
+    assert sa_email in bindings.get('roles/storage.admin', [])
+    assert sa_email in bindings.get('roles/storage.objectViewer', [])
+
+
+@terraform("bucket_iam_policy_matched")
+def test_bucket_set_iam_policy_matched_chained_exact_and_glob(test, bucket_iam_policy_matched):
+    """
+    chained iam-policy filters combine exact-role matching
+    (op: in) AND glob-pattern matching (op: glob + normalize)
+    into a single policy via accumulated c7n:matched-iam-bindings.
+
+    After running, only roles/storage.objectViewer retains the SA.
+    """
+    bucket_name = bucket_iam_policy_matched.resources['google_storage_bucket']['bucket']['name']
+    sa_email = (
+        'serviceAccount:'
+        + bucket_iam_policy_matched.resources['google_service_account']['sa']['email']
+    )
+    factory = test.replay_flight_data('bucket-iam-policy-matched-chained')
+
+    policy = test.load_policy(
+        {
+            'name': 'bucket-iam-policy-matched-chained',
+            'resource': 'gcp.bucket',
+            'filters': [
+                {'type': 'value', 'key': 'name', 'value': bucket_name},
+                {
+                    'type': 'iam-policy',
+                    'user-role': {
+                        'role': {
+                            'op': 'in',
+                            'value': ['roles/storage.legacyBucketOwner'],
+                        },
+                        'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                    },
+                },
+                {
+                    'type': 'iam-policy',
+                    'user-role': {
+                        'role': {
+                            'op': 'glob',
+                            'value_type': 'normalize',
+                            'value': 'roles/*admin',
+                        },
+                        'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                    },
+                },
+            ],
+            'actions': [{'type': 'set-iam-policy', 'remove-bindings': 'matched'}],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    matched = resources[0]['c7n:matched-iam-bindings']
+    matched_roles = {pair['role'] for pair in matched}
+    assert 'roles/storage.legacyBucketOwner' in matched_roles
+    assert 'roles/storage.objectAdmin' in matched_roles
+    assert 'roles/storage.admin' in matched_roles
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'bucket': bucket_name})
+    bindings = {b['role']: b['members'] for b in updated_policy.get('bindings', [])}
+
+    assert sa_email not in bindings.get('roles/storage.objectAdmin', [])
+    assert sa_email not in bindings.get('roles/storage.admin', [])
+    assert sa_email not in bindings.get('roles/storage.legacyBucketOwner', [])
+
+    assert sa_email in bindings.get('roles/storage.objectViewer', [])
+
+    assert 'allAuthenticatedUsers' in bindings.get('roles/storage.objectAdmin', [])

--- a/tools/c7n_gcp/tests/test_resourcemanager.py
+++ b/tools/c7n_gcp/tests/test_resourcemanager.py
@@ -7,6 +7,7 @@ import time
 from unittest import mock
 
 import pytest
+from pytest_terraform import terraform
 
 from c7n_gcp.resources.resourcemanager import (
     FolderIamPolicyFilter, HierarchyAction, OrganizationIamPolicyFilter
@@ -522,6 +523,73 @@ class ProjectTest(BaseTest):
             self.assertTrue("abcdefg" in user_role_pair)
             self.assertTrue('roles/admin' in user_role_pair["abcdefg"])
 
+    def test_project_iam_policy_user_role_value_filter_glob(self):
+        """user-role with value filter objects (glob) annotates matched bindings."""
+        factory = self.replay_flight_data('project-iam-policy')
+        p = self.load_policy({
+            'name': 'resource',
+            'resource': 'gcp.project',
+            'filters': [{
+                'type': 'iam-policy',
+                'user-role': {
+                    'role': {'op': 'glob', 'value': 'roles/owner'},
+                    'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                }
+            }]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['projectId'], 'custodian-test')
+        matched = resources[0]['c7n:matched-iam-bindings']
+        self.assertEqual(len(matched), 1)
+        self.assertEqual(matched[0]['role'], 'roles/owner')
+        self.assertEqual(
+            matched[0]['member'], 'serviceAccount:abc@testproject.iam.gserviceaccount.com')
+
+    def test_project_iam_policy_user_role_value_filter_glob_multi(self):
+        """user-role value filter matching serviceAccounts across roles returns all matches."""
+        factory = self.replay_flight_data('project-iam-policy')
+        p = self.load_policy({
+            'name': 'resource',
+            'resource': 'gcp.project',
+            'filters': [{
+                'type': 'iam-policy',
+                'user-role': {
+                    'role': {'op': 'glob', 'value': 'roles/*'},
+                    'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                }
+            }]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+        project_ids = {r['projectId'] for r in resources}
+        self.assertIn('custodian-test', project_ids)
+        self.assertIn('custodian-test-2', project_ids)
+        for r in resources:
+            self.assertIn('c7n:matched-iam-bindings', r)
+            for pair in r['c7n:matched-iam-bindings']:
+                self.assertTrue(pair['member'].startswith('serviceAccount:'))
+
+    def test_project_iam_policy_user_role_value_filter_has_false(self):
+        """user-role with has: false returns resources with no matching pairs."""
+        factory = self.replay_flight_data('project-iam-policy')
+        p = self.load_policy({
+            'name': 'resource',
+            'resource': 'gcp.project',
+            'filters': [{
+                'type': 'iam-policy',
+                'user-role': {
+                    'has': False,
+                    'role': {'op': 'glob', 'value': 'roles/owner'},
+                    'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                }
+            }]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+        project_ids = {r['projectId'] for r in resources}
+        self.assertNotIn('custodian-test', project_ids)
+
     def test_compute_meta_filter(self):
         factory = self.replay_flight_data('project-compute-meta')
 
@@ -727,3 +795,107 @@ class TestOrgPoliciesFilter(BaseTest):
             'c7n:MatchedFilters': ['constraint']
         }])
         self.assertEqual(len(resources), 1)
+
+
+@terraform("project_iam_policy_chained")
+def test_project_iam_policy_user_role_value_filter_chained_appends(
+    test, project_iam_policy_chained
+):
+    """Chained iam-policy user-role filters accumulate matched bindings instead of overwriting.
+
+    Two sequential filters each match a different role/SA pair on the same project.
+    The action's ``remove-bindings: matched`` then removes both accumulated pairs.
+    """
+    project_id = project_iam_policy_chained.resources['google_project']['project']['project_id']
+    factory = test.replay_flight_data('project-iam-policy-chained-filters')
+    p = test.load_policy(
+        {
+            'name': 'chained-iam-policy-filters',
+            'resource': 'gcp.project',
+            'filters': [
+                {'type': 'value', 'key': 'projectId', 'value': project_id},
+                {
+                    'type': 'iam-policy',
+                    'user-role': {
+                        'role': {'op': 'glob', 'value': 'roles/owner'},
+                        'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                    },
+                },
+                {
+                    'type': 'iam-policy',
+                    'user-role': {
+                        'role': {'op': 'glob', 'value': 'roles/editor'},
+                        'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                    },
+                },
+            ],
+            'actions': [{'type': 'set-iam-policy', 'remove-bindings': 'matched'}],
+        },
+        session_factory=factory,
+    )
+    resources = p.run()
+    assert len(resources) == 1
+    matched = resources[0]['c7n:matched-iam-bindings']
+    roles = {pair['role'] for pair in matched}
+    assert 'roles/owner' in roles
+    assert 'roles/editor' in roles
+
+
+@terraform("project_iam_policy_chained")
+def test_project_set_iam_policy_remove_matched(test, project_iam_policy_chained):
+    """remove-bindings: matched removes only the (role, member) pairs annotated by the filter.
+
+    The project has a SA bound to roles/owner (matched and removed) and
+    roles/viewer (not matched, preserved).
+
+    Policy:
+      filters:
+        - type: iam-policy
+          user-role:
+            role: {op: glob, value: 'roles/owner'}
+            user: {op: glob, value: 'serviceAccount:*'}
+      actions:
+        - type: set-iam-policy
+          remove-bindings: matched
+    """
+    sa_email = (
+        'serviceAccount:'
+        + project_iam_policy_chained.resources['google_service_account']['sa']['email']
+    )
+    project_id = project_iam_policy_chained.resources['google_project']['project']['project_id']
+    factory = test.replay_flight_data('project-iam-policy-matched-action')
+
+    policy = test.load_policy(
+        {
+            'name': 'remove-sa-owners',
+            'resource': 'gcp.project',
+            'filters': [
+                {'type': 'value', 'key': 'projectId', 'value': project_id},
+                {
+                    'type': 'iam-policy',
+                    'user-role': {
+                        'role': {'op': 'glob', 'value': 'roles/owner'},
+                        'user': {'op': 'glob', 'value': 'serviceAccount:*'},
+                    },
+                },
+            ],
+            'actions': [{'type': 'set-iam-policy', 'remove-bindings': 'matched'}],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    matched = resources[0]['c7n:matched-iam-bindings']
+    assert len(matched) >= 1
+    assert any(p['role'] == 'roles/owner' for p in matched)
+    assert any(p['member'].startswith('serviceAccount:') for p in matched)
+
+    client = policy.resource_manager.get_client()
+    updated_policy = client.execute_query('getIamPolicy', {'resource': project_id})
+    bindings = {b['role']: b['members'] for b in updated_policy.get('bindings', [])}
+
+    assert sa_email not in bindings.get('roles/owner', [])
+
+    assert sa_email in bindings.get('roles/viewer', [])

--- a/tools/c7n_gcp/tests/test_spanner.py
+++ b/tools/c7n_gcp/tests/test_spanner.py
@@ -381,6 +381,42 @@ class SpannerDatabaseInstanceTest(BaseTest):
 
         self.assertEqual(test_method(existing_bindings, bindings_to_remove), expected_bindings)
 
+    def test_set_iam_policy_remove_bindings_preserves_condition(self):
+        """
+        Tests that a binding's ``condition`` field is preserved when only some members are
+        removed and the binding survives. Previously, ``_remove_bindings`` constructed a fresh
+        ``{'role': ..., 'members': ...}`` dict, silently dropping any extra fields such as
+        ``condition``. The fix uses ``{**existing_binding, 'members': updated_members}`` so
+        that all original fields are retained.
+        """
+        policy = self.load_policy(
+            {'name': 'spanner-database-instance-set-iam-policy-condition',
+             'resource': 'gcp.spanner-database-instance',
+             'actions': [{'type': 'set-iam-policy'}]})
+        test_method = policy.resource_manager.actions[0]._remove_bindings
+
+        condition = {
+            'title': 'Expires 2025',
+            'expression': "request.time < timestamp('2025-01-01T00:00:00Z')",
+        }
+        existing_bindings = [
+            {'role': 'roles/owner',
+             'members': ['serviceAccount:sa@project.iam.gserviceaccount.com',
+                         'user:alice@example.com'],
+             'condition': condition},
+        ]
+        bindings_to_remove = [
+            {'role': 'roles/owner',
+             'members': ['serviceAccount:sa@project.iam.gserviceaccount.com']},
+        ]
+        expected_bindings = [
+            {'role': 'roles/owner',
+             'members': ['user:alice@example.com'],
+             'condition': condition},
+        ]
+
+        self.assertEqual(test_method(existing_bindings, bindings_to_remove), expected_bindings)
+
 
 class TestSpannerInstanceBackup(BaseTest):
 


### PR DESCRIPTION
This PR addresses https://github.com/cloud-custodian/cloud-custodian/issues/10518

Changes apply to both gcp.project and gcp.bucket resources: the iam-policy filter's user-role block is extended to accept value filter sub-objects for role and user, enabling operators such as "glob, in" and value_type: normalize alongside the existing exact-string matching. When a match is found the filter annotates the resource with `c7n:matched-iam-bindings` that a new "remove-bindings: matched" option on set-iam-policy can read in order to remove those pairs, leaving all other bindings intact. Chaining multiple iam-policy filters accumulates matches. . 

Also fixes a bug in BucketSetIamPolicy.get_resource_params and BucketIamPolicyFilter._verb_arguments introduced in #10596 that would have prevented bucket IAM policy removal from working correctly.