### PR TITLE
docs - add dmytro-afanasiev as a maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -8,6 +8,7 @@
 - Pratyush Mishra (@PratMis)
 - Matt Heidelbaugh (@mattheidelbaugh)
 - AJ Kerrigan (@ajkerrigan)
+- Dmytro Afanasiev (@dmytro-afanasiev)
 
 ## Aws Provider Maintainers
 


### PR DESCRIPTION
This is a long overdue change recognizing his enduring contributions to Cloud Custodian over the past several years.

Based on a discussion with @kapilt . Thanks for years of making Custodian better @dmytro-afanasiev ! :saluting_face: 