### PR TITLE
feat: Created an automatic/reflective BotoResource.

### DIFF
--- a/c7n/resources/boto_resource.py
+++ b/c7n/resources/boto_resource.py
@@ -1,0 +1,199 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from c7n.actions import ActionRegistry
+from c7n.filters import FilterRegistry
+from c7n.manager import ResourceManager, resources
+from c7n.query import TypeInfo
+from c7n.utils import local_session
+
+
+@resources.register('boto-resource')
+class BotoResource(ResourceManager):
+    """Reflective PoC resource manager for arbitrary boto3 client list methods.
+
+    This manager allows policies to dynamically enumerate resources from AWS
+    services that do not yet have first-class Cloud Custodian resource support.
+
+    Example
+    -------
+    .. code-block:: yaml
+
+        policies:
+          - name: duck-db-instances
+            resource: boto-resource
+            service: cloudduck
+            method: list_instances
+
+    Optional keys:
+      - ``params``: dict of kwargs passed to the boto client call/paginator.
+      - ``result_key``: explicit response key containing the list of resources.
+      - ``id-field``: resource field used by ``get_resources`` lookups.
+    """
+
+    filter_registry = FilterRegistry('boto-resource.filters')
+    action_registry = ActionRegistry('boto-resource.actions')
+
+    class resource_type(TypeInfo):
+        service = 'boto-resource'
+        id = 'id'
+        name = 'id'
+        cfn_type = None
+        config_type = None
+
+    @classmethod
+    def has_arn(cls):
+        """Indicate this pseudo-resource does not provide generic ARN support."""
+        return False
+
+    @classmethod
+    def get_schema(cls, type_name, resource_defs, definitions, provider_name):
+        """Register dynamic policy schema for ``boto-resource``.
+
+        Ensures top-level policy keys (``service``, ``method``, etc.) are
+        recognized by both the global policy schema and this resource policy.
+        """
+        # NOTE: this is intentionally minimal and permissive for PoC use.
+        r = resource_defs.setdefault(type_name, {'actions': {}, 'filters': {}})
+
+        # The base policy schema has additionalProperties: false, so custom
+        # top-level keys must be declared there as well.
+        definitions['policy']['properties'].setdefault(
+            'service', {'type': 'string', 'minLength': 1})
+        definitions['policy']['properties'].setdefault(
+            'method', {'type': 'string', 'minLength': 1})
+        definitions['policy']['properties'].setdefault(
+            'params', {'type': 'object'})
+        definitions['policy']['properties'].setdefault(
+            'result_key', {'type': 'string'})
+        definitions['policy']['properties'].setdefault(
+            'id-field', {'type': 'string'})
+
+        resource_enum = [type_name]
+        if provider_name == 'aws' and '.' in type_name:
+            resource_enum.append(type_name.split('.', 1)[1])
+
+        r['policy'] = {
+            'allOf': [
+                {'$ref': '#/definitions/policy'},
+                {'properties': {
+                    'resource': {'enum': resource_enum},
+                    'service': {'type': 'string', 'minLength': 1},
+                    'method': {'type': 'string', 'minLength': 1},
+                    'params': {'type': 'object'},
+                    'result_key': {'type': 'string'},
+                    'id-field': {'type': 'string'},
+                    'filters': {'type': 'array'},
+                    'actions': {'type': 'array', 'maxItems': 0},
+                },
+                 'required': ['service', 'method']}
+            ]
+        }
+
+        # defs are expected in schema output shape.
+        r.setdefault('actions', {})
+        r.setdefault('filters', {})
+
+    def get_resource_manager(self, resource_type, data=None):
+        """Return resource managers, with special-case self-resolution.
+
+        The base implementation resolves managers through provider resource maps.
+        For dynamic self-references to ``boto-resource`` we can directly create a
+        new ``BotoResource`` instance.
+        """
+        # Base impl attempts provider map lookup/load, which is unnecessary for
+        # self-references in this dynamic pseudo resource.
+        if resource_type in ('boto-resource', 'aws.boto-resource'):
+            return self.__class__(self.ctx, data or self.data)
+        return super(BotoResource, self).get_resource_manager(resource_type, data=data)
+
+    def get_model(self):
+        """Return a minimal runtime TypeInfo derived from policy configuration."""
+        id_field = self.data.get('id-field', 'id')
+        return type('BotoTypeInfo', (TypeInfo,), {
+            'service': self.data.get('service'),
+            'name': id_field,
+            'id': id_field,
+            'arn': False,
+            'dimension': None,
+        })
+
+    def _extract_resources(self, result):
+        """Extract a list of resources from a boto response payload.
+
+        Behavior:
+          1. If response is already a list, return it.
+          2. If ``result_key`` is set, return ``response[result_key]`` when list.
+          3. Otherwise return the first list-valued key (excluding metadata).
+        """
+        if isinstance(result, list):
+            return result
+
+        if not isinstance(result, dict):
+            return []
+
+        result_key = self.data.get('result_key')
+        if result_key:
+            values = result.get(result_key, [])
+            return values if isinstance(values, list) else []
+
+        # Best-effort reflective extraction: first list-shaped payload member.
+        for k, v in result.items():
+            if k == 'ResponseMetadata':
+                continue
+            if isinstance(v, list):
+                return v
+
+        return []
+
+    def _fetch_resources(self):
+        """Call the configured boto client method and return enumerated resources.
+
+        Uses a paginator when available, otherwise performs a single method call.
+        """
+        client = local_session(self.session_factory).client(self.data['service'])
+        method_name = self.data['method']
+        params = self.data.get('params', {})
+
+        if client.can_paginate(method_name):
+            paginator = client.get_paginator(method_name)
+            resources = []
+            for page in paginator.paginate(**params):
+                resources.extend(self._extract_resources(page))
+            return resources
+
+        method = getattr(client, method_name)
+        return self._extract_resources(method(**params))
+
+    def resources(self):
+        """Enumerate and filter resources for policy execution."""
+        return self.filter_resources(self._fetch_resources())
+
+    def _get_id_field(self, resources):
+        """Resolve the identifier key used for ``get_resources`` lookups."""
+        id_field = self.data.get('id-field')
+        if id_field:
+            return id_field
+
+        if not resources or not isinstance(resources[0], dict):
+            return None
+
+        for candidate in ('id', 'Id', 'arn', 'Arn', 'name', 'Name'):
+            if candidate in resources[0]:
+                return candidate
+
+        return None
+
+    def get_resources(self, resource_ids):
+        """Return resources whose identifier field matches ``resource_ids``.
+
+        This PoC implementation re-enumerates via ``_fetch_resources`` and then
+        performs in-memory filtering.
+        """
+        resources = self._fetch_resources()
+        id_field = self._get_id_field(resources)
+        if not id_field:
+            return []
+
+        resource_id_set = set(resource_ids)
+        return [r for r in resources if isinstance(r, dict) and r.get(id_field) in resource_id_set]

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -41,6 +41,7 @@ ResourceMap = {
   "aws.bedrock-custom-model": "c7n.resources.bedrock.BedrockCustomModel",
   "aws.bedrock-knowledge-base": "c7n.resources.bedrock.BedrockKnowledgeBase",
   "aws.bedrock-model-invocation-job": "c7n.resources.bedrock.BedrockModelInvocationJob",
+  "aws.boto-resource": "c7n.resources.boto_resource.BotoResource",
   "aws.budget": "c7n.resources.budgets.Budget",
   "aws.cache-cluster": "c7n.resources.elasticache.ElastiCacheCluster",
   "aws.cache-snapshot": "c7n.resources.elasticache.ElastiCacheSnapshot",

--- a/c7n/structure.py
+++ b/c7n/structure.py
@@ -17,6 +17,8 @@ class StructureParser:
     allowed_policy_keys = {'name', 'resource', 'title', 'description', 'mode',
          'tags', 'max-resources', 'metadata', 'query',
          'filters', 'actions', 'source', 'conditions',
+         # boto-resource PoC keys
+         'service', 'method', 'params', 'result_key', 'id-field',
          # legacy keys subject to deprecation.
          'region', 'start', 'end', 'tz', 'max-resources-percent',
          'comments', 'comment'}

--- a/tests/test_boto_resource.py
+++ b/tests/test_boto_resource.py
@@ -1,0 +1,144 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from pytest_terraform import terraform
+
+from .common import BaseTest
+from c7n.resources import boto_resource
+
+
+class FakePaginator:
+
+    def __init__(self, pages):
+        self.pages = pages
+
+    def paginate(self, **params):
+        assert params == {'maxResults': 10}
+        return self.pages
+
+
+class FakeClient:
+
+    def __init__(self):
+        self._pages = [
+            {
+                'modelDeploymentSummaries': [
+                    {'modelDeploymentArn': 'arn:1', 'name': 'a'},
+                    {'modelDeploymentArn': 'arn:2', 'name': 'b'},
+                ]
+            }
+        ]
+
+    def can_paginate(self, method_name):
+        return method_name == 'list_custom_model_deployments'
+
+    def get_paginator(self, method_name):
+        assert method_name == 'list_custom_model_deployments'
+        return FakePaginator(self._pages)
+
+
+class FakeSession:
+
+    def __init__(self, client):
+        self._client = client
+
+    def client(self, service_name):
+        assert service_name == 'bedrock'
+        return self._client
+
+
+@terraform('bedrock_application_inference_profile')
+def test_boto_resource_bedrock_inference_profiles(
+        test, bedrock_application_inference_profile):
+    session_factory = test.replay_flight_data(
+        'test_bedrock_application_inference_profile', region='us-east-1')
+
+    profile_arn = bedrock_application_inference_profile[
+        'aws_bedrock_inference_profile.test_profile.arn']
+
+    policy = test.load_policy(
+        {
+            'name': 'boto-resource-bedrock-inference-profile',
+            'resource': 'boto-resource',
+            'service': 'bedrock',
+            'method': 'list_inference_profiles',
+            'params': {'typeEquals': 'APPLICATION'},
+            'result_key': 'inferenceProfileSummaries',
+            'id-field': 'inferenceProfileArn',
+            'filters': [
+                {'inferenceProfileArn': profile_arn},
+            ],
+        },
+        session_factory=session_factory,
+        config={'region': 'us-east-1'},
+    )
+
+    resources = policy.run()
+    test.assertEqual(len(resources), 1)
+    test.assertEqual(resources[0]['inferenceProfileArn'], profile_arn)
+
+    selected = policy.resource_manager.get_resources([profile_arn])
+    test.assertEqual(len(selected), 1)
+    test.assertEqual(selected[0]['inferenceProfileArn'], profile_arn)
+
+
+class TestBotoResource(BaseTest):
+
+    def test_schema_validate(self):
+        self.load_policy(
+            {
+                'name': 'boto-resource-schema',
+                'resource': 'boto-resource',
+                'service': 'bedrock',
+                'method': 'list_custom_model_deployments',
+            },
+            validate=True,
+        )
+
+    def test_resources_and_get_resources(self):
+        fake_client = FakeClient()
+        self.patch(
+            boto_resource,
+            'local_session',
+            lambda session_factory: FakeSession(fake_client),
+        )
+
+        policy = self.load_policy(
+            {
+                'name': 'boto-resource-bedrock',
+                'resource': 'boto-resource',
+                'service': 'bedrock',
+                'method': 'list_custom_model_deployments',
+                'params': {'maxResults': 10},
+                'result_key': 'modelDeploymentSummaries',
+                'id-field': 'modelDeploymentArn',
+                'filters': [
+                    {'name': 'b'},
+                ],
+            }
+        )
+
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['modelDeploymentArn'], 'arn:2')
+
+        manager = policy.resource_manager
+        selected = manager.get_resources(['arn:1'])
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0]['name'], 'a')
+
+    def test_get_resource_manager_self_reference(self):
+        policy = self.load_policy(
+            {
+                'name': 'boto-resource-rm',
+                'resource': 'boto-resource',
+                'service': 'bedrock',
+                'method': 'list_custom_model_deployments',
+            }
+        )
+
+        related = policy.resource_manager.get_resource_manager('boto-resource', data={
+            'service': 'bedrock',
+            'method': 'list_custom_model_deployments',
+        })
+        self.assertIsInstance(related, boto_resource.BotoResource)


