### PR TITLE
gcp - disk - add snapshots filter

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/compute.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/compute.py
@@ -5,7 +5,7 @@ import re
 
 from datetime import datetime
 
-from c7n.utils import local_session, type_schema
+from c7n.utils import local_session, type_schema, group_by
 
 from c7n_gcp.actions import MethodAction
 from c7n_gcp.filters import IamPolicyFilter
@@ -13,7 +13,7 @@ from c7n_gcp.filters.iampolicy import IamPolicyValueFilter
 from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo, ChildResourceManager, ChildTypeInfo
 
-from c7n.filters.core import ValueFilter
+from c7n.filters.core import ListItemFilter, ValueFilter
 from c7n.filters.offhours import OffHour, OnHour
 
 
@@ -411,6 +411,60 @@ class Disk(QueryResourceManager):
                         'labels': all_labels,
                         'labelFingerprint': resource['labelFingerprint']
                     }}
+
+
+@Disk.filter_registry.register('snapshots')
+class DiskSnapshotsFilter(ListItemFilter):
+    """
+    Filter GCP disks by their snapshots.
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: disk-without-recent-snapshot
+            resource: gcp.disk
+            filters:
+              - not:
+                - type: snapshots
+                  attrs:
+                    - type: value
+                      key: creationTimestamp
+                      value_type: age
+                      value: 7
+                      op: less-than
+    """
+    schema = type_schema(
+        'snapshots',
+        attrs={'$ref': '#/definitions/filters_common/list_item_attrs'},
+        count={'type': 'number'},
+        count_op={'$ref': '#/definitions/filters_common/comparison_operators'}
+    )
+    permissions = ('compute.snapshots.list',)
+    item_annotation_key = 'c7n:Snapshots'
+    annotate_items = True
+
+    def process(self, resources, event=None):
+        session = local_session(self.manager.session_factory)
+        client = session.client('compute', 'v1', 'snapshots')
+        project = session.get_default_project()
+
+        all_snapshots = []
+        for page in client.execute_paged_query('list', {'project': project}):
+            page_items = page.get('items', [])
+            if page_items:
+                all_snapshots.extend(page_items)
+
+        grouped = group_by(all_snapshots, 'sourceDisk')
+        for resource in resources:
+            resource[self.item_annotation_key] = grouped.get(
+                resource['selfLink'], [])
+
+        return super().process(resources, event)
+
+    def get_item_values(self, resource):
+        return resource.get(self.item_annotation_key, [])
 
 
 @Disk.action_registry.register('snapshot')

--- a/tools/c7n_gcp/c7n_gcp/resources/compute.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/compute.py
@@ -442,29 +442,22 @@ class DiskSnapshotsFilter(ListItemFilter):
         count_op={'$ref': '#/definitions/filters_common/comparison_operators'}
     )
     permissions = ('compute.snapshots.list',)
-    item_annotation_key = 'c7n:Snapshots'
+    annotation_key = 'c7n:Snapshots'
+    item_annotation_key = 'c7n:MatchedSnapshots'
     annotate_items = True
 
     def process(self, resources, event=None):
-        session = local_session(self.manager.session_factory)
-        client = session.client('compute', 'v1', 'snapshots')
-        project = session.get_default_project()
-
-        all_snapshots = []
-        for page in client.execute_paged_query('list', {'project': project}):
-            page_items = page.get('items', [])
-            if page_items:
-                all_snapshots.extend(page_items)
+        all_snapshots = self.manager.get_resource_manager('gcp.snapshot').resources()
 
         grouped = group_by(all_snapshots, 'sourceDisk')
         for resource in resources:
