### PR TITLE
Add Azure compute-gallery image resources

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/image_gallery.py
+++ b/tools/c7n_azure/c7n_azure/resources/image_gallery.py
@@ -1,0 +1,329 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+
+from c7n.filters import Filter, AgeFilter
+from c7n.utils import type_schema, group_by
+from c7n_azure.provider import resources
+from c7n_azure.query import ChildTypeInfo
+from c7n_azure.resources.arm import ArmResourceManager, ChildArmResourceManager, ArmTypeInfo
+from c7n_azure.utils import ResourceIdParser
+
+
+@resources.register('compute-gallery', aliases=['image-gallery'])
+class ComputeGallery(ArmResourceManager):
+    """Azure Compute Gallery (formerly Shared Image Gallery)
+
+    :example:
+
+    Find all compute galleries in a specific region
+
+    .. code-block:: yaml
+
+        policies:
+          - name: compute-galleries-westus
+            resource: azure.compute-gallery
+            filters:
+              - type: value
+                key: location
+                op: eq
+                value: westus2
+
+    """
+    class resource_type(ArmTypeInfo):
+        doc_groups = ['Compute']
+
+        service = 'azure.mgmt.compute'
+        client = 'ComputeManagementClient'
+        enum_spec = ('galleries', 'list', None)
+        resource_type = 'Microsoft.Compute/galleries'
+
+        default_report_fields = (
+            'name',
+            'location',
+            'resourceGroup'
+        )
+
+
+@resources.register('compute-gallery-image', aliases=['image-gallery-image'])
+class ComputeGalleryImage(ChildArmResourceManager):
+    """Azure Compute Gallery Image Definition
+
+    :example:
+
+    Find all Linux-based image definitions
+
+    .. code-block:: yaml
+
+        policies:
+          - name: find-linux-images
+            resource: azure.compute-gallery-image
+            filters:
+              - type: value
+                key: properties.osType
+                op: eq
+                value: Linux
+    
+    :example:
+
+    Get image definitions within a specific gallery
+
+    .. code-block:: yaml
+
+        policies:
+          - name: images-within-mygallery
+            resource: azure.compute-gallery-image
+            filters:
+              - type: gallery
+                value: MyGallery
+
+    """
+    class resource_type(ChildTypeInfo, ArmTypeInfo):
+        doc_groups = ['Compute']
+
+        service = 'azure.mgmt.compute'
+        client = 'ComputeManagementClient'
+        resource_type = 'Microsoft.Compute/galleries/images'
+
+        enum_spec = (
+            'gallery_images',
+            'list_by_gallery',
+            None
+        )
+
+        parent_manager_name = 'compute-gallery'
+
+        @classmethod
+        def extra_args(cls, parent_resource):
+            return {
+                'resource_group_name': parent_resource['resourceGroup'],
+                'gallery_name': parent_resource['name']
+            }
+
+
+@ComputeGalleryImage.filter_registry.register('gallery')
+class GalleryFilter(Filter):
+    """Filter images by gallery name.
+
+    :example:
+
+    Find all image definitions in a specific gallery
+
+    .. code-block:: yaml
+
+        policies:
+          - name: images-in-my-gallery
+            resource: azure.compute-gallery-image
+            filters:
+              - type: gallery
+                value: MyImageGallery
+    """
+    schema = type_schema('gallery', value={'type': 'string'})
+
+    def process(self, resources, event=None):
+        gallery_name = self.data.get('value')
+        parent_key = self.manager.resource_type.parent_key
+        return [r for r in resources
+                if ResourceIdParser.get_resource_name(r[parent_key]) == gallery_name]
+
+
+@resources.register('compute-gallery-image-version', aliases=['image-gallery-image-version'])
+class ComputeGalleryImageVersion(ChildArmResourceManager):
+    """Azure Compute Gallery Image Version
+
+    :example:
+
+    Find all image versions published in the last 30 days
+
+    .. code-block:: yaml
+
+        policies:
+          - name: recent-compute-gallery-image-versions
+            resource: azure.compute-gallery-image-version
+            filters:
+              - type: value
+                key: properties.publishingProfile.publishedDate
+                op: greater-than
+                value_type: age
+                value: 30
+
+    """
+    class resource_type(ChildTypeInfo, ArmTypeInfo):
+        doc_groups = ['Compute']
+
+        service = 'azure.mgmt.compute'
+        client = 'ComputeManagementClient'
+        resource_type = 'Microsoft.Compute/galleries/images/versions'
+
+        enum_spec = (
+            'gallery_image_versions',
+            'list_by_gallery_image',
+            None
+        )
+
+        parent_manager_name = 'compute-gallery-image'
+        parent_key = 'image_name'
+        raise_on_exception = False
+
+        @classmethod
+        def extra_args(cls, parent_resource):
+            # parent_resource is the gallery image
+            # Get gallery name from the image's parent ID
+            gallery_id = parent_resource.get('c7n:parent-id')
+            gallery_name = ResourceIdParser.get_resource_name(gallery_id) if gallery_id else None
+
+            return {
+                'resource_group_name': parent_resource['resourceGroup'],
+                'gallery_name': gallery_name,
+                'gallery_image_name': parent_resource['name']
+            }
+
+
+@ComputeGalleryImageVersion.filter_registry.register('image-definition')
+class ImageDefinitionFilter(Filter):
+    """Filter image versions by image definition name.
+
+    :example:
+
+    Find all versions of a specific image definition
+
+    .. code-block:: yaml
+
+        policies:
+          - name: versions-of-my-image
+            resource: azure.compute-gallery-image-version
+            filters:
+              - type: image-definition
+                value: MyImageDefinition
+    """
+    schema = type_schema('image-definition', value={'type': 'string'})
+
+    def process(self, resources, event=None):
+        image_name = self.data.get('value')
+        parent_key = self.manager.resource_type.parent_key
+        return [r for r in resources
+                if ResourceIdParser.get_resource_name(r.get(parent_key, '')) == image_name]
+
+
+@ComputeGalleryImageVersion.filter_registry.register('age')
+class ImageVersionAgeFilter(AgeFilter):
+    """Filter image versions by age based on the image published date.
+
+    :example:
+
+    Find image versions older than 90 days
+
+    .. code-block:: yaml
+
+        policies:
+          - name: old-image-versions
+            resource: azure.compute-gallery-image-version
+            filters:
+              - type: age
+                days: 90
+    """
+    date_attribute = 'properties.publishingProfile.publishedDate'
+    schema = type_schema(
+        'age',
+        days={'type': 'number', 'minimum': 0},
+        hours={'type': 'number', 'minimum': 0},
+        minutes={'type': 'number', 'minimum': 0},
+        op={'$ref': '#/definitions/filters_common/comparison_operators'}
+    )
+
+    def get_resource_date(self, resource):
+        """Safely extract the published date from nested resource properties."""
+        try:
+            date_str = resource.get('properties', {}).get('publishingProfile', {}).get('publishedDate')
+            if not date_str:
+                return None
+
+            # Parse ISO format datetime
+            if not isinstance(date_str, datetime):
+                from dateutil.parser import parse
+                from dateutil.tz import tzutc
+                v = parse(date_str)
+                if not v.tzinfo:
+                    v = v.replace(tzinfo=tzutc())
+                return v
+            return date_str
+        except (ValueError, AttributeError, TypeError):
+            return None
+
+
+@ComputeGalleryImageVersion.filter_registry.register('latest')
+class LatestImageVersionFilter(Filter):
+    """Filter to include or exclude the latest image version per image definition.
+
+    When true, only the latest version of each image is returned.
+    When false, all versions except the latest are returned.
+
+    The latest version is derived from the publishedDate field.
+
+    :example:
+
+    Find only the latest version of each image
+
+    .. code-block:: yaml
+
+        policies:
+          - name: latest-image-versions
+            resource: azure.compute-gallery-image-version
+            filters:
+              - type: latest
+                value: true
+
+    :example:
+
+    Get all versions except the latest one
+
+    .. code-block:: yaml
+
+        policies:
+          - name: get-old-image-versions
+            resource: azure.compute-gallery-image-version
+            filters:
+              - type: latest
+                value: false
+    """
+    schema = type_schema('latest', value={'type': 'boolean'})
+
+    def process(self, resources, event=None):
+        include_latest = self.data.get('value', True)
+        parent_key = self.manager.resource_type.parent_key
+
+        # Group resources by parent image
+        grouped = group_by(resources, parent_key)
+
+        result = []
+        for image_id, versions in grouped.items():
+            if not versions:
+                continue
+
+            # Find the latest version by published date
+            latest_version = max(
+                versions,
+                key=lambda v: self._get_published_date(v)
+            )
+
+            if include_latest:
+                # Only include the latest version
+                result.append(latest_version)
+            else:
+                # Include all versions except the latest
+                result.extend([v for v in versions if v != latest_version])
+
+        return result
+
+    def _get_published_date(self, resource):
+        """Extract published date from resource, defaulting to epoch if not found."""
+        try:
+            date_str = resource.get('properties', {}).get('publishingProfile', {}).get('publishedDate')
+            if date_str:
+                # Parse ISO format datetime
+                return datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+        except (ValueError, AttributeError):
+            pass
+        # Return epoch as fallback for unpublished or malformed dates
+        return datetime(1970, 1, 1)

