### PR TITLE
gcp - label actions for loadbalancer

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/actions/labels.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/labels.py
@@ -19,7 +19,17 @@ from c7n_gcp.provider import resources as gcp_resources
 class BaseLabelAction(MethodAction):
 
     method_spec = {}
-    method_perm = 'update'
+
+    @property
+    def method_perm(self):
+        model = self.manager.get_model()
+
+        # Allow overriding via labels_perm
+        if override := getattr(model, 'labels_perm', None):
+            return override
+
+        # Default the permission name to the operation name
+        return model.labels_op
 
     def get_labels_to_add(self, resource):
         return None

--- a/tools/c7n_gcp/c7n_gcp/resources/artifactregistry.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/artifactregistry.py
@@ -26,6 +26,7 @@ class ArtifactRegistryRepository(RegionalResourceManager):
         default_report_fields = ['name', 'description', 'updateTime', 'sizeBytes']
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
 
         @staticmethod
         def get_label_params(resource, all_labels):

--- a/tools/c7n_gcp/c7n_gcp/resources/bigquery.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/bigquery.py
@@ -31,6 +31,7 @@ class DataSet(QueryResourceManager):
         urn_id_path = "datasetReference.datasetId"
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
 
         @staticmethod
         def get(client, event):
@@ -124,6 +125,7 @@ class BigQueryTable(ChildResourceManager):
         urn_id_path = "tableReference.tableId"
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
 
         @classmethod
         def _get_urn_id(cls, resource):

--- a/tools/c7n_gcp/c7n_gcp/resources/bigtable.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/bigtable.py
@@ -27,6 +27,7 @@ class BigTableInstance(QueryResourceManager):
         default_report_fields = ['displayName', 'expireTime']
         labels = True
         labels_op = 'partialUpdateInstance'
+        labels_perm = 'update'
 
         @staticmethod
         def get_label_params(resource, all_labels):

