### PR TITLE
gcp - api-key - add gcp-audit mode support

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/iam.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/iam.py
@@ -219,6 +219,11 @@ class ApiKey(QueryResourceManager):
         default_report_fields = ['name', 'displayName', 'createTime', 'updateTime']
         asset_type = "apikeys.googleapis.com/projects.locations.keys"
 
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_query(
+                'get', {'name': resource_info['resourceName']})
+
 
 @ApiKey.filter_registry.register('time-range')
 class ApiKeyTimeRangeFilter(TimeRangeFilter):

--- a/tools/c7n_gcp/tests/data/flights/api-key-create/get-v2-projects-cloud-custodian-locations-global-keys-test-key-audit-ed9977277800_1.json
+++ b/tools/c7n_gcp/tests/data/flights/api-key-create/get-v2-projects-cloud-custodian-locations-global-keys-test-key-audit-ed9977277800_1.json
@@ -1,0 +1,37 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Mon, 09 Mar 2026 12:23:37 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "527",
+    "-content-encoding": "gzip",
+    "content-location": "https://apikeys.googleapis.com/v2/projects/cloud-custodian/locations/global/keys/test-key-audit-ed9977277800?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/global/keys/test-key-audit-ed9977277800",
+    "displayName": "Test API Key for Audit Mode",
+    "createTime": "2026-03-09T12:23:30.364834Z",
+    "uid": "71a9769b-3c85-4372-bf1f-c71ed595e430",
+    "updateTime": "2026-03-09T12:23:30.418496Z",
+    "restrictions": {
+      "serverKeyRestrictions": {
+        "allowedIps": [
+          "192.0.2.0/24"
+        ]
+      },
+      "apiTargets": [
+        {
+          "service": "translate.googleapis.com"
+        }
+      ]
+    },
+    "etag": "W/\"Dws66M0SWcZLruFeBKf8mg==\""
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/api_key_audit/main.tf
+++ b/tools/c7n_gcp/tests/terraform/api_key_audit/main.tf
@@ -1,0 +1,29 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project               = var.google_project_id
+  billing_project       = var.google_project_id
+  user_project_override = true
+}
+
+resource "random_id" "suffix" {
+  byte_length = 6
+}
+
+resource "google_apikeys_key" "api_key" {
+  name         = "test-key-audit-${random_id.suffix.hex}"
+  display_name = "Test API Key for Audit Mode"
+  project      = var.google_project_id
+
+  restrictions {
+    api_targets {
+      service = "translate.googleapis.com"
+    }
+
+    server_key_restrictions {
+      allowed_ips = ["192.0.2.0/24"]
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/api_key_audit/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/api_key_audit/tf_resources.json
@@ -1,0 +1,50 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_apikeys_key": {
+            "api_key": {
+                "display_name": "Test API Key for Audit Mode",
+                "id": "projects/cloud-custodian/locations/global/keys/test-key-audit-ed9977277800",
+                "key_string": "AIzaSyCQQeouEAcayXCqX8WgOe6pLTLtRfx1Ssc",
+                "name": "test-key-audit-ed9977277800",
+                "project": "stacklet-test-policies",
+                "restrictions": [
+                    {
+                        "android_key_restrictions": [],
+                        "api_targets": [
+                            {
+                                "methods": null,
+                                "service": "translate.googleapis.com"
+                            }
+                        ],
+                        "browser_key_restrictions": [],
+                        "ios_key_restrictions": [],
+                        "server_key_restrictions": [
+                            {
+                                "allowed_ips": [
+                                    "192.0.2.0/24"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "service_account_email": "",
+                "timeouts": null,
+                "uid": "71a9769b-3c85-4372-bf1f-c71ed595e430"
+            }
+        },
+        "random_id": {
+            "suffix": {
+                "b64_std": "7Zl3J3gA",
+                "b64_url": "7Zl3J3gA",
+                "byte_length": 6,
+                "dec": "261243384854528",
+                "hex": "ed9977277800",
+                "id": "7Zl3J3gA",
+                "keepers": null,
+                "prefix": null
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/test_gcp_iam.py
+++ b/tools/c7n_gcp/tests/test_gcp_iam.py
@@ -5,6 +5,7 @@ import time
 
 from gcp_common import BaseTest, event_data
 from googleapiclient.errors import HttpError
+from pytest_terraform import terraform
 
 
 class ProjectRoleTest(BaseTest):
@@ -277,6 +278,39 @@ class IAMRoleTest(BaseTest):
                 "gcp:iam:::role/accesscontextmanager.policyAdmin",
             ],
         )
+
+
+@terraform("api_key_audit")
+def test_api_key_get_audit_mode(test, api_key_audit):
+    # export TF_VAR_GCP_PROJECT_ID variable prior to running functional test
+    api_key = api_key_audit.resources['google_apikeys_key']['api_key']
+    short_key_name = api_key['name']
+    project_id = api_key['project']
+    factory = test.replay_flight_data('api-key-create')
+    p = test.load_policy(
+        {
+            'name': 'api-key-get',
+            'resource': 'gcp.api-key',
+            'mode': {
+                'type': 'gcp-audit',
+                'methods': ['google.api.apikeys.v2.ApiKeys.CreateKey'],
+            },
+        },
+        session_factory=factory,
+    )
+    exec_mode = p.get_execution_mode()
+    event = {
+        'protoPayload': {
+            'resourceName': f'projects/{project_id}/locations/global/keys/{short_key_name}',
+        },
+        'resource': {
+            'labels': {},
+        },
+    }
+    keys = exec_mode.run(event, None)
+    assert len(keys) == 1
+    assert keys[0]['name'].endswith(f'/keys/{short_key_name}')
+    assert 'restrictions' in keys[0]
 
 
 class ApiKeyTest(BaseTest):


### PR DESCRIPTION
This PR resolves https://github.com/cloud-custodian/cloud-custodian/issues/10527

It adds a `GET` method to the `gcp.api-key` resource type so it can be used with `mode: gcp-audit`. The method resolves a key from its audit log resourceName, satisfying the retrieval interface required by ApiAuditMode.validate(). 