### PR TITLE
fix(gcp): add get_metric_resource_name for Cloud Run revisions

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/cloudrun.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/cloudrun.py
@@ -6,7 +6,7 @@ from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo
 from c7n_gcp.filters import IamPolicyFilter
 from c7n_gcp.filters.iampolicy import IamPolicyValueFilter
-from c7n.utils import local_session
+from c7n.utils import local_session, jmespath_search
 
 
 @resources.register("cloud-run-service")
@@ -129,3 +129,16 @@ class CloudRunRevision(QueryResourceManager):
         asset_type = "run.googleapis.com/Revision"
         urn_component = "revision"
         urn_id_segments = (-1,)
+
+        @classmethod
+        def get_metric_resource_name(cls, resource, metric_key=None):
+            # Handle different metric keys for Cloud Run revisions
+            # Since Cloud Run uses nested metadata structure, we must use jmespath
+            if metric_key == 'resource.labels.revision_name':
+                # Extract revision name (e.g., "service-00001-abc")
+                return jmespath_search("metadata.name", resource)
+            elif metric_key == 'resource.labels.service_name':
+                # Extract service name from Knative label (e.g., "service")
+                return jmespath_search('metadata.labels."serving.knative.dev/service"', resource)
+            # Default: return revision name (most common case)
+            return jmespath_search("metadata.name", resource)

--- a/tools/c7n_gcp/tests/test_cloudrun.py
+++ b/tools/c7n_gcp/tests/test_cloudrun.py
@@ -127,3 +127,86 @@ class RevisionServiceTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['metadata']['name'], 'hello-00001-nvq')
+
+    def test_get_metric_resource_name_revision_name(self):
+        """Test extraction of revision name for metrics filtering"""
+        from c7n_gcp.resources.cloudrun import CloudRunRevision
+
+        sample_resource = {
+            'metadata': {
+                'name': 'myservice-00015-kkr',
+                'namespace': '123456789',
+                'labels': {
+                    'serving.knative.dev/service': 'myservice',
+                    'cloud.googleapis.com/location': 'us-central1'
+                }
+            }
+        }
+
+        result = CloudRunRevision.resource_type.get_metric_resource_name(
+            sample_resource,
+            metric_key='resource.labels.revision_name'
+        )
+        self.assertEqual(result, 'myservice-00015-kkr')
+        self.assertIsNotNone(result)
+
+    def test_get_metric_resource_name_service_name(self):
+        """Test extraction of service name for metrics filtering"""
+        from c7n_gcp.resources.cloudrun import CloudRunRevision
+
+        sample_resource = {
+            'metadata': {
+                'name': 'myservice-00015-kkr',
+                'namespace': '123456789',
+                'labels': {
+                    'serving.knative.dev/service': 'myservice',
+                    'cloud.googleapis.com/location': 'us-central1'
+                }
+            }
+        }
+
+        result = CloudRunRevision.resource_type.get_metric_resource_name(
+            sample_resource,
+            metric_key='resource.labels.service_name'
+        )
+        self.assertEqual(result, 'myservice')
+        self.assertIsNotNone(result)
+
+    def test_get_metric_resource_name_default(self):
+        """Test default behavior (returns revision name)"""
+        from c7n_gcp.resources.cloudrun import CloudRunRevision
+
+        sample_resource = {
+            'metadata': {
+                'name': 'myservice-00015-kkr',
+                'namespace': '123456789',
+                'labels': {
+                    'serving.knative.dev/service': 'myservice'
+                }
+            }
+        }
+
+        result = CloudRunRevision.resource_type.get_metric_resource_name(
+            sample_resource,
+            metric_key=None
+        )
+        self.assertEqual(result, 'myservice-00015-kkr')
+
+        result = CloudRunRevision.resource_type.get_metric_resource_name(sample_resource)
+        self.assertEqual(result, 'myservice-00015-kkr')
+
+    def test_get_metric_resource_name_handles_nested_structure(self):
+        """Test that nested metadata.name is correctly extracted (not None)"""
+        from c7n_gcp.resources.cloudrun import CloudRunRevision
+
+        sample_resource = {
+            'metadata': {
+                'name': 'test-revision-abc-123',
+                'namespace': '999999999'
+            }
+        }
+
+        result = CloudRunRevision.resource_type.get_metric_resource_name(sample_resource)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, 'test-revision-abc-123')
+        self.assertNotEqual(result, 'None')


### PR DESCRIPTION
Cloud Run revisions use nested metadata structure (metadata.name)
which requires jmespath_search to extract the revision name for
metrics filtering. Without this, the base class method returns None,
causing metrics queries to fail with 0 results.

This enables metrics filters (CPU, memory, request count) to work
correctly with gcp.cloud-run-revision resources.

fixes : https://github.com/cloud-custodian/cloud-custodian/issues/10806#issue-4548548426