### PR DESCRIPTION
## what

Adds a _proof-of-concept_ `BotoResource`, which allows for dynamic construction of resources for currently unsupported services/endpoints.

## why

A lot of time/effort is spent adding concrete classes to Cloud Custodian, to support new services/endpoints. 

`botocore`/`boto3` use a data-driven approach ([data here](https://github.com/boto/botocore/tree/develop/botocore/data/bedrock/2023-04-20)) to metaprogram [the necessary classes/clients](https://github.com/boto/botocore/blob/develop/botocore/client.py#L192-L209). We don't need to metaprogram; just reflect on the Python APIs provided.

This could cut down significantly on new `*Resource` churn.

## example policy

Let's say a new service is released by AWS called "cloudduck" (**NOT REAL**, don't try to find documentation on it). Cloud Custodian has no support for it at the moment. The user should be able to look at the `boto3` documentation, find the list endpoint & provide the following YAML policy.

### User-provided YAML Policy

```yaml
policies:
- name: duck-db-instances  # This is just an human-readable, unique identifier
  type: aws.boto-resource  # This is new, says to use the code we're creating, & **NOT** in `c7n/resources/resource_map.py` right now.
  service: cloudduck       # This is the new service name. It would roughly equate to `client = boto3.client('cloudduck')`.
  method: list_instances   # This is the name of the client method on the `boto3` client.
```

...and get back a reasonable list of resources.

## tests

- [x] Added unittests
- [x] Added terraform-style tests against a existant service/endpoint

## docs

N/A, since this is PoC/R&D-style work for now.