### PR TITLE
c7n-left - gracefully handle uuids that aren't references

### DIFF
--- a/tests/terraform/traverse_multiple_references/main.tf
+++ b/tests/terraform/traverse_multiple_references/main.tf
@@ -34,4 +34,5 @@ resource "azurerm_private_endpoint" "single_reference" {
 resource "azurerm_storage_account" "no_references" {
   name                          = "private"
   public_network_access_enabled = "false"
+  this_is_not_a_reference       = "9fe8886e-f58d-49a4-afbc-ad62c4ec3b6a"
 }

--- a/tools/c7n_left/c7n_left/providers/terraform/graph.py
+++ b/tools/c7n_left/c7n_left/providers/terraform/graph.py
@@ -85,7 +85,7 @@ class Resolver:
     def resolve_refs(self, block, types=None):
         refs = self._ref_map.get(block["id"], ())
         for rid in refs:
-            r = self._id_map[rid]
+            r = self._id_map.get(rid, {})
             if "__tfmeta" not in r:
                 continue
             rtype = r["__tfmeta"]["label"]


### PR DESCRIPTION
As we walk the Terraform resource graph, we consider any UUID to be a reference to another resource in the graph but that's not the case.

If we falsely flag a UUID as a reference when it isn't, it won't appear in our map of resource IDs. Gracefully handle that case and make sure there's a test that fails without the change.