--- a/tools/c7n_gcp/c7n_gcp/resources/certificatemanager.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/certificatemanager.py
@@ -28,6 +28,7 @@ class CertificateManagerCertificate(QueryResourceManager):
         id = 'name'
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
         default_report_fields = [
             'name', 'description', 'createTime', 'expireTime',
             'updateTime', 'labels', 'sanDnsnames', 'usedBy'

--- a/tools/c7n_gcp/c7n_gcp/resources/cloudrun.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/cloudrun.py
@@ -27,6 +27,7 @@ class CloudRunService(QueryResourceManager):
         asset_type = "run.googleapis.com/Service"
         labels = True
         labels_op = 'replaceService'
+        labels_perm = 'update'
 
         @staticmethod
         def get_label_params(resource, all_labels):
@@ -90,6 +91,7 @@ class CloudRunJob(QueryResourceManager):
         asset_type = "run.googleapis.com/Job"
         labels = True
         labels_op = 'replaceJob'
+        labels_perm = 'update'
 
         @staticmethod
         def get_label_params(resource, all_labels):

--- a/tools/c7n_gcp/c7n_gcp/resources/gke.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/gke.py
@@ -36,6 +36,7 @@ class KubernetesCluster(QueryResourceManager):
         urn_component = 'cluster'
         labels = True
         labels_op = 'setResourceLabels'
+        labels_perm = 'update'
         urn_zonal = True
 
         @staticmethod

--- a/tools/c7n_gcp/c7n_gcp/resources/kms.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/kms.py
@@ -110,6 +110,7 @@ class KmsCryptoKey(ChildResourceManager):
         urn_id_segments = (5, 7)
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
 
         @staticmethod
         def get(client, resource_info):

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
@@ -537,6 +537,8 @@ class LoadBalancingGlobalForwardingRule(QueryResourceManager):
         enum_spec = ('list', 'items[]', None)
         scope = 'project'
         name = id = 'name'
+        labels = True
+        labels_op = 'setLabels'
         default_report_fields = [
             "name", "description", "creationTimestamp", "network",
             "networkTier", "loadBalancingScheme", "subnetwork", "allowGlobalAccess"
@@ -545,10 +547,32 @@ class LoadBalancingGlobalForwardingRule(QueryResourceManager):
         urn_component = "global-forwarding-rule"
 
         @staticmethod
-        def get(client, resource_info):
-            return client.execute_command('get', {
-                'project': resource_info['project_id'],
-                'forwardingRule': resource_info['resourceName'].rsplit('/', 1)[-1]})
+        def parse_params(resc_name):
+            """Takes resourceName (from a log) or selfLink (from a resource) and parses from it the
+            parameters needed to make a request (project and rule)"""
+            exp = r".*projects/(.*)/global/forwardingRules/(.*)"
+            return re.match(exp, resc_name).groups()
+
+        @classmethod
+        def get(cls, client, resource_info):
+            project, rule = cls.parse_params(resource_info['resourceName'])
+            return client.execute_command('get', {'project': project, 'forwardingRule': rule})
+
+        @classmethod
+        def get_label_params(cls, resource, all_labels):
+            project, rule = cls.parse_params(resource['selfLink'])
+            return {
+                'project': project,
+                'resource': rule,
+                'body': {
+                    'labels': all_labels,
+                    'labelFingerprint': resource['labelFingerprint']
+                }
+            }
+
+        @classmethod
+        def refresh(cls, client, resource):
+            return cls.get(client, {'resourceName': resource['selfLink']})
 
 
 @resources.register('loadbalancer-global-address')

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
@@ -562,6 +562,8 @@ class LoadBalancingGlobalAddress(QueryResourceManager):
         enum_spec = ('list', 'items[]', None)
         scope = 'project'
         name = id = 'name'
+        labels = True
+        labels_op = 'setLabels'
         default_report_fields = [
             "name", "description", "status", "creationTimestamp", "address", "region"
         ]
@@ -569,7 +571,29 @@ class LoadBalancingGlobalAddress(QueryResourceManager):
         urn_component = "global-address"
 
         @staticmethod
-        def get(client, resource_info):
-            return client.execute_command('get', {
-                'project': resource_info['project_id'],
-                'address': resource_info['resourceName'].rsplit('/', 1)[-1]})
+        def parse_params(resc_name):
+            """Takes resourceName (from a log) or selfLink (from a resource) and parses from it the
+            parameters needed to make a request (project and address)"""
+            exp = r".*projects/(.*)/global/addresses\/(.*)"
+            return re.match(exp, resc_name).groups()
+
+        @classmethod
+        def get(cls, client, resource_info):
+            project_id, address = cls.parse_params(resource_info['resourceName'])
+            return client.execute_command('get', {'project': project_id, 'address': address})
+
+        @classmethod
+        def get_label_params(cls, resource, all_labels):
+            project_id, address = cls.parse_params(resource['selfLink'])
+            return {
+                'project': project_id,
+                'resource': address,
+                'body': {
+                    'labels': all_labels,
+                    'labelFingerprint': resource['labelFingerprint']
+                }
+            }
+
+        @classmethod
+        def refresh(cls, client, resource):
+            return cls.get(client, {'resourceName': resource['selfLink']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
@@ -523,6 +523,8 @@ class LoadBalancingForwardingRule(QueryResourceManager):
 
         @classmethod
         def refresh(cls, client, resource):
+            """This method is used to refresh labelFingerprint when a label action fails because the
+            fingerprint was stale."""
             return cls.get(client, {'resourceName': resource['selfLink']})
 
 
@@ -572,6 +574,8 @@ class LoadBalancingGlobalForwardingRule(QueryResourceManager):
 
         @classmethod
         def refresh(cls, client, resource):
+            """This method is used to refresh labelFingerprint when a label action fails because the
+            fingerprint was stale."""
             return cls.get(client, {'resourceName': resource['selfLink']})
 
 
@@ -598,7 +602,7 @@ class LoadBalancingGlobalAddress(QueryResourceManager):
         def parse_params(resc_name):
             """Takes resourceName (from a log) or selfLink (from a resource) and parses from it the
             parameters needed to make a request (project and address)"""
-            exp = r".*projects/(.*)/global/addresses\/(.*)"
+            exp = r".*projects/(.*)/global/addresses/(.*)"
             return re.match(exp, resc_name).groups()
 
         @classmethod
@@ -620,4 +624,6 @@ class LoadBalancingGlobalAddress(QueryResourceManager):
 
         @classmethod
         def refresh(cls, client, resource):
+            """This method is used to refresh labelFingerprint when a label action fails because the
+            fingerprint was stale."""
             return cls.get(client, {'resourceName': resource['selfLink']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
@@ -1,5 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+import re
+
 from c7n.utils import type_schema, local_session
 from c7n_gcp.actions import MethodAction
 from c7n_gcp.provider import resources
@@ -473,7 +475,7 @@ class LoadBalancingTargetPool(QueryResourceManager):
 
 @resources.register('loadbalancer-forwarding-rule')
 class LoadBalancingForwardingRule(QueryResourceManager):
-    """GCP resource: https://cloud.google.com/compute/docs/reference/rest/v1/addresses
+    """GCP resource: https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules
     """
     class resource_type(TypeInfo):
         service = 'compute'
@@ -482,6 +484,8 @@ class LoadBalancingForwardingRule(QueryResourceManager):
         enum_spec = ('aggregatedList', 'items.*.forwardingRules[]', None)
         scope = 'project'
         name = id = 'name'
+        labels = True
+        labels_op = 'setLabels'
         default_report_fields = [
             "name", "description", "region", "IPAddress", "IPProtocol", "target",
             "loadBalancingScheme", "serviceName", "network"
@@ -490,11 +494,36 @@ class LoadBalancingForwardingRule(QueryResourceManager):
         urn_component = "forwarding-rule"
 
         @staticmethod
-        def get(client, resource_info):
+        def parse_params(resc_name):
+            """Takes resourceName (from a log) or selfLink (from a resource) and parses from it the
+            parameters needed to make a request (project, region, and rule)"""
+            exp = r".*projects/(.*)/regions/(.*)/forwardingRules/(.*)"
+            return re.match(exp, resc_name).groups()
+
+        @classmethod
+        def get(cls, client, resource_info):
+            project, region, rule = cls.parse_params(resource_info['resourceName'])
             return client.execute_command('get', {
-                'project': resource_info['project_id'],
-                'region': resource_info['region'],
-                'forwardingRule': resource_info['resourceName'].rsplit('/', 1)[-1]})
+                'project': project,
+                'region': region,
+                'forwardingRule': rule})
+
+        @classmethod
+        def get_label_params(cls, resource, all_labels):
+            project, region, rule = cls.parse_params(resource['selfLink'])
+            return {
+                'project': project,
+                'region': region,
+                'resource': rule,
+                'body': {
+                    'labels': all_labels,
+                    'labelFingerprint': resource['labelFingerprint']
+                }
+            }
+
+        @classmethod
+        def refresh(cls, client, resource):
+            return cls.get(client, {'resourceName': resource['selfLink']})
 
 
 @resources.register('loadbalancer-global-forwarding-rule')

--- a/tools/c7n_gcp/c7n_gcp/resources/spanner.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/spanner.py
@@ -24,6 +24,7 @@ class SpannerInstance(QueryResourceManager):
             "name", "displayName", "nodeCount", "state", "config"]
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
         asset_type = "spanner.googleapis.com/Instance"
         metric_key = "resource.labels.instance_id"
         urn_component = "instance"

--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -25,6 +25,7 @@ class SqlInstance(QueryResourceManager):
         scope = 'project'
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
         name = id = 'name'
         default_report_fields = [
             "name", "state", "databaseVersion", "settings.tier", "settings.dataDiskSizeGb"]

--- a/tools/c7n_gcp/c7n_gcp/resources/storage.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/storage.py
@@ -26,6 +26,7 @@ class Bucket(QueryResourceManager):
         urn_component = "bucket"
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
 
         @staticmethod
         def get(client, resource_info):

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-forwarding-rule-labels/get-compute-v1-projects-cloud-custodian-aggregated-forwardingRules_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-forwarding-rule-labels/get-compute-v1-projects-cloud-custodian-aggregated-forwardingRules_1.json
@@ -1,0 +1,586 @@
+{
+  "headers": {
+    "etag": "eyvqV3KEJ6j-x2SC9Gv5UDDyhMo=/ADqvo5Y9y7N2uWqJo6MS_X5Kjc0=",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 20:48:00 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "15763",
+    "-content-encoding": "gzip",
+    "content-location": "https://compute.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/forwardingRules?alt=json"
+  },
+  "body": {
+    "kind": "compute#forwardingRuleAggregatedList",
+    "id": "projects/cloud-custodian/aggregated/forwardingRules",
+    "items": {
+      "global": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'global'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "global"
+            }
+          ]
+        }
+      },
+      "regions/us-central1": {
+        "forwardingRules": [
+          {
+            "kind": "compute#forwardingRule",
+            "id": "330641587841948827",
+            "creationTimestamp": "2026-04-21T13:47:48.047-07:00",
+            "name": "c7n-forwarding-rule-default-d536",
+            "description": "",
+            "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1",
+            "IPAddress": "34.172.85.61",
+            "IPProtocol": "TCP",
+            "portRange": "80-80",
+            "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/targetPools/c7n-target-pool-default-d536",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/c7n-forwarding-rule-default-d536",
+            "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/330641587841948827",
+            "loadBalancingScheme": "EXTERNAL",
+            "networkTier": "PREMIUM",
+            "labels": {
+              "env": "default"
+            },
+            "labelFingerprint": "aMJEA_pTI0o=",
+            "fingerprint": "yDsnn6Ls0os="
+          },
+          {
+            "kind": "compute#forwardingRule",
+            "id": "3848090722319190174",
+            "creationTimestamp": "2026-04-17T11:05:37.170-07:00",
+            "name": "c7n-ilb-fr-calebsyring-b30e",
+            "description": "",
+            "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1",
+            "IPAddress": "10.0.1.2",
+            "IPProtocol": "TCP",
+            "portRange": "80-80",
+            "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/targetHttpProxies/c7n-ilb-prx-calebsyring-b30e",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/c7n-ilb-fr-calebsyring-b30e",
+            "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/3848090722319190174",
+            "loadBalancingScheme": "INTERNAL_MANAGED",
+            "subnetwork": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/subnetworks/c7n-ilb-sub-calebsyring-b30e",
+            "network": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/networks/c7n-ilb-net-calebsyring-b30e",
+            "networkTier": "PREMIUM",
+            "labelFingerprint": "42WmSpB8rSM=",
+            "fingerprint": "up4gjVYcKtM="
+          }
+        ]
+      },
+      "regions/europe-west1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west1"
+            }
+          ]
+        }
+      },
+      "regions/us-west1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/us-west1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-west1"
+            }
+          ]
+        }
+      },
+      "regions/asia-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-east1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-east1"
+            }
+          ]
+        }
+      },
+      "regions/us-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/us-east1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-east1"
+            }
+          ]
+        }
+      },
+      "regions/asia-northeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-northeast1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-northeast1"
+            }
+          ]
+        }
+      },
+      "regions/asia-southeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-southeast1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-southeast1"
+            }
+          ]
+        }
+      },
+      "regions/us-east4": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/us-east4'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-east4"
+            }
+          ]
+        }
+      },
+      "regions/australia-southeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/australia-southeast1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/australia-southeast1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west2"
+            }
+          ]
+        }
+      },
+      "regions/europe-west3": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west3'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west3"
+            }
+          ]
+        }
+      },
+      "regions/southamerica-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/southamerica-east1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/southamerica-east1"
+            }
+          ]
+        }
+      },
+      "regions/asia-south1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-south1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-south1"
+            }
+          ]
+        }
+      },
+      "regions/northamerica-northeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/northamerica-northeast1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/northamerica-northeast1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west4": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west4'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west4"
+            }
+          ]
+        }
+      },
+      "regions/europe-north1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-north1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-north1"
+            }
+          ]
+        }
+      },
+      "regions/us-west2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/us-west2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-west2"
+            }
+          ]
+        }
+      },
+      "regions/asia-east2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-east2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-east2"
+            }
+          ]
+        }
+      },
+      "regions/europe-west6": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west6'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west6"
+            }
+          ]
+        }
+      },
+      "regions/asia-northeast2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-northeast2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-northeast2"
+            }
+          ]
+        }
+      },
+      "regions/asia-northeast3": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-northeast3'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-northeast3"
+            }
+          ]
+        }
+      },
+      "regions/us-west3": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/us-west3'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-west3"
+            }
+          ]
+        }
+      },
+      "regions/us-west4": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/us-west4'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-west4"
+            }
+          ]
+        }
+      },
+      "regions/asia-southeast2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-southeast2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-southeast2"
+            }
+          ]
+        }
+      },
+      "regions/europe-central2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-central2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-central2"
+            }
+          ]
+        }
+      },
+      "regions/northamerica-northeast2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/northamerica-northeast2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/northamerica-northeast2"
+            }
+          ]
+        }
+      },
+      "regions/asia-south2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-south2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-south2"
+            }
+          ]
+        }
+      },
+      "regions/australia-southeast2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/australia-southeast2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/australia-southeast2"
+            }
+          ]
+        }
+      },
+      "regions/southamerica-west1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/southamerica-west1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/southamerica-west1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west8": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west8'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west8"
+            }
+          ]
+        }
+      },
+      "regions/europe-west9": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west9'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west9"
+            }
+          ]
+        }
+      },
+      "regions/us-east5": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/us-east5'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-east5"
+            }
+          ]
+        }
+      },
+      "regions/europe-southwest1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-southwest1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-southwest1"
+            }
+          ]
+        }
+      },
+      "regions/us-south1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/us-south1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-south1"
+            }
+          ]
+        }
+      },
+      "regions/me-west1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/me-west1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/me-west1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west12": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west12'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west12"
+            }
+          ]
+        }
+      },
+      "regions/me-central1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/me-central1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/me-central1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west10": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-west10'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west10"
+            }
+          ]
+        }
+      },
+      "regions/me-central2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/me-central2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/me-central2"
+            }
+          ]
+        }
+      },
+      "regions/africa-south1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/africa-south1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/africa-south1"
+            }
+          ]
+        }
+      },
+      "regions/northamerica-south1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/northamerica-south1'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/northamerica-south1"
+            }
+          ]
+        }
+      },
+      "regions/europe-north2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/europe-north2'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-north2"
+            }
+          ]
+        }
+      },
+      "regions/asia-southeast3": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "No results for the scope 'regions/asia-southeast3'.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-southeast3"
+            }
+          ]
+        }
+      }
+    },
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/forwardingRules"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-forwarding-rule-labels/get-compute-v1-projects-cloud-custodian-regions-us-central1-forwardingRules-c7n-forwarding-rule-default-d536_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-forwarding-rule-labels/get-compute-v1-projects-cloud-custodian-regions-us-central1-forwardingRules-c7n-forwarding-rule-default-d536_1.json
@@ -1,0 +1,39 @@
+{
+  "headers": {
+    "etag": "4_OtCcr8wr1J1Qb4c_znfyowy0A=/PgMFB7YfXmK30JvON_w5OA36Sao=",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 20:48:01 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1009",
+    "-content-encoding": "gzip",
+    "content-location": "https://compute.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/c7n-forwarding-rule-default-d536?alt=json"
+  },
+  "body": {
+    "kind": "compute#forwardingRule",
+    "id": "330641587841948827",
+    "creationTimestamp": "2026-04-21T13:47:48.047-07:00",
+    "name": "c7n-forwarding-rule-default-d536",
+    "description": "",
+    "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1",
+    "IPAddress": "34.172.85.61",
+    "IPProtocol": "TCP",
+    "portRange": "80-80",
+    "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/targetPools/c7n-target-pool-default-d536",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/c7n-forwarding-rule-default-d536",
+    "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/330641587841948827",
+    "loadBalancingScheme": "EXTERNAL",
+    "networkTier": "PREMIUM",
+    "labels": {
+      "env": "not-the-default"
+    },
+    "labelFingerprint": "ORv95NNSHWA=",
+    "fingerprint": "yDsnn6Ls0os="
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-forwarding-rule-labels/post-compute-v1-projects-cloud-custodian-regions-us-central1-forwardingRules-c7n-forwarding-rule-default-d536-setLabels_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-forwarding-rule-labels/post-compute-v1-projects-cloud-custodian-regions-us-central1-forwardingRules-c7n-forwarding-rule-default-d536-setLabels_1.json
@@ -1,0 +1,32 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 20:48:00 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "861",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "kind": "compute#operation",
+    "id": "3896081819300945007",
+    "name": "operation-1776804480695-64ffe87e83b50-6e852bb9-24c0cd4f",
+    "operationType": "setLabels",
+    "targetLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/c7n-forwarding-rule-default-d536",
+    "targetId": "330641587841948827",
+    "status": "DONE",
+    "user": "caleb.syring@sixfeetup.com",
+    "progress": 100,
+    "insertTime": "2026-04-21T13:48:00.848-07:00",
+    "startTime": "2026-04-21T13:48:00.848-07:00",
+    "endTime": "2026-04-21T13:48:00.848-07:00",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/operations/operation-1776804480695-64ffe87e83b50-6e852bb9-24c0cd4f",
+    "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-global-address-labels/get-compute-v1-projects-cloud-custodian-global-addresses-c7n-global-address-default-abf3_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-global-address-labels/get-compute-v1-projects-cloud-custodian-global-addresses-c7n-global-address-default-abf3_1.json
@@ -1,0 +1,34 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 20:41:01 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "561",
+    "-content-encoding": "gzip",
+    "content-location": "https://compute.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/c7n-global-address-default-abf3?alt=json"
+  },
+  "body": {
+    "kind": "compute#address",
+    "id": "1846832603165515296",
+    "creationTimestamp": "2026-04-21T13:40:47.496-07:00",
+    "name": "c7n-global-address-default-abf3",
+    "description": "",
+    "address": "34.102.242.222",
+    "status": "RESERVED",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/c7n-global-address-default-abf3",
+    "networkTier": "PREMIUM",
+    "labels": {
+      "goog-terraform-provisioned": "true",
+      "env": "not-the-default"
+    },
+    "labelFingerprint": "XzoNciJNMTE=",
+    "addressType": "EXTERNAL"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-global-address-labels/get-compute-v1-projects-cloud-custodian-global-addresses_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-global-address-labels/get-compute-v1-projects-cloud-custodian-global-addresses_1.json
@@ -1,0 +1,61 @@
+{
+  "headers": {
+    "etag": "3fzjVuMGlhwtuJJJ9j-XvRscJf8=/o9CYy2Mwg07y8vIEAuEHlCCavhU=",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 20:41:00 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1568",
+    "-content-encoding": "gzip",
+    "content-location": "https://compute.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses?alt=json"
+  },
+  "body": {
+    "kind": "compute#addressList",
+    "id": "projects/cloud-custodian/global/addresses",
+    "items": [
+      {
+        "kind": "compute#address",
+        "id": "1846832603165515296",
+        "creationTimestamp": "2026-04-21T13:40:47.496-07:00",
+        "name": "c7n-global-address-default-abf3",
+        "description": "",
+        "address": "34.102.242.222",
+        "status": "RESERVED",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/c7n-global-address-default-abf3",
+        "networkTier": "PREMIUM",
+        "labels": {
+          "goog-terraform-provisioned": "true",
+          "env": "default"
+        },
+        "labelFingerprint": "oWv7t93mrS4=",
+        "addressType": "EXTERNAL"
+      },
+      {
+        "kind": "compute#address",
+        "id": "4733793131429703510",
+        "creationTimestamp": "2026-02-26T10:32:25.293-08:00",
+        "name": "redis-ip-range",
+        "description": "",
+        "address": "10.96.0.0",
+        "prefixLength": 16,
+        "status": "RESERVED",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/redis-ip-range",
+        "networkTier": "PREMIUM",
+        "labels": {
+          "goog-terraform-provisioned": "true"
+        },
+        "labelFingerprint": "vezUS-42LLM=",
+        "addressType": "INTERNAL",
+        "purpose": "VPC_PEERING",
+        "network": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/networks/default"
+      }
+    ],
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-global-address-labels/post-compute-v1-projects-cloud-custodian-global-addresses-c7n-global-address-default-abf3-setLabels_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-global-address-labels/post-compute-v1-projects-cloud-custodian-global-addresses-c7n-global-address-default-abf3-setLabels_1.json
@@ -1,0 +1,31 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 20:41:00 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "724",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "kind": "compute#operation",
+    "id": "5327556666295213619",
+    "name": "operation-1776804060699-64ffe6edf9c14-7741da62-505aecf2",
+    "operationType": "setLabels",
+    "targetLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/c7n-global-address-default-abf3",
+    "targetId": "1846832603165515296",
+    "status": "DONE",
+    "user": "caleb.syring@sixfeetup.com",
+    "progress": 100,
+    "insertTime": "2026-04-21T13:41:00.767-07:00",
+    "startTime": "2026-04-21T13:41:00.771-07:00",
+    "endTime": "2026-04-21T13:41:00.771-07:00",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/operations/operation-1776804060699-64ffe6edf9c14-7741da62-505aecf2"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-global-forwarding-rule-labels/get-compute-v1-projects-cloud-custodian-global-forwardingRules-c7n-lb-gfr-default-5d7e_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-global-forwarding-rule-labels/get-compute-v1-projects-cloud-custodian-global-forwardingRules-c7n-lb-gfr-default-5d7e_1.json
@@ -1,0 +1,37 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 21:08:11 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "853",
+    "-content-encoding": "gzip",
+    "content-location": "https://compute.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/c7n-lb-gfr-default-5d7e?alt=json"
+  },
+  "body": {
+    "kind": "compute#forwardingRule",
+    "id": "8038463216630258124",
+    "creationTimestamp": "2026-04-21T14:07:47.610-07:00",
+    "name": "c7n-lb-gfr-default-5d7e",
+    "description": "",
+    "IPAddress": "34.160.244.216",
+    "IPProtocol": "TCP",
+    "portRange": "80-80",
+    "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/c7n-lb-http-default-5d7e",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/c7n-lb-gfr-default-5d7e",
+    "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/8038463216630258124",
+    "loadBalancingScheme": "EXTERNAL",
+    "networkTier": "PREMIUM",
+    "labels": {
+      "env": "not-the-default"
+    },
+    "labelFingerprint": "ORv95NNSHWA=",
+    "fingerprint": "K-q4bzMtiEA="
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-global-forwarding-rule-labels/get-compute-v1-projects-cloud-custodian-global-forwardingRules_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-global-forwarding-rule-labels/get-compute-v1-projects-cloud-custodian-global-forwardingRules_1.json
@@ -1,0 +1,45 @@
+{
+  "headers": {
+    "etag": "xXxk9FbDAubumk5Xb_HAnXEar2o=/WCYbVQFJNC0yfx1oIiI74d1NYG8=",
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 21:08:10 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1162",
+    "-content-encoding": "gzip",
+    "content-location": "https://compute.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules?alt=json"
+  },
+  "body": {
+    "kind": "compute#forwardingRuleList",
+    "id": "projects/cloud-custodian/global/forwardingRules",
+    "items": [
+      {
+        "kind": "compute#forwardingRule",
+        "id": "8038463216630258124",
+        "creationTimestamp": "2026-04-21T14:07:47.610-07:00",
+        "name": "c7n-lb-gfr-default-5d7e",
+        "description": "",
+        "IPAddress": "34.160.244.216",
+        "IPProtocol": "TCP",
+        "portRange": "80-80",
+        "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/c7n-lb-http-default-5d7e",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/c7n-lb-gfr-default-5d7e",
+        "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/8038463216630258124",
+        "loadBalancingScheme": "EXTERNAL",
+        "networkTier": "PREMIUM",
+        "labels": {
+          "env": "default"
+        },
+        "labelFingerprint": "aMJEA_pTI0o=",
+        "fingerprint": "K-q4bzMtiEA="
+      }
+    ],
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/loadbalancer-global-forwarding-rule-labels/post-compute-v1-projects-cloud-custodian-global-forwardingRules-c7n-lb-gfr-default-5d7e-setLabels_1.json
+++ b/tools/c7n_gcp/tests/data/flights/loadbalancer-global-forwarding-rule-labels/post-compute-v1-projects-cloud-custodian-global-forwardingRules-c7n-lb-gfr-default-5d7e-setLabels_1.json
@@ -1,0 +1,31 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 21 Apr 2026 21:08:10 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "722",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "kind": "compute#operation",
+    "id": "7326198643559127509",
+    "name": "operation-1776805690349-64ffed00218bd-4824207f-c3bc9464",
+    "operationType": "setLabels",
+    "targetLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/c7n-lb-gfr-default-5d7e",
+    "targetId": "8038463216630258124",
+    "status": "DONE",
+    "user": "caleb.syring@sixfeetup.com",
+    "progress": 100,
+    "insertTime": "2026-04-21T14:08:10.677-07:00",
+    "startTime": "2026-04-21T14:08:10.678-07:00",
+    "endTime": "2026-04-21T14:08:10.678-07:00",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/operations/operation-1776805690349-64ffed00218bd-4824207f-c3bc9464"
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/loadbalancer_forwarding_rule_labels/main.tf
+++ b/tools/c7n_gcp/tests/terraform/loadbalancer_forwarding_rule_labels/main.tf
@@ -1,31 +1,17 @@
-variable "google_project_id" {
-  description = "GCP project ID"
-}
-
-provider "google" {
-  project = var.google_project_id
-  region  = "us-central1"
-}
-
 resource "random_id" "suffix" {
   byte_length = 2
 }
 
-locals {
-  forwarding_rule_name = "c7n-forwarding-rule-${terraform.workspace}-${random_id.suffix.hex}"
-  target_pool_name     = "c7n-target-pool-${terraform.workspace}-${random_id.suffix.hex}"
-}
-
 resource "google_compute_target_pool" "default" {
-  name   = local.target_pool_name
+  name   = "c7n-target-pool-${terraform.workspace}-${random_id.suffix.hex}"
   region = "us-central1"
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  name       = local.forwarding_rule_name
-  region     = "us-central1"
-  target     = google_compute_target_pool.default.id
-  port_range = "80"
+  name        = "c7n-forwarding-rule-${terraform.workspace}-${random_id.suffix.hex}"
+  region      = "us-central1"
+  target      = google_compute_target_pool.default.id
+  port_range  = "80"
   ip_protocol = "TCP"
 
   labels = {

--- a/tools/c7n_gcp/tests/terraform/loadbalancer_forwarding_rule_labels/main.tf
+++ b/tools/c7n_gcp/tests/terraform/loadbalancer_forwarding_rule_labels/main.tf
@@ -1,0 +1,34 @@
+variable "google_project_id" {
+  description = "GCP project ID"
+}
+
+provider "google" {
+  project = var.google_project_id
+  region  = "us-central1"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 2
+}
+
+locals {
+  forwarding_rule_name = "c7n-forwarding-rule-${terraform.workspace}-${random_id.suffix.hex}"
+  target_pool_name     = "c7n-target-pool-${terraform.workspace}-${random_id.suffix.hex}"
+}
+
+resource "google_compute_target_pool" "default" {
+  name   = local.target_pool_name
+  region = "us-central1"
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  name       = local.forwarding_rule_name
+  region     = "us-central1"
+  target     = google_compute_target_pool.default.id
+  port_range = "80"
+  ip_protocol = "TCP"
+
+  labels = {
+    env = "default"
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/loadbalancer_forwarding_rule_labels/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/loadbalancer_forwarding_rule_labels/tf_resources.json
@@ -1,0 +1,82 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_compute_forwarding_rule": {
+            "default": {
+                "all_ports": false,
+                "allow_global_access": false,
+                "allow_psc_global_access": false,
+                "backend_service": "",
+                "base_forwarding_rule": "",
+                "creation_timestamp": "2026-04-21T13:47:48.047-07:00",
+                "description": "",
+                "effective_labels": {
+                    "env": "default"
+                },
+                "forwarding_rule_id": 330641587841948827,
+                "id": "projects/cloud-custodian/regions/us-central1/forwardingRules/c7n-forwarding-rule-default-d536",
+                "ip_address": "34.172.85.61",
+                "ip_collection": "",
+                "ip_protocol": "TCP",
+                "ip_version": "",
+                "is_mirroring_collector": false,
+                "label_fingerprint": "aMJEA_pTI0o=",
+                "labels": {
+                    "env": "default"
+                },
+                "load_balancing_scheme": "EXTERNAL",
+                "name": "c7n-forwarding-rule-default-d536",
+                "network": "",
+                "network_tier": "PREMIUM",
+                "no_automate_dns_zone": null,
+                "port_range": "80-80",
+                "ports": null,
+                "project": "stacklet-test-policies",
+                "psc_connection_id": "",
+                "psc_connection_status": "",
+                "recreate_closed_psc": false,
+                "region": "us-central1",
+                "self_link": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/c7n-forwarding-rule-default-d536",
+                "service_directory_registrations": [],
+                "service_label": "",
+                "service_name": "",
+                "source_ip_ranges": null,
+                "subnetwork": "",
+                "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/targetPools/c7n-target-pool-default-d536",
+                "terraform_labels": {
+                    "env": "default"
+                },
+                "timeouts": null
+            }
+        },
+        "google_compute_target_pool": {
+            "default": {
+                "backup_pool": "",
+                "description": "",
+                "failover_ratio": 0,
+                "health_checks": null,
+                "id": "projects/cloud-custodian/regions/us-central1/targetPools/c7n-target-pool-default-d536",
+                "instances": [],
+                "name": "c7n-target-pool-default-d536",
+                "project": "stacklet-test-policies",
+                "region": "us-central1",
+                "self_link": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/targetPools/c7n-target-pool-default-d536",
+                "session_affinity": "NONE",
+                "timeouts": null
+            }
+        },
+        "random_id": {
+            "suffix": {
+                "b64_std": "1TY=",
+                "b64_url": "1TY",
+                "byte_length": 2,
+                "dec": "54582",
+                "hex": "d536",
+                "id": "1TY",
+                "keepers": null,
+                "prefix": null
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/terraform/loadbalancer_global_address_labels/main.tf
+++ b/tools/c7n_gcp/tests/terraform/loadbalancer_global_address_labels/main.tf
@@ -1,0 +1,11 @@
+resource "random_id" "suffix" {
+  byte_length = 2
+}
+
+resource "google_compute_global_address" "default" {
+  name = "c7n-global-address-${terraform.workspace}-${random_id.suffix.hex}"
+
+  labels = {
+    env = "default"
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/loadbalancer_global_address_labels/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/loadbalancer_global_address_labels/tf_resources.json
@@ -1,0 +1,47 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_compute_global_address": {
+            "default": {
+                "address": "34.102.242.222",
+                "address_type": "EXTERNAL",
+                "creation_timestamp": "2026-04-21T13:40:47.496-07:00",
+                "description": "",
+                "effective_labels": {
+                    "env": "default",
+                    "goog-terraform-provisioned": "true"
+                },
+                "id": "projects/cloud-custodian/global/addresses/c7n-global-address-default-abf3",
+                "ip_version": "",
+                "label_fingerprint": "oWv7t93mrS4=",
+                "labels": {
+                    "env": "default"
+                },
+                "name": "c7n-global-address-default-abf3",
+                "network": "",
+                "prefix_length": 0,
+                "project": "stacklet-test-policies",
+                "purpose": "",
+                "self_link": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/c7n-global-address-default-abf3",
+                "terraform_labels": {
+                    "env": "default",
+                    "goog-terraform-provisioned": "true"
+                },
+                "timeouts": null
+            }
+        },
+        "random_id": {
+            "suffix": {
+                "b64_std": "q/M=",
+                "b64_url": "q_M",
+                "byte_length": 2,
+                "dec": "44019",
+                "hex": "abf3",
+                "id": "q_M",
+                "keepers": null,
+                "prefix": null
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/terraform/loadbalancer_global_forwarding_rule_labels/main.tf
+++ b/tools/c7n_gcp/tests/terraform/loadbalancer_global_forwarding_rule_labels/main.tf
@@ -1,0 +1,36 @@
+resource "random_id" "suffix" {
+  byte_length = 2
+}
+
+resource "google_storage_bucket" "default" {
+  name          = "c7n-lb-gfr-${terraform.workspace}-${random_id.suffix.hex}"
+  location      = "US"
+  force_destroy = true
+}
+
+resource "google_compute_backend_bucket" "default" {
+  name        = "c7n-lb-bb-${terraform.workspace}-${random_id.suffix.hex}"
+  bucket_name = google_storage_bucket.default.name
+  enable_cdn  = false
+}
+
+resource "google_compute_url_map" "default" {
+  name            = "c7n-lb-um-${terraform.workspace}-${random_id.suffix.hex}"
+  default_service = google_compute_backend_bucket.default.id
+}
+
+resource "google_compute_target_http_proxy" "default" {
+  name    = "c7n-lb-http-${terraform.workspace}-${random_id.suffix.hex}"
+  url_map = google_compute_url_map.default.id
+}
+
+resource "google_compute_global_forwarding_rule" "default" {
+  name        = "c7n-lb-gfr-${terraform.workspace}-${random_id.suffix.hex}"
+  target      = google_compute_target_http_proxy.default.id
+  port_range  = "80"
+  ip_protocol = "TCP"
+
+  labels = {
+    env = "default"
+  }
+}

--- a/tools/c7n_gcp/tests/terraform/loadbalancer_global_forwarding_rule_labels/tf_resources.json
+++ b/tools/c7n_gcp/tests/terraform/loadbalancer_global_forwarding_rule_labels/tf_resources.json
@@ -1,0 +1,163 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "google_compute_backend_bucket": {
+            "default": {
+                "bucket_name": "c7n-lb-gfr-default-5d7e",
+                "cdn_policy": [],
+                "compression_mode": "",
+                "creation_timestamp": "2026-04-21T14:07:03.190-07:00",
+                "custom_response_headers": null,
+                "description": "",
+                "edge_security_policy": "",
+                "enable_cdn": false,
+                "id": "projects/cloud-custodian/global/backendBuckets/c7n-lb-bb-default-5d7e",
+                "load_balancing_scheme": "",
+                "name": "c7n-lb-bb-default-5d7e",
+                "params": [],
+                "project": "stacklet-test-policies",
+                "self_link": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/c7n-lb-bb-default-5d7e",
+                "timeouts": null
+            }
+        },
+        "google_compute_global_forwarding_rule": {
+            "default": {
+                "base_forwarding_rule": "",
+                "description": "",
+                "effective_labels": {
+                    "env": "default"
+                },
+                "external_managed_backend_bucket_migration_state": "",
+                "external_managed_backend_bucket_migration_testing_percentage": 0,
+                "forwarding_rule_id": 8038463216630258124,
+                "id": "projects/cloud-custodian/global/forwardingRules/c7n-lb-gfr-default-5d7e",
+                "ip_address": "34.160.244.216",
+                "ip_protocol": "TCP",
+                "ip_version": "",
+                "label_fingerprint": "aMJEA_pTI0o=",
+                "labels": {
+                    "env": "default"
+                },
+                "load_balancing_scheme": "EXTERNAL",
+                "metadata_filters": [],
+                "name": "c7n-lb-gfr-default-5d7e",
+                "network": "",
+                "network_tier": "PREMIUM",
+                "no_automate_dns_zone": null,
+                "port_range": "80-80",
+                "project": "stacklet-test-policies",
+                "psc_connection_id": "",
+                "psc_connection_status": "",
+                "self_link": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/c7n-lb-gfr-default-5d7e",
+                "service_directory_registrations": [],
+                "source_ip_ranges": null,
+                "subnetwork": "",
+                "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/c7n-lb-http-default-5d7e",
+                "terraform_labels": {
+                    "env": "default"
+                },
+                "timeouts": null
+            }
+        },
+        "google_compute_target_http_proxy": {
+            "default": {
+                "creation_timestamp": "2026-04-21T14:07:36.260-07:00",
+                "description": "",
+                "fingerprint": "o1A9ZzECGDw=",
+                "http_keep_alive_timeout_sec": 0,
+                "id": "projects/cloud-custodian/global/targetHttpProxies/c7n-lb-http-default-5d7e",
+                "name": "c7n-lb-http-default-5d7e",
+                "project": "stacklet-test-policies",
+                "proxy_bind": false,
+                "proxy_id": 7570639349931989495,
+                "self_link": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/c7n-lb-http-default-5d7e",
+                "timeouts": null,
+                "url_map": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/c7n-lb-um-default-5d7e"
+            }
+        },
+        "google_compute_url_map": {
+            "default": {
+                "creation_timestamp": "2026-04-21T14:07:25.104-07:00",
+                "default_custom_error_response_policy": [],
+                "default_route_action": [],
+                "default_service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/c7n-lb-bb-default-5d7e",
+                "default_url_redirect": [],
+                "description": "",
+                "fingerprint": "I5nZ33KcGyA=",
+                "header_action": [],
+                "host_rule": [],
+                "id": "projects/cloud-custodian/global/urlMaps/c7n-lb-um-default-5d7e",
+                "map_id": 1401657486293490146,
+                "name": "c7n-lb-um-default-5d7e",
+                "path_matcher": [],
+                "project": "stacklet-test-policies",
+                "self_link": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/c7n-lb-um-default-5d7e",
+                "test": [],
+                "timeouts": null
+            }
+        },
+        "google_storage_bucket": {
+            "default": {
+                "autoclass": [],
+                "cors": [],
+                "custom_placement_config": [],
+                "default_event_based_hold": false,
+                "effective_labels": {
+                    "goog-terraform-provisioned": "true"
+                },
+                "enable_object_retention": false,
+                "encryption": [],
+                "force_destroy": true,
+                "hierarchical_namespace": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "id": "c7n-lb-gfr-default-5d7e",
+                "ip_filter": [],
+                "labels": null,
+                "lifecycle_rule": [],
+                "location": "US",
+                "logging": [],
+                "name": "c7n-lb-gfr-default-5d7e",
+                "project": "stacklet-test-policies",
+                "project_number": 859150599087,
+                "public_access_prevention": "inherited",
+                "requester_pays": false,
+                "retention_policy": [],
+                "rpo": "DEFAULT",
+                "self_link": "https://www.googleapis.com/storage/v1/b/c7n-lb-gfr-default-5d7e",
+                "soft_delete_policy": [
+                    {
+                        "effective_time": "2026-04-21T21:07:02.123Z",
+                        "retention_duration_seconds": 604800
+                    }
+                ],
+                "storage_class": "STANDARD",
+                "terraform_labels": {
+                    "goog-terraform-provisioned": "true"
+                },
+                "time_created": "2026-04-21T21:07:02.123Z",
+                "timeouts": null,
+                "uniform_bucket_level_access": false,
+                "updated": "2026-04-21T21:07:02.123Z",
+                "url": "gs://c7n-lb-gfr-default-5d7e",
+                "versioning": [],
+                "website": []
+            }
+        },
+        "random_id": {
+            "suffix": {
+                "b64_std": "XX4=",
+                "b64_url": "XX4",
+                "byte_length": 2,
+                "dec": "23934",
+                "hex": "5d7e",
+                "id": "XX4",
+                "keepers": null,
+                "prefix": null
+            }
+        }
+    }
+}

--- a/tools/c7n_gcp/tests/test_loadbalancer.py
+++ b/tools/c7n_gcp/tests/test_loadbalancer.py
@@ -4,6 +4,7 @@ from time import sleep
 from gcp_common import BaseTest, event_data
 from pytest_terraform import terraform
 from c7n_gcp.resources.loadbalancer import LoadBalancingGlobalAddress
+from c7n_gcp.resources.loadbalancer import LoadBalancingGlobalForwardingRule
 from c7n_gcp.resources.loadbalancer import LoadBalancingForwardingRule
 
 
@@ -953,5 +954,43 @@ def test_loadbalancer_global_address_labels(test, loadbalancer_global_address_la
 
     client = policy.resource_manager.get_client()
     resource = LoadBalancingGlobalAddress.resource_type.refresh(client, resources[0])
+    assert resource['labels']['env'] == 'not-the-default'
+    assert resource['labelFingerprint'] != label_fingerprint
+
+
+@terraform('loadbalancer_global_forwarding_rule_labels')
+def test_loadbalancer_global_forwarding_rule_labels(
+        test, loadbalancer_global_forwarding_rule_labels):
+    global_forwarding_rule = loadbalancer_global_forwarding_rule_labels.resources[
+        'google_compute_global_forwarding_rule']['default']
+    project_id = global_forwarding_rule['project']
+    name = global_forwarding_rule['name']
+    label_fingerprint = global_forwarding_rule['label_fingerprint']
+    labels = global_forwarding_rule['labels']
+
+    assert labels['env'] == 'default'
+
+    factory = test.replay_flight_data(
+        'loadbalancer-global-forwarding-rule-labels',
+        project_id=project_id,
+    )
+    policy = test.load_policy(
+        {
+            'name': 'loadbalancer-global-forwarding-rule-labels',
+            'resource': 'gcp.loadbalancer-global-forwarding-rule',
+            'filters': [{'name': name}],
+            'actions': [
+                {'type': 'set-labels',
+                 'labels': {'env': 'not-the-default'}}
+            ],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    client = policy.resource_manager.get_client()
+    resource = LoadBalancingGlobalForwardingRule.resource_type.refresh(client, resources[0])
     assert resource['labels']['env'] == 'not-the-default'
     assert resource['labelFingerprint'] != label_fingerprint

--- a/tools/c7n_gcp/tests/test_loadbalancer.py
+++ b/tools/c7n_gcp/tests/test_loadbalancer.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from time import sleep
 from gcp_common import BaseTest, event_data
+from pytest_terraform import terraform
+from c7n_gcp.resources.loadbalancer import LoadBalancingForwardingRule
 
 
 class LoadBalancingAddressTest(BaseTest):
@@ -884,3 +886,37 @@ class LoadBalancingGlobalAddressTest(BaseTest):
                 'gcp:compute::cloud-custodian:global-address/custodian-global-address-0',
             ],
         )
+
+
+@terraform('loadbalancer_forwarding_rule_labels')
+def test_loadbalancer_forwarding_rule_labels(test, loadbalancer_forwarding_rule_labels):
+    forwarding_rule = loadbalancer_forwarding_rule_labels.resources[
+        'google_compute_forwarding_rule']['default']
+    project_id = forwarding_rule['project']
+    name = forwarding_rule['name']
+    label_fingerprint = forwarding_rule['label_fingerprint']
+    labels = forwarding_rule['labels']
+
+    assert labels['env'] == 'default'
+
+    factory = test.replay_flight_data('loadbalancer-forwarding-rule-labels', project_id=project_id)
+    policy = test.load_policy(
+        {
+            'name': 'loadbalancer-forwarding-rule-labels',
+            'resource': 'gcp.loadbalancer-forwarding-rule',
+            'filters': [{'name': name}],
+            'actions': [
+                {'type': 'set-labels',
+                 'labels': {'env': 'not-the-default'}}
+            ],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    client = policy.resource_manager.get_client()
+    resource = LoadBalancingForwardingRule.resource_type.refresh(client, resources[0])
+    assert resource['labels']['env'] == 'not-the-default'
+    assert resource['labelFingerprint'] != label_fingerprint

--- a/tools/c7n_gcp/tests/test_loadbalancer.py
+++ b/tools/c7n_gcp/tests/test_loadbalancer.py
@@ -3,6 +3,7 @@
 from time import sleep
 from gcp_common import BaseTest, event_data
 from pytest_terraform import terraform
+from c7n_gcp.resources.loadbalancer import LoadBalancingGlobalAddress
 from c7n_gcp.resources.loadbalancer import LoadBalancingForwardingRule
 
 
@@ -918,5 +919,39 @@ def test_loadbalancer_forwarding_rule_labels(test, loadbalancer_forwarding_rule_
 
     client = policy.resource_manager.get_client()
     resource = LoadBalancingForwardingRule.resource_type.refresh(client, resources[0])
+    assert resource['labels']['env'] == 'not-the-default'
+    assert resource['labelFingerprint'] != label_fingerprint
+
+
+@terraform('loadbalancer_global_address_labels')
+def test_loadbalancer_global_address_labels(test, loadbalancer_global_address_labels):
+    global_address = loadbalancer_global_address_labels.resources[
+        'google_compute_global_address']['default']
+    project_id = global_address['project']
+    name = global_address['name']
+    label_fingerprint = global_address['label_fingerprint']
+    labels = global_address['labels']
+
+    assert labels['env'] == 'default'
+
+    factory = test.replay_flight_data('loadbalancer-global-address-labels', project_id=project_id)
+    policy = test.load_policy(
+        {
+            'name': 'loadbalancer-global-address-labels',
+            'resource': 'gcp.loadbalancer-global-address',
+            'filters': [{'name': name}],
+            'actions': [
+                {'type': 'set-labels',
+                 'labels': {'env': 'not-the-default'}}
+            ],
+        },
+        session_factory=factory,
+    )
+
+    resources = policy.run()
+    assert len(resources) == 1
+
+    client = policy.resource_manager.get_client()
+    resource = LoadBalancingGlobalAddress.resource_type.refresh(client, resources[0])
     assert resource['labels']['env'] == 'not-the-default'
     assert resource['labelFingerprint'] != label_fingerprint

--- a/tools/c7n_gcp/tests/test_loadbalancer.py
+++ b/tools/c7n_gcp/tests/test_loadbalancer.py
@@ -899,8 +899,10 @@ def test_loadbalancer_forwarding_rule_labels(test, loadbalancer_forwarding_rule_
     label_fingerprint = forwarding_rule['label_fingerprint']
     labels = forwarding_rule['labels']
 
+    # Confirm the starting label
     assert labels['env'] == 'default'
 
+    # Update the label using the action
     factory = test.replay_flight_data('loadbalancer-forwarding-rule-labels', project_id=project_id)
     policy = test.load_policy(
         {
@@ -914,10 +916,10 @@ def test_loadbalancer_forwarding_rule_labels(test, loadbalancer_forwarding_rule_
         },
         session_factory=factory,
     )
-
     resources = policy.run()
     assert len(resources) == 1
 
+    # Refresh and confirm that the label and fingerprint updated
     client = policy.resource_manager.get_client()
     resource = LoadBalancingForwardingRule.resource_type.refresh(client, resources[0])
     assert resource['labels']['env'] == 'not-the-default'
@@ -933,8 +935,10 @@ def test_loadbalancer_global_address_labels(test, loadbalancer_global_address_la
     label_fingerprint = global_address['label_fingerprint']
     labels = global_address['labels']
 
+    # Confirm the starting label
     assert labels['env'] == 'default'
 
+    # Update the label using the action
     factory = test.replay_flight_data('loadbalancer-global-address-labels', project_id=project_id)
     policy = test.load_policy(
         {
@@ -948,10 +952,10 @@ def test_loadbalancer_global_address_labels(test, loadbalancer_global_address_la
         },
         session_factory=factory,
     )
-
     resources = policy.run()
     assert len(resources) == 1
 
+    # Refresh and confirm that the label and fingerprint updated
     client = policy.resource_manager.get_client()
     resource = LoadBalancingGlobalAddress.resource_type.refresh(client, resources[0])
     assert resource['labels']['env'] == 'not-the-default'
@@ -968,8 +972,10 @@ def test_loadbalancer_global_forwarding_rule_labels(
     label_fingerprint = global_forwarding_rule['label_fingerprint']
     labels = global_forwarding_rule['labels']
 
+    # Confirm the starting label
     assert labels['env'] == 'default'
 
+    # Update the label using an action
     factory = test.replay_flight_data(
         'loadbalancer-global-forwarding-rule-labels',
         project_id=project_id,
@@ -986,10 +992,10 @@ def test_loadbalancer_global_forwarding_rule_labels(
         },
         session_factory=factory,
     )
-
     resources = policy.run()
     assert len(resources) == 1
 
+    # Refresh and confirm that the label and fingerprint updated
     client = policy.resource_manager.get_client()
     resource = LoadBalancingGlobalForwardingRule.resource_type.refresh(client, resources[0])
     assert resource['labels']['env'] == 'not-the-default'


### PR DESCRIPTION
resolves #10723 
resolves #10722 
resolves #10721 
(combined to avoid conflicts)

This also resolves a bug I ran into:
- The permission for label actions defaults to `update`. 
- Our permission validation only checks that the referenced permission exists on the resource, _not that it's the correct permission_ for the action.
- In many cases, `update` is not the correct permission for the action that changes labels, but the bad default still passes validation because it's a permission that exists for some other operation.
- Therefore, I had to change to a safer default (the operation name) and allow explicitly specifying the permission when different, which required updating several resources.