-            resource[self.item_annotation_key] = grouped.get(
+            resource[self.annotation_key] = grouped.get(
                 resource['selfLink'], [])
 
         return super().process(resources, event)
 
     def get_item_values(self, resource):
-        return resource.get(self.item_annotation_key, [])
+        return resource.get(self.annotation_key, [])
 
 
 @Disk.action_registry.register('snapshot')

--- a/tools/c7n_gcp/tests/data/flights/disk-snapshots-filter/get-compute-v1-projects-cloud-custodian-aggregated-disks_1.json
+++ b/tools/c7n_gcp/tests/data/flights/disk-snapshots-filter/get-compute-v1-projects-cloud-custodian-aggregated-disks_1.json
@@ -1,0 +1,104 @@
+{
+  "body": {
+    "items": {
+      "zones/us-east1-b": {
+        "disks": [
+          {
+            "status": "READY",
+            "kind": "compute#disk",
+            "sizeGb": "10",
+            "zone": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-east1-b",
+            "creationTimestamp": "2017-05-01T12:34:32.960-07:00",
+            "labelFingerprint": "42WmSpB8rSM=",
+            "name": "custodian-dev",
+            "sourceImageId": "6314006526179709993",
+            "lastAttachTimestamp": "2017-05-01T12:34:33.013-07:00",
+            "sourceImage": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20170330",
+            "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial"
+            ],
+            "users": [
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-east1-b/instances/custodian-dev"
+            ],
+            "type": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-east1-b/diskTypes/pd-standard",
+            "id": "1926261635889640234",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-east1-b/disks/custodian-dev",
+            "licenseCodes": [
+              "1000201"
+            ]
+          }
+        ]
+      },
+      "zones/us-central1-b": {
+        "disks": [
+          {
+            "status": "READY",
+            "sourceImageId": "6358156582333702971",
+            "kind": "compute#disk",
+            "sizeGb": "10",
+            "zone": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b",
+            "creationTimestamp": "2018-05-19T05:15:46.031-07:00",
+            "labelFingerprint": "42WmSpB8rSM=",
+            "name": "c7n-jenkins",
+            "guestOsFeatures": [
+              {
+                "type": "VIRTIO_SCSI_MULTIQUEUE"
+              }
+            ],
+            "lastAttachTimestamp": "2018-05-19T05:15:46.034-07:00",
+            "sourceImage": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20180426b",
+            "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1804-lts"
+            ],
+            "users": [
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/instances/c7n-jenkins"
+            ],
+            "type": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/diskTypes/pd-standard",
+            "id": "2788076175605214111",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/disks/c7n-jenkins",
+            "licenseCodes": [
+              "5926592092274602096"
+            ]
+          },
+          {
+            "status": "READY",
+            "sourceImageId": "6140086446928574013",
+            "kind": "compute#disk",
+            "sizeGb": "16",
+            "zone": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b",
+            "creationTimestamp": "2017-11-01T03:28:50.900-07:00",
+            "labelFingerprint": "42WmSpB8rSM=",
+            "name": "drone",
+            "guestOsFeatures": [
+              {
+                "type": "VIRTIO_SCSI_MULTIQUEUE"
+              }
+            ],
+            "lastAttachTimestamp": "2017-11-01T03:28:50.905-07:00",
+            "sourceImage": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20171026a",
+            "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial"
+            ],
+            "users": [
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/instances/drone"
+            ],
+            "type": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/diskTypes/pd-standard",
+            "id": "3901503733671141133",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/disks/drone",
+            "licenseCodes": [
+              "1000201"
+            ]
+          }
+        ]
+      }
+    },
+    "kind": "compute#diskAggregatedList",
+    "id": "projects/cloud-custodian/aggregated/disks",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/disks"
+  },
+  "headers": {
+    "status": "200",
+    "content-type": "application/json; charset=UTF-8",
+    "content-length": "8192"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/disk-snapshots-filter/get-compute-v1-projects-cloud-custodian-global-snapshots_1.json
+++ b/tools/c7n_gcp/tests/data/flights/disk-snapshots-filter/get-compute-v1-projects-cloud-custodian-global-snapshots_1.json
@@ -1,0 +1,50 @@
+{
+  "headers": {
+    "status": "200",
+    "content-type": "application/json; charset=UTF-8",
+    "content-length": "2048"
+  },
+  "body": {
+    "kind": "compute#snapshotList",
+    "id": "projects/cloud-custodian/global/snapshots",
+    "items": [
+      {
+        "kind": "compute#snapshot",
+        "id": "1111111111111111111",
+        "creationTimestamp": "2018-06-01T10:00:00.000-07:00",
+        "name": "c7n-jenkins-snap-1",
+        "status": "READY",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/disks/c7n-jenkins",
+        "sourceDiskId": "2788076175605214111",
+        "diskSizeGb": "10",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/snapshots/c7n-jenkins-snap-1",
+        "labelFingerprint": "42WmSpB8rSM="
+      },
+      {
+        "kind": "compute#snapshot",
+        "id": "2222222222222222222",
+        "creationTimestamp": "2018-06-02T10:00:00.000-07:00",
+        "name": "c7n-jenkins-snap-2",
+        "status": "READY",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/disks/c7n-jenkins",
+        "sourceDiskId": "2788076175605214111",
+        "diskSizeGb": "10",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/snapshots/c7n-jenkins-snap-2",
+        "labelFingerprint": "42WmSpB8rSM="
+      },
+      {
+        "kind": "compute#snapshot",
+        "id": "3333333333333333333",
+        "creationTimestamp": "2018-06-01T12:00:00.000-07:00",
+        "name": "drone-snap-1",
+        "status": "READY",
+        "sourceDisk": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-b/disks/drone",
+        "sourceDiskId": "3901503733671141133",
+        "diskSizeGb": "16",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/snapshots/drone-snap-1",
+        "labelFingerprint": "42WmSpB8rSM="
+      }
+    ],
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/snapshots"
+  }
+}

--- a/tools/c7n_gcp/tests/test_compute.py
+++ b/tools/c7n_gcp/tests/test_compute.py
@@ -408,6 +408,52 @@ class DiskTest(BaseTest):
         result = rec_filter.match_resources(recommends_with_none, resources)
         assert result == []
 
+    def test_disk_snapshots_filter(self):
+        factory = self.replay_flight_data('disk-snapshots-filter', project_id='cloud-custodian')
+        p = self.load_policy(
+            {'name': 'disks-with-snapshots',
+             'resource': 'gcp.disk',
+             'filters': [
+                 {'type': 'snapshots',
+                  'count': 1,
+                  'count_op': 'gte'}]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+        names = {r['name'] for r in resources}
+        self.assertEqual(names, {'c7n-jenkins', 'drone'})
+
+    def test_disk_snapshots_filter_attrs(self):
+        factory = self.replay_flight_data('disk-snapshots-filter', project_id='cloud-custodian')
+        p = self.load_policy(
+            {'name': 'disks-with-ready-snapshots',
+             'resource': 'gcp.disk',
+             'filters': [
+                 {'type': 'snapshots',
+                  'attrs': [
+                      {'type': 'value',
+                       'key': 'status',
+                       'value': 'READY'}]}]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+        for r in resources:
+            self.assertIn('c7n:Snapshots', r)
+
+    def test_disk_no_snapshots_filter(self):
+        factory = self.replay_flight_data('disk-snapshots-filter', project_id='cloud-custodian')
+        p = self.load_policy(
+            {'name': 'disks-without-snapshots',
+             'resource': 'gcp.disk',
+             'filters': [
+                 {'type': 'snapshots',
+                  'count': 0,
+                  'count_op': 'eq'}]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'custodian-dev')
+
 
 class SnapshotTest(BaseTest):
 


### PR DESCRIPTION
Fixes: https://github.com/cloud-custodian/cloud-custodian/issues/10801

### Summary
This PR adds a snapshots filter for GCP gcp.disk resources, bringing parity with the existing snapshots filter available on AWS aws.ebs volumes. Users can now filter GCP disks based on their associated snapshots — including count, recency, and any snapshot attribute.

### Why
AWS EBS resources in Cloud Custodian already support snapshot-based filtering, allowing users to:
- Filter volumes based on properties of their associated snapshots
- Identify volumes with or without snapshots
- Apply snapshot attribute-based conditions (age, tags, count, etc.)

GCP disk resources had no equivalent functionality. GCP's Compute API does not embed snapshot information in disk resources — snapshots must be queried separately and correlated by sourceDisk. This gap made it impossible to write a policy such as "flag disks that have not been snapshotted in the last 7 days," a common compliance requirement.

### What Changed
A new DiskSnapshotsFilter (registered as snapshots on gcp.disk) is added to compute.py. It extends ListItemFilter and:

- Fetches all snapshots in the project via the GCP compute.snapshots.list API (with pagination)
- Groups snapshots by sourceDisk using group_by
- Annotates each disk resource with its snapshots under the c7n:Snapshots key
- Delegates attribute/count filtering to the `ListItemFilter` base class

Example
```
policies:
  - name: disk-without-recent-snapshot
    resource: gcp.disk
    filters:
      - not:
        - type: snapshots
          attrs:
            - type: value
              key: creationTimestamp
              value_type: age
              value: 7
              op: less-than
```

```
policies:
  - name: disks-missing-any-snapshot
    resource: gcp.disk
    filters:
      - type: snapshots
        count: 0
        count_op: eq
```

Matched disks will have a c7n:Snapshots annotation containing the list of associated snapshot objects.

### Notes

- Requires compute.snapshots.list permission
- Fully backward compatible — no existing disk fields are modified; snapshots are added as a new annotation key
- Pagination handled — all project snapshots are fetched across pages before grouping before grouping
- AWS EBS parity — filter schema (attrs, count, count_op) mirrors the existing snapshots filter on aws.ebs
- Three tests added covering: disks with ≥1 snapshot, disks with attribute-filtered snapshots (e.g. status: READY), and disks with zero snapshots