### PR TITLE
fix(c7n_azure): set TagDelayedAction.type so PullMode.run doesn't crash

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions/tagging.py
+++ b/tools/c7n_azure/c7n_azure/actions/tagging.py
@@ -487,6 +487,7 @@ class TagDelayedAction(AzureBaseAction):
 
     """
 
+    type = 'mark-for-op'
     schema = utils.type_schema(
         'mark-for-op',
         tag={'type': 'string'},

--- a/tools/c7n_azure/tests_azure/test_actions_mark-for-op.py
+++ b/tools/c7n_azure/tests_azure/test_actions_mark-for-op.py
@@ -28,6 +28,10 @@ class ActionsMarkForOpTest(BaseTest):
                 ]),
                 validate=True))
 
+    def test_class_type_attribute(self):
+        # Regression for https://github.com/cloud-custodian/cloud-custodian/issues/10795.
+        self.assertEqual(TagDelayedAction.type, 'mark-for-op')
+
     @patch('c7n_azure.tags.TagHelper.update_resource_tags')
     def test_mark_for_op(self, update_resource_tags):
         self.patch(TagDelayedAction, 'type', 'mark-for-op')


### PR DESCRIPTION
Fixes #10795. `PullMode.run` reads `a.type` for every action while wrapping it in a tracer subsegment, but `TagDelayedAction` only acquires that attribute as a side effect of `ActionRegistry.register('mark-for-op', TagDelayedAction)` in `c7n_azure/resources/arm.py`. If the action is executed before that registration runs (the container_host execution path the issue reports, and the existing unit test which has to monkey-patch `type` to work around it) the policy crashes with `AttributeError: 'TagDelayedAction' object has no attribute 'type'`. Setting the class attribute explicitly matches the action name and adds a regression check.
