### PR TITLE
Add unused filter for rds-param-group and rds-cluster-param-group

### DIFF
--- a/c7n/resources/rdsparamgroup.py
+++ b/c7n/resources/rdsparamgroup.py
@@ -6,10 +6,10 @@ import itertools
 from botocore.exceptions import ClientError
 
 from c7n.actions import ActionRegistry, BaseAction
-from c7n.filters import FilterRegistry, ValueFilter
+from c7n.filters import FilterRegistry, ValueFilter, Filter
 from c7n.manager import resources
 from c7n.query import QueryResourceManager, TypeInfo
-from c7n.utils import (type_schema, local_session, chunks)
+from c7n.utils import (type_schema, local_session, chunks, jmespath_search)
 from c7n.tags import universal_augment
 from c7n.resources.rds import ParameterFilter
 
@@ -167,6 +167,68 @@ class PGClusterParameterFilter(PGClusterMixin, ParameterGroupFilter):
             for p in paginator.paginate(DBClusterParameterGroupName=pg)]))
 
         return param_list
+
+
+@pg_filters.register('unused')
+class UnusedRDSDBParameterGroup(Filter):
+    """Filters RDS parameter groups that are not associated with any DB instance.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: rds-param-group-unused
+                resource: rds-param-group
+                filters:
+                  - unused
+    """
+
+    schema = type_schema('unused')
+
+    def get_permissions(self):
+        return self.manager.get_resource_manager('rds').get_permissions()
+
+    def process(self, resources, event=None):
+        rds = self.manager.get_resource_manager('rds').resources()
+        names = jmespath_search(
+            '[].DBParameterGroups[].DBParameterGroupName', rds)
+        self.used = set(n for n in (names or []) if n)
+        return super().process(resources, event)
+
+    def __call__(self, resource):
+        return resource['DBParameterGroupName'] not in self.used
+
+
+@pg_cluster_filters.register('unused')
+class UnusedRDSClusterParameterGroup(Filter):
+    """Filters RDS cluster parameter groups not associated with any DB cluster.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: rds-cluster-param-group-unused
+                resource: rds-cluster-param-group
+                filters:
+                  - unused
+    """
+
+    schema = type_schema('unused')
+
+    def get_permissions(self):
+        return self.manager.get_resource_manager('rds-cluster').get_permissions()
+
+    def process(self, resources, event=None):
+        clusters = self.manager.get_resource_manager(
+            'rds-cluster').resources(augment=False)
+        names = jmespath_search('[].DBClusterParameterGroup', clusters)
+        self.used = set(n for n in (names or []) if n)
+        return super().process(resources, event)
+
+    def __call__(self, resource):
+        return resource['DBClusterParameterGroupName'] not in self.used
 
 
 class Copy(BaseAction):