--- a/tools/c7n_azure/c7n_azure/resources/image_gallery.py
+++ b/tools/c7n_azure/c7n_azure/resources/image_gallery.py
@@ -64,7 +64,7 @@ class ComputeGalleryImage(ChildArmResourceManager):
                 key: properties.osType
                 op: eq
                 value: Linux
-    
+
     :example:
 
     Get image definitions within a specific gallery
@@ -235,7 +235,8 @@ class ImageVersionAgeFilter(AgeFilter):
     def get_resource_date(self, resource):
         """Safely extract the published date from nested resource properties."""
         try:
-            date_str = resource.get('properties', {}).get('publishingProfile', {}).get('publishedDate')
+            publishing_profile = resource.get('properties', {}).get('publishingProfile', {})
+            date_str = publishing_profile.get('publishedDate')
             if not date_str:
                 return None
 
@@ -319,7 +320,8 @@ class LatestImageVersionFilter(Filter):
     def _get_published_date(self, resource):
         """Extract published date from resource, defaulting to epoch if not found."""
         try:
-            date_str = resource.get('properties', {}).get('publishingProfile', {}).get('publishedDate')
+            publishing_profile = resource.get('properties', {}).get('publishingProfile', {})
+            date_str = publishing_profile.get('publishedDate')
             if date_str:
                 # Parse ISO format datetime
                 return datetime.fromisoformat(date_str.replace('Z', '+00:00'))

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -29,7 +29,9 @@ ResourceMap = {
     "azure.cognitiveservice-deployment": "c7n_azure.resources.ai_foundry.AiFoundryCognitiveServiceDeployment", # noqa
     "azure.compute-gallery": "c7n_azure.resources.image_gallery.ComputeGallery",
     "azure.compute-gallery-image": "c7n_azure.resources.image_gallery.ComputeGalleryImage",
-    "azure.compute-gallery-image-version": "c7n_azure.resources.image_gallery.ComputeGalleryImageVersion",
+    "azure.compute-gallery-image-version": (
+        "c7n_azure.resources.image_gallery.ComputeGalleryImageVersion"
+    ),
     "azure.container-group": "c7n_azure.resources.aci.ContainerGroup",
     "azure.containerregistry": "c7n_azure.resources.container_registry.ContainerRegistry",
     "azure.container-registry": "c7n_azure.resources.container_registry.ContainerRegistry",

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -27,6 +27,9 @@ ResourceMap = {
     "azure.cognitiveservice": "c7n_azure.resources.ai_foundry.CognitiveService",
     "azure.ai-foundry-deployment": "c7n_azure.resources.ai_foundry.AiFoundryDeployment",
     "azure.cognitiveservice-deployment": "c7n_azure.resources.ai_foundry.AiFoundryCognitiveServiceDeployment", # noqa
+    "azure.compute-gallery": "c7n_azure.resources.image_gallery.ComputeGallery",
+    "azure.compute-gallery-image": "c7n_azure.resources.image_gallery.ComputeGalleryImage",
+    "azure.compute-gallery-image-version": "c7n_azure.resources.image_gallery.ComputeGalleryImageVersion",
     "azure.container-group": "c7n_azure.resources.aci.ContainerGroup",
     "azure.containerregistry": "c7n_azure.resources.container_registry.ContainerRegistry",
     "azure.container-registry": "c7n_azure.resources.container_registry.ContainerRegistry",

--- a/tools/c7n_azure/tests_azure/tests_resources/terraform/compute_gallery/main.tf
+++ b/tools/c7n_azure/tests_azure/tests_resources/terraform/compute_gallery/main.tf
@@ -1,0 +1,163 @@
+# Terraform configuration for Compute Gallery testing
+# Creates test galleries, images, and versions for Cloud Custodian policy testing
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+# Generate random suffix for unique naming
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+# Get current subscription data
+data "azurerm_client_config" "current" {}
+data "azurerm_subscription" "current" {}
+
+# Create resource group for test resources
+resource "azurerm_resource_group" "test" {
+  name     = "c7n-test-gallery-${random_string.suffix.result}"
+  location = "West Europe"
+}
+
+# Test Gallery 1: Main test gallery
+resource "azurerm_shared_image_gallery" "test_gallery" {
+  name                = "c7ntestgallery${random_string.suffix.result}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  description         = "C7N Test Compute Gallery"
+
+  tags = {
+    Environment = "Test"
+    Purpose     = "CloudCustodian"
+  }
+}
+
+# Test Gallery 2: Secondary gallery for filter testing
+resource "azurerm_shared_image_gallery" "secondary_gallery" {
+  name                = "c7nsecondary${random_string.suffix.result}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  description         = "C7N Secondary Test Gallery"
+
+  tags = {
+    Environment = "Test"
+    Purpose     = "FilterTesting"
+  }
+}
+
+# Image Definition 1: Linux image
+resource "azurerm_shared_image" "linux_image" {
+  name                = "c7n-linux-image"
+  gallery_name        = azurerm_shared_image_gallery.test_gallery.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+
+  identifier {
+    publisher = "C7N"
+    offer     = "TestLinux"
+    sku       = "v1"
+  }
+
+  tags = {
+    OSType = "Linux"
+  }
+}
+
+# Image Definition 2: Windows image
+resource "azurerm_shared_image" "windows_image" {
+  name                = "c7n-windows-image"
+  gallery_name        = azurerm_shared_image_gallery.test_gallery.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Windows"
+
+  identifier {
+    publisher = "C7N"
+    offer     = "TestWindows"
+    sku       = "v1"
+  }
+
+  tags = {
+    OSType = "Windows"
+  }
+}
+
+# Image Definition 3: Image in secondary gallery
+resource "azurerm_shared_image" "secondary_image" {
+  name                = "c7n-secondary-image"
+  gallery_name        = azurerm_shared_image_gallery.secondary_gallery.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+
+  identifier {
+    publisher = "C7N"
+    offer     = "Secondary"
+    sku       = "v1"
+  }
+}
+
+# Outputs for test assertions
+output "resource_group_name" {
+  value = azurerm_resource_group.test.name
+}
+
+output "test_gallery" {
+  value = {
+    name     = azurerm_shared_image_gallery.test_gallery.name
+    id       = azurerm_shared_image_gallery.test_gallery.id
+    location = azurerm_shared_image_gallery.test_gallery.location
+  }
+}
+
+output "secondary_gallery" {
+  value = {
+    name     = azurerm_shared_image_gallery.secondary_gallery.name
+    id       = azurerm_shared_image_gallery.secondary_gallery.id
+    location = azurerm_shared_image_gallery.secondary_gallery.location
+  }
+}
+
+output "linux_image" {
+  value = {
+    name     = azurerm_shared_image.linux_image.name
+    id       = azurerm_shared_image.linux_image.id
+    os_type  = azurerm_shared_image.linux_image.os_type
+    gallery  = azurerm_shared_image_gallery.test_gallery.name
+  }
+}
+
+output "windows_image" {
+  value = {
+    name     = azurerm_shared_image.windows_image.name
+    id       = azurerm_shared_image.windows_image.id
+    os_type  = azurerm_shared_image.windows_image.os_type
+    gallery  = azurerm_shared_image_gallery.test_gallery.name
+  }
+}
+
+output "secondary_image" {
+  value = {
+    name     = azurerm_shared_image.secondary_image.name
+    id       = azurerm_shared_image.secondary_image.id
+    os_type  = azurerm_shared_image.secondary_image.os_type
+    gallery  = azurerm_shared_image_gallery.secondary_gallery.name
+  }
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/terraform/compute_gallery/main.tf
+++ b/tools/c7n_azure/tests_azure/tests_resources/terraform/compute_gallery/main.tf
@@ -137,27 +137,27 @@ output "secondary_gallery" {
 
 output "linux_image" {
   value = {
-    name     = azurerm_shared_image.linux_image.name
-    id       = azurerm_shared_image.linux_image.id
-    os_type  = azurerm_shared_image.linux_image.os_type
-    gallery  = azurerm_shared_image_gallery.test_gallery.name
+    name    = azurerm_shared_image.linux_image.name
+    id      = azurerm_shared_image.linux_image.id
+    os_type = azurerm_shared_image.linux_image.os_type
+    gallery = azurerm_shared_image_gallery.test_gallery.name
   }
 }
 
 output "windows_image" {
   value = {
-    name     = azurerm_shared_image.windows_image.name
-    id       = azurerm_shared_image.windows_image.id
-    os_type  = azurerm_shared_image.windows_image.os_type
-    gallery  = azurerm_shared_image_gallery.test_gallery.name
+    name    = azurerm_shared_image.windows_image.name
+    id      = azurerm_shared_image.windows_image.id
+    os_type = azurerm_shared_image.windows_image.os_type
+    gallery = azurerm_shared_image_gallery.test_gallery.name
   }
 }
 
 output "secondary_image" {
   value = {
-    name     = azurerm_shared_image.secondary_image.name
-    id       = azurerm_shared_image.secondary_image.id
-    os_type  = azurerm_shared_image.secondary_image.os_type
-    gallery  = azurerm_shared_image_gallery.secondary_gallery.name
+    name    = azurerm_shared_image.secondary_image.name
+    id      = azurerm_shared_image.secondary_image.id
+    os_type = azurerm_shared_image.secondary_image.os_type
+    gallery = azurerm_shared_image_gallery.secondary_gallery.name
   }
 }

--- a/tools/c7n_azure/tests_azure/tests_resources/test_compute_gallery.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_compute_gallery.py
@@ -24,50 +24,6 @@ class ComputeGalleryTest(BaseTest):
             }, validate=True)
             self.assertTrue(p)
 
-    @terraform('compute_gallery')
-    @pytest.mark.functional
-    def test_compute_gallery_discovery_terraform(self, test, compute_gallery):
-        """Test that Cloud Custodian can discover galleries provisioned by Terraform"""
-        # Verify terraform fixtures loaded successfully
-        assert 'test_gallery' in compute_gallery.outputs
-        assert 'secondary_gallery' in compute_gallery.outputs
-
-        test_gallery = compute_gallery.outputs['test_gallery']['value']
-        secondary_gallery = compute_gallery.outputs['secondary_gallery']['value']
-
-        # Run discovery policy
-        policy = self.load_policy({
-            'name': 'test-gallery-discovery',
-            'resource': 'azure.compute-gallery'
-        })
-
-        resources = policy.run()
-
-        # Verify both galleries are discovered
-        gallery_names = {r['name'] for r in resources}
-        assert test_gallery['name'] in gallery_names
-        assert secondary_gallery['name'] in gallery_names
-
-    @terraform('compute_gallery')
-    @pytest.mark.functional
-    def test_compute_gallery_location_filter_terraform(self, test, compute_gallery):
-        """Test location filter on compute galleries"""
-
-        # Filter by location
-        policy = self.load_policy({
-            'name': 'test-gallery-location',
-            'resource': 'azure.compute-gallery',
-            'filters': [
-                {'type': 'value', 'key': 'location', 'op': 'eq', 'value': 'westeurope'}
-            ]
-        })
-
-        resources = policy.run()
-
-        # Verify filtered results
-        assert len(resources) >= 2
-        assert all(r['location'] == 'westeurope' for r in resources)
-
 
 class ComputeGalleryImageTest(BaseTest):
     """Test Compute Gallery Image resource functionality"""
@@ -86,75 +42,6 @@ class ComputeGalleryImageTest(BaseTest):
                 ]
             }, validate=True)
             self.assertTrue(p)
