### PR TITLE
gcp - fix label perms

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/dns.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/dns.py
@@ -21,6 +21,7 @@ class DnsManagedZone(QueryResourceManager):
         name = 'name'
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
         default_report_fields = ['id', 'name', 'dnsName', 'creationTime', 'visibility']
         asset_type = "dns.googleapis.com/ManagedZone"
         scc_type = "google.cloud.dns.ManagedZone"

--- a/tools/c7n_gcp/c7n_gcp/resources/secret.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/secret.py
@@ -19,6 +19,7 @@ class Secret(QueryResourceManager):
         name = id = "name"
         labels = True
         labels_op = 'patch'
+        labels_perm = 'update'
         asset_type = "secretmanager.googleapis.com/Secret"
         default_report_fields = ['name', 'createTime', 'expireTime', 'ttl']
 


### PR DESCRIPTION
Fixes CI failure introduced in https://github.com/cloud-custodian/cloud-custodian/pull/10754

I did parallel work (https://github.com/cloud-custodian/cloud-custodian/pull/10735, https://github.com/cloud-custodian/cloud-custodian/pull/10729) that didn't set `label_perms`