--- a/tests/data/placebo/test_rdsclusterparamgroup_unused/rds.DescribeDBClusterParameterGroups_1.json
+++ b/tests/data/placebo/test_rdsclusterparamgroup_unused/rds.DescribeDBClusterParameterGroups_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterParameterGroups": [
+            {
+                "DBClusterParameterGroupName": "default.aurora-mysql8.0",
+                "DBParameterGroupFamily": "aurora-mysql8.0",
+                "Description": "Default cluster parameter group for aurora-mysql8.0",
+                "DBClusterParameterGroupArn": "arn:aws:rds:us-east-1:644160558196:cluster-pg:default.aurora-mysql8.0"
+            },
+            {
+                "DBClusterParameterGroupName": "custom-cluster-pg-used",
+                "DBParameterGroupFamily": "aurora-mysql8.0",
+                "Description": "Custom cluster parameter group in use",
+                "DBClusterParameterGroupArn": "arn:aws:rds:us-east-1:644160558196:cluster-pg:custom-cluster-pg-used"
+            },
+            {
+                "DBClusterParameterGroupName": "custom-cluster-pg-orphan",
+                "DBParameterGroupFamily": "aurora-mysql8.0",
+                "Description": "Custom cluster parameter group not in use",
+                "DBClusterParameterGroupArn": "arn:aws:rds:us-east-1:644160558196:cluster-pg:custom-cluster-pg-orphan"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsclusterparamgroup_unused/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdsclusterparamgroup_unused/rds.DescribeDBClusters_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusters": [
+            {
+                "DBClusterIdentifier": "mycluster",
+                "DBClusterParameterGroup": "custom-cluster-pg-used",
+                "DBSubnetGroup": "default",
+                "Status": "available",
+                "Engine": "aurora-mysql",
+                "EngineVersion": "8.0.mysql_aurora.3.04.0",
+                "Port": 3306,
+                "DBClusterArn": "arn:aws:rds:us-east-1:644160558196:cluster:mycluster"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsclusterparamgroup_unused/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdsclusterparamgroup_unused/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsparamgroup_unused/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rdsparamgroup_unused/rds.DescribeDBInstances_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "mydb",
+                "DBInstanceClass": "db.t3.micro",
+                "Engine": "mysql",
+                "DBInstanceStatus": "available",
+                "MasterUsername": "admin",
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "custom-pg-used",
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ],
+                "DBSubnetGroup": {
+                    "DBSubnetGroupName": "default"
+                },
+                "DBInstanceArn": "arn:aws:rds:us-east-1:644160558196:db:mydb"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsparamgroup_unused/rds.DescribeDBParameterGroups_1.json
+++ b/tests/data/placebo/test_rdsparamgroup_unused/rds.DescribeDBParameterGroups_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBParameterGroups": [
+            {
+                "DBParameterGroupName": "default.mysql8.0",
+                "DBParameterGroupFamily": "mysql8.0",
+                "Description": "Default parameter group for mysql8.0",
+                "DBParameterGroupArn": "arn:aws:rds:us-east-1:644160558196:pg:default.mysql8.0"
+            },
+            {
+                "DBParameterGroupName": "custom-pg-used",
+                "DBParameterGroupFamily": "mysql8.0",
+                "Description": "Custom parameter group in use",
+                "DBParameterGroupArn": "arn:aws:rds:us-east-1:644160558196:pg:custom-pg-used"
+            },
+            {
+                "DBParameterGroupName": "custom-pg-orphan",
+                "DBParameterGroupFamily": "mysql8.0",
+                "Description": "Custom parameter group not in use",
+                "DBParameterGroupArn": "arn:aws:rds:us-east-1:644160558196:pg:custom-pg-orphan"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_rdsparamgroup_unused/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rdsparamgroup_unused/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_rdsparamgroup.py
+++ b/tests/test_rdsparamgroup.py
@@ -132,6 +132,23 @@ class RDSParamGroupTest(BaseTest):
                 break
         self.assertEqual(count, 2)
 
+    def test_rdsparamgroup_unused(self):
+        session_factory = self.replay_flight_data("test_rdsparamgroup_unused")
+        policy = self.load_policy(
+            {
+                "name": "rds-param-group-unused",
+                "resource": "rds-param-group",
+                "filters": [{"type": "unused"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 2)
+        names = {r['DBParameterGroupName'] for r in resources}
+        self.assertIn("default.mysql8.0", names)
+        self.assertIn("custom-pg-orphan", names)
+        self.assertNotIn("custom-pg-used", names)
+
     def test_rdsparamgroup_param_value_filter(self):
         session_factory = self.replay_flight_data('test_rdsparamgroup_param_value_filter')
         policy = self.load_policy(
@@ -295,6 +312,23 @@ class RDSClusterParamGroupTest(BaseTest):
             if count == 2:
                 break
         self.assertEqual(count, 2)
+
+    def test_rdsclusterparamgroup_unused(self):
+        session_factory = self.replay_flight_data("test_rdsclusterparamgroup_unused")
+        policy = self.load_policy(
+            {
+                "name": "rds-cluster-param-group-unused",
+                "resource": "rds-cluster-param-group",
+                "filters": [{"type": "unused"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 2)
+        names = {r['DBClusterParameterGroupName'] for r in resources}
+        self.assertIn("default.aurora-mysql8.0", names)
+        self.assertIn("custom-cluster-pg-orphan", names)
+        self.assertNotIn("custom-cluster-pg-used", names)
 
     def test_rdsclusterparamgroup_param_value_filter(self):
         session_factory = self.replay_flight_data('test_rdsclusterparamgroup_param_value_filter')


### PR DESCRIPTION
Adds an 'unused' filter to both RDS DB parameter group and RDS cluster parameter group resource managers, matching the pattern already used by rds-subnet-group.

The filter cross-references parameter groups against active RDS instances (for DB parameter groups) or active RDS clusters (for cluster parameter groups) and returns those that are not associated with any resource.

This enables policies to detect and clean up orphaned parameter groups that are no longer referenced by any database instance or cluster.

Includes placebo-based unit tests for both resource types.