-
-    @terraform('compute_gallery')
-    @pytest.mark.functional
-    def test_compute_gallery_image_discovery_terraform(self, test, compute_gallery):
-        """Test that Cloud Custodian can discover image definitions"""
-        linux_image = compute_gallery.outputs['linux_image']['value']
-        windows_image = compute_gallery.outputs['windows_image']['value']
-
-        # Run discovery policy
-        policy = self.load_policy({
-            'name': 'test-image-discovery',
-            'resource': 'azure.compute-gallery-image'
-        })
-
-        resources = policy.run()
-
-        # Verify images are discovered
-        image_names = {r['name'] for r in resources}
-        assert linux_image['name'] in image_names
-        assert windows_image['name'] in image_names
-
-    @terraform('compute_gallery')
-    @pytest.mark.functional
-    def test_compute_gallery_image_os_filter_terraform(self, test, compute_gallery):
-        """Test OS type filter on image definitions"""
-        linux_image = compute_gallery.outputs['linux_image']['value']
-
-        # Filter by Linux OS type
-        policy = self.load_policy({
-            'name': 'test-linux-images',
-            'resource': 'azure.compute-gallery-image',
-            'filters': [
-                {'type': 'value', 'key': 'properties.osType', 'op': 'eq', 'value': 'Linux'}
-            ]
-        })
-
-        resources = policy.run()
-
-        # Verify all returned resources are Linux
-        assert all(r['properties']['osType'] == 'Linux' for r in resources)
-        assert any(r['name'] == linux_image['name'] for r in resources)
-
-    @terraform('compute_gallery')
-    @pytest.mark.functional
-    def test_compute_gallery_image_gallery_filter_terraform(self, test, compute_gallery):
-        """Test gallery filter on image definitions"""
-        test_gallery = compute_gallery.outputs['test_gallery']['value']
-        linux_image = compute_gallery.outputs['linux_image']['value']
-        windows_image = compute_gallery.outputs['windows_image']['value']
-
-        # Filter by gallery name
-        policy = self.load_policy({
-            'name': 'test-gallery-filter',
-            'resource': 'azure.compute-gallery-image',
-            'filters': [
-                {'type': 'gallery', 'value': test_gallery['name']}
-            ]
-        })
-
-        resources = policy.run()
-
-        # Verify only images from the specified gallery are returned
-        image_names = {r['name'] for r in resources}
-        assert linux_image['name'] in image_names
-        assert windows_image['name'] in image_names
-
-        # Verify all resources belong to the test gallery
-        for r in resources:
-            assert r.get('c7n:parent-id'), "Missing parent-id annotation"
 
 
 class ComputeGalleryImageVersionTest(BaseTest):
