### PR TITLE
tests - use bucket prefix in s3 functional test

### DIFF
--- a/tests/data/placebo/test_s3_tag/s3.GetBucketTagging_1.json
+++ b/tests/data/placebo/test_s3_tag/s3.GetBucketTagging_1.json
@@ -2,11 +2,6 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "TagSet": [
-            {
-                "Key": "original-tag",
-                "Value": "original-value"
-            }
-        ]
+        "TagSet": []
     }
 }

--- a/tests/data/placebo/test_s3_tag/s3.GetBucketTagging_2.json
+++ b/tests/data/placebo/test_s3_tag/s3.GetBucketTagging_2.json
@@ -2,11 +2,6 @@
     "status_code": 200,
     "data": {
         "ResponseMetadata": {},
-        "TagSet": [
-            {
-                "Key": "original-tag",
-                "Value": "original-value"
-            }
-        ]
+        "TagSet": []
     }
 }

--- a/tests/data/placebo/test_s3_tag/s3.GetBucketTagging_3.json
+++ b/tests/data/placebo/test_s3_tag/s3.GetBucketTagging_3.json
@@ -6,10 +6,6 @@
             {
                 "Key": "original-tag",
                 "Value": "original-value"
-            },
-            {
-                "Key": "new-tag",
-                "Value": "new-value"
             }
         ]
     }

--- a/tests/data/placebo/test_s3_tag/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_tag/s3.ListBuckets_1.json
@@ -4,22 +4,50 @@
         "ResponseMetadata": {},
         "Buckets": [
             {
-                "Name": "my-custodian-test-bucket",
+                "Name": "644160558196-us-east-1-s3-logs",
                 "CreationDate": {
                     "__class__": "datetime",
                     "year": 2021,
-                    "month": 2,
-                    "day": 4,
-                    "hour": 22,
-                    "minute": 38,
-                    "second": 48,
+                    "month": 10,
+                    "day": 19,
+                    "hour": 18,
+                    "minute": 6,
+                    "second": 8,
                     "microsecond": 0
-                }
+                },
+                "BucketArn": "arn:aws:s3:::644160558196-us-east-1-s3-logs"
+            },
+            {
+                "Name": "644160558196-us-east-1-sambox-sceptre-artifacts",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 7,
+                    "day": 7,
+                    "hour": 8,
+                    "minute": 40,
+                    "second": 35,
+                    "microsecond": 0
+                },
+                "BucketArn": "arn:aws:s3:::644160558196-us-east-1-sambox-sceptre-artifacts"
+            },
+            {
+                "Name": "c7ntest20260528182536469500000001",
+                "CreationDate": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 5,
+                    "day": 28,
+                    "hour": 18,
+                    "minute": 25,
+                    "second": 37,
+                    "microsecond": 0
+                },
+                "BucketArn": "arn:aws:s3:::c7ntest20260528182536469500000001"
             }
         ],
         "Owner": {
-            "DisplayName": "alfred",
-            "ID": "278eecaaf33ac93d4c62b8214e7a13ed5f9a169ac2f8ce1601e83a2b312a5506"
+            "ID": "e46bca81657fdc9f58bc5bab457564bb66f16636bd724a9f51d212fa2185a2b0"
         }
     }
 }

--- a/tests/terraform/s3_tag/main.tf
+++ b/tests/terraform/s3_tag/main.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "example" {
-  bucket = "my-custodian-test-bucket"
-  acl    = "private"
+  bucket_prefix = "c7ntest"
+  acl           = "private"
 
   tags = {
     original-tag = "original-value"

--- a/tests/terraform/s3_tag/tf_resources.json
+++ b/tests/terraform/s3_tag/tf_resources.json
@@ -6,27 +6,56 @@
             "example": {
                 "acceleration_status": "",
                 "acl": "private",
-                "arn": "arn:aws:s3:::my-custodian-test-bucket",
-                "bucket": "my-custodian-test-bucket",
-                "bucket_domain_name": "my-custodian-test-bucket.s3.amazonaws.com",
-                "bucket_prefix": null,
-                "bucket_regional_domain_name": "my-custodian-test-bucket.s3.amazonaws.com",
+                "arn": "arn:aws:s3:::c7ntest20260528182536469500000001",
+                "bucket": "c7ntest20260528182536469500000001",
+                "bucket_domain_name": "c7ntest20260528182536469500000001.s3.amazonaws.com",
+                "bucket_prefix": "c7ntest",
+                "bucket_region": "us-east-1",
+                "bucket_regional_domain_name": "c7ntest20260528182536469500000001.s3.us-east-1.amazonaws.com",
                 "cors_rule": [],
                 "force_destroy": false,
-                "grant": [],
+                "grant": [
+                    {
+                        "id": "e46bca81657fdc9f58bc5bab457564bb66f16636bd724a9f51d212fa2185a2b0",
+                        "permissions": [
+                            "FULL_CONTROL"
+                        ],
+                        "type": "CanonicalUser",
+                        "uri": ""
+                    }
+                ],
                 "hosted_zone_id": "Z3AQBSTGFYJSTF",
-                "id": "my-custodian-test-bucket",
+                "id": "c7ntest20260528182536469500000001",
                 "lifecycle_rule": [],
                 "logging": [],
                 "object_lock_configuration": [],
-                "policy": null,
+                "object_lock_enabled": false,
+                "policy": "",
                 "region": "us-east-1",
                 "replication_configuration": [],
                 "request_payer": "BucketOwner",
-                "server_side_encryption_configuration": [],
+                "server_side_encryption_configuration": [
+                    {
+                        "rule": [
+                            {
+                                "apply_server_side_encryption_by_default": [
+                                    {
+                                        "kms_master_key_id": "",
+                                        "sse_algorithm": "AES256"
+                                    }
+                                ],
+                                "bucket_key_enabled": false
+                            }
+                        ]
+                    }
+                ],
                 "tags": {
                     "original-tag": "original-value"
                 },
+                "tags_all": {
+                    "original-tag": "original-value"
+                },
+                "timeouts": null,
                 "versioning": [
                     {
                         "enabled": false,


### PR DESCRIPTION
Avoid functional test failures like [this](https://github.com/cloud-custodian/cloud-custodian/actions/runs/26589244391/job/78343376178) by not relying on a hardcoded bucket name.