### PR TITLE
gcp - api-key - add delete and patch actions (#10536)

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/iam.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/iam.py
@@ -220,6 +220,94 @@ class ApiKey(QueryResourceManager):
         asset_type = "apikeys.googleapis.com/projects.locations.keys"
 
 
+@ApiKey.action_registry.register('delete')
+class ApiKeyDelete(MethodAction):
+    """Delete a GCP API key.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: delete-unused-api-keys
+            resource: gcp.api-key
+            filters:
+              - type: time-range
+                value: 90
+            actions:
+              - delete
+    """
+
+    schema = type_schema('delete')
+    method_spec = {'op': 'delete'}
+    permissions = ('apikeys.keys.delete',)
+
+    def get_resource_params(self, m, r):
+        return {'name': r['name']}
+
+
+@ApiKey.action_registry.register('patch')
+class ApiKeyPatch(MethodAction):
+    """Patch mutable fields on a GCP API key.
+
+    Supports updating any combination of ``displayName``, ``restrictions``,
+    and ``annotations``.  At least one field must be provided.
+
+    The ``restrictions`` object accepts an optional ``apiTargets`` list and
+    exactly one of the following client restriction types:
+
+    - ``browserKeyRestrictions`` – ``allowedReferrers[]``
+    - ``serverKeyRestrictions`` – ``allowedIps[]``
+    - ``androidKeyRestrictions`` – ``allowedApplications[]``
+    - ``iosKeyRestrictions`` – ``allowedBundleIds[]``
+
+    .. code-block:: yaml
+
+        policies:
+          - name: restrict-unrestricted-api-keys
+            resource: gcp.api-key
+            filters:
+              - type: value
+                key: restrictions
+                value: absent
+            actions:
+              - type: patch
+                restrictions:
+                  serverKeyRestrictions:
+                    allowedIps:
+                      - 192.0.2.0/24
+                  apiTargets:
+                    - service: translate.googleapis.com
+                annotations:
+                  custodian-remediated: "true"
+    """
+
+    MUTABLE_FIELDS = ('displayName', 'restrictions', 'annotations')
+
+    schema = type_schema(
+        'patch',
+        displayName={'type': 'string'},
+        restrictions={'type': 'object'},
+        annotations={'type': 'object'},
+    )
+    method_spec = {'op': 'patch'}
+    method_perm = 'update'
+    permissions = ('apikeys.keys.update',)
+
+    def validate(self):
+        if not set(self.MUTABLE_FIELDS).intersection(self.data):
+            raise ValueError(
+                "patch action requires at least one of: {}".format(
+                    ', '.join(self.MUTABLE_FIELDS)))
+        return super().validate()
+
+    def get_resource_params(self, m, r):
+        body = {f: self.data[f] for f in self.MUTABLE_FIELDS if f in self.data}
+        return {
+            'name': r['name'],
+            'updateMask': ','.join(body.keys()),
+            'body': body,
+        }
+
+
 @ApiKey.filter_registry.register('time-range')
 class ApiKeyTimeRangeFilter(TimeRangeFilter):
     """Filters api keys that have been changed during a specific time range.

--- a/tools/c7n_gcp/tests/data/flights/api-key-delete/delete-v2-projects-cloud-custodian-locations-global-keys-test-key-22f9774c3e5a_1.json
+++ b/tools/c7n_gcp/tests/data/flights/api-key-delete/delete-v2-projects-cloud-custodian-locations-global-keys-test-key-22f9774c3e5a_1.json
@@ -1,0 +1,19 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Wed, 11 Mar 2026 07:51:40 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "86",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "operations/akmf.p12-859150599087-9d60e693-dad6-4d77-9321-74a1231e07d4"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/api-key-delete/get-v2-projects-cloud-custodian-locations-global-keys_1.json
+++ b/tools/c7n_gcp/tests/data/flights/api-key-delete/get-v2-projects-cloud-custodian-locations-global-keys_1.json
@@ -1,0 +1,29 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Wed, 11 Mar 2026 07:51:39 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1420",
+    "-content-encoding": "gzip",
+    "content-location": "https://apikeys.googleapis.com/v2/projects/cloud-custodian/locations/global/keys?alt=json"
+  },
+  "body": {
+    "keys": [
+      {
+        "name": "projects/cloud-custodian/locations/global/keys/test-key-22f9774c3e5a",
+        "displayName": "Test API Key",
+        "createTime": "2026-03-11T07:51:33.004789Z",
+        "uid": "a3943a6e-1e3b-4ba8-b510-4a6e826e642b",
+        "updateTime": "2026-03-11T07:51:33.056410Z",
+        "etag": "W/\"1kXRauUAR3+H+C3wgdPVGQ==\""
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/api-key-delete/get-v2-projects-cloud-custodian-locations-global-keys_2.json
+++ b/tools/c7n_gcp/tests/data/flights/api-key-delete/get-v2-projects-cloud-custodian-locations-global-keys_2.json
@@ -1,0 +1,20 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Wed, 11 Mar 2026 07:51:41 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1085",
+    "-content-encoding": "gzip",
+    "content-location": "https://apikeys.googleapis.com/v2/projects/cloud-custodian/locations/global/keys?alt=json"
+  },
+  "body": {
+    "keys": []
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/api-key-patch/get-v2-projects-cloud-custodian-locations-global-keys-test-key-903d8f3a04c3_1.json
+++ b/tools/c7n_gcp/tests/data/flights/api-key-patch/get-v2-projects-cloud-custodian-locations-global-keys-test-key-903d8f3a04c3_1.json
@@ -1,0 +1,40 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Wed, 11 Mar 2026 07:52:15 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "565",
+    "-content-encoding": "gzip",
+    "content-location": "https://apikeys.googleapis.com/v2/projects/cloud-custodian/locations/global/keys/test-key-903d8f3a04c3?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/global/keys/test-key-903d8f3a04c3",
+    "displayName": "Test API Key",
+    "createTime": "2026-03-11T07:52:07.383311Z",
+    "uid": "09ce29ea-6bc4-4899-b5eb-b0d88a0d549e",
+    "updateTime": "2026-03-11T07:52:15.123651Z",
+    "annotations": {
+      "custodian-remediated": "true"
+    },
+    "restrictions": {
+      "serverKeyRestrictions": {
+        "allowedIps": [
+          "192.0.2.0/24"
+        ]
+      },
+      "apiTargets": [
+        {
+          "service": "translate.googleapis.com"
+        }
+      ]
+    },
+    "etag": "W/\"40FyrKjTOnSwGJirYCKXdQ==\""
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/api-key-patch/get-v2-projects-cloud-custodian-locations-global-keys_1.json
+++ b/tools/c7n_gcp/tests/data/flights/api-key-patch/get-v2-projects-cloud-custodian-locations-global-keys_1.json
@@ -1,0 +1,29 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Wed, 11 Mar 2026 07:52:13 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1420",
+    "-content-encoding": "gzip",
+    "content-location": "https://apikeys.googleapis.com/v2/projects/cloud-custodian/locations/global/keys?alt=json"
+  },
+  "body": {
+    "keys": [
+      {
+        "name": "projects/cloud-custodian/locations/global/keys/test-key-903d8f3a04c3",
+        "displayName": "Test API Key",
+        "createTime": "2026-03-11T07:52:07.383311Z",
+        "uid": "09ce29ea-6bc4-4899-b5eb-b0d88a0d549e",
+        "updateTime": "2026-03-11T07:52:07.410820Z",
+        "etag": "W/\"0jVMP6rigggInaLo8FCPwQ==\""
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/api-key-patch/patch-v2-projects-cloud-custodian-locations-global-keys-test-key-903d8f3a04c3_1.json
+++ b/tools/c7n_gcp/tests/data/flights/api-key-patch/patch-v2-projects-cloud-custodian-locations-global-keys-test-key-903d8f3a04c3_1.json
@@ -1,0 +1,19 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Wed, 11 Mar 2026 07:52:15 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "86",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "operations/akmf.p10-859150599087-d99c271d-6f10-4fdd-bc28-fec75f10a449"
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/api_key_delete/main.tf
+++ b/tools/c7n_gcp/tests/terraform/api_key_delete/main.tf
@@ -1,0 +1,22 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project               = var.google_project_id
+  billing_project       = var.google_project_id
+  user_project_override = true
+}
+
+resource "random_id" "suffix" {
+  byte_length = 6
+}
+
+resource "google_apikeys_key" "api_key" {
+  name         = "test-key-${random_id.suffix.hex}"
+  display_name = "Test API Key"
+  project      = var.google_project_id
+
+  # No restrictions — this key is intentionally unrestricted so the
+  # policy can find and delete it.
+}

--- a/tools/c7n_gcp/tests/terraform/api_key_delete/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/api_key_delete/tf_resources.json
@@ -1,0 +1,31 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_apikeys_key": {
+            "api_key": {
+                "display_name": "Test API Key",
+                "id": "projects/cloud-custodian/locations/global/keys/test-key-22f9774c3e5a",
+                "key_string": "AIzaSyBY2zqBTNjfDIuMciw13H_q2sCKHd3N0GY",
+                "name": "test-key-22f9774c3e5a",
+                "project": "stacklet-test-policies",
+                "restrictions": [],
+                "service_account_email": "",
+                "timeouts": null,
+                "uid": "a3943a6e-1e3b-4ba8-b510-4a6e826e642b"
+            }
+        },
+        "random_id": {
+            "suffix": {
+                "b64_std": "Ivl3TD5a",
+                "b64_url": "Ivl3TD5a",
+                "byte_length": 6,
+                "dec": "38454843686490",
+                "hex": "22f9774c3e5a",
+                "id": "Ivl3TD5a",
+                "keepers": null,
+                "prefix": null
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/terraform/api_key_patch/main.tf
+++ b/tools/c7n_gcp/tests/terraform/api_key_patch/main.tf
@@ -1,0 +1,22 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project               = var.google_project_id
+  billing_project       = var.google_project_id
+  user_project_override = true
+}
+
+resource "random_id" "suffix" {
+  byte_length = 6
+}
+
+resource "google_apikeys_key" "api_key" {
+  name         = "test-key-${random_id.suffix.hex}"
+  display_name = "Test API Key"
+  project      = var.google_project_id
+
+  # No restrictions — this key is intentionally unrestricted so the
+  # policy can find and remediate it.
+}

--- a/tools/c7n_gcp/tests/terraform/api_key_patch/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/api_key_patch/tf_resources.json
@@ -1,0 +1,31 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_apikeys_key": {
+            "api_key": {
+                "display_name": "Test API Key",
+                "id": "projects/cloud-custodian/locations/global/keys/test-key-903d8f3a04c3",
+                "key_string": "AIzaSyCn5d01w6kVqXbGrXc3pwedseYpjh2o4Ew",
+                "name": "test-key-903d8f3a04c3",
+                "project": "stacklet-test-policies",
+                "restrictions": [],
+                "service_account_email": "",
+                "timeouts": null,
+                "uid": "09ce29ea-6bc4-4899-b5eb-b0d88a0d549e"
+            }
+        },
+        "random_id": {
+            "suffix": {
+                "b64_std": "kD2POgTD",
+                "b64_url": "kD2POgTD",
+                "byte_length": 6,
+                "dec": "158594070348995",
+                "hex": "903d8f3a04c3",
+                "id": "kD2POgTD",
+                "keepers": null,
+                "prefix": null
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/test_gcp_iam.py
+++ b/tools/c7n_gcp/tests/test_gcp_iam.py
@@ -5,6 +5,7 @@ import time
 
 from gcp_common import BaseTest, event_data
 from googleapiclient.errors import HttpError
+from pytest_terraform import terraform
 
 
 class ProjectRoleTest(BaseTest):
@@ -314,3 +315,85 @@ class ApiKeyTest(BaseTest):
             resources[0]["name"],
             "projects/cloud-custodian/locations/global/keys/03b651c2-718a-4702-b5d7-9946987cc4da"
         )
+
+
+@terraform("api_key_patch")
+def test_api_key_patch_restrictions_and_annotations(test, api_key_patch):
+    short_key_name = api_key_patch.resources['google_apikeys_key']['api_key']['name']
+    factory = test.replay_flight_data('api-key-patch')
+    policy = test.load_policy(
+        {
+            'name': 'api-key-patch',
+            'resource': 'gcp.api-key',
+            'filters': [
+                {
+                    'type': 'value',
+                    'key': 'name',
+                    'op': 'glob',
+                    'value': f'*/{short_key_name}',
+                }
+            ],
+            'actions': [
+                {
+                    'type': 'patch',
+                    'restrictions': {
+                        'serverKeyRestrictions': {
+                            'allowedIps': ['192.0.2.0/24'],
+                        },
+                        'apiTargets': [
+                            {'service': 'translate.googleapis.com'},
+                        ],
+                    },
+                    'annotations': {
+                        'custodian-remediated': 'true',
+                    },
+                }
+            ],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+    actual_key_name = resources[0]['name']
+
+    client = policy.resource_manager.get_client()
+    for _ in range(10):
+        updated_key = client.execute_query('get', {'name': actual_key_name})
+        if 'restrictions' in updated_key:
+            break
+        time.sleep(3)
+
+    assert 'restrictions' in updated_key
+    assert 'serverKeyRestrictions' in updated_key['restrictions']
+    assert '192.0.2.0/24' in updated_key['restrictions']['serverKeyRestrictions']['allowedIps']
+    assert {'service': 'translate.googleapis.com'} in updated_key['restrictions']['apiTargets']
+    assert updated_key.get('annotations', {}).get('custodian-remediated') == 'true'
+
+
+@terraform("api_key_delete")
+def test_api_key_delete(test, api_key_delete):
+    short_key_name = api_key_delete.resources['google_apikeys_key']['api_key']['name']
+    factory = test.replay_flight_data('api-key-delete')
+
+    policy = test.load_policy(
+        {
+            'name': 'api-key-delete',
+            'resource': 'gcp.api-key',
+            'filters': [
+                {'type': 'value', 'key': 'name', 'op': 'glob',
+                 'value': f'*/{short_key_name}'},
+            ],
+            'actions': ['delete'],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+    actual_key_name = resources[0]['name']
+
+    client = policy.resource_manager.get_client()
+    parent = actual_key_name.rsplit('/keys/', 1)[0]
+    remaining = client.execute_query('list', {'parent': parent})
+    assert actual_key_name not in [k['name'] for k in remaining.get('keys', [])]


### PR DESCRIPTION
This PR resolves https://github.com/cloud-custodian/cloud-custodian/issues/10536

It adds delete and patch remediation actions to the `gcp.api-key` resource. 

* The patch action supports updating any combination of displayName, restrictions (browser, server, Android, iOS key restrictions and API targets), and annotations, computing updateMask dynamically from whichever fields are provided. 
* The delete action removes a key entirely. 