@@ -242,3 +129,122 @@ class ComputeGalleryImageVersionTest(BaseTest):
                 ]
             }, validate=True)
             self.assertTrue(p)
+
+
+# Terraform-based functional tests (must be module-level functions)
+
+@terraform('compute_gallery')
+@pytest.mark.functional
+def test_compute_gallery_discovery_terraform(test, compute_gallery):
+    """Test that Cloud Custodian can discover galleries provisioned by Terraform"""
+    # Verify terraform fixtures loaded successfully
+    assert 'test_gallery' in compute_gallery.outputs
+    assert 'secondary_gallery' in compute_gallery.outputs
+
+    test_gallery = compute_gallery.outputs['test_gallery']['value']
+    secondary_gallery = compute_gallery.outputs['secondary_gallery']['value']
+
+    # Run discovery policy
+    policy = test.load_policy({
+        'name': 'test-gallery-discovery',
+        'resource': 'azure.compute-gallery'
+    })
+
+    resources = policy.run()
+
+    # Verify both galleries are discovered
+    gallery_names = {r['name'] for r in resources}
+    assert test_gallery['name'] in gallery_names
+    assert secondary_gallery['name'] in gallery_names
+
+
+@terraform('compute_gallery')
+@pytest.mark.functional
+def test_compute_gallery_location_filter_terraform(test, compute_gallery):
+    """Test location filter on compute galleries"""
+    # Filter by location
+    policy = test.load_policy({
+        'name': 'test-gallery-location',
+        'resource': 'azure.compute-gallery',
+        'filters': [
+            {'type': 'value', 'key': 'location', 'op': 'eq', 'value': 'westeurope'}
+        ]
+    })
+
+    resources = policy.run()
+
+    # Verify filtered results
+    assert len(resources) >= 2
+    assert all(r['location'] == 'westeurope' for r in resources)
+
+
+@terraform('compute_gallery')
+@pytest.mark.functional
+def test_compute_gallery_image_discovery_terraform(test, compute_gallery):
+    """Test that Cloud Custodian can discover image definitions"""
+    linux_image = compute_gallery.outputs['linux_image']['value']
+    windows_image = compute_gallery.outputs['windows_image']['value']
+
+    # Run discovery policy
+    policy = test.load_policy({
+        'name': 'test-image-discovery',
+        'resource': 'azure.compute-gallery-image'
+    })
+
+    resources = policy.run()
+
+    # Verify images are discovered
+    image_names = {r['name'] for r in resources}
+    assert linux_image['name'] in image_names
+    assert windows_image['name'] in image_names
+
+
+@terraform('compute_gallery')
+@pytest.mark.functional
+def test_compute_gallery_image_os_filter_terraform(test, compute_gallery):
+    """Test OS type filter on image definitions"""
+    linux_image = compute_gallery.outputs['linux_image']['value']
+
+    # Filter by Linux OS type
+    policy = test.load_policy({
+        'name': 'test-linux-images',
+        'resource': 'azure.compute-gallery-image',
+        'filters': [
+            {'type': 'value', 'key': 'properties.osType', 'op': 'eq', 'value': 'Linux'}
+        ]
+    })
+
+    resources = policy.run()
+
+    # Verify all returned resources are Linux
+    assert all(r['properties']['osType'] == 'Linux' for r in resources)
+    assert any(r['name'] == linux_image['name'] for r in resources)
+
+
+@terraform('compute_gallery')
+@pytest.mark.functional
+def test_compute_gallery_image_gallery_filter_terraform(test, compute_gallery):
+    """Test gallery filter on image definitions"""
+    test_gallery = compute_gallery.outputs['test_gallery']['value']
+    linux_image = compute_gallery.outputs['linux_image']['value']
+    windows_image = compute_gallery.outputs['windows_image']['value']
+
+    # Filter by gallery name
+    policy = test.load_policy({
+        'name': 'test-gallery-filter',
+        'resource': 'azure.compute-gallery-image',
+        'filters': [
+            {'type': 'gallery', 'value': test_gallery['name']}
+        ]
+    })
+
+    resources = policy.run()
+
+    # Verify only images from the specified gallery are returned
+    image_names = {r['name'] for r in resources}
+    assert linux_image['name'] in image_names
+    assert windows_image['name'] in image_names
+
+    # Verify all resources belong to the test gallery
+    for r in resources:
+        assert r.get('c7n:parent-id'), "Missing parent-id annotation"

