### PR TITLE
k8s - fix custom resource delete/patch missing group/version/plural args

### DIFF
--- a/tools/c7n_kube/c7n_kube/actions/core.py
+++ b/tools/c7n_kube/c7n_kube/actions/core.py
@@ -71,6 +71,11 @@ class PatchAction(MethodAction):
 
         op = getattr(client, self.manager.get_model().patch)
         namespaced = self.manager.get_model().namespaced
+        query = self.manager.get_resource_query()
+        if query and all(k in query for k in ("group", "version", "plural")):
+            patch_args.update(
+                group=query["group"], version=query["version"], plural=query["plural"]
+            )
         for r in resources:
             patch_args["name"] = r["metadata"]["name"]
             if namespaced:
@@ -240,6 +245,11 @@ class DeleteAction(MethodAction):
     def delete_resources(self, client, resources, **delete_args):
         op = getattr(client, self.manager.get_model().delete)
         namespaced = self.manager.get_model().namespaced
+        query = self.manager.get_resource_query()
+        if query and all(k in query for k in ("group", "version", "plural")):
+            delete_args.update(
+                group=query["group"], version=query["version"], plural=query["plural"]
+            )
         for r in resources:
             delete_args["name"] = r["metadata"]["name"]
             if namespaced:

--- a/tools/c7n_kube/tests/data/flights/TestCustomResource.test_custom_cluster_resource_delete.yaml
+++ b/tools/c7n_kube/tests/data/flights/TestCustomResource.test_custom_cluster_resource_delete.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Swagger-Codegen/9.0.0/python
+    method: GET
+    uri: https://ghost/apis/stable.example.com/v1/crontabscluster
+  response:
+    body:
+      string: '{"apiVersion":"stable.example.com/v1","items":[{"apiVersion":"stable.example.com/v1","kind":"CronTabCluster","metadata":{"creationTimestamp":"2019-03-25T17:34:22Z","generation":1,"name":"my-new-cron-object","resourceVersion":"60237","selfLink":"/apis/stable.example.com/v1/crontabscluster/my-new-cron-object","uid":"3a4a5225-4f24-11e9-86a8-080027415632"},"spec":{"cronSpec":"*
+        * * * */5","image":"my-awesome-cron-image"}}],"kind":"CronTabClusterList","metadata":{"continue":"","resourceVersion":"69373","selfLink":"/apis/stable.example.com/v1/crontabscluster"}}
+
+        '
+    headers:
+      Content-Length:
+      - '562'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 22:14:53 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"gracePeriodSeconds": 30}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Swagger-Codegen/9.0.0/python
+    method: DELETE
+    uri: https://ghost/apis/stable.example.com/v1/crontabscluster/my-new-cron-object
+  response:
+    body:
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"my-new-cron-object","kind":"crontabscluster","uid":"3a4a5225-4f24-11e9-86a8-080027415632"}}
+
+        '
+    headers:
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 22:14:54 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tools/c7n_kube/tests/data/flights/TestCustomResource.test_custom_cluster_resource_label.yaml
+++ b/tools/c7n_kube/tests/data/flights/TestCustomResource.test_custom_cluster_resource_label.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Swagger-Codegen/9.0.0/python
+    method: GET
+    uri: https://ghost/apis/stable.example.com/v1/crontabscluster
+  response:
+    body:
+      string: '{"apiVersion":"stable.example.com/v1","items":[{"apiVersion":"stable.example.com/v1","kind":"CronTabCluster","metadata":{"creationTimestamp":"2019-03-25T17:34:22Z","generation":1,"name":"my-new-cron-object","resourceVersion":"60237","selfLink":"/apis/stable.example.com/v1/crontabscluster/my-new-cron-object","uid":"3a4a5225-4f24-11e9-86a8-080027415632"},"spec":{"cronSpec":"*
+        * * * */5","image":"my-awesome-cron-image"}}],"kind":"CronTabClusterList","metadata":{"continue":"","resourceVersion":"69373","selfLink":"/apis/stable.example.com/v1/crontabscluster"}}
+
+        '
+    headers:
+      Content-Length:
+      - '562'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 22:14:53 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"metadata": {"labels": {"custodian-test": "value"}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/strategic-merge-patch+json
+      User-Agent:
+      - Swagger-Codegen/9.0.0/python
+    method: PATCH
+    uri: https://ghost/apis/stable.example.com/v1/crontabscluster/my-new-cron-object
+  response:
+    body:
+      string: '{"apiVersion":"stable.example.com/v1","kind":"CronTabCluster","metadata":{"creationTimestamp":"2019-03-25T17:34:22Z","generation":2,"labels":{"custodian-test":"value"},"name":"my-new-cron-object","resourceVersion":"60238","selfLink":"/apis/stable.example.com/v1/crontabscluster/my-new-cron-object","uid":"3a4a5225-4f24-11e9-86a8-080027415632"},"spec":{"cronSpec":"*
+        * * * */5","image":"my-awesome-cron-image"}}
+
+        '
+    headers:
+      Content-Length:
+      - '420'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 22:14:54 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tools/c7n_kube/tests/data/flights/TestCustomResource.test_custom_namespaced_resource_delete.yaml
+++ b/tools/c7n_kube/tests/data/flights/TestCustomResource.test_custom_namespaced_resource_delete.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Swagger-Codegen/9.0.0/python
+    method: GET
+    uri: https://ghost/apis/stable.example.com/v1/crontabs
+  response:
+    body:
+      string: '{"apiVersion":"stable.example.com/v1","items":[{"apiVersion":"stable.example.com/v1","kind":"CronTab","metadata":{"creationTimestamp":"2019-03-25T16:07:29Z","generation":1,"name":"my-new-cron-object","namespace":"default","resourceVersion":"60107","selfLink":"/apis/stable.example.com/v1/namespaces/default/crontabs/my-new-cron-object","uid":"16c8eb7a-4f18-11e9-86a8-080027415632"},"spec":{"cronSpec":"*
+        * * * */5","image":"my-awesome-cron-image"}}],"kind":"CronTabList","metadata":{"continue":"","resourceVersion":"69373","selfLink":"/apis/stable.example.com/v1/crontabs"}}
+
+        '
+    headers:
+      Content-Length:
+      - '575'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 22:14:53 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"gracePeriodSeconds": 30}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Swagger-Codegen/9.0.0/python
+    method: DELETE
+    uri: https://ghost/apis/stable.example.com/v1/namespaces/default/crontabs/my-new-cron-object
+  response:
+    body:
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"my-new-cron-object","kind":"crontabs","uid":"16c8eb7a-4f18-11e9-86a8-080027415632"}}
+
+        '
+    headers:
+      Content-Length:
+      - '168'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 22:14:54 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tools/c7n_kube/tests/data/flights/TestCustomResource.test_custom_namespaced_resource_label.yaml
+++ b/tools/c7n_kube/tests/data/flights/TestCustomResource.test_custom_namespaced_resource_label.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Swagger-Codegen/9.0.0/python
+    method: GET
+    uri: https://ghost/apis/stable.example.com/v1/crontabs
+  response:
+    body:
+      string: '{"apiVersion":"stable.example.com/v1","items":[{"apiVersion":"stable.example.com/v1","kind":"CronTab","metadata":{"creationTimestamp":"2019-03-25T16:07:29Z","generation":1,"name":"my-new-cron-object","namespace":"default","resourceVersion":"60107","selfLink":"/apis/stable.example.com/v1/namespaces/default/crontabs/my-new-cron-object","uid":"16c8eb7a-4f18-11e9-86a8-080027415632"},"spec":{"cronSpec":"*
+        * * * */5","image":"my-awesome-cron-image"}}],"kind":"CronTabList","metadata":{"continue":"","resourceVersion":"69373","selfLink":"/apis/stable.example.com/v1/crontabs"}}
+
+        '
+    headers:
+      Content-Length:
+      - '575'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 22:14:53 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"metadata": {"labels": {"custodian-test": "value"}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/strategic-merge-patch+json
+      User-Agent:
+      - Swagger-Codegen/9.0.0/python
+    method: PATCH
+    uri: https://ghost/apis/stable.example.com/v1/namespaces/default/crontabs/my-new-cron-object
+  response:
+    body:
+      string: '{"apiVersion":"stable.example.com/v1","kind":"CronTab","metadata":{"creationTimestamp":"2019-03-25T16:07:29Z","generation":2,"labels":{"custodian-test":"value"},"name":"my-new-cron-object","namespace":"default","resourceVersion":"60108","selfLink":"/apis/stable.example.com/v1/namespaces/default/crontabs/my-new-cron-object","uid":"16c8eb7a-4f18-11e9-86a8-080027415632"},"spec":{"cronSpec":"*
+        * * * */5","image":"my-awesome-cron-image"}}
+
+        '
+    headers:
+      Content-Length:
+      - '430'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 22:14:54 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tools/c7n_kube/tests/test_custom_resource.py
+++ b/tools/c7n_kube/tests/test_custom_resource.py
@@ -94,6 +94,48 @@ class TestCustomResource(KubeTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["metadata"]["name"], "my-new-cron-object")
 
+    def test_custom_cluster_resource_label(self):
+        factory = self.replay_flight_data()
+        policy = self.load_policy(
+            {
+                "name": "custom-resources",
+                "resource": "k8s.custom-cluster-resource",
+                "query": [
+                    {
+                        "group": "stable.example.com",
+                        "version": "v1",
+                        "plural": "crontabscluster",
+                    }
+                ],
+                "actions": [{"type": "label", "labels": {"custodian-test": "value"}}],
+            },
+            session_factory=factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["metadata"]["name"], "my-new-cron-object")
+
+    def test_custom_namespaced_resource_label(self):
+        factory = self.replay_flight_data()
+        policy = self.load_policy(
+            {
+                "name": "custom-resources",
+                "resource": "k8s.custom-namespaced-resource",
+                "query": [
+                    {
+                        "group": "stable.example.com",
+                        "version": "v1",
+                        "plural": "crontabs",
+                    }
+                ],
+                "actions": [{"type": "label", "labels": {"custodian-test": "value"}}],
+            },
+            session_factory=factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["metadata"]["name"], "my-new-cron-object")
+
     def test_custom_resource_validation(self):
         self.assertRaises(
             PolicyValidationError,

--- a/tools/c7n_kube/tests/test_custom_resource.py
+++ b/tools/c7n_kube/tests/test_custom_resource.py
@@ -52,6 +52,48 @@ class TestCustomResource(KubeTest):
         self.assertEqual(resources[0]["apiVersion"], "stable.example.com/v1")
         self.assertEqual(resources[0]["kind"], "CronTab")
 
+    def test_custom_cluster_resource_delete(self):
+        factory = self.replay_flight_data()
+        policy = self.load_policy(
+            {
+                "name": "custom-resources",
+                "resource": "k8s.custom-cluster-resource",
+                "query": [
+                    {
+                        "group": "stable.example.com",
+                        "version": "v1",
+                        "plural": "crontabscluster",
+                    }
+                ],
+                "actions": [{"type": "delete"}],
+            },
+            session_factory=factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["metadata"]["name"], "my-new-cron-object")
+
+    def test_custom_namespaced_resource_delete(self):
+        factory = self.replay_flight_data()
+        policy = self.load_policy(
+            {
+                "name": "custom-resources",
+                "resource": "k8s.custom-namespaced-resource",
+                "query": [
+                    {
+                        "group": "stable.example.com",
+                        "version": "v1",
+                        "plural": "crontabs",
+                    }
+                ],
+                "actions": [{"type": "delete"}],
+            },
+            session_factory=factory,
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["metadata"]["name"], "my-new-cron-object")
+
     def test_custom_resource_validation(self):
         self.assertRaises(
             PolicyValidationError,


### PR DESCRIPTION
 Fixes #10799

 DeleteAction.delete_resources() and PatchAction.patch_resources() were
 not passing the required 'group', 'version', and 'plural' arguments to
 the Kubernetes CustomObjectsApi when deleting or patching custom
 resources (k8s.custom-namespaced-resource and k8s.custom-cluster-resource).

 The fix checks whether the resource manager's query contains a 'group'
 key (which custom resources always have) and, if so, injects the
 group/version/plural into the API call kwargs before invoking the
 operation.