### PR TITLE
aws - vpc-endpoint - handle InvalidServiceName in service-details filter

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2936,8 +2936,21 @@ class EndpointServiceDetailsFilter(ValueFilter):
             if cached is not None:
                 return cached
 
-            resp = client.describe_vpc_endpoint_services(ServiceNames=service_names)
-            service_map = {d["ServiceName"]: d for d in resp.get("ServiceDetails", [])}
+            try:
+                resp = client.describe_vpc_endpoint_services(ServiceNames=service_names)
+                service_map = {d["ServiceName"]: d for d in resp.get("ServiceDetails", [])}
+            except ClientError:
+                service_map = {}
+                for name in service_names:
+                    try:
+                        resp = client.describe_vpc_endpoint_services(ServiceNames=[name])
+                        for d in resp.get("ServiceDetails", []):
+                            service_map[d["ServiceName"]] = d
+                    except ClientError as e:
+                        self.log.warning(
+                            "Error describing VPC endpoint service %s: %s",
+                            name, e
+                        )
 
             cache.save(cache_key, service_map)
             return service_map

--- a/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpointServices_1.json
+++ b/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpointServices_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Code": "InvalidServiceName",
+            "Message": "The Vpc Endpoint Service 'com.amazonaws.us-west-2.s3' does not exist"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpointServices_2.json
+++ b/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpointServices_2.json
@@ -1,0 +1,88 @@
+{
+    "status_code": 200,
+    "data": {
+        "ServiceNames": [
+            "com.amazonaws.us-east-1.dynamodb",
+            "com.amazonaws.us-east-1.dynamodb"
+        ],
+        "ServiceDetails": [
+            {
+                "ServiceName": "com.amazonaws.us-east-1.dynamodb",
+                "ServiceId": "vpce-svc-04b9ffcb9ee7ef983",
+                "ServiceType": [
+                    {
+                        "ServiceType": "Interface"
+                    }
+                ],
+                "ServiceRegion": "us-east-1",
+                "AvailabilityZoneIds": [
+                    "use1-az4",
+                    "use1-az6",
+                    "use1-az1",
+                    "use1-az2",
+                    "use1-az3",
+                    "use1-az5"
+                ],
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c",
+                    "us-east-1d",
+                    "us-east-1e",
+                    "us-east-1f"
+                ],
+                "Owner": "amazon",
+                "BaseEndpointDnsNames": [
+                    "dynamodb.us-east-1.vpce.amazonaws.com"
+                ],
+                "VpcEndpointPolicySupported": true,
+                "AcceptanceRequired": false,
+                "ManagesVpcEndpoints": false,
+                "Tags": [],
+                "SupportedIpAddressTypes": [
+                    "ipv6",
+                    "ipv4"
+                ]
+            },
+            {
+                "ServiceName": "com.amazonaws.us-east-1.dynamodb",
+                "ServiceId": "vpce-svc-099eb39957ebe7ecc",
+                "ServiceType": [
+                    {
+                        "ServiceType": "Gateway"
+                    }
+                ],
+                "ServiceRegion": "us-east-1",
+                "AvailabilityZoneIds": [
+                    "use1-az4",
+                    "use1-az6",
+                    "use1-az1",
+                    "use1-az2",
+                    "use1-az3",
+                    "use1-az5"
+                ],
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c",
+                    "us-east-1d",
+                    "us-east-1e",
+                    "us-east-1f"
+                ],
+                "Owner": "amazon",
+                "BaseEndpointDnsNames": [
+                    "dynamodb.us-east-1.amazonaws.com"
+                ],
+                "VpcEndpointPolicySupported": true,
+                "AcceptanceRequired": false,
+                "ManagesVpcEndpoints": false,
+                "Tags": [],
+                "SupportedIpAddressTypes": [
+                    "ipv4",
+                    "ipv6"
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpointServices_3.json
+++ b/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpointServices_3.json
@@ -1,0 +1,110 @@
+{
+    "status_code": 200,
+    "data": {
+        "ServiceNames": [
+            "com.amazonaws.us-east-1.s3",
+            "com.amazonaws.us-east-1.s3"
+        ],
+        "ServiceDetails": [
+            {
+                "ServiceName": "com.amazonaws.us-east-1.s3",
+                "ServiceId": "vpce-svc-0aa7c06513d4872d5",
+                "ServiceType": [
+                    {
+                        "ServiceType": "Gateway"
+                    }
+                ],
+                "ServiceRegion": "us-east-1",
+                "AvailabilityZoneIds": [
+                    "use1-az4",
+                    "use1-az6",
+                    "use1-az1",
+                    "use1-az2",
+                    "use1-az3",
+                    "use1-az5"
+                ],
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c",
+                    "us-east-1d",
+                    "us-east-1e",
+                    "us-east-1f"
+                ],
+                "Owner": "amazon",
+                "BaseEndpointDnsNames": [
+                    "s3.us-east-1.amazonaws.com"
+                ],
+                "VpcEndpointPolicySupported": true,
+                "AcceptanceRequired": false,
+                "ManagesVpcEndpoints": false,
+                "Tags": [],
+                "SupportedIpAddressTypes": [
+                    "ipv4",
+                    "ipv6"
+                ]
+            },
+            {
+                "ServiceName": "com.amazonaws.us-east-1.s3",
+                "ServiceId": "vpce-svc-081d84efcdc7bac15",
+                "ServiceType": [
+                    {
+                        "ServiceType": "Interface"
+                    }
+                ],
+                "ServiceRegion": "us-east-1",
+                "AvailabilityZoneIds": [
+                    "use1-az4",
+                    "use1-az6",
+                    "use1-az1",
+                    "use1-az2",
+                    "use1-az3",
+                    "use1-az5"
+                ],
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c",
+                    "us-east-1d",
+                    "us-east-1e",
+                    "us-east-1f"
+                ],
+                "Owner": "amazon",
+                "BaseEndpointDnsNames": [
+                    "s3.us-east-1.vpce.amazonaws.com"
+                ],
+                "PrivateDnsName": "*.s3.us-east-1.amazonaws.com",
+                "PrivateDnsNames": [
+                    {
+                        "PrivateDnsName": "*.s3.us-east-1.amazonaws.com"
+                    },
+                    {
+                        "PrivateDnsName": "*.s3-accesspoint.us-east-1.amazonaws.com"
+                    },
+                    {
+                        "PrivateDnsName": "*.s3-control.us-east-1.amazonaws.com"
+                    },
+                    {
+                        "PrivateDnsName": "*.s3.dualstack.us-east-1.amazonaws.com"
+                    },
+                    {
+                        "PrivateDnsName": "*.s3-control.dualstack.us-east-1.amazonaws.com"
+                    },
+                    {
+                        "PrivateDnsName": "*.s3-accesspoint.dualstack.us-east-1.amazonaws.com"
+                    }
+                ],
+                "VpcEndpointPolicySupported": true,
+                "AcceptanceRequired": false,
+                "ManagesVpcEndpoints": false,
+                "Tags": [],
+                "PrivateDnsNameVerificationState": "verified",
+                "SupportedIpAddressTypes": [
+                    "ipv6",
+                    "ipv4"
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpointServices_4.json
+++ b/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpointServices_4.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Code": "InvalidServiceName",
+            "Message": "The Vpc Endpoint Service 'com.amazonaws.us-west-2.s3' does not exist"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpoints_1.json
+++ b/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpoints_1.json
@@ -1,0 +1,169 @@
+{
+    "status_code": 200,
+    "data": {
+        "VpcEndpoints": [
+            {
+                "VpcEndpointId": "vpce-0d3fa19c3b50341d2",
+                "VpcEndpointType": "Gateway",
+                "VpcId": "vpc-d2d616b5",
+                "ServiceName": "com.amazonaws.us-east-1.dynamodb",
+                "State": "available",
+                "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                "RouteTableIds": [
+                    "rtb-3bf1b05c"
+                ],
+                "SubnetIds": [],
+                "Groups": [],
+                "IpAddressType": "ipv4",
+                "DnsOptions": {
+                    "DnsRecordIpType": "service-defined"
+                },
+                "PrivateDnsEnabled": false,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [],
+                "DnsEntries": [],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 8,
+                    "day": 30,
+                    "hour": 13,
+                    "minute": 49,
+                    "second": 28,
+                    "microsecond": 0
+                },
+                "Tags": [],
+                "OwnerId": "644160558196",
+                "ServiceRegion": "us-east-1"
+            },
+            {
+                "VpcEndpointId": "vpce-0e0a16ee0436b31ac",
+                "VpcEndpointType": "Gateway",
+                "VpcId": "vpc-d2d616b5",
+                "ServiceName": "com.amazonaws.us-east-1.s3",
+                "State": "available",
+                "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                "RouteTableIds": [
+                    "rtb-3bf1b05c"
+                ],
+                "SubnetIds": [],
+                "Groups": [],
+                "IpAddressType": "ipv4",
+                "DnsOptions": {
+                    "DnsRecordIpType": "service-defined"
+                },
+                "PrivateDnsEnabled": false,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [],
+                "DnsEntries": [],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 8,
+                    "day": 30,
+                    "hour": 13,
+                    "minute": 50,
+                    "second": 46,
+                    "microsecond": 0
+                },
+                "Tags": [],
+                "OwnerId": "644160558196",
+                "ServiceRegion": "us-east-1"
+            },
+            {
+                "VpcEndpointId": "vpce-056fff30475955130",
+                "VpcEndpointType": "Gateway",
+                "VpcId": "vpc-03c66c266923c5427",
+                "ServiceName": "com.amazonaws.us-east-1.s3",
+                "State": "available",
+                "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                "RouteTableIds": [
+                    "rtb-025de1f331d524a17",
+                    "rtb-01ab2c397a777eb7b"
+                ],
+                "SubnetIds": [],
+                "Groups": [],
+                "IpAddressType": "ipv4",
+                "DnsOptions": {
+                    "DnsRecordIpType": "service-defined"
+                },
+                "PrivateDnsEnabled": false,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [],
+                "DnsEntries": [],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 5,
+                    "day": 5,
+                    "hour": 23,
+                    "minute": 5,
+                    "second": 40,
+                    "microsecond": 0
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "project-vpce-s3"
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ServiceRegion": "us-east-1"
+            },
+            {
+                "VpcEndpointId": "vpce-0ed5e77b9c6578e6a",
+                "VpcEndpointType": "Interface",
+                "VpcId": "vpc-0207cdabbb60970eb",
+                "ServiceName": "com.amazonaws.us-west-2.s3",
+                "State": "available",
+                "PolicyDocument": "{\n  \"Statement\": [\n    {\n      \"Action\": \"*\",\n      \"Effect\": \"Allow\",\n      \"Principal\": \"*\",\n      \"Resource\": \"*\"\n    }\n  ]\n}",
+                "RouteTableIds": [],
+                "SubnetIds": [
+                    "subnet-060cc450a3823ecd4",
+                    "subnet-0a0cc24bfabbd5f02"
+                ],
+                "Groups": [
+                    {
+                        "GroupId": "sg-091e5c25316cfc6bc",
+                        "GroupName": "default"
+                    }
+                ],
+                "IpAddressType": "ipv4",
+                "DnsOptions": {
+                    "DnsRecordIpType": "ipv4"
+                },
+                "PrivateDnsEnabled": false,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [
+                    "eni-04304521a025b7fb8",
+                    "eni-0e1df1136f719048f"
+                ],
+                "DnsEntries": [
+                    {
+                        "DnsName": "*.vpce-0ed5e77b9c6578e6a-lqoz98qp.s3.us-west-2.vpce.amazonaws.com",
+                        "HostedZoneId": "Z1YSA3EXCYUU9Z"
+                    }
+                ],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 4,
+                    "day": 21,
+                    "hour": 20,
+                    "minute": 1,
+                    "second": 11,
+                    "microsecond": 667000
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "vpcendpoint-test"
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ServiceRegion": "us-west-2"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpoints_2.json
+++ b/tests/data/placebo/test_vpc_endpoint_service_details_live/ec2.DescribeVpcEndpoints_2.json
@@ -1,0 +1,169 @@
+{
+    "status_code": 200,
+    "data": {
+        "VpcEndpoints": [
+            {
+                "VpcEndpointId": "vpce-0d3fa19c3b50341d2",
+                "VpcEndpointType": "Gateway",
+                "VpcId": "vpc-d2d616b5",
+                "ServiceName": "com.amazonaws.us-east-1.dynamodb",
+                "State": "available",
+                "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                "RouteTableIds": [
+                    "rtb-3bf1b05c"
+                ],
+                "SubnetIds": [],
+                "Groups": [],
+                "IpAddressType": "ipv4",
+                "DnsOptions": {
+                    "DnsRecordIpType": "service-defined"
+                },
+                "PrivateDnsEnabled": false,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [],
+                "DnsEntries": [],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 8,
+                    "day": 30,
+                    "hour": 13,
+                    "minute": 49,
+                    "second": 28,
+                    "microsecond": 0
+                },
+                "Tags": [],
+                "OwnerId": "644160558196",
+                "ServiceRegion": "us-east-1"
+            },
+            {
+                "VpcEndpointId": "vpce-0e0a16ee0436b31ac",
+                "VpcEndpointType": "Gateway",
+                "VpcId": "vpc-d2d616b5",
+                "ServiceName": "com.amazonaws.us-east-1.s3",
+                "State": "available",
+                "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                "RouteTableIds": [
+                    "rtb-3bf1b05c"
+                ],
+                "SubnetIds": [],
+                "Groups": [],
+                "IpAddressType": "ipv4",
+                "DnsOptions": {
+                    "DnsRecordIpType": "service-defined"
+                },
+                "PrivateDnsEnabled": false,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [],
+                "DnsEntries": [],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 8,
+                    "day": 30,
+                    "hour": 13,
+                    "minute": 50,
+                    "second": 46,
+                    "microsecond": 0
+                },
+                "Tags": [],
+                "OwnerId": "644160558196",
+                "ServiceRegion": "us-east-1"
+            },
+            {
+                "VpcEndpointId": "vpce-056fff30475955130",
+                "VpcEndpointType": "Gateway",
+                "VpcId": "vpc-03c66c266923c5427",
+                "ServiceName": "com.amazonaws.us-east-1.s3",
+                "State": "available",
+                "PolicyDocument": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"*\",\"Resource\":\"*\"}]}",
+                "RouteTableIds": [
+                    "rtb-025de1f331d524a17",
+                    "rtb-01ab2c397a777eb7b"
+                ],
+                "SubnetIds": [],
+                "Groups": [],
+                "IpAddressType": "ipv4",
+                "DnsOptions": {
+                    "DnsRecordIpType": "service-defined"
+                },
+                "PrivateDnsEnabled": false,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [],
+                "DnsEntries": [],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2024,
+                    "month": 5,
+                    "day": 5,
+                    "hour": 23,
+                    "minute": 5,
+                    "second": 40,
+                    "microsecond": 0
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "project-vpce-s3"
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ServiceRegion": "us-east-1"
+            },
+            {
+                "VpcEndpointId": "vpce-0ed5e77b9c6578e6a",
+                "VpcEndpointType": "Interface",
+                "VpcId": "vpc-0207cdabbb60970eb",
+                "ServiceName": "com.amazonaws.us-west-2.s3",
+                "State": "available",
+                "PolicyDocument": "{\n  \"Statement\": [\n    {\n      \"Action\": \"*\",\n      \"Effect\": \"Allow\",\n      \"Principal\": \"*\",\n      \"Resource\": \"*\"\n    }\n  ]\n}",
+                "RouteTableIds": [],
+                "SubnetIds": [
+                    "subnet-060cc450a3823ecd4",
+                    "subnet-0a0cc24bfabbd5f02"
+                ],
+                "Groups": [
+                    {
+                        "GroupId": "sg-091e5c25316cfc6bc",
+                        "GroupName": "default"
+                    }
+                ],
+                "IpAddressType": "ipv4",
+                "DnsOptions": {
+                    "DnsRecordIpType": "ipv4"
+                },
+                "PrivateDnsEnabled": false,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [
+                    "eni-04304521a025b7fb8",
+                    "eni-0e1df1136f719048f"
+                ],
+                "DnsEntries": [
+                    {
+                        "DnsName": "*.vpce-0ed5e77b9c6578e6a-lqoz98qp.s3.us-west-2.vpce.amazonaws.com",
+                        "HostedZoneId": "Z1YSA3EXCYUU9Z"
+                    }
+                ],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 4,
+                    "day": 21,
+                    "hour": 20,
+                    "minute": 1,
+                    "second": 11,
+                    "microsecond": 667000
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "vpcendpoint-test"
+                    }
+                ],
+                "OwnerId": "644160558196",
+                "ServiceRegion": "us-west-2"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -4793,4 +4793,5 @@ class TestVpcEndpointServiceDetails(BaseTest):
         filtered_names = {r["ServiceName"] for r in filtered_resources}
 
         self.assertLess(len(filtered_resources), len(all_resources))
+        self.assertIn("com.amazonaws.us-east-1.s3", filtered_names)
         self.assertNotIn("com.amazonaws.us-west-2.s3", filtered_names)

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -4762,3 +4762,84 @@ class TestVpcEndpointServiceDetails(BaseTest):
             "com.amazonaws.us-east-1.s3",
         )
         self.assertTrue(service_details["VpcEndpointPolicySupported"])
+
+
+    def test_endpoint_service_details_invalid_service(self):
+        # Covers endpoints whose service no longer exists — both deprecated service
+        # names and cross-account PrivateLink (vpce-svc-*) services that the calling
+        # account cannot describe.
+        from unittest import mock
+
+        session_factory = self.replay_flight_data(
+            "test_vpc_endpoint_service_details_filter"
+        )
+        p = self.load_policy(
+            {
+                "name": "vpc-endpoint-services-invalid-service",
+                "resource": "aws.vpc-endpoint",
+                "filters": [
+                    {
+                        "type": "service-details",
+                        "key": "VpcEndpointPolicySupported",
+                        "value": True,
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+
+        filter_instance = p.resource_manager.filters[0]
+
+        invalid_service_error = BotoClientError(
+            {"Error": {
+                "Code": "InvalidServiceName",
+                "Message": "The Vpc Endpoint Service does not exist",
+            }},
+            operation_name="DescribeVpcEndpointServices",
+        )
+        valid_service_response = {
+            "ServiceDetails": [{
+                "ServiceName": "com.amazonaws.us-east-1.s3",
+                "VpcEndpointPolicySupported": True,
+            }],
+            "ResponseMetadata": {},
+        }
+
+        resources = [
+            {
+                "VpcEndpointId": "vpce-aaa",
+                "ServiceName": "com.amazonaws.us-east-1.s3",
+                "VpcEndpointType": "Gateway",
+                "State": "available",
+            },
+            {
+                "VpcEndpointId": "vpce-bbb",
+                "ServiceName": "com.amazonaws.us-east-1.deprecated-service",
+                "VpcEndpointType": "Interface",
+                "State": "available",
+            },
+            {
+                "VpcEndpointId": "vpce-ccc",
+                "ServiceName": "com.amazonaws.vpce.us-east-1.vpce-svc-0123456789abcdef0",
+                "VpcEndpointType": "Interface",
+                "State": "available",
+            },
+        ]
+
+        mock_client = MagicMock()
+
+        mock_client.describe_vpc_endpoint_services.side_effect = [
+            invalid_service_error,
+            invalid_service_error,
+            valid_service_response,
+            invalid_service_error,
+        ]
+
+        with mock.patch("c7n.resources.vpc.local_session") as mock_ls:
+            mock_ls.return_value.client.return_value = mock_client
+            result = filter_instance.process(resources)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["ServiceName"], "com.amazonaws.us-east-1.s3")
+        self.assertTrue(result[0]["c7n:ServiceDetails"]["VpcEndpointPolicySupported"])
+

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -4763,7 +4763,6 @@ class TestVpcEndpointServiceDetails(BaseTest):
         )
         self.assertTrue(service_details["VpcEndpointPolicySupported"])
 
-
     def test_endpoint_service_details_invalid_service(self):
         # Covers endpoints whose service no longer exists — both deprecated service
         # names and cross-account PrivateLink (vpce-svc-*) services that the calling
@@ -4798,10 +4797,19 @@ class TestVpcEndpointServiceDetails(BaseTest):
             operation_name="DescribeVpcEndpointServices",
         )
         valid_service_response = {
-            "ServiceDetails": [{
-                "ServiceName": "com.amazonaws.us-east-1.s3",
-                "VpcEndpointPolicySupported": True,
-            }],
+            "ServiceNames": ["com.amazonaws.us-east-1.s3"],
+            "ServiceDetails": [
+                {
+                    "ServiceName": "com.amazonaws.us-east-1.s3",
+                    "ServiceId": "vpce-svc-0aa7c06513d4872d5",
+                    "ServiceType": [{"ServiceType": "Gateway"}],
+                    "Owner": "amazon",
+                    "VpcEndpointPolicySupported": True,
+                    "AcceptanceRequired": False,
+                    "ManagesVpcEndpoints": False,
+                    "Tags": [],
+                }
+            ],
             "ResponseMetadata": {},
         }
 
@@ -4842,4 +4850,3 @@ class TestVpcEndpointServiceDetails(BaseTest):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["ServiceName"], "com.amazonaws.us-east-1.s3")
         self.assertTrue(result[0]["c7n:ServiceDetails"]["VpcEndpointPolicySupported"])
-

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -4763,18 +4763,13 @@ class TestVpcEndpointServiceDetails(BaseTest):
         )
         self.assertTrue(service_details["VpcEndpointPolicySupported"])
 
-    def test_endpoint_service_details_invalid_service(self):
-        # Covers endpoints whose service no longer exists — both deprecated service
-        # names and cross-account PrivateLink (vpce-svc-*) services that the calling
-        # account cannot describe.
-        from unittest import mock
-
+    def test_endpoint_service_details_invalid_service_names_excluded(self):
         session_factory = self.replay_flight_data(
-            "test_vpc_endpoint_service_details_filter"
+            "test_vpc_endpoint_service_details_live"
         )
         p = self.load_policy(
             {
-                "name": "vpc-endpoint-services-invalid-service",
+                "name": "vpc-endpoint-policy-supported-only",
                 "resource": "aws.vpc-endpoint",
                 "filters": [
                     {
@@ -4786,67 +4781,16 @@ class TestVpcEndpointServiceDetails(BaseTest):
             },
             session_factory=session_factory,
         )
-
-        filter_instance = p.resource_manager.filters[0]
-
-        invalid_service_error = BotoClientError(
-            {"Error": {
-                "Code": "InvalidServiceName",
-                "Message": "The Vpc Endpoint Service does not exist",
-            }},
-            operation_name="DescribeVpcEndpointServices",
-        )
-        valid_service_response = {
-            "ServiceNames": ["com.amazonaws.us-east-1.s3"],
-            "ServiceDetails": [
-                {
-                    "ServiceName": "com.amazonaws.us-east-1.s3",
-                    "ServiceId": "vpce-svc-0aa7c06513d4872d5",
-                    "ServiceType": [{"ServiceType": "Gateway"}],
-                    "Owner": "amazon",
-                    "VpcEndpointPolicySupported": True,
-                    "AcceptanceRequired": False,
-                    "ManagesVpcEndpoints": False,
-                    "Tags": [],
-                }
-            ],
-            "ResponseMetadata": {},
-        }
-
-        resources = [
+        all_resources = self.load_policy(
             {
-                "VpcEndpointId": "vpce-aaa",
-                "ServiceName": "com.amazonaws.us-east-1.s3",
-                "VpcEndpointType": "Gateway",
-                "State": "available",
+                "name": "vpc-endpoint-all",
+                "resource": "aws.vpc-endpoint",
             },
-            {
-                "VpcEndpointId": "vpce-bbb",
-                "ServiceName": "com.amazonaws.us-east-1.deprecated-service",
-                "VpcEndpointType": "Interface",
-                "State": "available",
-            },
-            {
-                "VpcEndpointId": "vpce-ccc",
-                "ServiceName": "com.amazonaws.vpce.us-east-1.vpce-svc-0123456789abcdef0",
-                "VpcEndpointType": "Interface",
-                "State": "available",
-            },
-        ]
+            session_factory=session_factory,
+        ).run()
+        filtered_resources = p.run()
 
-        mock_client = MagicMock()
+        filtered_names = {r["ServiceName"] for r in filtered_resources}
 
-        mock_client.describe_vpc_endpoint_services.side_effect = [
-            invalid_service_error,
-            invalid_service_error,
-            valid_service_response,
-            invalid_service_error,
-        ]
-
-        with mock.patch("c7n.resources.vpc.local_session") as mock_ls:
-            mock_ls.return_value.client.return_value = mock_client
-            result = filter_instance.process(resources)
-
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["ServiceName"], "com.amazonaws.us-east-1.s3")
-        self.assertTrue(result[0]["c7n:ServiceDetails"]["VpcEndpointPolicySupported"])
+        self.assertLess(len(filtered_resources), len(all_resources))
+        self.assertNotIn("com.amazonaws.us-west-2.s3", filtered_names)


### PR DESCRIPTION
The service-details filter would fail with an unhandled ClientError when an account has VPC endpoints pointing to services that can no longer be described — such as deprecated AWS services or cross-account PrivateLink (vpce-svc-*) services that the calling account does not have access to. 
The batch DescribeVpcEndpointServices call raises InvalidServiceName in these cases, causing policies to fail entirely.
                                                                                                                                                                                                          
The fix falls back to per-service individual calls when the batch fails, logging a warning for any service that errors and continuing to scan the remaining endpoints normally. 