### PR TITLE
fix(ebs): handle InvalidVolume.NotFound when tagging EBS volumes

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -132,6 +132,16 @@ class ErrorHandler:
             log.warning("Volume id malformed %s" % e_vol_id)
         return e_vol_id
 
+    @staticmethod
+    def remove_volume(rid, resource_set):
+        found = None
+        for r in resource_set:
+            if r['VolumeId'] == rid:
+                found = r
+                break
+        if found:
+            resource_set.remove(found)
+
 
 class SnapshotQueryParser(QueryParser):
 
@@ -727,6 +737,24 @@ class EBS(QueryResourceManager):
                     continue
                 raise
         return []
+
+
+@EBS.action_registry.register('tag')
+class VolumeTag(Tag):
+
+    permissions = ('ec2:CreateTags',)
+
+    def process_resource_set(self, client, resource_set, tags):
+        while resource_set:
+            try:
+                return super(VolumeTag, self).process_resource_set(
+                    client, resource_set, tags)
+            except ClientError as e:
+                bad_vol = ErrorHandler.extract_bad_volume(e)
+                if bad_vol:
+                    ErrorHandler.remove_volume(bad_vol, resource_set)
+                    continue
+                raise
 
 
 @EBS.filter_registry.register('snapshots')

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -235,6 +235,60 @@ class SnapshotErrorHandler(BaseTest):
         vol = ErrorHandler.extract_bad_volume(e)
         self.assertEqual(vol, "vol-notfound")
 
+    def test_remove_volume(self):
+        vols = [{'VolumeId': 'a'}, {'VolumeId': 'b'}, {'VolumeId': 'c'}]
+
+        t1 = list(vols)
+        ErrorHandler.remove_volume('c', t1)
+        self.assertEqual([t['VolumeId'] for t in t1], ['a', 'b'])
+
+        ErrorHandler.remove_volume('d', vols)
+        self.assertEqual(len(vols), 3)
+
+    def test_volume_tag_error(self):
+        vols = [{'VolumeId': 'vol-aa'}]
+        error_response = {
+            "Error": {
+                "Message": "The volume 'vol-aa' does not exist.",
+                "Code": "InvalidVolume.NotFound",
+            }
+        }
+        client = mock.MagicMock()
+        client.create_tags.side_effect = ClientError(error_response, 'CreateTags')
+
+        p = self.load_policy({
+            "name": "ebs-tag",
+            "resource": "ebs",
+            'actions': [{'type': 'tag', 'tags': {'bar': 'foo'}}]})
+        tagger = p.resource_manager.actions[0]
+        tagger.process_resource_set(client, vols, [{'Key': 'bar', 'Value': 'foo'}])
+        client.create_tags.assert_called_once()
+
+    def test_volume_tag_error_remaining_resources_tagged(self):
+        vols = [{'VolumeId': 'vol-missing'}, {'VolumeId': 'vol-exists'}]
+        error_response = {
+            "Error": {
+                "Message": "The volume 'vol-missing' does not exist.",
+                "Code": "InvalidVolume.NotFound",
+            }
+        }
+        client = mock.MagicMock()
+        client.create_tags.side_effect = [
+            ClientError(error_response, 'CreateTags'),
+            None,
+        ]
+
+        p = self.load_policy({
+            "name": "ebs-tag",
+            "resource": "ebs",
+            'actions': [{'type': 'tag', 'tags': {'bar': 'foo'}}]})
+        tagger = p.resource_manager.actions[0]
+        tagger.process_resource_set(client, vols, [{'Key': 'bar', 'Value': 'foo'}])
+        self.assertEqual(client.create_tags.call_count, 2)
+        # second call should only contain the existing volume
+        _, second_call_kwargs = client.create_tags.call_args_list[1]
+        self.assertEqual(second_call_kwargs['Resources'], ['vol-exists'])
+
     def test_snapshot_copy_related_tags_missing_volumes(self):
         factory = self.replay_flight_data(
             "test_ebs_snapshot_copy_related_tags_missing_volumes")


### PR DESCRIPTION
If an EBS volume is deleted between filter execution and the `tag`/`mark-for-op` action, `CreateTags` throws `InvalidVolume.NotFound`, failing the entire batch. The EBS snapshot resource already handled this via `SnapshotTag`; volumes did not.

## Changes

- **`c7n/resources/ebs.py`**
  - Add `ErrorHandler.remove_volume()` — mirrors existing `remove_snapshot()`
  - Add `VolumeTag` class registered as `@EBS.action_registry.register('tag')` — overrides `process_resource_set` to catch `InvalidVolume.NotFound`, drop the missing volume, and retry the remaining batch (mirrors `SnapshotTag` pattern exactly)

- **`tests/test_ebs.py`**
  - `test_remove_volume` — validates `ErrorHandler.remove_volume` behavior
  - `test_volume_tag_error` — single missing volume is skipped gracefully
  - `test_volume_tag_error_remaining_resources_tagged` — valid volumes in a mixed batch are still tagged when one is missing

```python
# Before: entire batch fails if vol-missing no longer exists
client.create_tags(Resources=['vol-missing', 'vol-exists'], Tags=[...])
# → ClientError: InvalidVolume.NotFound

# After: vol-missing is dropped, vol-exists is tagged successfully
```

## references
- closes https://github.com/cloud-custodian/cloud-custodian/issues/6011
