### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ env:
   UV_VERSION: "0.7.12"
   DEFAULT_PY_VERSION: "3.12"
 
+permissions: {}
+
 jobs:
   Lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,10 @@ on:
     tags:
       # todo: update for 1.0
       - 0.*
+
+permissions:
+  contents: read
+
 jobs:
   Publish:
     permissions:

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -7,6 +7,8 @@ env:
   UV_VERSION: "0.7.12"
   DEFAULT_PY_VERSION: "3.12"
 
+permissions: {}
+
 jobs:
   AWS:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ env:
   UV_VERSION: "0.7.12"
   DEFAULT_PY_VERSION: "3.12"
 
+permissions: {}
+
 jobs:
   BuildWheels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

Fixes #10730