--- a/tools/c7n_azure/tests_azure/tests_resources/test_compute_gallery.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_compute_gallery.py
@@ -52,7 +52,6 @@ class ComputeGalleryTest(BaseTest):
     @pytest.mark.functional
     def test_compute_gallery_location_filter_terraform(self, test, compute_gallery):
         """Test location filter on compute galleries"""
-        test_gallery = compute_gallery.outputs['test_gallery']['value']
 
         # Filter by location
         policy = self.load_policy({

--- a/tools/c7n_azure/tests_azure/tests_resources/test_compute_gallery.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_compute_gallery.py
@@ -1,0 +1,245 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pytest_terraform import terraform
+from tests_azure.azure_common import BaseTest
+
+
+class ComputeGalleryTest(BaseTest):
+    """Test Compute Gallery resource functionality"""
+
+    def setUp(self):
+        super().setUp()
+
+    def test_compute_gallery_schema_validate(self):
+        """Test that the Compute Gallery resource schema validates correctly"""
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-compute-gallery',
+                'resource': 'azure.compute-gallery',
+                'filters': [
+                    {'type': 'value', 'key': 'location', 'value': 'westeurope'}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+    @terraform('compute_gallery')
+    @pytest.mark.functional
+    def test_compute_gallery_discovery_terraform(self, test, compute_gallery):
+        """Test that Cloud Custodian can discover galleries provisioned by Terraform"""
+        # Verify terraform fixtures loaded successfully
+        assert 'test_gallery' in compute_gallery.outputs
+        assert 'secondary_gallery' in compute_gallery.outputs
+
+        test_gallery = compute_gallery.outputs['test_gallery']['value']
+        secondary_gallery = compute_gallery.outputs['secondary_gallery']['value']
+
+        # Run discovery policy
+        policy = self.load_policy({
+            'name': 'test-gallery-discovery',
+            'resource': 'azure.compute-gallery'
+        })
+
+        resources = policy.run()
+
+        # Verify both galleries are discovered
+        gallery_names = {r['name'] for r in resources}
+        assert test_gallery['name'] in gallery_names
+        assert secondary_gallery['name'] in gallery_names
+
+    @terraform('compute_gallery')
+    @pytest.mark.functional
+    def test_compute_gallery_location_filter_terraform(self, test, compute_gallery):
+        """Test location filter on compute galleries"""
+        test_gallery = compute_gallery.outputs['test_gallery']['value']
+
+        # Filter by location
+        policy = self.load_policy({
+            'name': 'test-gallery-location',
+            'resource': 'azure.compute-gallery',
+            'filters': [
+                {'type': 'value', 'key': 'location', 'op': 'eq', 'value': 'westeurope'}
+            ]
+        })
+
+        resources = policy.run()
+
+        # Verify filtered results
+        assert len(resources) >= 2
+        assert all(r['location'] == 'westeurope' for r in resources)
+
+
+class ComputeGalleryImageTest(BaseTest):
+    """Test Compute Gallery Image resource functionality"""
+
+    def setUp(self):
+        super().setUp()
+
+    def test_compute_gallery_image_schema_validate(self):
+        """Test that the Compute Gallery Image resource schema validates correctly"""
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-compute-gallery-image',
+                'resource': 'azure.compute-gallery-image',
+                'filters': [
+                    {'type': 'value', 'key': 'properties.osType', 'value': 'Linux'}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+    @terraform('compute_gallery')
+    @pytest.mark.functional
+    def test_compute_gallery_image_discovery_terraform(self, test, compute_gallery):
+        """Test that Cloud Custodian can discover image definitions"""
+        linux_image = compute_gallery.outputs['linux_image']['value']
+        windows_image = compute_gallery.outputs['windows_image']['value']
+
+        # Run discovery policy
+        policy = self.load_policy({
+            'name': 'test-image-discovery',
+            'resource': 'azure.compute-gallery-image'
+        })
+
+        resources = policy.run()
+
+        # Verify images are discovered
+        image_names = {r['name'] for r in resources}
+        assert linux_image['name'] in image_names
+        assert windows_image['name'] in image_names
+
+    @terraform('compute_gallery')
+    @pytest.mark.functional
+    def test_compute_gallery_image_os_filter_terraform(self, test, compute_gallery):
+        """Test OS type filter on image definitions"""
+        linux_image = compute_gallery.outputs['linux_image']['value']
+
+        # Filter by Linux OS type
+        policy = self.load_policy({
+            'name': 'test-linux-images',
+            'resource': 'azure.compute-gallery-image',
+            'filters': [
+                {'type': 'value', 'key': 'properties.osType', 'op': 'eq', 'value': 'Linux'}
+            ]
+        })
+
+        resources = policy.run()
+
+        # Verify all returned resources are Linux
+        assert all(r['properties']['osType'] == 'Linux' for r in resources)
+        assert any(r['name'] == linux_image['name'] for r in resources)
+
+    @terraform('compute_gallery')
+    @pytest.mark.functional
+    def test_compute_gallery_image_gallery_filter_terraform(self, test, compute_gallery):
+        """Test gallery filter on image definitions"""
+        test_gallery = compute_gallery.outputs['test_gallery']['value']
+        linux_image = compute_gallery.outputs['linux_image']['value']
+        windows_image = compute_gallery.outputs['windows_image']['value']
+
+        # Filter by gallery name
+        policy = self.load_policy({
+            'name': 'test-gallery-filter',
+            'resource': 'azure.compute-gallery-image',
+            'filters': [
+                {'type': 'gallery', 'value': test_gallery['name']}
+            ]
+        })
+
+        resources = policy.run()
+
+        # Verify only images from the specified gallery are returned
+        image_names = {r['name'] for r in resources}
+        assert linux_image['name'] in image_names
+        assert windows_image['name'] in image_names
+
+        # Verify all resources belong to the test gallery
+        for r in resources:
+            assert r.get('c7n:parent-id'), "Missing parent-id annotation"
+
+
+class ComputeGalleryImageVersionTest(BaseTest):
+    """Test Compute Gallery Image Version resource functionality"""
+
+    def setUp(self):
+        super().setUp()
+
+    def test_compute_gallery_image_version_schema_validate(self):
+        """Test that the Image Version resource schema validates correctly"""
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-image-version',
+                'resource': 'azure.compute-gallery-image-version',
+                'filters': [
+                    {'type': 'age', 'days': 90}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_image_definition_filter_schema(self):
+        """Test image-definition filter schema validation"""
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-image-def-filter',
+                'resource': 'azure.compute-gallery-image-version',
+                'filters': [
+                    {'type': 'image-definition', 'value': 'test-image'}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_latest_filter_schema(self):
+        """Test latest filter schema validation"""
+        with self.sign_out_patch():
+            # Test with value: true
+            p = self.load_policy({
+                'name': 'test-latest-filter-true',
+                'resource': 'azure.compute-gallery-image-version',
+                'filters': [
+                    {'type': 'latest', 'value': True}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+            # Test with value: false
+            p = self.load_policy({
+                'name': 'test-latest-filter-false',
+                'resource': 'azure.compute-gallery-image-version',
+                'filters': [
+                    {'type': 'latest', 'value': False}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_age_filter_schema(self):
+        """Test age filter schema validation"""
+        with self.sign_out_patch():
+            # Test with days
+            p = self.load_policy({
+                'name': 'test-age-days',
+                'resource': 'azure.compute-gallery-image-version',
+                'filters': [
+                    {'type': 'age', 'days': 90}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+            # Test with hours
+            p = self.load_policy({
+                'name': 'test-age-hours',
+                'resource': 'azure.compute-gallery-image-version',
+                'filters': [
+                    {'type': 'age', 'hours': 24}
+                ]
+            }, validate=True)
+            self.assertTrue(p)
+
+            # Test with operator
+            p = self.load_policy({
+                'name': 'test-age-operator',
+                'resource': 'azure.compute-gallery-image-version',
+                'filters': [
+                    {'type': 'age', 'days': 30, 'op': 'less-than'}
+                ]
+            }, validate=True)
+            self.assertTrue(p)


### PR DESCRIPTION
# Summary
This PR adds support for Azure Compute Gallery images (formerly known as Shared Image Gallery).  As per the Slack discussion, I am using the name `Compute Gallery` instead of `Image Gallery` to allow for extension once Microsoft adds `Application` to the `Compute Gallery` object type.

## Three new resources are introduced: 

- `azure.compute-gallery` - Allows policies to target the Image galleries themselves.
- `azure.compute-gallery-image` - Allows policies to target the Image Definitions within the galleries.
- `azure.compute-gallery-image-version` - Allows policies to target the Image Version (the actual images used to create VMs). 

## Additional Filters:
I have also added some resource-specific filters that made sense to me. These include: 

- For `compute-gallery-image`:
  - `GalleryFilter` - Used to target only image definitions within a specific Gallery.
- For `compute-gallery-image-version` there are 3 filters:
  - `ImageDefinitionFilter` - Used to target versions of a specific Image Definition.
  - `ImageVersionAgeFilter` - Used to filter the image versions based on the `age` filter similar to other resources, with the options to use `days`, `hours`, `minutes`.
  - `LatestImageVersionFilter` - Used to either select or exclude the `latest` image version. 
 
 ## Manual validation:
 By using the following policy, I get the following results: 
 **POLICY**
 ```
 policies:
  - name: test-compute-gallery
    resource: azure.compute-gallery

  - name: test-compute-gallery-image-with-gallery-filter
    resource: azure.compute-gallery-image
    filters:
      - type: gallery
        value: test_image_gallery

  - name: test-compute-gallery-image-version
    resource: azure.compute-gallery-image-version
    filters:
      - type: value
        key: properties.publishingProfile.publishedDate
        value_type: age
        value: 30
        op: less-than
 ```
 
 **RESULTS:**
 
 ```
2026-04-21 10:43:11,810: custodian.policy:INFO policy:test-compute-gallery resource:azure.compute-gallery region:AzureCloud count:1 time:2.85
2026-04-21 10:43:12,273: custodian.policy:INFO policy:test-compute-gallery-image resource:azure.compute-gallery-image region:AzureCloud count:94 time:0.46
2026-04-21 10:43:26,562: custodian.policy:INFO policy:test-compute-gallery-image-version resource:azure.compute-gallery-image-version region:AzureCloud count:182 time:14.29
 ```
 ## Disclaimers
 I have used AI (claude sonnet 4.5) to assist with the `ImageVersionAgeFilter` and `LatestImageVersionFilter` logic. I tried to "simplify" some of the logic, but then the filters stopped working as expected.
 
I have based my tests on the Entra ID tests and I am also using claude to assist with the pytest part.