### PR TITLE
tools/c7n_mailer - datadog remove unused session attribute

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/datadog_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/datadog_delivery.py
@@ -12,10 +12,9 @@ class DataDogDelivery:
     DATADOG_API_KEY = "datadog_api_key"
     DATADOG_APPLICATION_KEY = "datadog_application_key"
 
-    def __init__(self, config, session, logger):
+    def __init__(self, config, logger):
         self.config = config
         self.logger = logger
-        self.session = session
         self.datadog_api_key = self.config.get(self.DATADOG_API_KEY, None)
         self.datadog_application_key = self.config.get(self.DATADOG_APPLICATION_KEY, None)
 

--- a/tools/c7n_mailer/c7n_mailer/target.py
+++ b/tools/c7n_mailer/c7n_mailer/target.py
@@ -49,7 +49,7 @@ class MessageTargetMixin(object):
         if any(e.startswith("datadog") for e in message.get("action", ()).get("to")):
             from .datadog_delivery import DataDogDelivery
 
-            datadog_delivery = DataDogDelivery(self.config, self.session, self.logger)
+            datadog_delivery = DataDogDelivery(self.config, self.logger)
             datadog_message_packages = datadog_delivery.get_datadog_message_packages(message)
 
             try:

--- a/tools/c7n_mailer/tests/test_datadog.py
+++ b/tools/c7n_mailer/tests/test_datadog.py
@@ -85,7 +85,6 @@ class TestDataDogDelivery(unittest.TestCase):
             "datadog_application_key": DATADOG_APPLICATION_KEY,
             "datadog_api_key": DATADOG_API_KEY,
         }
-        self.session = patch("boto3.Session")
         self.logger = MagicMock()
 
         self.patcher_datadog_initialize = patch("c7n_mailer.datadog_delivery.initialize")
@@ -95,25 +94,25 @@ class TestDataDogDelivery(unittest.TestCase):
         self.patcher_datadog_initialize.stop()
 
     def test_should_initialize_datadog_with_keys_in_config(self):
-        DataDogDelivery(self.config, self.session, self.logger)
+        DataDogDelivery(self.config, self.logger)
 
         self.mock_datadog_initialize.assert_called_with(
             api_key=DATADOG_API_KEY, app_key=DATADOG_APPLICATION_KEY
         )
 
     def test_should_not_initialize_datadog_with_no_keys_in_config(self):
-        DataDogDelivery({}, self.session, self.logger)
+        DataDogDelivery({}, self.logger)
 
         self.mock_datadog_initialize.assert_not_called()
 
     def test_datadog_message_packages_should_return_empty_list_if_no_sqs_messages_returned(self):
-        data_dog_delivery = DataDogDelivery(self.config, self.session, self.logger)
+        data_dog_delivery = DataDogDelivery(self.config, self.logger)
 
         assert data_dog_delivery.get_datadog_message_packages(None) == []
 
     @patch("c7n_mailer.datadog_delivery.time.time", return_value=0)
     def test_datadog_message_packages_should_return_messages(self, mock_time):
-        data_dog_delivery = DataDogDelivery(self.config, self.session, self.logger)
+        data_dog_delivery = DataDogDelivery(self.config, self.logger)
 
         answer = data_dog_delivery.get_datadog_message_packages(SQS_MESSAGE_2)
         answer[0]["tags"].sort()
@@ -127,7 +126,7 @@ class TestDataDogDelivery(unittest.TestCase):
     def test_deliver_datadog_messages_should_send_correct_metric_to_datadog(
         self, mock_datadog_api, mock_time
     ):
-        datadog_delivery = DataDogDelivery(self.config, self.session, self.logger)
+        datadog_delivery = DataDogDelivery(self.config, self.logger)
         datadog_message_packages = datadog_delivery.get_datadog_message_packages(SQS_MESSAGE_2)
         datadog_delivery.deliver_datadog_messages(datadog_message_packages, SQS_MESSAGE_2)
 
@@ -142,7 +141,7 @@ class TestDataDogDelivery(unittest.TestCase):
     def test_deliver_datadog_messages_should_send_correct_metric_value_to_datadog(
         self, mock_datadog_api, mock_time
     ):
-        datadog_delivery = DataDogDelivery(self.config, self.session, self.logger)
+        datadog_delivery = DataDogDelivery(self.config, self.logger)
         datadog_message_packages = datadog_delivery.get_datadog_message_packages(SQS_MESSAGE_3)
         datadog_delivery.deliver_datadog_messages(datadog_message_packages, SQS_MESSAGE_3)
 
@@ -156,7 +155,7 @@ class TestDataDogDelivery(unittest.TestCase):
     def test_deliver_datadog_messages_should_not_send_metric_if_metrics_are_empty(
         self, mock_datadog_api, mock_time
     ):
-        datadog_delivery = DataDogDelivery(self.config, self.session, self.logger)
+        datadog_delivery = DataDogDelivery(self.config, self.logger)
         datadog_delivery.deliver_datadog_messages([], SQS_MESSAGE_3)
 
         mock_datadog_api.assert_not_called()


### PR DESCRIPTION
Small change as part of a larger effort to clean up the mailer