### PR TITLE
releng - bump azure cosmosdb version v6.4.0 --> v9.9.0

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
+++ b/tools/c7n_azure/c7n_azure/resources/cosmos_db.py
@@ -627,7 +627,7 @@ class OfferHelper:
         if not resources[0].get('c7n:offer'):
             offers = list(account_data_client.ReadOffers())
             for resource in resources:
-                offer = next((o for o in offers if o['resource'] == resource['_self']), None)
+                offer = next((o for o in offers if o['offerResourceId'] == resource['_rid']), None)
                 resource['c7n:offer'] = offer
 
     @staticmethod

--- a/tools/c7n_azure/pyproject.toml
+++ b/tools/c7n_azure/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "azure-mgmt-containerinstance<8.0.0,>=7.0.0",
     "azure-mgmt-containerregistry<15.0.0,>=14.0.0",
     "azure-mgmt-containerservice<16.0.0,>=15.0.0",
-    "azure-mgmt-cosmosdb<7.0.0,>=6.1.0",
+    "azure-mgmt-cosmosdb<10.0.0,>=6.1.0",
     "azure-mgmt-costmanagement<2.0.0,>=1.0.0",
     "azure-mgmt-databricks==1.0.0b1",
     "azure-mgmt-datafactory<2.0.0,>=1.0.0",

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.firewall.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.firewall.json
@@ -4,27 +4,39 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2021-01-15",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
                     "content-type": [
-                        "application/json"
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
                     ],
                     "date": [
-                        "Thu, 11 Mar 2021 21:07:38 GMT"
+                        "Tue, 02 Jun 2026 16:01:33 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 131FEE05183A4656BC0C4B61D00AF1C7 Ref B: MNZ221060608045 Ref C: 2026-06-02T16:01:32Z"
+                    ],
+                    "content-length": [
+                        "3314"
                     ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "content-length": [
-                        "2657"
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
                     ]
                 },
                 "body": {
@@ -36,18 +48,16 @@
                                 "location": "South Central US",
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
-                                "tags": {
-                                    "test-store-throughput": "W0I8AMnW7pw=:4",
-                                    "test-restore-throughput": "W0I8AMnW7pw=:4"
-                                },
+                                "tags": {},
                                 "systemData": {
-                                    "createdAt": "2021-03-11T20:32:39.4599798Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
                                     "publicNetworkAccess": "Enabled",
-                                    "enableAutomaticFailover": false,
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -56,17 +66,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "7949a528-d449-4ebe-995e-a249c3af05b5",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
                                     "defaultIdentity": "FirstPartyIdentity",
                                     "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -108,7 +128,7 @@
                                     "capabilities": [],
                                     "ipRules": [
                                         {
-                                            "ipAddressOrRange": "73.239.235.58"
+                                            "ipAddressOrRange": "173.2.147.78"
                                         },
                                         {
                                             "ipAddressOrRange": "104.42.195.92"
@@ -134,7 +154,21 @@
                                             "backupStorageRedundancy": "Geo"
                                         }
                                     },
-                                    "networkAclBypassResourceIds": []
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        }
+                                    }
                                 },
                                 "identity": {
                                     "type": "None"

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.firewall_include.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.firewall_include.json
@@ -11,51 +11,60 @@
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "OK"
+                    "message": ""
                 },
                 "headers": {
+                    "content-type": [
+                        "text/plain;charset=UTF-8"
+                    ],
                     "date": [
-                        "Sat, 31 Oct 2020 04:39:17 GMT"
+                        "Tue, 02 Jun 2026 16:01:33 GMT"
                     ],
                     "content-length": [
                         "13"
-                    ],
-                    "content-type": [
-                        "text/plain"
-                    ],
-                    "via": [
-                        "1.1 vegur"
                     ]
                 },
                 "body": {
-                    "string": "67.185.99.110\n"
+                    "string": "173.2.147.78\n"
                 }
             }
         },
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:35 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: AEB817ADC0F24826A819F3A29A8F1C46 Ref B: BL2AA2030101009 Ref C: 2026-06-02T16:01:35Z"
+                    ],
+                    "content-length": [
+                        "3314"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:16 GMT"
-                    ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "content-length": [
-                        "2336"
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
                     ]
                 },
                 "body": {
@@ -67,17 +76,16 @@
                                 "location": "South Central US",
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
-                                "tags": {
-                                    "test-store-throughput": "JZ07ANKIMdw=:4",
-                                    "test-restore-throughput": "JZ07ANKIMdw=:4"
-                                },
+                                "tags": {},
                                 "systemData": {
-                                    "createdAt": "2020-10-31T03:48:04.4977476Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                                    "enableAutomaticFailover": false,
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "publicNetworkAccess": "Enabled",
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -86,16 +94,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
-                                    "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                                    "defaultIdentity": "FirstPartyIdentity",
+                                    "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -135,13 +154,52 @@
                                     ],
                                     "cors": [],
                                     "capabilities": [],
+                                    "ipRules": [
+                                        {
+                                            "ipAddressOrRange": "173.2.147.78"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "104.42.195.92"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "40.76.54.131"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.176.6.30"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.169.50.45"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.187.184.26"
+                                        }
+                                    ],
                                     "backupPolicy": {
                                         "type": "Periodic",
                                         "periodicModeProperties": {
                                             "backupIntervalInMinutes": 240,
-                                            "backupRetentionIntervalInHours": 8
+                                            "backupRetentionIntervalInHours": 8,
+                                            "backupStorageRedundancy": "Geo"
+                                        }
+                                    },
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                         }
                                     }
+                                },
+                                "identity": {
+                                    "type": "None"
                                 }
                             }
                         ]

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_collection_metrics_filter.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_collection_metrics_filter.json
@@ -4,27 +4,39 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:18 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 40E8188EB6714648A871DAD318BD0010 Ref B: BL2AA2011005031 Ref C: 2026-06-02T16:01:18Z"
+                    ],
+                    "content-length": [
+                        "3314"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:02 GMT"
-                    ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "content-length": [
-                        "2336"
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
                     ]
                 },
                 "body": {
@@ -36,17 +48,16 @@
                                 "location": "South Central US",
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
-                                "tags": {
-                                    "test-store-throughput": "JZ07ANKIMdw=:4",
-                                    "test-restore-throughput": "JZ07ANKIMdw=:4"
-                                },
+                                "tags": {},
                                 "systemData": {
-                                    "createdAt": "2020-10-31T03:48:04.4977476Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                                    "enableAutomaticFailover": false,
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "publicNetworkAccess": "Enabled",
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -55,16 +66,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
-                                    "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                                    "defaultIdentity": "FirstPartyIdentity",
+                                    "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -104,13 +126,52 @@
                                     ],
                                     "cors": [],
                                     "capabilities": [],
+                                    "ipRules": [
+                                        {
+                                            "ipAddressOrRange": "173.2.147.78"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "104.42.195.92"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "40.76.54.131"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.176.6.30"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.169.50.45"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.187.184.26"
+                                        }
+                                    ],
                                     "backupPolicy": {
                                         "type": "Periodic",
                                         "periodicModeProperties": {
                                             "backupIntervalInMinutes": 240,
-                                            "backupRetentionIntervalInHours": 8
+                                            "backupRetentionIntervalInHours": 8,
+                                            "backupStorageRedundancy": "Geo"
+                                        }
+                                    },
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                         }
                                     }
+                                },
+                                "identity": {
+                                    "type": "None"
                                 }
                             }
                         ]
@@ -121,7 +182,7 @@
         {
             "request": {
                 "method": "POST",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -131,20 +192,29 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:02 GMT"
-                    ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-ratelimit-remaining-subscription-writes": [
-                        "1196"
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:19 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "799"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 4AF369E253384C578E41E733A94015EF Ref B: MNZ221060610027 Ref C: 2026-06-02T16:01:19Z"
                     ],
                     "content-length": [
                         "461"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/154c7852-d75f-49a4-80f7-8c522b163a69"
                     ]
                 },
                 "body": {
@@ -160,7 +230,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39.documents.azure.com/",
+                "uri": "https://cctestcosmosdbc2295d913936.documents.azure.com/",
                 "body": null,
                 "headers": {}
             },
@@ -170,26 +240,26 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "cache-control": [
-                        "no-store, no-cache"
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:20 GMT"
                     ],
                     "x-ms-databaseaccount-provisioned-mb": [
                         "0"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:03 GMT"
+                    "x-ms-databaseaccount-consumed-mb": [
+                        "0"
                     ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "x-ms-max-media-storage-usage-mb": [
-                        "2048"
+                    "cache-control": [
+                        "no-store, no-cache"
                     ],
                     "x-ms-media-storage-usage-mb": [
                         "0"
                     ],
-                    "x-ms-databaseaccount-consumed-mb": [
-                        "0"
+                    "x-ms-max-media-storage-usage-mb": [
+                        "2048"
                     ],
                     "x-ms-databaseaccount-reserved-mb": [
                         "0"
@@ -198,24 +268,28 @@
                 "body": {
                     "data": {
                         "_self": "",
-                        "id": "cctestcosmosdbfafbee1d5b39",
-                        "_rid": "cctestcosmosdbfafbee1d5b39.documents.azure.com",
+                        "id": "cctestcosmosdbc2295d913936",
+                        "_rid": "cctestcosmosdbc2295d913936.documents.azure.com",
                         "media": "//media/",
                         "addresses": "//addresses/",
                         "_dbs": "//dbs/",
                         "writableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "readableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "enableMultipleWriteLocations": false,
+                        "continuousBackupEnabled": false,
+                        "enableNRegionSynchronousCommit": false,
+                        "enablePerPartitionFailoverBehavior": false,
+                        "disableCrossRegionalHedging": false,
                         "userReplicationPolicy": {
                             "asyncReplication": false,
                             "minReplicaSetSize": 3,
@@ -232,7 +306,7 @@
                             "primaryReadCoefficient": 1,
                             "secondaryReadCoefficient": 1
                         },
-                        "queryEngineConfiguration": "{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":true,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlDisableQueryILOptimization\":false,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"
+                        "queryEngineConfiguration": "{\"allowNewKeywords\":true,\"maxJoinsPerSqlQuery\":10,\"maxQueryRequestTimeoutFraction\":0.9,\"maxSqlQueryInputLength\":524288,\"maxUdfRefPerSqlQuery\":10,\"queryMaxInMemorySortDocumentCount\":-1000,\"spatialMaxGeometryPointCount\":256,\"sqlAllowNonFiniteNumbers\":false,\"sqlDisableOptimizationFlags\":0,\"sqlQueryILDisableOptimizationFlags\":0,\"clientDisableOptimisticDirectExecution\":false,\"queryEnableFullText\":true,\"queryEnableFullTextPreviewFeatures\":false,\"queryMaxFullTextScoreSearchTerms\":30,\"queryMaxRrfArgumentCount\":100,\"enableSpatialIndexing\":true,\"maxInExpressionItemsCount\":2147483647,\"maxLogicalAndPerSqlQuery\":2147483647,\"maxLogicalOrPerSqlQuery\":2147483647,\"maxSpatialQueryCells\":2147483647,\"sqlAllowAggregateFunctions\":true,\"sqlAllowGroupByClause\":true,\"sqlAllowLike\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"sqlAllowTop\":true}"
                     }
                 }
             }
@@ -240,7 +314,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs",
                 "body": null,
                 "headers": {}
             },
@@ -250,50 +324,53 @@
                     "message": "Ok"
                 },
                 "headers": {
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:20 GMT"
+                    ],
                     "lsn": [
-                        "18"
+                        "12"
+                    ],
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-resource-quota": [
+                        "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;azureRbac=200000;"
+                    ],
+                    "x-ms-schemaversion": [
+                        "1.21"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.553"
                     ],
                     "x-ms-activity-id": [
-                        "f90dd00a-d9d1-43ee-83b0-9b5680d38c54"
+                        "2e549954-1f08-4343-b245-c18580b026f0"
                     ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-serviceversion": [
+                        "version=2.14.0.0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
-                    "x-ms-serviceversion": [
-                        "version=2.11.0.0"
-                    ],
-                    "x-ms-resource-usage": [
-                        "databases=1;collections=1;users=0;permissions=0;"
-                    ],
-                    "x-ms-item-count": [
-                        "1"
-                    ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
-                    ],
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:04 GMT"
-                    ],
-                    "x-ms-request-duration-ms": [
-                        "0.612"
-                    ],
                     "x-ms-transport-request-id": [
-                        "55642"
+                        "133894"
                     ],
                     "x-ms-number-of-read-regions": [
                         "0"
                     ],
-                    "x-ms-resource-quota": [
-                        "databases=1000;collections=5000;users=500000;permissions=2000000;"
+                    "x-ms-item-count": [
+                        "1"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
+                    ],
+                    "x-ms-session-token": [
+                        "0:-1#12"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-resource-usage": [
+                        "databases=1;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;roleDefinitions=0;roleAssignments=0;azureRbac=0;"
                     ]
                 },
                 "body": {
@@ -302,12 +379,12 @@
                         "Databases": [
                             {
                                 "id": "cctestcdatabase",
-                                "_rid": "JZ07AA==",
-                                "_self": "dbs/JZ07AA==/",
-                                "_etag": "\"00001500-0000-0500-0000-5f9cde870000\"",
+                                "_rid": "yV8QAA==",
+                                "_self": "dbs/yV8QAA==/",
+                                "_etag": "\"0000e101-0000-0500-0000-6a1ef8780000\"",
                                 "_colls": "colls/",
                                 "_users": "users/",
-                                "_ts": 1604116103
+                                "_ts": 1780414584
                             }
                         ],
                         "_count": 1
@@ -318,7 +395,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs/JZ07AA==/colls/",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs/yV8QAA==/colls/",
                 "body": null,
                 "headers": {}
             },
@@ -328,50 +405,53 @@
                     "message": "Ok"
                 },
                 "headers": {
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:21 GMT"
+                    ],
                     "lsn": [
-                        "18"
+                        "12"
+                    ],
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-resource-quota": [
+                        "collections=5000;"
+                    ],
+                    "x-ms-schemaversion": [
+                        "1.21"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.591"
                     ],
                     "x-ms-activity-id": [
-                        "ac4f2ba2-d29a-4cd1-850a-f9730dd82e83"
+                        "fd1be1c2-9c78-4cb4-b455-4d78c2d9b01d"
                     ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-serviceversion": [
+                        "version=2.14.0.0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
-                    "x-ms-serviceversion": [
-                        "version=2.11.0.0"
-                    ],
-                    "x-ms-resource-usage": [
-                        "collections=1;"
-                    ],
-                    "x-ms-item-count": [
-                        "1"
-                    ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
-                    ],
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:04 GMT"
-                    ],
-                    "x-ms-request-duration-ms": [
-                        "0.902"
-                    ],
                     "x-ms-transport-request-id": [
-                        "35276"
+                        "148785"
                     ],
                     "x-ms-number-of-read-regions": [
                         "0"
                     ],
-                    "x-ms-resource-quota": [
-                        "collections=5000;"
+                    "x-ms-item-count": [
+                        "1"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
+                    ],
+                    "x-ms-session-token": [
+                        "0:-1#12"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-resource-usage": [
+                        "collections=1;"
                     ],
                     "x-ms-alt-content-path": [
                         "dbs/cctestcdatabase"
@@ -398,7 +478,8 @@
                                         {
                                             "path": "/\"_etag\"/?"
                                         }
-                                    ]
+                                    ],
+                                    "fullTextIndexes": []
                                 },
                                 "partitionKey": {
                                     "paths": [
@@ -417,15 +498,16 @@
                                 "geospatialConfig": {
                                     "type": "Geography"
                                 },
-                                "_rid": "JZ07ANKIMdw=",
-                                "_ts": 1604116125,
-                                "_self": "dbs/JZ07AA==/colls/JZ07ANKIMdw=/",
-                                "_etag": "\"00001700-0000-0500-0000-5f9cde9d0000\"",
+                                "_rid": "yV8QAL3IfmQ=",
+                                "_ts": 1780414601,
+                                "_self": "DEC0DEDITtVwMoyAuTz1LioKkC+gB/EpRlQKNIaszQEhVidjWyP1kLW1z+jo/MGFHKc+t+M20PxoraNCslng9w==/colls/yV8QAL3IfmQ=/",
+                                "_etag": "\"0000e301-0000-0500-0000-6a1ef8890000\"",
                                 "_docs": "docs/",
                                 "_sprocs": "sprocs/",
                                 "_triggers": "triggers/",
                                 "_udfs": "udfs/",
-                                "_conflicts": "conflicts/"
+                                "_conflicts": "conflicts/",
+                                "computedProperties": []
                             }
                         ],
                         "_count": 1
@@ -436,7 +518,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/providers/microsoft.insights/metrics?timespan=2020-10-30%2023%3A59%3A59%2F2020-10-31%2023%3A59%3A59&interval=PT5M&metricnames=ProvisionedThroughput&aggregation=average&$filter=DatabaseName%20eq%20%27cctestcdatabase%27%20and%20CollectionName%20eq%20%27cccontainer%27&api-version=2018-01-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/providers/microsoft.insights/metrics?timespan=2026-06-01%2023%3A59%3A59%2F2026-06-02%2023%3A59%3A59&interval=PT5M&metricnames=ProvisionedThroughput&aggregation=average&$filter=DatabaseName%20eq%20%27cctestcdatabase%27%20and%20CollectionName%20eq%20%27cccontainer%27&api-version=2018-01-01",
                 "body": null,
                 "headers": {}
             },
@@ -446,29 +528,38 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:22 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "999"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 7A3BC2D814E04EEEAFE2BEF7C2BBA141 Ref B: BL2AA2010205007 Ref C: 2026-06-02T16:01:21Z"
+                    ],
+                    "content-length": [
+                        "11535"
+                    ],
                     "cache-control": [
                         "no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:04 GMT"
+                    "mise-correlation-id": [
+                        "2daf8af6-bac1-45d8-99b1-04cc80358f31"
                     ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "request-context": [
-                        "appId=cid-v1:b021da79-5252-4375-9df5-2e17c1dcd822"
-                    ],
-                    "access-control-expose-headers": [
-                        "Request-Context"
-                    ],
-                    "content-length": [
-                        "11890"
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/0f249d9b-d231-48bd-9b78-3a475876c166"
                     ]
                 },
                 "body": {
                     "data": {
-                        "cost": 0,
-                        "timespan": "2020-10-30T23:59:59Z/2020-10-31T23:59:59Z",
+                        "cost": 1439,
+                        "timespan": "2026-06-01T23:59:59Z/2026-06-02T23:59:59Z",
                         "interval": "PT5M",
                         "value": [
                             {
@@ -500,893 +591,871 @@
                                         ],
                                         "data": [
                                             {
-                                                "timeStamp": "2020-10-30T23:59:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-01T23:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:04:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:09:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:14:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:19:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:24:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:29:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:34:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:39:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:44:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:49:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:54:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:59:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:04:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T01:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:09:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T01:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:14:00Z"
+                                                "timeStamp": "2026-06-02T01:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:19:00Z"
+                                                "timeStamp": "2026-06-02T01:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:24:00Z"
+                                                "timeStamp": "2026-06-02T01:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:29:00Z"
+                                                "timeStamp": "2026-06-02T01:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:34:00Z"
+                                                "timeStamp": "2026-06-02T01:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:39:00Z"
+                                                "timeStamp": "2026-06-02T01:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:44:00Z"
+                                                "timeStamp": "2026-06-02T01:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:49:00Z"
+                                                "timeStamp": "2026-06-02T01:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:54:00Z"
+                                                "timeStamp": "2026-06-02T01:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:59:00Z"
+                                                "timeStamp": "2026-06-02T01:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:04:00Z"
+                                                "timeStamp": "2026-06-02T02:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:09:00Z"
+                                                "timeStamp": "2026-06-02T02:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:14:00Z"
+                                                "timeStamp": "2026-06-02T02:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:19:00Z"
+                                                "timeStamp": "2026-06-02T02:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:24:00Z"
+                                                "timeStamp": "2026-06-02T02:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:29:00Z"
+                                                "timeStamp": "2026-06-02T02:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:34:00Z"
+                                                "timeStamp": "2026-06-02T02:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:39:00Z"
+                                                "timeStamp": "2026-06-02T02:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:44:00Z"
+                                                "timeStamp": "2026-06-02T02:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:49:00Z"
+                                                "timeStamp": "2026-06-02T02:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:54:00Z"
+                                                "timeStamp": "2026-06-02T02:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:59:00Z"
+                                                "timeStamp": "2026-06-02T02:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:04:00Z"
+                                                "timeStamp": "2026-06-02T03:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:09:00Z"
+                                                "timeStamp": "2026-06-02T03:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:14:00Z"
+                                                "timeStamp": "2026-06-02T03:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:19:00Z"
+                                                "timeStamp": "2026-06-02T03:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:24:00Z"
+                                                "timeStamp": "2026-06-02T03:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:29:00Z"
+                                                "timeStamp": "2026-06-02T03:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:34:00Z"
+                                                "timeStamp": "2026-06-02T03:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:39:00Z"
+                                                "timeStamp": "2026-06-02T03:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:44:00Z"
+                                                "timeStamp": "2026-06-02T03:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:49:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T03:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:54:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T03:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:59:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T03:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:04:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T04:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:09:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T04:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:14:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T04:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:19:00Z",
-                                                "average": 500.0
+                                                "timeStamp": "2026-06-02T04:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:24:00Z",
-                                                "average": 500.0
+                                                "timeStamp": "2026-06-02T04:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:29:00Z",
-                                                "average": 500.0
+                                                "timeStamp": "2026-06-02T04:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:34:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T04:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:39:00Z"
+                                                "timeStamp": "2026-06-02T04:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:44:00Z"
+                                                "timeStamp": "2026-06-02T04:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:49:00Z"
+                                                "timeStamp": "2026-06-02T04:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:54:00Z"
+                                                "timeStamp": "2026-06-02T04:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:59:00Z"
+                                                "timeStamp": "2026-06-02T04:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:04:00Z"
+                                                "timeStamp": "2026-06-02T05:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:09:00Z"
+                                                "timeStamp": "2026-06-02T05:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:14:00Z"
+                                                "timeStamp": "2026-06-02T05:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:19:00Z"
+                                                "timeStamp": "2026-06-02T05:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:24:00Z"
+                                                "timeStamp": "2026-06-02T05:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:29:00Z"
+                                                "timeStamp": "2026-06-02T05:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:34:00Z"
+                                                "timeStamp": "2026-06-02T05:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:39:00Z"
+                                                "timeStamp": "2026-06-02T05:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:44:00Z"
+                                                "timeStamp": "2026-06-02T05:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:49:00Z"
+                                                "timeStamp": "2026-06-02T05:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:54:00Z"
+                                                "timeStamp": "2026-06-02T05:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:59:00Z"
+                                                "timeStamp": "2026-06-02T05:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:04:00Z"
+                                                "timeStamp": "2026-06-02T06:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:09:00Z"
+                                                "timeStamp": "2026-06-02T06:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:14:00Z"
+                                                "timeStamp": "2026-06-02T06:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:19:00Z"
+                                                "timeStamp": "2026-06-02T06:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:24:00Z"
+                                                "timeStamp": "2026-06-02T06:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:29:00Z"
+                                                "timeStamp": "2026-06-02T06:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:34:00Z"
+                                                "timeStamp": "2026-06-02T06:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:39:00Z"
+                                                "timeStamp": "2026-06-02T06:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:44:00Z"
+                                                "timeStamp": "2026-06-02T06:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:49:00Z"
+                                                "timeStamp": "2026-06-02T06:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:54:00Z"
+                                                "timeStamp": "2026-06-02T06:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:59:00Z"
+                                                "timeStamp": "2026-06-02T06:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:04:00Z"
+                                                "timeStamp": "2026-06-02T07:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:09:00Z"
+                                                "timeStamp": "2026-06-02T07:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:14:00Z"
+                                                "timeStamp": "2026-06-02T07:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:19:00Z"
+                                                "timeStamp": "2026-06-02T07:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:24:00Z"
+                                                "timeStamp": "2026-06-02T07:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:29:00Z"
+                                                "timeStamp": "2026-06-02T07:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:34:00Z"
+                                                "timeStamp": "2026-06-02T07:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:39:00Z"
+                                                "timeStamp": "2026-06-02T07:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:44:00Z"
+                                                "timeStamp": "2026-06-02T07:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:49:00Z"
+                                                "timeStamp": "2026-06-02T07:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:54:00Z"
+                                                "timeStamp": "2026-06-02T07:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:59:00Z"
+                                                "timeStamp": "2026-06-02T07:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:04:00Z"
+                                                "timeStamp": "2026-06-02T08:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:09:00Z"
+                                                "timeStamp": "2026-06-02T08:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:14:00Z"
+                                                "timeStamp": "2026-06-02T08:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:19:00Z"
+                                                "timeStamp": "2026-06-02T08:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:24:00Z"
+                                                "timeStamp": "2026-06-02T08:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:29:00Z"
+                                                "timeStamp": "2026-06-02T08:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:34:00Z"
+                                                "timeStamp": "2026-06-02T08:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:39:00Z"
+                                                "timeStamp": "2026-06-02T08:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:44:00Z"
+                                                "timeStamp": "2026-06-02T08:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:49:00Z"
+                                                "timeStamp": "2026-06-02T08:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:54:00Z"
+                                                "timeStamp": "2026-06-02T08:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:59:00Z"
+                                                "timeStamp": "2026-06-02T08:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:04:00Z"
+                                                "timeStamp": "2026-06-02T09:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:09:00Z"
+                                                "timeStamp": "2026-06-02T09:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:14:00Z"
+                                                "timeStamp": "2026-06-02T09:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:19:00Z"
+                                                "timeStamp": "2026-06-02T09:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:24:00Z"
+                                                "timeStamp": "2026-06-02T09:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:29:00Z"
+                                                "timeStamp": "2026-06-02T09:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:34:00Z"
+                                                "timeStamp": "2026-06-02T09:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:39:00Z"
+                                                "timeStamp": "2026-06-02T09:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:44:00Z"
+                                                "timeStamp": "2026-06-02T09:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:49:00Z"
+                                                "timeStamp": "2026-06-02T09:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:54:00Z"
+                                                "timeStamp": "2026-06-02T09:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:59:00Z"
+                                                "timeStamp": "2026-06-02T09:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:04:00Z"
+                                                "timeStamp": "2026-06-02T10:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:09:00Z"
+                                                "timeStamp": "2026-06-02T10:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:14:00Z"
+                                                "timeStamp": "2026-06-02T10:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:19:00Z"
+                                                "timeStamp": "2026-06-02T10:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:24:00Z"
+                                                "timeStamp": "2026-06-02T10:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:29:00Z"
+                                                "timeStamp": "2026-06-02T10:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:34:00Z"
+                                                "timeStamp": "2026-06-02T10:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:39:00Z"
+                                                "timeStamp": "2026-06-02T10:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:44:00Z"
+                                                "timeStamp": "2026-06-02T10:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:49:00Z"
+                                                "timeStamp": "2026-06-02T10:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:54:00Z"
+                                                "timeStamp": "2026-06-02T10:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:59:00Z"
+                                                "timeStamp": "2026-06-02T10:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:04:00Z"
+                                                "timeStamp": "2026-06-02T11:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:09:00Z"
+                                                "timeStamp": "2026-06-02T11:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:14:00Z"
+                                                "timeStamp": "2026-06-02T11:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:19:00Z"
+                                                "timeStamp": "2026-06-02T11:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:24:00Z"
+                                                "timeStamp": "2026-06-02T11:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:29:00Z"
+                                                "timeStamp": "2026-06-02T11:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:34:00Z"
+                                                "timeStamp": "2026-06-02T11:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:39:00Z"
+                                                "timeStamp": "2026-06-02T11:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:44:00Z"
+                                                "timeStamp": "2026-06-02T11:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:49:00Z"
+                                                "timeStamp": "2026-06-02T11:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:54:00Z"
+                                                "timeStamp": "2026-06-02T11:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:59:00Z"
+                                                "timeStamp": "2026-06-02T11:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:04:00Z"
+                                                "timeStamp": "2026-06-02T12:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:09:00Z"
+                                                "timeStamp": "2026-06-02T12:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:14:00Z"
+                                                "timeStamp": "2026-06-02T12:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:19:00Z"
+                                                "timeStamp": "2026-06-02T12:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:24:00Z"
+                                                "timeStamp": "2026-06-02T12:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:29:00Z"
+                                                "timeStamp": "2026-06-02T12:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:34:00Z"
+                                                "timeStamp": "2026-06-02T12:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:39:00Z"
+                                                "timeStamp": "2026-06-02T12:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:44:00Z"
+                                                "timeStamp": "2026-06-02T12:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:49:00Z"
+                                                "timeStamp": "2026-06-02T12:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:54:00Z"
+                                                "timeStamp": "2026-06-02T12:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:59:00Z"
+                                                "timeStamp": "2026-06-02T12:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:04:00Z"
+                                                "timeStamp": "2026-06-02T13:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:09:00Z"
+                                                "timeStamp": "2026-06-02T13:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:14:00Z"
+                                                "timeStamp": "2026-06-02T13:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:19:00Z"
+                                                "timeStamp": "2026-06-02T13:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:24:00Z"
+                                                "timeStamp": "2026-06-02T13:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:29:00Z"
+                                                "timeStamp": "2026-06-02T13:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:34:00Z"
+                                                "timeStamp": "2026-06-02T13:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:39:00Z"
+                                                "timeStamp": "2026-06-02T13:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:44:00Z"
+                                                "timeStamp": "2026-06-02T13:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:49:00Z"
+                                                "timeStamp": "2026-06-02T13:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:54:00Z"
+                                                "timeStamp": "2026-06-02T13:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:59:00Z"
+                                                "timeStamp": "2026-06-02T13:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:04:00Z"
+                                                "timeStamp": "2026-06-02T14:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:09:00Z"
+                                                "timeStamp": "2026-06-02T14:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:14:00Z"
+                                                "timeStamp": "2026-06-02T14:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:19:00Z"
+                                                "timeStamp": "2026-06-02T14:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:24:00Z"
+                                                "timeStamp": "2026-06-02T14:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:29:00Z"
+                                                "timeStamp": "2026-06-02T14:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:34:00Z"
+                                                "timeStamp": "2026-06-02T14:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:39:00Z"
+                                                "timeStamp": "2026-06-02T14:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:44:00Z"
+                                                "timeStamp": "2026-06-02T14:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:49:00Z"
+                                                "timeStamp": "2026-06-02T14:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:54:00Z"
+                                                "timeStamp": "2026-06-02T14:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:59:00Z"
+                                                "timeStamp": "2026-06-02T14:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:04:00Z"
+                                                "timeStamp": "2026-06-02T15:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:09:00Z"
+                                                "timeStamp": "2026-06-02T15:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:14:00Z"
+                                                "timeStamp": "2026-06-02T15:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:19:00Z"
+                                                "timeStamp": "2026-06-02T15:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:24:00Z"
+                                                "timeStamp": "2026-06-02T15:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:29:00Z"
+                                                "timeStamp": "2026-06-02T15:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:34:00Z"
+                                                "timeStamp": "2026-06-02T15:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:39:00Z"
+                                                "timeStamp": "2026-06-02T15:39:00Z",
+                                                "average": 400
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:44:00Z"
+                                                "timeStamp": "2026-06-02T15:44:00Z",
+                                                "average": 400
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:49:00Z"
+                                                "timeStamp": "2026-06-02T15:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:54:00Z"
+                                                "timeStamp": "2026-06-02T15:54:00Z",
+                                                "average": 400
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:59:00Z"
+                                                "timeStamp": "2026-06-02T15:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:04:00Z"
+                                                "timeStamp": "2026-06-02T16:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:09:00Z"
+                                                "timeStamp": "2026-06-02T16:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:14:00Z"
+                                                "timeStamp": "2026-06-02T16:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:19:00Z"
+                                                "timeStamp": "2026-06-02T16:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:24:00Z"
+                                                "timeStamp": "2026-06-02T16:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:29:00Z"
+                                                "timeStamp": "2026-06-02T16:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:34:00Z"
+                                                "timeStamp": "2026-06-02T16:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:39:00Z"
+                                                "timeStamp": "2026-06-02T16:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:44:00Z"
+                                                "timeStamp": "2026-06-02T16:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:49:00Z"
+                                                "timeStamp": "2026-06-02T16:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:54:00Z"
+                                                "timeStamp": "2026-06-02T16:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:59:00Z"
+                                                "timeStamp": "2026-06-02T16:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:04:00Z"
+                                                "timeStamp": "2026-06-02T17:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:09:00Z"
+                                                "timeStamp": "2026-06-02T17:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:14:00Z"
+                                                "timeStamp": "2026-06-02T17:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:19:00Z"
+                                                "timeStamp": "2026-06-02T17:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:24:00Z"
+                                                "timeStamp": "2026-06-02T17:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:29:00Z"
+                                                "timeStamp": "2026-06-02T17:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:34:00Z"
+                                                "timeStamp": "2026-06-02T17:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:39:00Z"
+                                                "timeStamp": "2026-06-02T17:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:44:00Z"
+                                                "timeStamp": "2026-06-02T17:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:49:00Z"
+                                                "timeStamp": "2026-06-02T17:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:54:00Z"
+                                                "timeStamp": "2026-06-02T17:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:59:00Z"
+                                                "timeStamp": "2026-06-02T17:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:04:00Z"
+                                                "timeStamp": "2026-06-02T18:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:09:00Z"
+                                                "timeStamp": "2026-06-02T18:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:14:00Z"
+                                                "timeStamp": "2026-06-02T18:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:19:00Z"
+                                                "timeStamp": "2026-06-02T18:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:24:00Z"
+                                                "timeStamp": "2026-06-02T18:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:29:00Z"
+                                                "timeStamp": "2026-06-02T18:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:34:00Z"
+                                                "timeStamp": "2026-06-02T18:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:39:00Z"
+                                                "timeStamp": "2026-06-02T18:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:44:00Z"
+                                                "timeStamp": "2026-06-02T18:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:49:00Z"
+                                                "timeStamp": "2026-06-02T18:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:54:00Z"
+                                                "timeStamp": "2026-06-02T18:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:59:00Z"
+                                                "timeStamp": "2026-06-02T18:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:04:00Z"
+                                                "timeStamp": "2026-06-02T19:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:09:00Z"
+                                                "timeStamp": "2026-06-02T19:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:14:00Z"
+                                                "timeStamp": "2026-06-02T19:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:19:00Z"
+                                                "timeStamp": "2026-06-02T19:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:24:00Z"
+                                                "timeStamp": "2026-06-02T19:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:29:00Z"
+                                                "timeStamp": "2026-06-02T19:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:34:00Z"
+                                                "timeStamp": "2026-06-02T19:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:39:00Z"
+                                                "timeStamp": "2026-06-02T19:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:44:00Z"
+                                                "timeStamp": "2026-06-02T19:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:49:00Z"
+                                                "timeStamp": "2026-06-02T19:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:54:00Z"
+                                                "timeStamp": "2026-06-02T19:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:59:00Z"
+                                                "timeStamp": "2026-06-02T19:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:04:00Z"
+                                                "timeStamp": "2026-06-02T20:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:09:00Z"
+                                                "timeStamp": "2026-06-02T20:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:14:00Z"
+                                                "timeStamp": "2026-06-02T20:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:19:00Z"
+                                                "timeStamp": "2026-06-02T20:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:24:00Z"
+                                                "timeStamp": "2026-06-02T20:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:29:00Z"
+                                                "timeStamp": "2026-06-02T20:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:34:00Z"
+                                                "timeStamp": "2026-06-02T20:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:39:00Z"
+                                                "timeStamp": "2026-06-02T20:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:44:00Z"
+                                                "timeStamp": "2026-06-02T20:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:49:00Z"
+                                                "timeStamp": "2026-06-02T20:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:54:00Z"
+                                                "timeStamp": "2026-06-02T20:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:59:00Z"
+                                                "timeStamp": "2026-06-02T20:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:04:00Z"
+                                                "timeStamp": "2026-06-02T21:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:09:00Z"
+                                                "timeStamp": "2026-06-02T21:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:14:00Z"
+                                                "timeStamp": "2026-06-02T21:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:19:00Z"
+                                                "timeStamp": "2026-06-02T21:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:24:00Z"
+                                                "timeStamp": "2026-06-02T21:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:29:00Z"
+                                                "timeStamp": "2026-06-02T21:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:34:00Z"
+                                                "timeStamp": "2026-06-02T21:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:39:00Z"
+                                                "timeStamp": "2026-06-02T21:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:44:00Z"
+                                                "timeStamp": "2026-06-02T21:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:49:00Z"
+                                                "timeStamp": "2026-06-02T21:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:54:00Z"
+                                                "timeStamp": "2026-06-02T21:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:59:00Z"
+                                                "timeStamp": "2026-06-02T21:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:04:00Z"
+                                                "timeStamp": "2026-06-02T22:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:09:00Z"
+                                                "timeStamp": "2026-06-02T22:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:14:00Z"
+                                                "timeStamp": "2026-06-02T22:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:19:00Z"
+                                                "timeStamp": "2026-06-02T22:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:24:00Z"
+                                                "timeStamp": "2026-06-02T22:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:29:00Z"
+                                                "timeStamp": "2026-06-02T22:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:34:00Z"
+                                                "timeStamp": "2026-06-02T22:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:39:00Z"
+                                                "timeStamp": "2026-06-02T22:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:44:00Z"
+                                                "timeStamp": "2026-06-02T22:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:49:00Z"
+                                                "timeStamp": "2026-06-02T22:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:54:00Z"
+                                                "timeStamp": "2026-06-02T22:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:59:00Z"
+                                                "timeStamp": "2026-06-02T22:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:04:00Z"
+                                                "timeStamp": "2026-06-02T23:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:09:00Z"
+                                                "timeStamp": "2026-06-02T23:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:14:00Z"
+                                                "timeStamp": "2026-06-02T23:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:19:00Z"
+                                                "timeStamp": "2026-06-02T23:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:24:00Z"
+                                                "timeStamp": "2026-06-02T23:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:29:00Z"
+                                                "timeStamp": "2026-06-02T23:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:34:00Z"
+                                                "timeStamp": "2026-06-02T23:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:39:00Z"
+                                                "timeStamp": "2026-06-02T23:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:44:00Z"
+                                                "timeStamp": "2026-06-02T23:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:49:00Z"
+                                                "timeStamp": "2026-06-02T23:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:54:00Z"
+                                                "timeStamp": "2026-06-02T23:54:00Z"
                                             }
                                         ]
                                     }

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_database_metrics_filter.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_database_metrics_filter.json
@@ -4,27 +4,39 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:23 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: E866EFE7C57E42F7967FACBC36571DCF Ref B: MNZ221060608025 Ref C: 2026-06-02T16:01:23Z"
+                    ],
+                    "content-length": [
+                        "3314"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:04 GMT"
-                    ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "content-length": [
-                        "2336"
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
                     ]
                 },
                 "body": {
@@ -36,17 +48,16 @@
                                 "location": "South Central US",
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
-                                "tags": {
-                                    "test-store-throughput": "JZ07ANKIMdw=:4",
-                                    "test-restore-throughput": "JZ07ANKIMdw=:4"
-                                },
+                                "tags": {},
                                 "systemData": {
-                                    "createdAt": "2020-10-31T03:48:04.4977476Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                                    "enableAutomaticFailover": false,
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "publicNetworkAccess": "Enabled",
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -55,16 +66,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
-                                    "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                                    "defaultIdentity": "FirstPartyIdentity",
+                                    "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -104,13 +126,52 @@
                                     ],
                                     "cors": [],
                                     "capabilities": [],
+                                    "ipRules": [
+                                        {
+                                            "ipAddressOrRange": "173.2.147.78"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "104.42.195.92"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "40.76.54.131"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.176.6.30"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.169.50.45"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.187.184.26"
+                                        }
+                                    ],
                                     "backupPolicy": {
                                         "type": "Periodic",
                                         "periodicModeProperties": {
                                             "backupIntervalInMinutes": 240,
-                                            "backupRetentionIntervalInHours": 8
+                                            "backupRetentionIntervalInHours": 8,
+                                            "backupStorageRedundancy": "Geo"
+                                        }
+                                    },
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                         }
                                     }
+                                },
+                                "identity": {
+                                    "type": "None"
                                 }
                             }
                         ]
@@ -121,7 +182,7 @@
         {
             "request": {
                 "method": "POST",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -131,20 +192,29 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:05 GMT"
-                    ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-ratelimit-remaining-subscription-writes": [
-                        "1197"
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:23 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "799"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 5C1A3B8EE0C54E178FDBF8AD69336B24 Ref B: BL2AA2011002040 Ref C: 2026-06-02T16:01:24Z"
                     ],
                     "content-length": [
                         "461"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/43c371c4-0d40-40af-9697-a3ce8307b169"
                     ]
                 },
                 "body": {
@@ -160,7 +230,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39.documents.azure.com/",
+                "uri": "https://cctestcosmosdbc2295d913936.documents.azure.com/",
                 "body": null,
                 "headers": {}
             },
@@ -170,26 +240,26 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "cache-control": [
-                        "no-store, no-cache"
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:24 GMT"
                     ],
                     "x-ms-databaseaccount-provisioned-mb": [
                         "0"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:06 GMT"
+                    "x-ms-databaseaccount-consumed-mb": [
+                        "0"
                     ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "x-ms-max-media-storage-usage-mb": [
-                        "2048"
+                    "cache-control": [
+                        "no-store, no-cache"
                     ],
                     "x-ms-media-storage-usage-mb": [
                         "0"
                     ],
-                    "x-ms-databaseaccount-consumed-mb": [
-                        "0"
+                    "x-ms-max-media-storage-usage-mb": [
+                        "2048"
                     ],
                     "x-ms-databaseaccount-reserved-mb": [
                         "0"
@@ -198,24 +268,28 @@
                 "body": {
                     "data": {
                         "_self": "",
-                        "id": "cctestcosmosdbfafbee1d5b39",
-                        "_rid": "cctestcosmosdbfafbee1d5b39.documents.azure.com",
+                        "id": "cctestcosmosdbc2295d913936",
+                        "_rid": "cctestcosmosdbc2295d913936.documents.azure.com",
                         "media": "//media/",
                         "addresses": "//addresses/",
                         "_dbs": "//dbs/",
                         "writableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "readableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "enableMultipleWriteLocations": false,
+                        "continuousBackupEnabled": false,
+                        "enableNRegionSynchronousCommit": false,
+                        "enablePerPartitionFailoverBehavior": false,
+                        "disableCrossRegionalHedging": false,
                         "userReplicationPolicy": {
                             "asyncReplication": false,
                             "minReplicaSetSize": 3,
@@ -232,7 +306,7 @@
                             "primaryReadCoefficient": 1,
                             "secondaryReadCoefficient": 1
                         },
-                        "queryEngineConfiguration": "{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":true,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlDisableQueryILOptimization\":false,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"
+                        "queryEngineConfiguration": "{\"allowNewKeywords\":true,\"maxJoinsPerSqlQuery\":10,\"maxQueryRequestTimeoutFraction\":0.9,\"maxSqlQueryInputLength\":524288,\"maxUdfRefPerSqlQuery\":10,\"queryMaxInMemorySortDocumentCount\":-1000,\"spatialMaxGeometryPointCount\":256,\"sqlAllowNonFiniteNumbers\":false,\"sqlDisableOptimizationFlags\":0,\"sqlQueryILDisableOptimizationFlags\":0,\"clientDisableOptimisticDirectExecution\":false,\"queryEnableFullText\":true,\"queryEnableFullTextPreviewFeatures\":false,\"queryMaxFullTextScoreSearchTerms\":30,\"queryMaxRrfArgumentCount\":100,\"enableSpatialIndexing\":true,\"maxInExpressionItemsCount\":2147483647,\"maxLogicalAndPerSqlQuery\":2147483647,\"maxLogicalOrPerSqlQuery\":2147483647,\"maxSpatialQueryCells\":2147483647,\"sqlAllowAggregateFunctions\":true,\"sqlAllowGroupByClause\":true,\"sqlAllowLike\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"sqlAllowTop\":true}"
                     }
                 }
             }
@@ -240,7 +314,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs",
                 "body": null,
                 "headers": {}
             },
@@ -250,50 +324,53 @@
                     "message": "Ok"
                 },
                 "headers": {
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:24 GMT"
+                    ],
                     "lsn": [
-                        "18"
+                        "12"
+                    ],
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-resource-quota": [
+                        "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;azureRbac=200000;"
+                    ],
+                    "x-ms-schemaversion": [
+                        "1.21"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.32"
                     ],
                     "x-ms-activity-id": [
-                        "972dc60f-1bb9-42cf-96c3-5e689e4c1517"
+                        "00428fd2-dff8-43f0-b268-455e57ba306a"
                     ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-serviceversion": [
+                        "version=2.14.0.0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
-                    "x-ms-serviceversion": [
-                        "version=2.11.0.0"
-                    ],
-                    "x-ms-resource-usage": [
-                        "databases=1;collections=1;users=0;permissions=0;"
-                    ],
-                    "x-ms-item-count": [
-                        "1"
-                    ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
-                    ],
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:06 GMT"
-                    ],
-                    "x-ms-request-duration-ms": [
-                        "0.505"
-                    ],
                     "x-ms-transport-request-id": [
-                        "60132"
+                        "140414"
                     ],
                     "x-ms-number-of-read-regions": [
                         "0"
                     ],
-                    "x-ms-resource-quota": [
-                        "databases=1000;collections=5000;users=500000;permissions=2000000;"
+                    "x-ms-item-count": [
+                        "1"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
+                    ],
+                    "x-ms-session-token": [
+                        "0:-1#12"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-resource-usage": [
+                        "databases=1;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;roleDefinitions=0;roleAssignments=0;azureRbac=0;"
                     ]
                 },
                 "body": {
@@ -302,12 +379,12 @@
                         "Databases": [
                             {
                                 "id": "cctestcdatabase",
-                                "_rid": "JZ07AA==",
-                                "_self": "dbs/JZ07AA==/",
-                                "_etag": "\"00001500-0000-0500-0000-5f9cde870000\"",
+                                "_rid": "yV8QAA==",
+                                "_self": "dbs/yV8QAA==/",
+                                "_etag": "\"0000e101-0000-0500-0000-6a1ef8780000\"",
                                 "_colls": "colls/",
                                 "_users": "users/",
-                                "_ts": 1604116103
+                                "_ts": 1780414584
                             }
                         ],
                         "_count": 1
@@ -318,7 +395,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/providers/microsoft.insights/metrics?timespan=2020-10-30%2023%3A59%3A59%2F2020-10-31%2023%3A59%3A59&interval=PT5M&metricnames=ProvisionedThroughput&aggregation=average&$filter=DatabaseName%20eq%20%27cctestcdatabase%27&api-version=2018-01-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/providers/microsoft.insights/metrics?timespan=2026-06-01%2023%3A59%3A59%2F2026-06-02%2023%3A59%3A59&interval=PT5M&metricnames=ProvisionedThroughput&aggregation=average&$filter=DatabaseName%20eq%20%27cctestcdatabase%27&api-version=2018-01-01",
                 "body": null,
                 "headers": {}
             },
@@ -328,29 +405,38 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:25 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "999"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 1B4925380A084D99BA7F9B9A8E8F823F Ref B: BL2AA2011002029 Ref C: 2026-06-02T16:01:25Z"
+                    ],
+                    "content-length": [
+                        "11443"
+                    ],
                     "cache-control": [
                         "no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:06 GMT"
+                    "mise-correlation-id": [
+                        "0b7be385-ac7f-4694-9b37-f6f1d3826f27"
                     ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "request-context": [
-                        "appId=cid-v1:b021da79-5252-4375-9df5-2e17c1dcd822"
-                    ],
-                    "access-control-expose-headers": [
-                        "Request-Context"
-                    ],
-                    "content-length": [
-                        "11798"
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/0366bb47-940d-48a3-967b-76d015395c9e"
                     ]
                 },
                 "body": {
                     "data": {
-                        "cost": 0,
-                        "timespan": "2020-10-30T23:59:59Z/2020-10-31T23:59:59Z",
+                        "cost": 1439,
+                        "timespan": "2026-06-01T23:59:59Z/2026-06-02T23:59:59Z",
                         "interval": "PT5M",
                         "value": [
                             {
@@ -375,893 +461,871 @@
                                         ],
                                         "data": [
                                             {
-                                                "timeStamp": "2020-10-30T23:59:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-01T23:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:04:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:09:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:14:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:19:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:24:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:29:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:34:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:39:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:44:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:49:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:54:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T00:59:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T00:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:04:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T01:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:09:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T01:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:14:00Z"
+                                                "timeStamp": "2026-06-02T01:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:19:00Z"
+                                                "timeStamp": "2026-06-02T01:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:24:00Z"
+                                                "timeStamp": "2026-06-02T01:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:29:00Z"
+                                                "timeStamp": "2026-06-02T01:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:34:00Z"
+                                                "timeStamp": "2026-06-02T01:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:39:00Z"
+                                                "timeStamp": "2026-06-02T01:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:44:00Z"
+                                                "timeStamp": "2026-06-02T01:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:49:00Z"
+                                                "timeStamp": "2026-06-02T01:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:54:00Z"
+                                                "timeStamp": "2026-06-02T01:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T01:59:00Z"
+                                                "timeStamp": "2026-06-02T01:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:04:00Z"
+                                                "timeStamp": "2026-06-02T02:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:09:00Z"
+                                                "timeStamp": "2026-06-02T02:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:14:00Z"
+                                                "timeStamp": "2026-06-02T02:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:19:00Z"
+                                                "timeStamp": "2026-06-02T02:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:24:00Z"
+                                                "timeStamp": "2026-06-02T02:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:29:00Z"
+                                                "timeStamp": "2026-06-02T02:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:34:00Z"
+                                                "timeStamp": "2026-06-02T02:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:39:00Z"
+                                                "timeStamp": "2026-06-02T02:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:44:00Z"
+                                                "timeStamp": "2026-06-02T02:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:49:00Z"
+                                                "timeStamp": "2026-06-02T02:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:54:00Z"
+                                                "timeStamp": "2026-06-02T02:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T02:59:00Z"
+                                                "timeStamp": "2026-06-02T02:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:04:00Z"
+                                                "timeStamp": "2026-06-02T03:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:09:00Z"
+                                                "timeStamp": "2026-06-02T03:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:14:00Z"
+                                                "timeStamp": "2026-06-02T03:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:19:00Z"
+                                                "timeStamp": "2026-06-02T03:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:24:00Z"
+                                                "timeStamp": "2026-06-02T03:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:29:00Z"
+                                                "timeStamp": "2026-06-02T03:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:34:00Z"
+                                                "timeStamp": "2026-06-02T03:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:39:00Z"
+                                                "timeStamp": "2026-06-02T03:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:44:00Z"
+                                                "timeStamp": "2026-06-02T03:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:49:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T03:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:54:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T03:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T03:59:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T03:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:04:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T04:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:09:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T04:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:14:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T04:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:19:00Z",
-                                                "average": 500.0
+                                                "timeStamp": "2026-06-02T04:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:24:00Z",
-                                                "average": 500.0
+                                                "timeStamp": "2026-06-02T04:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:29:00Z",
-                                                "average": 500.0
+                                                "timeStamp": "2026-06-02T04:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:34:00Z",
-                                                "average": 400.0
+                                                "timeStamp": "2026-06-02T04:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:39:00Z"
+                                                "timeStamp": "2026-06-02T04:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:44:00Z"
+                                                "timeStamp": "2026-06-02T04:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:49:00Z"
+                                                "timeStamp": "2026-06-02T04:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:54:00Z"
+                                                "timeStamp": "2026-06-02T04:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T04:59:00Z"
+                                                "timeStamp": "2026-06-02T04:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:04:00Z"
+                                                "timeStamp": "2026-06-02T05:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:09:00Z"
+                                                "timeStamp": "2026-06-02T05:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:14:00Z"
+                                                "timeStamp": "2026-06-02T05:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:19:00Z"
+                                                "timeStamp": "2026-06-02T05:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:24:00Z"
+                                                "timeStamp": "2026-06-02T05:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:29:00Z"
+                                                "timeStamp": "2026-06-02T05:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:34:00Z"
+                                                "timeStamp": "2026-06-02T05:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:39:00Z"
+                                                "timeStamp": "2026-06-02T05:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:44:00Z"
+                                                "timeStamp": "2026-06-02T05:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:49:00Z"
+                                                "timeStamp": "2026-06-02T05:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:54:00Z"
+                                                "timeStamp": "2026-06-02T05:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T05:59:00Z"
+                                                "timeStamp": "2026-06-02T05:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:04:00Z"
+                                                "timeStamp": "2026-06-02T06:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:09:00Z"
+                                                "timeStamp": "2026-06-02T06:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:14:00Z"
+                                                "timeStamp": "2026-06-02T06:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:19:00Z"
+                                                "timeStamp": "2026-06-02T06:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:24:00Z"
+                                                "timeStamp": "2026-06-02T06:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:29:00Z"
+                                                "timeStamp": "2026-06-02T06:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:34:00Z"
+                                                "timeStamp": "2026-06-02T06:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:39:00Z"
+                                                "timeStamp": "2026-06-02T06:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:44:00Z"
+                                                "timeStamp": "2026-06-02T06:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:49:00Z"
+                                                "timeStamp": "2026-06-02T06:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:54:00Z"
+                                                "timeStamp": "2026-06-02T06:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T06:59:00Z"
+                                                "timeStamp": "2026-06-02T06:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:04:00Z"
+                                                "timeStamp": "2026-06-02T07:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:09:00Z"
+                                                "timeStamp": "2026-06-02T07:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:14:00Z"
+                                                "timeStamp": "2026-06-02T07:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:19:00Z"
+                                                "timeStamp": "2026-06-02T07:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:24:00Z"
+                                                "timeStamp": "2026-06-02T07:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:29:00Z"
+                                                "timeStamp": "2026-06-02T07:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:34:00Z"
+                                                "timeStamp": "2026-06-02T07:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:39:00Z"
+                                                "timeStamp": "2026-06-02T07:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:44:00Z"
+                                                "timeStamp": "2026-06-02T07:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:49:00Z"
+                                                "timeStamp": "2026-06-02T07:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:54:00Z"
+                                                "timeStamp": "2026-06-02T07:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T07:59:00Z"
+                                                "timeStamp": "2026-06-02T07:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:04:00Z"
+                                                "timeStamp": "2026-06-02T08:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:09:00Z"
+                                                "timeStamp": "2026-06-02T08:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:14:00Z"
+                                                "timeStamp": "2026-06-02T08:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:19:00Z"
+                                                "timeStamp": "2026-06-02T08:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:24:00Z"
+                                                "timeStamp": "2026-06-02T08:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:29:00Z"
+                                                "timeStamp": "2026-06-02T08:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:34:00Z"
+                                                "timeStamp": "2026-06-02T08:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:39:00Z"
+                                                "timeStamp": "2026-06-02T08:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:44:00Z"
+                                                "timeStamp": "2026-06-02T08:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:49:00Z"
+                                                "timeStamp": "2026-06-02T08:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:54:00Z"
+                                                "timeStamp": "2026-06-02T08:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T08:59:00Z"
+                                                "timeStamp": "2026-06-02T08:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:04:00Z"
+                                                "timeStamp": "2026-06-02T09:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:09:00Z"
+                                                "timeStamp": "2026-06-02T09:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:14:00Z"
+                                                "timeStamp": "2026-06-02T09:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:19:00Z"
+                                                "timeStamp": "2026-06-02T09:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:24:00Z"
+                                                "timeStamp": "2026-06-02T09:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:29:00Z"
+                                                "timeStamp": "2026-06-02T09:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:34:00Z"
+                                                "timeStamp": "2026-06-02T09:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:39:00Z"
+                                                "timeStamp": "2026-06-02T09:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:44:00Z"
+                                                "timeStamp": "2026-06-02T09:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:49:00Z"
+                                                "timeStamp": "2026-06-02T09:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:54:00Z"
+                                                "timeStamp": "2026-06-02T09:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T09:59:00Z"
+                                                "timeStamp": "2026-06-02T09:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:04:00Z"
+                                                "timeStamp": "2026-06-02T10:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:09:00Z"
+                                                "timeStamp": "2026-06-02T10:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:14:00Z"
+                                                "timeStamp": "2026-06-02T10:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:19:00Z"
+                                                "timeStamp": "2026-06-02T10:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:24:00Z"
+                                                "timeStamp": "2026-06-02T10:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:29:00Z"
+                                                "timeStamp": "2026-06-02T10:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:34:00Z"
+                                                "timeStamp": "2026-06-02T10:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:39:00Z"
+                                                "timeStamp": "2026-06-02T10:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:44:00Z"
+                                                "timeStamp": "2026-06-02T10:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:49:00Z"
+                                                "timeStamp": "2026-06-02T10:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:54:00Z"
+                                                "timeStamp": "2026-06-02T10:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T10:59:00Z"
+                                                "timeStamp": "2026-06-02T10:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:04:00Z"
+                                                "timeStamp": "2026-06-02T11:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:09:00Z"
+                                                "timeStamp": "2026-06-02T11:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:14:00Z"
+                                                "timeStamp": "2026-06-02T11:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:19:00Z"
+                                                "timeStamp": "2026-06-02T11:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:24:00Z"
+                                                "timeStamp": "2026-06-02T11:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:29:00Z"
+                                                "timeStamp": "2026-06-02T11:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:34:00Z"
+                                                "timeStamp": "2026-06-02T11:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:39:00Z"
+                                                "timeStamp": "2026-06-02T11:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:44:00Z"
+                                                "timeStamp": "2026-06-02T11:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:49:00Z"
+                                                "timeStamp": "2026-06-02T11:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:54:00Z"
+                                                "timeStamp": "2026-06-02T11:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T11:59:00Z"
+                                                "timeStamp": "2026-06-02T11:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:04:00Z"
+                                                "timeStamp": "2026-06-02T12:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:09:00Z"
+                                                "timeStamp": "2026-06-02T12:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:14:00Z"
+                                                "timeStamp": "2026-06-02T12:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:19:00Z"
+                                                "timeStamp": "2026-06-02T12:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:24:00Z"
+                                                "timeStamp": "2026-06-02T12:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:29:00Z"
+                                                "timeStamp": "2026-06-02T12:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:34:00Z"
+                                                "timeStamp": "2026-06-02T12:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:39:00Z"
+                                                "timeStamp": "2026-06-02T12:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:44:00Z"
+                                                "timeStamp": "2026-06-02T12:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:49:00Z"
+                                                "timeStamp": "2026-06-02T12:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:54:00Z"
+                                                "timeStamp": "2026-06-02T12:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T12:59:00Z"
+                                                "timeStamp": "2026-06-02T12:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:04:00Z"
+                                                "timeStamp": "2026-06-02T13:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:09:00Z"
+                                                "timeStamp": "2026-06-02T13:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:14:00Z"
+                                                "timeStamp": "2026-06-02T13:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:19:00Z"
+                                                "timeStamp": "2026-06-02T13:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:24:00Z"
+                                                "timeStamp": "2026-06-02T13:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:29:00Z"
+                                                "timeStamp": "2026-06-02T13:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:34:00Z"
+                                                "timeStamp": "2026-06-02T13:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:39:00Z"
+                                                "timeStamp": "2026-06-02T13:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:44:00Z"
+                                                "timeStamp": "2026-06-02T13:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:49:00Z"
+                                                "timeStamp": "2026-06-02T13:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:54:00Z"
+                                                "timeStamp": "2026-06-02T13:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T13:59:00Z"
+                                                "timeStamp": "2026-06-02T13:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:04:00Z"
+                                                "timeStamp": "2026-06-02T14:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:09:00Z"
+                                                "timeStamp": "2026-06-02T14:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:14:00Z"
+                                                "timeStamp": "2026-06-02T14:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:19:00Z"
+                                                "timeStamp": "2026-06-02T14:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:24:00Z"
+                                                "timeStamp": "2026-06-02T14:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:29:00Z"
+                                                "timeStamp": "2026-06-02T14:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:34:00Z"
+                                                "timeStamp": "2026-06-02T14:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:39:00Z"
+                                                "timeStamp": "2026-06-02T14:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:44:00Z"
+                                                "timeStamp": "2026-06-02T14:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:49:00Z"
+                                                "timeStamp": "2026-06-02T14:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:54:00Z"
+                                                "timeStamp": "2026-06-02T14:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T14:59:00Z"
+                                                "timeStamp": "2026-06-02T14:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:04:00Z"
+                                                "timeStamp": "2026-06-02T15:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:09:00Z"
+                                                "timeStamp": "2026-06-02T15:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:14:00Z"
+                                                "timeStamp": "2026-06-02T15:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:19:00Z"
+                                                "timeStamp": "2026-06-02T15:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:24:00Z"
+                                                "timeStamp": "2026-06-02T15:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:29:00Z"
+                                                "timeStamp": "2026-06-02T15:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:34:00Z"
+                                                "timeStamp": "2026-06-02T15:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:39:00Z"
+                                                "timeStamp": "2026-06-02T15:39:00Z",
+                                                "average": 400
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:44:00Z"
+                                                "timeStamp": "2026-06-02T15:44:00Z",
+                                                "average": 400
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:49:00Z"
+                                                "timeStamp": "2026-06-02T15:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:54:00Z"
+                                                "timeStamp": "2026-06-02T15:54:00Z",
+                                                "average": 400
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T15:59:00Z"
+                                                "timeStamp": "2026-06-02T15:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:04:00Z"
+                                                "timeStamp": "2026-06-02T16:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:09:00Z"
+                                                "timeStamp": "2026-06-02T16:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:14:00Z"
+                                                "timeStamp": "2026-06-02T16:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:19:00Z"
+                                                "timeStamp": "2026-06-02T16:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:24:00Z"
+                                                "timeStamp": "2026-06-02T16:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:29:00Z"
+                                                "timeStamp": "2026-06-02T16:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:34:00Z"
+                                                "timeStamp": "2026-06-02T16:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:39:00Z"
+                                                "timeStamp": "2026-06-02T16:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:44:00Z"
+                                                "timeStamp": "2026-06-02T16:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:49:00Z"
+                                                "timeStamp": "2026-06-02T16:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:54:00Z"
+                                                "timeStamp": "2026-06-02T16:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T16:59:00Z"
+                                                "timeStamp": "2026-06-02T16:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:04:00Z"
+                                                "timeStamp": "2026-06-02T17:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:09:00Z"
+                                                "timeStamp": "2026-06-02T17:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:14:00Z"
+                                                "timeStamp": "2026-06-02T17:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:19:00Z"
+                                                "timeStamp": "2026-06-02T17:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:24:00Z"
+                                                "timeStamp": "2026-06-02T17:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:29:00Z"
+                                                "timeStamp": "2026-06-02T17:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:34:00Z"
+                                                "timeStamp": "2026-06-02T17:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:39:00Z"
+                                                "timeStamp": "2026-06-02T17:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:44:00Z"
+                                                "timeStamp": "2026-06-02T17:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:49:00Z"
+                                                "timeStamp": "2026-06-02T17:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:54:00Z"
+                                                "timeStamp": "2026-06-02T17:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T17:59:00Z"
+                                                "timeStamp": "2026-06-02T17:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:04:00Z"
+                                                "timeStamp": "2026-06-02T18:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:09:00Z"
+                                                "timeStamp": "2026-06-02T18:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:14:00Z"
+                                                "timeStamp": "2026-06-02T18:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:19:00Z"
+                                                "timeStamp": "2026-06-02T18:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:24:00Z"
+                                                "timeStamp": "2026-06-02T18:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:29:00Z"
+                                                "timeStamp": "2026-06-02T18:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:34:00Z"
+                                                "timeStamp": "2026-06-02T18:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:39:00Z"
+                                                "timeStamp": "2026-06-02T18:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:44:00Z"
+                                                "timeStamp": "2026-06-02T18:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:49:00Z"
+                                                "timeStamp": "2026-06-02T18:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:54:00Z"
+                                                "timeStamp": "2026-06-02T18:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T18:59:00Z"
+                                                "timeStamp": "2026-06-02T18:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:04:00Z"
+                                                "timeStamp": "2026-06-02T19:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:09:00Z"
+                                                "timeStamp": "2026-06-02T19:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:14:00Z"
+                                                "timeStamp": "2026-06-02T19:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:19:00Z"
+                                                "timeStamp": "2026-06-02T19:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:24:00Z"
+                                                "timeStamp": "2026-06-02T19:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:29:00Z"
+                                                "timeStamp": "2026-06-02T19:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:34:00Z"
+                                                "timeStamp": "2026-06-02T19:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:39:00Z"
+                                                "timeStamp": "2026-06-02T19:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:44:00Z"
+                                                "timeStamp": "2026-06-02T19:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:49:00Z"
+                                                "timeStamp": "2026-06-02T19:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:54:00Z"
+                                                "timeStamp": "2026-06-02T19:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T19:59:00Z"
+                                                "timeStamp": "2026-06-02T19:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:04:00Z"
+                                                "timeStamp": "2026-06-02T20:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:09:00Z"
+                                                "timeStamp": "2026-06-02T20:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:14:00Z"
+                                                "timeStamp": "2026-06-02T20:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:19:00Z"
+                                                "timeStamp": "2026-06-02T20:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:24:00Z"
+                                                "timeStamp": "2026-06-02T20:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:29:00Z"
+                                                "timeStamp": "2026-06-02T20:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:34:00Z"
+                                                "timeStamp": "2026-06-02T20:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:39:00Z"
+                                                "timeStamp": "2026-06-02T20:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:44:00Z"
+                                                "timeStamp": "2026-06-02T20:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:49:00Z"
+                                                "timeStamp": "2026-06-02T20:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:54:00Z"
+                                                "timeStamp": "2026-06-02T20:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T20:59:00Z"
+                                                "timeStamp": "2026-06-02T20:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:04:00Z"
+                                                "timeStamp": "2026-06-02T21:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:09:00Z"
+                                                "timeStamp": "2026-06-02T21:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:14:00Z"
+                                                "timeStamp": "2026-06-02T21:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:19:00Z"
+                                                "timeStamp": "2026-06-02T21:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:24:00Z"
+                                                "timeStamp": "2026-06-02T21:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:29:00Z"
+                                                "timeStamp": "2026-06-02T21:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:34:00Z"
+                                                "timeStamp": "2026-06-02T21:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:39:00Z"
+                                                "timeStamp": "2026-06-02T21:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:44:00Z"
+                                                "timeStamp": "2026-06-02T21:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:49:00Z"
+                                                "timeStamp": "2026-06-02T21:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:54:00Z"
+                                                "timeStamp": "2026-06-02T21:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T21:59:00Z"
+                                                "timeStamp": "2026-06-02T21:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:04:00Z"
+                                                "timeStamp": "2026-06-02T22:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:09:00Z"
+                                                "timeStamp": "2026-06-02T22:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:14:00Z"
+                                                "timeStamp": "2026-06-02T22:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:19:00Z"
+                                                "timeStamp": "2026-06-02T22:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:24:00Z"
+                                                "timeStamp": "2026-06-02T22:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:29:00Z"
+                                                "timeStamp": "2026-06-02T22:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:34:00Z"
+                                                "timeStamp": "2026-06-02T22:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:39:00Z"
+                                                "timeStamp": "2026-06-02T22:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:44:00Z"
+                                                "timeStamp": "2026-06-02T22:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:49:00Z"
+                                                "timeStamp": "2026-06-02T22:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:54:00Z"
+                                                "timeStamp": "2026-06-02T22:54:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T22:59:00Z"
+                                                "timeStamp": "2026-06-02T22:59:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:04:00Z"
+                                                "timeStamp": "2026-06-02T23:04:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:09:00Z"
+                                                "timeStamp": "2026-06-02T23:09:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:14:00Z"
+                                                "timeStamp": "2026-06-02T23:14:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:19:00Z"
+                                                "timeStamp": "2026-06-02T23:19:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:24:00Z"
+                                                "timeStamp": "2026-06-02T23:24:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:29:00Z"
+                                                "timeStamp": "2026-06-02T23:29:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:34:00Z"
+                                                "timeStamp": "2026-06-02T23:34:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:39:00Z"
+                                                "timeStamp": "2026-06-02T23:39:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:44:00Z"
+                                                "timeStamp": "2026-06-02T23:44:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:49:00Z"
+                                                "timeStamp": "2026-06-02T23:49:00Z"
                                             },
                                             {
-                                                "timeStamp": "2020-10-31T23:54:00Z"
+                                                "timeStamp": "2026-06-02T23:54:00Z"
                                             }
                                         ]
                                     }

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_find_by_name.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_find_by_name.json
@@ -4,27 +4,39 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:26 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: DE2CF65380F74E7BB763B95CF02B289F Ref B: BL2AA2010205003 Ref C: 2026-06-02T16:01:26Z"
+                    ],
+                    "content-length": [
+                        "3314"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:07 GMT"
-                    ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "content-length": [
-                        "2336"
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
                     ]
                 },
                 "body": {
@@ -36,17 +48,16 @@
                                 "location": "South Central US",
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
-                                "tags": {
-                                    "test-store-throughput": "JZ07ANKIMdw=:4",
-                                    "test-restore-throughput": "JZ07ANKIMdw=:4"
-                                },
+                                "tags": {},
                                 "systemData": {
-                                    "createdAt": "2020-10-31T03:48:04.4977476Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                                    "enableAutomaticFailover": false,
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "publicNetworkAccess": "Enabled",
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -55,16 +66,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
-                                    "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                                    "defaultIdentity": "FirstPartyIdentity",
+                                    "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -104,13 +126,52 @@
                                     ],
                                     "cors": [],
                                     "capabilities": [],
+                                    "ipRules": [
+                                        {
+                                            "ipAddressOrRange": "173.2.147.78"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "104.42.195.92"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "40.76.54.131"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.176.6.30"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.169.50.45"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.187.184.26"
+                                        }
+                                    ],
                                     "backupPolicy": {
                                         "type": "Periodic",
                                         "periodicModeProperties": {
                                             "backupIntervalInMinutes": 240,
-                                            "backupRetentionIntervalInHours": 8
+                                            "backupRetentionIntervalInHours": 8,
+                                            "backupStorageRedundancy": "Geo"
+                                        }
+                                    },
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                         }
                                     }
+                                },
+                                "identity": {
+                                    "type": "None"
                                 }
                             }
                         ]

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_find_by_name_collection.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_find_by_name_collection.json
@@ -4,27 +4,39 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:27 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 2927BF4F75D04FCF9E45EC3220C01786 Ref B: BL2AA2011002025 Ref C: 2026-06-02T16:01:27Z"
+                    ],
+                    "content-length": [
+                        "3314"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:08 GMT"
-                    ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "content-length": [
-                        "2336"
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
                     ]
                 },
                 "body": {
@@ -36,17 +48,16 @@
                                 "location": "South Central US",
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
-                                "tags": {
-                                    "test-store-throughput": "JZ07ANKIMdw=:4",
-                                    "test-restore-throughput": "JZ07ANKIMdw=:4"
-                                },
+                                "tags": {},
                                 "systemData": {
-                                    "createdAt": "2020-10-31T03:48:04.4977476Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                                    "enableAutomaticFailover": false,
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "publicNetworkAccess": "Enabled",
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -55,16 +66,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
-                                    "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                                    "defaultIdentity": "FirstPartyIdentity",
+                                    "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -104,13 +126,52 @@
                                     ],
                                     "cors": [],
                                     "capabilities": [],
+                                    "ipRules": [
+                                        {
+                                            "ipAddressOrRange": "173.2.147.78"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "104.42.195.92"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "40.76.54.131"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.176.6.30"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.169.50.45"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.187.184.26"
+                                        }
+                                    ],
                                     "backupPolicy": {
                                         "type": "Periodic",
                                         "periodicModeProperties": {
                                             "backupIntervalInMinutes": 240,
-                                            "backupRetentionIntervalInHours": 8
+                                            "backupRetentionIntervalInHours": 8,
+                                            "backupStorageRedundancy": "Geo"
+                                        }
+                                    },
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                         }
                                     }
+                                },
+                                "identity": {
+                                    "type": "None"
                                 }
                             }
                         ]
@@ -121,7 +182,7 @@
         {
             "request": {
                 "method": "POST",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -131,20 +192,29 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:08 GMT"
-                    ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-ratelimit-remaining-subscription-writes": [
-                        "1198"
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:28 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "799"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 63B9EE46F24146B1815020E05E1F1ADD Ref B: MNZ221060619029 Ref C: 2026-06-02T16:01:28Z"
                     ],
                     "content-length": [
                         "461"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/446417e4-19ad-4cb7-a750-ec099dc972b5"
                     ]
                 },
                 "body": {
@@ -160,7 +230,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39.documents.azure.com/",
+                "uri": "https://cctestcosmosdbc2295d913936.documents.azure.com/",
                 "body": null,
                 "headers": {}
             },
@@ -170,26 +240,26 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "cache-control": [
-                        "no-store, no-cache"
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:28 GMT"
                     ],
                     "x-ms-databaseaccount-provisioned-mb": [
                         "0"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:08 GMT"
+                    "x-ms-databaseaccount-consumed-mb": [
+                        "0"
                     ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "x-ms-max-media-storage-usage-mb": [
-                        "2048"
+                    "cache-control": [
+                        "no-store, no-cache"
                     ],
                     "x-ms-media-storage-usage-mb": [
                         "0"
                     ],
-                    "x-ms-databaseaccount-consumed-mb": [
-                        "0"
+                    "x-ms-max-media-storage-usage-mb": [
+                        "2048"
                     ],
                     "x-ms-databaseaccount-reserved-mb": [
                         "0"
@@ -198,24 +268,28 @@
                 "body": {
                     "data": {
                         "_self": "",
-                        "id": "cctestcosmosdbfafbee1d5b39",
-                        "_rid": "cctestcosmosdbfafbee1d5b39.documents.azure.com",
+                        "id": "cctestcosmosdbc2295d913936",
+                        "_rid": "cctestcosmosdbc2295d913936.documents.azure.com",
                         "media": "//media/",
                         "addresses": "//addresses/",
                         "_dbs": "//dbs/",
                         "writableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "readableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "enableMultipleWriteLocations": false,
+                        "continuousBackupEnabled": false,
+                        "enableNRegionSynchronousCommit": false,
+                        "enablePerPartitionFailoverBehavior": false,
+                        "disableCrossRegionalHedging": false,
                         "userReplicationPolicy": {
                             "asyncReplication": false,
                             "minReplicaSetSize": 3,
@@ -232,7 +306,7 @@
                             "primaryReadCoefficient": 1,
                             "secondaryReadCoefficient": 1
                         },
-                        "queryEngineConfiguration": "{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":true,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlDisableQueryILOptimization\":false,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"
+                        "queryEngineConfiguration": "{\"allowNewKeywords\":true,\"maxJoinsPerSqlQuery\":10,\"maxQueryRequestTimeoutFraction\":0.9,\"maxSqlQueryInputLength\":524288,\"maxUdfRefPerSqlQuery\":10,\"queryMaxInMemorySortDocumentCount\":-1000,\"spatialMaxGeometryPointCount\":256,\"sqlAllowNonFiniteNumbers\":false,\"sqlDisableOptimizationFlags\":0,\"sqlQueryILDisableOptimizationFlags\":0,\"clientDisableOptimisticDirectExecution\":false,\"queryEnableFullText\":true,\"queryEnableFullTextPreviewFeatures\":false,\"queryMaxFullTextScoreSearchTerms\":30,\"queryMaxRrfArgumentCount\":100,\"enableSpatialIndexing\":true,\"maxInExpressionItemsCount\":2147483647,\"maxLogicalAndPerSqlQuery\":2147483647,\"maxLogicalOrPerSqlQuery\":2147483647,\"maxSpatialQueryCells\":2147483647,\"sqlAllowAggregateFunctions\":true,\"sqlAllowGroupByClause\":true,\"sqlAllowLike\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"sqlAllowTop\":true}"
                     }
                 }
             }
@@ -240,7 +314,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs",
                 "body": null,
                 "headers": {}
             },
@@ -250,50 +324,53 @@
                     "message": "Ok"
                 },
                 "headers": {
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:28 GMT"
+                    ],
                     "lsn": [
-                        "18"
+                        "12"
+                    ],
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-resource-quota": [
+                        "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;azureRbac=200000;"
+                    ],
+                    "x-ms-schemaversion": [
+                        "1.21"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.328"
                     ],
                     "x-ms-activity-id": [
-                        "d60dbd5c-7073-4d35-b094-ae394084659b"
+                        "32f2465b-261f-4aad-90df-2d5f01e9f7ed"
                     ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-serviceversion": [
+                        "version=2.14.0.0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
-                    "x-ms-serviceversion": [
-                        "version=2.11.0.0"
-                    ],
-                    "x-ms-resource-usage": [
-                        "databases=1;collections=1;users=0;permissions=0;"
-                    ],
-                    "x-ms-item-count": [
-                        "1"
-                    ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
-                    ],
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:09 GMT"
-                    ],
-                    "x-ms-request-duration-ms": [
-                        "0.649"
-                    ],
                     "x-ms-transport-request-id": [
-                        "35600"
+                        "143067"
                     ],
                     "x-ms-number-of-read-regions": [
                         "0"
                     ],
-                    "x-ms-resource-quota": [
-                        "databases=1000;collections=5000;users=500000;permissions=2000000;"
+                    "x-ms-item-count": [
+                        "1"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
+                    ],
+                    "x-ms-session-token": [
+                        "0:-1#12"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-resource-usage": [
+                        "databases=1;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;roleDefinitions=0;roleAssignments=0;azureRbac=0;"
                     ]
                 },
                 "body": {
@@ -302,12 +379,12 @@
                         "Databases": [
                             {
                                 "id": "cctestcdatabase",
-                                "_rid": "JZ07AA==",
-                                "_self": "dbs/JZ07AA==/",
-                                "_etag": "\"00001500-0000-0500-0000-5f9cde870000\"",
+                                "_rid": "yV8QAA==",
+                                "_self": "dbs/yV8QAA==/",
+                                "_etag": "\"0000e101-0000-0500-0000-6a1ef8780000\"",
                                 "_colls": "colls/",
                                 "_users": "users/",
-                                "_ts": 1604116103
+                                "_ts": 1780414584
                             }
                         ],
                         "_count": 1
@@ -318,7 +395,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs/JZ07AA==/colls/",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs/yV8QAA==/colls/",
                 "body": null,
                 "headers": {}
             },
@@ -328,50 +405,53 @@
                     "message": "Ok"
                 },
                 "headers": {
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:29 GMT"
+                    ],
                     "lsn": [
-                        "18"
+                        "12"
+                    ],
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-resource-quota": [
+                        "collections=5000;"
+                    ],
+                    "x-ms-schemaversion": [
+                        "1.21"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.681"
                     ],
                     "x-ms-activity-id": [
-                        "526267d1-9891-42b2-8530-f3e7ba1150ea"
+                        "214104fa-c32b-409c-8700-5032455ae0a2"
                     ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-serviceversion": [
+                        "version=2.14.0.0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
-                    "x-ms-serviceversion": [
-                        "version=2.11.0.0"
-                    ],
-                    "x-ms-resource-usage": [
-                        "collections=1;"
-                    ],
-                    "x-ms-item-count": [
-                        "1"
-                    ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
-                    ],
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:09 GMT"
-                    ],
-                    "x-ms-request-duration-ms": [
-                        "0.982"
-                    ],
                     "x-ms-transport-request-id": [
-                        "60135"
+                        "66746"
                     ],
                     "x-ms-number-of-read-regions": [
                         "0"
                     ],
-                    "x-ms-resource-quota": [
-                        "collections=5000;"
+                    "x-ms-item-count": [
+                        "1"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
+                    ],
+                    "x-ms-session-token": [
+                        "0:-1#12"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-resource-usage": [
+                        "collections=1;"
                     ],
                     "x-ms-alt-content-path": [
                         "dbs/cctestcdatabase"
@@ -398,7 +478,8 @@
                                         {
                                             "path": "/\"_etag\"/?"
                                         }
-                                    ]
+                                    ],
+                                    "fullTextIndexes": []
                                 },
                                 "partitionKey": {
                                     "paths": [
@@ -417,15 +498,16 @@
                                 "geospatialConfig": {
                                     "type": "Geography"
                                 },
-                                "_rid": "JZ07ANKIMdw=",
-                                "_ts": 1604116125,
-                                "_self": "dbs/JZ07AA==/colls/JZ07ANKIMdw=/",
-                                "_etag": "\"00001700-0000-0500-0000-5f9cde9d0000\"",
+                                "_rid": "yV8QAL3IfmQ=",
+                                "_ts": 1780414601,
+                                "_self": "DEC0DEDITtVwMoyAuTz1LioKkC+gB/EpRlQKNIaszQEhVidjWyP1kLW1z+jo/MGFHKc+t+M20PxoraNCslng9w==/colls/yV8QAL3IfmQ=/",
+                                "_etag": "\"0000e301-0000-0500-0000-6a1ef8890000\"",
                                 "_docs": "docs/",
                                 "_sprocs": "sprocs/",
                                 "_triggers": "triggers/",
                                 "_udfs": "udfs/",
-                                "_conflicts": "conflicts/"
+                                "_conflicts": "conflicts/",
+                                "computedProperties": []
                             }
                         ],
                         "_count": 1

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_find_by_name_database.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_find_by_name_database.json
@@ -4,27 +4,39 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:30 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 37AADEC656BF43B9A643DB51AE5E6687 Ref B: BL2AA2011003040 Ref C: 2026-06-02T16:01:30Z"
+                    ],
+                    "content-length": [
+                        "3314"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:09 GMT"
-                    ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "content-length": [
-                        "2336"
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
                     ]
                 },
                 "body": {
@@ -36,17 +48,16 @@
                                 "location": "South Central US",
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
-                                "tags": {
-                                    "test-store-throughput": "JZ07ANKIMdw=:4",
-                                    "test-restore-throughput": "JZ07ANKIMdw=:4"
-                                },
+                                "tags": {},
                                 "systemData": {
-                                    "createdAt": "2020-10-31T03:48:04.4977476Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                                    "enableAutomaticFailover": false,
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "publicNetworkAccess": "Enabled",
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -55,16 +66,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
-                                    "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                                    "defaultIdentity": "FirstPartyIdentity",
+                                    "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -104,13 +126,52 @@
                                     ],
                                     "cors": [],
                                     "capabilities": [],
+                                    "ipRules": [
+                                        {
+                                            "ipAddressOrRange": "173.2.147.78"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "104.42.195.92"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "40.76.54.131"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.176.6.30"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.169.50.45"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.187.184.26"
+                                        }
+                                    ],
                                     "backupPolicy": {
                                         "type": "Periodic",
                                         "periodicModeProperties": {
                                             "backupIntervalInMinutes": 240,
-                                            "backupRetentionIntervalInHours": 8
+                                            "backupRetentionIntervalInHours": 8,
+                                            "backupStorageRedundancy": "Geo"
+                                        }
+                                    },
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                         }
                                     }
+                                },
+                                "identity": {
+                                    "type": "None"
                                 }
                             }
                         ]
@@ -121,7 +182,7 @@
         {
             "request": {
                 "method": "POST",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -131,20 +192,29 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:09 GMT"
-                    ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-ratelimit-remaining-subscription-writes": [
-                        "1198"
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:30 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "799"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: CDD295CDC09146A8A197EDF882F8B8CD Ref B: MNZ221060619035 Ref C: 2026-06-02T16:01:31Z"
                     ],
                     "content-length": [
                         "461"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/8a51d74a-3ccc-45b5-a862-f8219031b1cb"
                     ]
                 },
                 "body": {
@@ -160,7 +230,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39.documents.azure.com/",
+                "uri": "https://cctestcosmosdbc2295d913936.documents.azure.com/",
                 "body": null,
                 "headers": {}
             },
@@ -170,26 +240,26 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "cache-control": [
-                        "no-store, no-cache"
+                    "content-type": [
+                        "application/json"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:31 GMT"
                     ],
                     "x-ms-databaseaccount-provisioned-mb": [
                         "0"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:10 GMT"
+                    "x-ms-databaseaccount-consumed-mb": [
+                        "0"
                     ],
-                    "content-type": [
-                        "application/json"
-                    ],
-                    "x-ms-max-media-storage-usage-mb": [
-                        "2048"
+                    "cache-control": [
+                        "no-store, no-cache"
                     ],
                     "x-ms-media-storage-usage-mb": [
                         "0"
                     ],
-                    "x-ms-databaseaccount-consumed-mb": [
-                        "0"
+                    "x-ms-max-media-storage-usage-mb": [
+                        "2048"
                     ],
                     "x-ms-databaseaccount-reserved-mb": [
                         "0"
@@ -198,24 +268,28 @@
                 "body": {
                     "data": {
                         "_self": "",
-                        "id": "cctestcosmosdbfafbee1d5b39",
-                        "_rid": "cctestcosmosdbfafbee1d5b39.documents.azure.com",
+                        "id": "cctestcosmosdbc2295d913936",
+                        "_rid": "cctestcosmosdbc2295d913936.documents.azure.com",
                         "media": "//media/",
                         "addresses": "//addresses/",
                         "_dbs": "//dbs/",
                         "writableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "readableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "enableMultipleWriteLocations": false,
+                        "continuousBackupEnabled": false,
+                        "enableNRegionSynchronousCommit": false,
+                        "enablePerPartitionFailoverBehavior": false,
+                        "disableCrossRegionalHedging": false,
                         "userReplicationPolicy": {
                             "asyncReplication": false,
                             "minReplicaSetSize": 3,
@@ -232,7 +306,7 @@
                             "primaryReadCoefficient": 1,
                             "secondaryReadCoefficient": 1
                         },
-                        "queryEngineConfiguration": "{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":true,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlDisableQueryILOptimization\":false,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"
+                        "queryEngineConfiguration": "{\"allowNewKeywords\":true,\"maxJoinsPerSqlQuery\":10,\"maxQueryRequestTimeoutFraction\":0.9,\"maxSqlQueryInputLength\":524288,\"maxUdfRefPerSqlQuery\":10,\"queryMaxInMemorySortDocumentCount\":-1000,\"spatialMaxGeometryPointCount\":256,\"sqlAllowNonFiniteNumbers\":false,\"sqlDisableOptimizationFlags\":0,\"sqlQueryILDisableOptimizationFlags\":0,\"clientDisableOptimisticDirectExecution\":false,\"queryEnableFullText\":true,\"queryEnableFullTextPreviewFeatures\":false,\"queryMaxFullTextScoreSearchTerms\":30,\"queryMaxRrfArgumentCount\":100,\"enableSpatialIndexing\":true,\"maxInExpressionItemsCount\":2147483647,\"maxLogicalAndPerSqlQuery\":2147483647,\"maxLogicalOrPerSqlQuery\":2147483647,\"maxSpatialQueryCells\":2147483647,\"sqlAllowAggregateFunctions\":true,\"sqlAllowGroupByClause\":true,\"sqlAllowLike\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"sqlAllowTop\":true}"
                     }
                 }
             }
@@ -240,7 +314,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs",
                 "body": null,
                 "headers": {}
             },
@@ -250,50 +324,53 @@
                     "message": "Ok"
                 },
                 "headers": {
+                    "date": [
+                        "Tue, 02 Jun 2026 16:01:31 GMT"
+                    ],
                     "lsn": [
-                        "18"
+                        "12"
+                    ],
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-resource-quota": [
+                        "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;azureRbac=200000;"
+                    ],
+                    "x-ms-schemaversion": [
+                        "1.21"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.343"
                     ],
                     "x-ms-activity-id": [
-                        "9edac3b8-abbf-42e6-9d0c-314f8a7a02d0"
+                        "da090352-701d-43a3-b6e8-1c543d3a3cef"
                     ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-serviceversion": [
+                        "version=2.14.0.0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
-                    "x-ms-serviceversion": [
-                        "version=2.11.0.0"
-                    ],
-                    "x-ms-resource-usage": [
-                        "databases=1;collections=1;users=0;permissions=0;"
-                    ],
-                    "x-ms-item-count": [
-                        "1"
-                    ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
-                    ],
-                    "cache-control": [
-                        "no-store, no-cache"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:10 GMT"
-                    ],
-                    "x-ms-request-duration-ms": [
-                        "0.572"
-                    ],
                     "x-ms-transport-request-id": [
-                        "28339"
+                        "66013"
                     ],
                     "x-ms-number-of-read-regions": [
                         "0"
                     ],
-                    "x-ms-resource-quota": [
-                        "databases=1000;collections=5000;users=500000;permissions=2000000;"
+                    "x-ms-item-count": [
+                        "1"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
+                    ],
+                    "x-ms-session-token": [
+                        "0:-1#12"
+                    ],
+                    "cache-control": [
+                        "no-store, no-cache"
+                    ],
+                    "x-ms-resource-usage": [
+                        "databases=1;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;roleDefinitions=0;roleAssignments=0;azureRbac=0;"
                     ]
                 },
                 "body": {
@@ -302,12 +379,12 @@
                         "Databases": [
                             {
                                 "id": "cctestcdatabase",
-                                "_rid": "JZ07AA==",
-                                "_self": "dbs/JZ07AA==/",
-                                "_etag": "\"00001500-0000-0500-0000-5f9cde870000\"",
+                                "_rid": "yV8QAA==",
+                                "_self": "dbs/yV8QAA==/",
+                                "_etag": "\"0000e101-0000-0500-0000-6a1ef8780000\"",
                                 "_colls": "colls/",
                                 "_users": "users/",
-                                "_ts": 1604116103
+                                "_ts": 1780414584
                             }
                         ],
                         "_count": 1

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_offer_collection.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_offer_collection.json
@@ -4,27 +4,39 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
                     "date": [
-                        "Sat, 31 Oct 2020 04:39:18 GMT"
+                        "Tue, 02 Jun 2026 16:06:37 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
                     ],
                     "content-type": [
-                        "application/json"
+                        "application/json; charset=utf-8"
                     ],
                     "content-length": [
-                        "2336"
+                        "3354"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: F14CD4DE408D4A37BD3746D877D677E1 Ref B: MNZ221060608017 Ref C: 2026-06-02T16:06:38Z"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
                     ]
                 },
                 "body": {
@@ -37,16 +49,17 @@
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
                                 "tags": {
-                                    "test-store-throughput": "JZ07ANKIMdw=:4",
-                                    "test-restore-throughput": "JZ07ANKIMdw=:4"
+                                    "test-store-throughput": "yV8QAL3IfmQ=:4"
                                 },
                                 "systemData": {
-                                    "createdAt": "2020-10-31T03:48:04.4977476Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                                    "enableAutomaticFailover": false,
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "publicNetworkAccess": "Enabled",
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -55,16 +68,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
-                                    "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                                    "defaultIdentity": "FirstPartyIdentity",
+                                    "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -104,13 +128,52 @@
                                     ],
                                     "cors": [],
                                     "capabilities": [],
+                                    "ipRules": [
+                                        {
+                                            "ipAddressOrRange": "173.2.147.78"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "104.42.195.92"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "40.76.54.131"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.176.6.30"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.169.50.45"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.187.184.26"
+                                        }
+                                    ],
                                     "backupPolicy": {
                                         "type": "Periodic",
                                         "periodicModeProperties": {
                                             "backupIntervalInMinutes": 240,
-                                            "backupRetentionIntervalInHours": 8
+                                            "backupRetentionIntervalInHours": 8,
+                                            "backupStorageRedundancy": "Geo"
+                                        }
+                                    },
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                         }
                                     }
+                                },
+                                "identity": {
+                                    "type": "None"
                                 }
                             }
                         ]
@@ -121,7 +184,7 @@
         {
             "request": {
                 "method": "POST",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -135,16 +198,25 @@
                         "no-store, no-cache"
                     ],
                     "date": [
-                        "Sat, 31 Oct 2020 04:39:18 GMT"
+                        "Tue, 02 Jun 2026 16:06:38 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-ratelimit-remaining-subscription-writes": [
-                        "1199"
-                    ],
                     "content-length": [
                         "461"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "799"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 9F07872C5E9048AEAD22CF5A1C1D94A7 Ref B: BL2AA2010204007 Ref C: 2026-06-02T16:06:38Z"
+                    ],
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/99dbe499-412b-4ea9-bf02-8f689ff08767"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
                     ]
                 },
                 "body": {
@@ -160,7 +232,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39.documents.azure.com/",
+                "uri": "https://cctestcosmosdbc2295d913936.documents.azure.com/",
                 "body": null,
                 "headers": {}
             },
@@ -173,17 +245,17 @@
                     "cache-control": [
                         "no-store, no-cache"
                     ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:38 GMT"
+                    ],
                     "x-ms-databaseaccount-provisioned-mb": [
                         "0"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:18 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-max-media-storage-usage-mb": [
-                        "2048"
+                    "x-ms-databaseaccount-reserved-mb": [
+                        "0"
                     ],
                     "x-ms-media-storage-usage-mb": [
                         "0"
@@ -191,31 +263,35 @@
                     "x-ms-databaseaccount-consumed-mb": [
                         "0"
                     ],
-                    "x-ms-databaseaccount-reserved-mb": [
-                        "0"
+                    "x-ms-max-media-storage-usage-mb": [
+                        "2048"
                     ]
                 },
                 "body": {
                     "data": {
                         "_self": "",
-                        "id": "cctestcosmosdbfafbee1d5b39",
-                        "_rid": "cctestcosmosdbfafbee1d5b39.documents.azure.com",
+                        "id": "cctestcosmosdbc2295d913936",
+                        "_rid": "cctestcosmosdbc2295d913936.documents.azure.com",
                         "media": "//media/",
                         "addresses": "//addresses/",
                         "_dbs": "//dbs/",
                         "writableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "readableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "enableMultipleWriteLocations": false,
+                        "continuousBackupEnabled": false,
+                        "enableNRegionSynchronousCommit": false,
+                        "enablePerPartitionFailoverBehavior": false,
+                        "disableCrossRegionalHedging": false,
                         "userReplicationPolicy": {
                             "asyncReplication": false,
                             "minReplicaSetSize": 3,
@@ -232,7 +308,7 @@
                             "primaryReadCoefficient": 1,
                             "secondaryReadCoefficient": 1
                         },
-                        "queryEngineConfiguration": "{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":true,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlDisableQueryILOptimization\":false,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"
+                        "queryEngineConfiguration": "{\"allowNewKeywords\":true,\"maxJoinsPerSqlQuery\":10,\"maxQueryRequestTimeoutFraction\":0.9,\"maxSqlQueryInputLength\":524288,\"maxUdfRefPerSqlQuery\":10,\"queryMaxInMemorySortDocumentCount\":-1000,\"spatialMaxGeometryPointCount\":256,\"sqlAllowNonFiniteNumbers\":false,\"sqlDisableOptimizationFlags\":0,\"sqlQueryILDisableOptimizationFlags\":0,\"clientDisableOptimisticDirectExecution\":false,\"queryEnableFullText\":true,\"queryEnableFullTextPreviewFeatures\":false,\"queryMaxFullTextScoreSearchTerms\":30,\"queryMaxRrfArgumentCount\":100,\"enableSpatialIndexing\":true,\"maxInExpressionItemsCount\":2147483647,\"maxLogicalAndPerSqlQuery\":2147483647,\"maxLogicalOrPerSqlQuery\":2147483647,\"maxSpatialQueryCells\":2147483647,\"sqlAllowAggregateFunctions\":true,\"sqlAllowGroupByClause\":true,\"sqlAllowLike\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"sqlAllowTop\":true}"
                     }
                 }
             }
@@ -240,7 +316,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs",
                 "body": null,
                 "headers": {}
             },
@@ -250,50 +326,53 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "lsn": [
-                        "18"
-                    ],
-                    "x-ms-activity-id": [
-                        "bfba3592-797c-440b-8378-c289c4ae631e"
-                    ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-number-of-read-regions": [
+                        "0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
                     "x-ms-serviceversion": [
-                        "version=2.11.0.0"
+                        "version=2.14.0.0"
                     ],
-                    "x-ms-resource-usage": [
-                        "databases=1;collections=1;users=0;permissions=0;"
+                    "x-ms-transport-request-id": [
+                        "144842"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.439"
                     ],
                     "x-ms-item-count": [
                         "1"
                     ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-activity-id": [
+                        "fc563825-26a2-4108-9a55-0b3d09df0209"
+                    ],
+                    "x-ms-resource-usage": [
+                        "databases=1;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;roleDefinitions=0;roleAssignments=0;azureRbac=0;"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:38 GMT"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
                     ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:19 GMT"
+                    "x-ms-session-token": [
+                        "0:-1#13"
                     ],
-                    "x-ms-request-duration-ms": [
-                        "0.486"
-                    ],
-                    "x-ms-transport-request-id": [
-                        "30684"
-                    ],
-                    "x-ms-number-of-read-regions": [
-                        "0"
+                    "x-ms-schemaversion": [
+                        "1.21"
                     ],
                     "x-ms-resource-quota": [
-                        "databases=1000;collections=5000;users=500000;permissions=2000000;"
+                        "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;azureRbac=200000;"
+                    ],
+                    "lsn": [
+                        "13"
                     ]
                 },
                 "body": {
@@ -302,12 +381,12 @@
                         "Databases": [
                             {
                                 "id": "cctestcdatabase",
-                                "_rid": "JZ07AA==",
-                                "_self": "dbs/JZ07AA==/",
-                                "_etag": "\"00001500-0000-0500-0000-5f9cde870000\"",
+                                "_rid": "yV8QAA==",
+                                "_self": "dbs/yV8QAA==/",
+                                "_etag": "\"0000e101-0000-0500-0000-6a1ef8780000\"",
                                 "_colls": "colls/",
                                 "_users": "users/",
-                                "_ts": 1604116103
+                                "_ts": 1780414584
                             }
                         ],
                         "_count": 1
@@ -318,7 +397,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs/JZ07AA==/colls/",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs/yV8QAA==/colls/",
                 "body": null,
                 "headers": {}
             },
@@ -328,53 +407,56 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "lsn": [
-                        "18"
-                    ],
-                    "x-ms-activity-id": [
-                        "55f713dd-fe22-40fe-8a51-ea430076a37e"
-                    ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-number-of-read-regions": [
+                        "0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
+                    "x-ms-alt-content-path": [
+                        "dbs/cctestcdatabase"
                     ],
                     "x-ms-serviceversion": [
-                        "version=2.11.0.0"
+                        "version=2.14.0.0"
                     ],
-                    "x-ms-resource-usage": [
-                        "collections=1;"
+                    "x-ms-transport-request-id": [
+                        "154149"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "1.07"
                     ],
                     "x-ms-item-count": [
                         "1"
                     ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-activity-id": [
+                        "5886e076-381f-487c-8ec2-53d6f51e58b8"
+                    ],
+                    "x-ms-resource-usage": [
+                        "collections=1;"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:39 GMT"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
                     ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:19 GMT"
+                    "x-ms-session-token": [
+                        "0:-1#13"
                     ],
-                    "x-ms-request-duration-ms": [
-                        "0.962"
-                    ],
-                    "x-ms-transport-request-id": [
-                        "60160"
-                    ],
-                    "x-ms-number-of-read-regions": [
-                        "0"
+                    "x-ms-schemaversion": [
+                        "1.21"
                     ],
                     "x-ms-resource-quota": [
                         "collections=5000;"
                     ],
-                    "x-ms-alt-content-path": [
-                        "dbs/cctestcdatabase"
+                    "lsn": [
+                        "13"
                     ]
                 },
                 "body": {
@@ -398,7 +480,8 @@
                                         {
                                             "path": "/\"_etag\"/?"
                                         }
-                                    ]
+                                    ],
+                                    "fullTextIndexes": []
                                 },
                                 "partitionKey": {
                                     "paths": [
@@ -417,15 +500,16 @@
                                 "geospatialConfig": {
                                     "type": "Geography"
                                 },
-                                "_rid": "JZ07ANKIMdw=",
-                                "_ts": 1604116125,
-                                "_self": "dbs/JZ07AA==/colls/JZ07ANKIMdw=/",
-                                "_etag": "\"00001700-0000-0500-0000-5f9cde9d0000\"",
+                                "_rid": "yV8QAL3IfmQ=",
+                                "_ts": 1780414601,
+                                "_self": "DEC0DEDITtVwMoyAuTz1LioKkC+gB/EpRlQKNIaszQEhVidjWyP1kLW1z+jo/MGFHKc+t+M20PxoraNCslng9w==/colls/yV8QAL3IfmQ=/",
+                                "_etag": "\"0000e301-0000-0500-0000-6a1ef8890000\"",
                                 "_docs": "docs/",
                                 "_sprocs": "sprocs/",
                                 "_triggers": "triggers/",
                                 "_udfs": "udfs/",
-                                "_conflicts": "conflicts/"
+                                "_conflicts": "conflicts/",
+                                "computedProperties": []
                             }
                         ],
                         "_count": 1
@@ -436,7 +520,7 @@
         {
             "request": {
                 "method": "POST",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -450,16 +534,25 @@
                         "no-store, no-cache"
                     ],
                     "date": [
-                        "Sat, 31 Oct 2020 04:39:19 GMT"
+                        "Tue, 02 Jun 2026 16:06:39 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-ratelimit-remaining-subscription-writes": [
-                        "1198"
-                    ],
                     "content-length": [
                         "461"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "799"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 5A2B264E581A4B1CA723A3C731044803 Ref B: BL2AA2010205047 Ref C: 2026-06-02T16:06:39Z"
+                    ],
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/901102b8-8717-4113-bf6d-2dcb59947a48"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
                     ]
                 },
                 "body": {
@@ -475,7 +568,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39.documents.azure.com/",
+                "uri": "https://cctestcosmosdbc2295d913936.documents.azure.com/",
                 "body": null,
                 "headers": {}
             },
@@ -488,17 +581,17 @@
                     "cache-control": [
                         "no-store, no-cache"
                     ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:39 GMT"
+                    ],
                     "x-ms-databaseaccount-provisioned-mb": [
                         "0"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:20 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-max-media-storage-usage-mb": [
-                        "2048"
+                    "x-ms-databaseaccount-reserved-mb": [
+                        "0"
                     ],
                     "x-ms-media-storage-usage-mb": [
                         "0"
@@ -506,31 +599,35 @@
                     "x-ms-databaseaccount-consumed-mb": [
                         "0"
                     ],
-                    "x-ms-databaseaccount-reserved-mb": [
-                        "0"
+                    "x-ms-max-media-storage-usage-mb": [
+                        "2048"
                     ]
                 },
                 "body": {
                     "data": {
                         "_self": "",
-                        "id": "cctestcosmosdbfafbee1d5b39",
-                        "_rid": "cctestcosmosdbfafbee1d5b39.documents.azure.com",
+                        "id": "cctestcosmosdbc2295d913936",
+                        "_rid": "cctestcosmosdbc2295d913936.documents.azure.com",
                         "media": "//media/",
                         "addresses": "//addresses/",
                         "_dbs": "//dbs/",
                         "writableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "readableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "enableMultipleWriteLocations": false,
+                        "continuousBackupEnabled": false,
+                        "enableNRegionSynchronousCommit": false,
+                        "enablePerPartitionFailoverBehavior": false,
+                        "disableCrossRegionalHedging": false,
                         "userReplicationPolicy": {
                             "asyncReplication": false,
                             "minReplicaSetSize": 3,
@@ -547,7 +644,7 @@
                             "primaryReadCoefficient": 1,
                             "secondaryReadCoefficient": 1
                         },
-                        "queryEngineConfiguration": "{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":true,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlDisableQueryILOptimization\":false,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"
+                        "queryEngineConfiguration": "{\"allowNewKeywords\":true,\"maxJoinsPerSqlQuery\":10,\"maxQueryRequestTimeoutFraction\":0.9,\"maxSqlQueryInputLength\":524288,\"maxUdfRefPerSqlQuery\":10,\"queryMaxInMemorySortDocumentCount\":-1000,\"spatialMaxGeometryPointCount\":256,\"sqlAllowNonFiniteNumbers\":false,\"sqlDisableOptimizationFlags\":0,\"sqlQueryILDisableOptimizationFlags\":0,\"clientDisableOptimisticDirectExecution\":false,\"queryEnableFullText\":true,\"queryEnableFullTextPreviewFeatures\":false,\"queryMaxFullTextScoreSearchTerms\":30,\"queryMaxRrfArgumentCount\":100,\"enableSpatialIndexing\":true,\"maxInExpressionItemsCount\":2147483647,\"maxLogicalAndPerSqlQuery\":2147483647,\"maxLogicalOrPerSqlQuery\":2147483647,\"maxSpatialQueryCells\":2147483647,\"sqlAllowAggregateFunctions\":true,\"sqlAllowGroupByClause\":true,\"sqlAllowLike\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"sqlAllowTop\":true}"
                     }
                 }
             }
@@ -555,7 +652,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//offers",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/offers",
                 "body": null,
                 "headers": {}
             },
@@ -565,44 +662,47 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "lsn": [
-                        "18"
-                    ],
-                    "x-ms-activity-id": [
-                        "ec61487d-7c78-4a7f-9100-b798c0a40e03"
-                    ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-number-of-read-regions": [
+                        "0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
                     "x-ms-serviceversion": [
-                        "version=2.11.0.0"
+                        "version=2.14.0.0"
+                    ],
+                    "x-ms-transport-request-id": [
+                        "65963"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.708"
                     ],
                     "x-ms-item-count": [
                         "1"
                     ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-activity-id": [
+                        "d60c056d-4cd5-4574-92e4-99c49633e129"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:40 GMT"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
                     ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:20 GMT"
+                    "x-ms-session-token": [
+                        "0:-1#13"
                     ],
-                    "x-ms-request-duration-ms": [
-                        "0.521"
+                    "x-ms-schemaversion": [
+                        "1.21"
                     ],
-                    "x-ms-transport-request-id": [
-                        "29119"
-                    ],
-                    "x-ms-number-of-read-regions": [
-                        "0"
+                    "lsn": [
+                        "13"
                     ]
                 },
                 "body": {
@@ -610,24 +710,23 @@
                         "_rid": "",
                         "Offers": [
                             {
-                                "resource": "dbs/JZ07AA==/colls/JZ07ANKIMdw=/",
+                                "resource": "dbs/yV8QAA==/colls/yV8QAL3IfmQ=/",
                                 "offerType": "Invalid",
-                                "offerResourceId": "JZ07ANKIMdw=",
+                                "offerResourceId": "yV8QAL3IfmQ=",
                                 "offerVersion": "V2",
                                 "content": {
                                     "offerThroughput": 400,
                                     "offerIsRUPerMinuteThroughputEnabled": false,
                                     "offerMinimumThroughputParameters": {
-                                        "maxThroughputEverProvisioned": 500,
+                                        "maxThroughputEverProvisioned": 400,
                                         "maxConsumedStorageEverInKB": 0
-                                    },
-                                    "offerLastReplaceTimestamp": 1604118651
+                                    }
                                 },
-                                "id": "+1KO",
-                                "_rid": "+1KO",
-                                "_self": "offers/+1KO/",
-                                "_etag": "\"0000bb05-0000-0500-0000-5f9ce8b70000\"",
-                                "_ts": 1604118711
+                                "id": "VYd4",
+                                "_rid": "VYd4",
+                                "_self": "offers/VYd4/",
+                                "_etag": "\"0000e401-0000-0500-0000-6a1ef8890000\"",
+                                "_ts": 1780414601
                             }
                         ],
                         "_count": 1

--- a/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_store_throughput_state_collection_action.json
+++ b/tools/c7n_azure/tests_azure/cassettes/CosmosDBTest.test_store_throughput_state_collection_action.json
@@ -4,27 +4,39 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.DocumentDB/databaseAccounts?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
             "response": {
                 "status": {
                     "code": 200,
-                    "message": "Ok"
+                    "message": "OK"
                 },
                 "headers": {
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
                     "date": [
-                        "Sat, 31 Oct 2020 04:39:20 GMT"
+                        "Tue, 02 Jun 2026 16:06:41 GMT"
+                    ],
+                    "x-ms-original-request-ids": [
+                        ""
                     ],
                     "content-type": [
-                        "application/json"
+                        "application/json; charset=utf-8"
                     ],
                     "content-length": [
-                        "2336"
+                        "3354"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 70A19C1C7FB44D93941AD35152E0610C Ref B: MNZ221060619045 Ref C: 2026-06-02T16:06:41Z"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
                     ]
                 },
                 "body": {
@@ -37,16 +49,17 @@
                                 "type": "Microsoft.DocumentDB/databaseAccounts",
                                 "kind": "GlobalDocumentDB",
                                 "tags": {
-                                    "test-store-throughput": "JZ07ANKIMdw=:4",
-                                    "test-restore-throughput": "JZ07ANKIMdw=:4"
+                                    "test-store-throughput": "yV8QAL3IfmQ=:4"
                                 },
                                 "systemData": {
-                                    "createdAt": "2020-10-31T03:48:04.4977476Z"
+                                    "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                                 },
                                 "properties": {
                                     "provisioningState": "Succeeded",
                                     "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                                    "enableAutomaticFailover": false,
+                                    "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                                    "publicNetworkAccess": "Enabled",
+                                    "enableAutomaticFailover": true,
                                     "enableMultipleWriteLocations": false,
                                     "enablePartitionKeyMonitor": false,
                                     "isVirtualNetworkFilterEnabled": false,
@@ -55,16 +68,27 @@
                                     "disableKeyBasedMetadataWriteAccess": false,
                                     "enableFreeTier": false,
                                     "enableAnalyticalStorage": false,
-                                    "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                                    "createMode": "Default",
+                                    "analyticalStorageConfiguration": {},
+                                    "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                                     "databaseAccountOfferType": "Standard",
-                                    "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                                    "defaultIdentity": "FirstPartyIdentity",
+                                    "networkAclBypass": "None",
+                                    "disableLocalAuth": false,
+                                    "enablePartitionMerge": false,
+                                    "enablePerRegionPerPartitionAutoscale": true,
+                                    "enableBurstCapacity": false,
+                                    "enablePriorityBasedExecution": false,
+                                    "defaultPriorityLevel": "High",
+                                    "minimalTlsVersion": "Tls12",
+                                    "enablePerPartitionAutomaticFailover": false,
                                     "consistencyPolicy": {
                                         "defaultConsistencyLevel": "Session",
                                         "maxIntervalInSeconds": 5,
                                         "maxStalenessPrefix": 100
                                     },
-                                    "configurationOverrides": {},
+                                    "configurationOverrides": {
+                                        "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                                    },
                                     "writeLocations": [
                                         {
                                             "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -104,13 +128,52 @@
                                     ],
                                     "cors": [],
                                     "capabilities": [],
+                                    "ipRules": [
+                                        {
+                                            "ipAddressOrRange": "173.2.147.78"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "104.42.195.92"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "40.76.54.131"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.176.6.30"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.169.50.45"
+                                        },
+                                        {
+                                            "ipAddressOrRange": "52.187.184.26"
+                                        }
+                                    ],
                                     "backupPolicy": {
                                         "type": "Periodic",
                                         "periodicModeProperties": {
                                             "backupIntervalInMinutes": 240,
-                                            "backupRetentionIntervalInHours": 8
+                                            "backupRetentionIntervalInHours": 8,
+                                            "backupStorageRedundancy": "Geo"
+                                        }
+                                    },
+                                    "networkAclBypassResourceIds": [],
+                                    "keysMetadata": {
+                                        "primaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "primaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                        },
+                                        "secondaryReadonlyMasterKey": {
+                                            "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                         }
                                     }
+                                },
+                                "identity": {
+                                    "type": "None"
                                 }
                             }
                         ]
@@ -121,7 +184,7 @@
         {
             "request": {
                 "method": "POST",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -135,16 +198,25 @@
                         "no-store, no-cache"
                     ],
                     "date": [
-                        "Sat, 31 Oct 2020 04:39:21 GMT"
+                        "Tue, 02 Jun 2026 16:06:41 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-ratelimit-remaining-subscription-writes": [
-                        "1197"
-                    ],
                     "content-length": [
                         "461"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "799"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: 995645D576A745FAB4D9F88FD96645D6 Ref B: BL2AA2011005042 Ref C: 2026-06-02T16:06:42Z"
+                    ],
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/abafa934-a62f-48b3-9d8d-e3b921af453e"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
                     ]
                 },
                 "body": {
@@ -160,7 +232,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39.documents.azure.com/",
+                "uri": "https://cctestcosmosdbc2295d913936.documents.azure.com/",
                 "body": null,
                 "headers": {}
             },
@@ -173,17 +245,17 @@
                     "cache-control": [
                         "no-store, no-cache"
                     ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:42 GMT"
+                    ],
                     "x-ms-databaseaccount-provisioned-mb": [
                         "0"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:21 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-max-media-storage-usage-mb": [
-                        "2048"
+                    "x-ms-databaseaccount-reserved-mb": [
+                        "0"
                     ],
                     "x-ms-media-storage-usage-mb": [
                         "0"
@@ -191,31 +263,35 @@
                     "x-ms-databaseaccount-consumed-mb": [
                         "0"
                     ],
-                    "x-ms-databaseaccount-reserved-mb": [
-                        "0"
+                    "x-ms-max-media-storage-usage-mb": [
+                        "2048"
                     ]
                 },
                 "body": {
                     "data": {
                         "_self": "",
-                        "id": "cctestcosmosdbfafbee1d5b39",
-                        "_rid": "cctestcosmosdbfafbee1d5b39.documents.azure.com",
+                        "id": "cctestcosmosdbc2295d913936",
+                        "_rid": "cctestcosmosdbc2295d913936.documents.azure.com",
                         "media": "//media/",
                         "addresses": "//addresses/",
                         "_dbs": "//dbs/",
                         "writableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "readableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "enableMultipleWriteLocations": false,
+                        "continuousBackupEnabled": false,
+                        "enableNRegionSynchronousCommit": false,
+                        "enablePerPartitionFailoverBehavior": false,
+                        "disableCrossRegionalHedging": false,
                         "userReplicationPolicy": {
                             "asyncReplication": false,
                             "minReplicaSetSize": 3,
@@ -232,7 +308,7 @@
                             "primaryReadCoefficient": 1,
                             "secondaryReadCoefficient": 1
                         },
-                        "queryEngineConfiguration": "{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":true,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlDisableQueryILOptimization\":false,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"
+                        "queryEngineConfiguration": "{\"allowNewKeywords\":true,\"maxJoinsPerSqlQuery\":10,\"maxQueryRequestTimeoutFraction\":0.9,\"maxSqlQueryInputLength\":524288,\"maxUdfRefPerSqlQuery\":10,\"queryMaxInMemorySortDocumentCount\":-1000,\"spatialMaxGeometryPointCount\":256,\"sqlAllowNonFiniteNumbers\":false,\"sqlDisableOptimizationFlags\":0,\"sqlQueryILDisableOptimizationFlags\":0,\"clientDisableOptimisticDirectExecution\":false,\"queryEnableFullText\":true,\"queryEnableFullTextPreviewFeatures\":false,\"queryMaxFullTextScoreSearchTerms\":30,\"queryMaxRrfArgumentCount\":100,\"enableSpatialIndexing\":true,\"maxInExpressionItemsCount\":2147483647,\"maxLogicalAndPerSqlQuery\":2147483647,\"maxLogicalOrPerSqlQuery\":2147483647,\"maxSpatialQueryCells\":2147483647,\"sqlAllowAggregateFunctions\":true,\"sqlAllowGroupByClause\":true,\"sqlAllowLike\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"sqlAllowTop\":true}"
                     }
                 }
             }
@@ -240,7 +316,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs",
                 "body": null,
                 "headers": {}
             },
@@ -250,50 +326,53 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "lsn": [
-                        "18"
-                    ],
-                    "x-ms-activity-id": [
-                        "c8841743-c23e-4bc0-a258-5f5f5b0e3f9b"
-                    ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-number-of-read-regions": [
+                        "0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
                     "x-ms-serviceversion": [
-                        "version=2.11.0.0"
+                        "version=2.14.0.0"
                     ],
-                    "x-ms-resource-usage": [
-                        "databases=1;collections=1;users=0;permissions=0;"
+                    "x-ms-transport-request-id": [
+                        "136283"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.412"
                     ],
                     "x-ms-item-count": [
                         "1"
                     ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-activity-id": [
+                        "e5a227b7-beb3-4244-be8d-d275d9d75d75"
+                    ],
+                    "x-ms-resource-usage": [
+                        "databases=1;collections=1;users=0;permissions=0;clientEncryptionKeys=0;interopUsers=0;authPolicyElements=0;roleDefinitions=0;roleAssignments=0;azureRbac=0;"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:43 GMT"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
                     ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:21 GMT"
+                    "x-ms-session-token": [
+                        "0:-1#13"
                     ],
-                    "x-ms-request-duration-ms": [
-                        "0.554"
-                    ],
-                    "x-ms-transport-request-id": [
-                        "35612"
-                    ],
-                    "x-ms-number-of-read-regions": [
-                        "0"
+                    "x-ms-schemaversion": [
+                        "1.21"
                     ],
                     "x-ms-resource-quota": [
-                        "databases=1000;collections=5000;users=500000;permissions=2000000;"
+                        "databases=1000;collections=5000;users=500000;permissions=2000000;clientEncryptionKeys=20;interopUsers=2000;authPolicyElements=200000;roleDefinitions=100;roleAssignments=2000;azureRbac=200000;"
+                    ],
+                    "lsn": [
+                        "13"
                     ]
                 },
                 "body": {
@@ -302,12 +381,12 @@
                         "Databases": [
                             {
                                 "id": "cctestcdatabase",
-                                "_rid": "JZ07AA==",
-                                "_self": "dbs/JZ07AA==/",
-                                "_etag": "\"00001500-0000-0500-0000-5f9cde870000\"",
+                                "_rid": "yV8QAA==",
+                                "_self": "dbs/yV8QAA==/",
+                                "_etag": "\"0000e101-0000-0500-0000-6a1ef8780000\"",
                                 "_colls": "colls/",
                                 "_users": "users/",
-                                "_ts": 1604116103
+                                "_ts": 1780414584
                             }
                         ],
                         "_count": 1
@@ -318,7 +397,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//dbs/JZ07AA==/colls/",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/dbs/yV8QAA==/colls/",
                 "body": null,
                 "headers": {}
             },
@@ -328,53 +407,56 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "lsn": [
-                        "18"
-                    ],
-                    "x-ms-activity-id": [
-                        "8e33a6e6-c642-4689-998a-e8c5a8b944b8"
-                    ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-number-of-read-regions": [
+                        "0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
+                    "x-ms-alt-content-path": [
+                        "dbs/cctestcdatabase"
                     ],
                     "x-ms-serviceversion": [
-                        "version=2.11.0.0"
+                        "version=2.14.0.0"
                     ],
-                    "x-ms-resource-usage": [
-                        "collections=1;"
+                    "x-ms-transport-request-id": [
+                        "148394"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "1.164"
                     ],
                     "x-ms-item-count": [
                         "1"
                     ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-activity-id": [
+                        "2c53b8cb-f382-4e66-a526-32662ba1979a"
+                    ],
+                    "x-ms-resource-usage": [
+                        "collections=1;"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:43 GMT"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
                     ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:21 GMT"
+                    "x-ms-session-token": [
+                        "0:-1#13"
                     ],
-                    "x-ms-request-duration-ms": [
-                        "0.835"
-                    ],
-                    "x-ms-transport-request-id": [
-                        "30687"
-                    ],
-                    "x-ms-number-of-read-regions": [
-                        "0"
+                    "x-ms-schemaversion": [
+                        "1.21"
                     ],
                     "x-ms-resource-quota": [
                         "collections=5000;"
                     ],
-                    "x-ms-alt-content-path": [
-                        "dbs/cctestcdatabase"
+                    "lsn": [
+                        "13"
                     ]
                 },
                 "body": {
@@ -398,7 +480,8 @@
                                         {
                                             "path": "/\"_etag\"/?"
                                         }
-                                    ]
+                                    ],
+                                    "fullTextIndexes": []
                                 },
                                 "partitionKey": {
                                     "paths": [
@@ -417,15 +500,16 @@
                                 "geospatialConfig": {
                                     "type": "Geography"
                                 },
-                                "_rid": "JZ07ANKIMdw=",
-                                "_ts": 1604116125,
-                                "_self": "dbs/JZ07AA==/colls/JZ07ANKIMdw=/",
-                                "_etag": "\"00001700-0000-0500-0000-5f9cde9d0000\"",
+                                "_rid": "yV8QAL3IfmQ=",
+                                "_ts": 1780414601,
+                                "_self": "DEC0DEDITtVwMoyAuTz1LioKkC+gB/EpRlQKNIaszQEhVidjWyP1kLW1z+jo/MGFHKc+t+M20PxoraNCslng9w==/colls/yV8QAL3IfmQ=/",
+                                "_etag": "\"0000e301-0000-0500-0000-6a1ef8890000\"",
                                 "_docs": "docs/",
                                 "_sprocs": "sprocs/",
                                 "_triggers": "triggers/",
                                 "_udfs": "udfs/",
-                                "_conflicts": "conflicts/"
+                                "_conflicts": "conflicts/",
+                                "computedProperties": []
                             }
                         ],
                         "_count": 1
@@ -436,7 +520,7 @@
         {
             "request": {
                 "method": "POST",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47/listKeys?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -450,16 +534,25 @@
                         "no-store, no-cache"
                     ],
                     "date": [
-                        "Sat, 31 Oct 2020 04:39:22 GMT"
+                        "Tue, 02 Jun 2026 16:06:43 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-ratelimit-remaining-subscription-writes": [
-                        "1196"
-                    ],
                     "content-length": [
                         "461"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "799"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: C573C9AC97C84C2094EF323D01CDCE59 Ref B: MNZ221060608037 Ref C: 2026-06-02T16:06:43Z"
+                    ],
+                    "x-ms-operation-identifier": [
+                        "tenantId=408b7351-82bd-44b5-aed5-59198cd1c1c6,objectId=17285ecf-6528-44e9-a94d-e77024b77418/southcentralus/e5419812-6a51-4bee-9ec7-2ce29a9e7416"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
                     ]
                 },
                 "body": {
@@ -475,7 +568,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39.documents.azure.com/",
+                "uri": "https://cctestcosmosdbc2295d913936.documents.azure.com/",
                 "body": null,
                 "headers": {}
             },
@@ -488,17 +581,17 @@
                     "cache-control": [
                         "no-store, no-cache"
                     ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:43 GMT"
+                    ],
                     "x-ms-databaseaccount-provisioned-mb": [
                         "0"
-                    ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:22 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-max-media-storage-usage-mb": [
-                        "2048"
+                    "x-ms-databaseaccount-reserved-mb": [
+                        "0"
                     ],
                     "x-ms-media-storage-usage-mb": [
                         "0"
@@ -506,31 +599,35 @@
                     "x-ms-databaseaccount-consumed-mb": [
                         "0"
                     ],
-                    "x-ms-databaseaccount-reserved-mb": [
-                        "0"
+                    "x-ms-max-media-storage-usage-mb": [
+                        "2048"
                     ]
                 },
                 "body": {
                     "data": {
                         "_self": "",
-                        "id": "cctestcosmosdbfafbee1d5b39",
-                        "_rid": "cctestcosmosdbfafbee1d5b39.documents.azure.com",
+                        "id": "cctestcosmosdbc2295d913936",
+                        "_rid": "cctestcosmosdbc2295d913936.documents.azure.com",
                         "media": "//media/",
                         "addresses": "//addresses/",
                         "_dbs": "//dbs/",
                         "writableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "readableLocations": [
                             {
                                 "name": "South Central US",
-                                "databaseAccountEndpoint": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com:443/"
+                                "databaseAccountEndpoint": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com:443/"
                             }
                         ],
                         "enableMultipleWriteLocations": false,
+                        "continuousBackupEnabled": false,
+                        "enableNRegionSynchronousCommit": false,
+                        "enablePerPartitionFailoverBehavior": false,
+                        "disableCrossRegionalHedging": false,
                         "userReplicationPolicy": {
                             "asyncReplication": false,
                             "minReplicaSetSize": 3,
@@ -547,7 +644,7 @@
                             "primaryReadCoefficient": 1,
                             "secondaryReadCoefficient": 1
                         },
-                        "queryEngineConfiguration": "{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":true,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlDisableQueryILOptimization\":false,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}"
+                        "queryEngineConfiguration": "{\"allowNewKeywords\":true,\"maxJoinsPerSqlQuery\":10,\"maxQueryRequestTimeoutFraction\":0.9,\"maxSqlQueryInputLength\":524288,\"maxUdfRefPerSqlQuery\":10,\"queryMaxInMemorySortDocumentCount\":-1000,\"spatialMaxGeometryPointCount\":256,\"sqlAllowNonFiniteNumbers\":false,\"sqlDisableOptimizationFlags\":0,\"sqlQueryILDisableOptimizationFlags\":0,\"clientDisableOptimisticDirectExecution\":false,\"queryEnableFullText\":true,\"queryEnableFullTextPreviewFeatures\":false,\"queryMaxFullTextScoreSearchTerms\":30,\"queryMaxRrfArgumentCount\":100,\"enableSpatialIndexing\":true,\"maxInExpressionItemsCount\":2147483647,\"maxLogicalAndPerSqlQuery\":2147483647,\"maxLogicalOrPerSqlQuery\":2147483647,\"maxSpatialQueryCells\":2147483647,\"sqlAllowAggregateFunctions\":true,\"sqlAllowGroupByClause\":true,\"sqlAllowLike\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"sqlAllowTop\":true}"
                     }
                 }
             }
@@ -555,7 +652,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://cctestcosmosdbfafbee1d5b39-southcentralus.documents.azure.com//offers",
+                "uri": "https://cctestcosmosdbc2295d913936-southcentralus.documents.azure.com/offers",
                 "body": null,
                 "headers": {}
             },
@@ -565,44 +662,47 @@
                     "message": "Ok"
                 },
                 "headers": {
-                    "lsn": [
-                        "18"
-                    ],
-                    "x-ms-activity-id": [
-                        "3556a97e-2ee6-4e19-ab8b-7aef89029a12"
-                    ],
-                    "x-ms-request-charge": [
-                        "2"
+                    "x-ms-number-of-read-regions": [
+                        "0"
                     ],
                     "content-type": [
                         "application/json"
                     ],
-                    "x-ms-schemaversion": [
-                        "1.10"
-                    ],
                     "x-ms-serviceversion": [
-                        "version=2.11.0.0"
+                        "version=2.14.0.0"
+                    ],
+                    "x-ms-transport-request-id": [
+                        "150932"
+                    ],
+                    "x-ms-request-duration-ms": [
+                        "0.457"
                     ],
                     "x-ms-item-count": [
                         "1"
                     ],
-                    "x-ms-session-token": [
-                        "0:-1#18"
+                    "x-ms-cosmos-internal-partition-id": [
+                        "77c11823-95f6-4f05-a07b-515159e87e23"
+                    ],
+                    "x-ms-activity-id": [
+                        "6c555027-8e42-4aa5-8d84-c810580cf4e1"
+                    ],
+                    "date": [
+                        "Tue, 02 Jun 2026 16:06:44 GMT"
+                    ],
+                    "x-ms-request-charge": [
+                        "2"
                     ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
-                    "date": [
-                        "Sat, 31 Oct 2020 04:39:22 GMT"
+                    "x-ms-session-token": [
+                        "0:-1#13"
                     ],
-                    "x-ms-request-duration-ms": [
-                        "0.571"
+                    "x-ms-schemaversion": [
+                        "1.21"
                     ],
-                    "x-ms-transport-request-id": [
-                        "46933"
-                    ],
-                    "x-ms-number-of-read-regions": [
-                        "0"
+                    "lsn": [
+                        "13"
                     ]
                 },
                 "body": {
@@ -610,24 +710,23 @@
                         "_rid": "",
                         "Offers": [
                             {
-                                "resource": "dbs/JZ07AA==/colls/JZ07ANKIMdw=/",
+                                "resource": "dbs/yV8QAA==/colls/yV8QAL3IfmQ=/",
                                 "offerType": "Invalid",
-                                "offerResourceId": "JZ07ANKIMdw=",
+                                "offerResourceId": "yV8QAL3IfmQ=",
                                 "offerVersion": "V2",
                                 "content": {
                                     "offerThroughput": 400,
                                     "offerIsRUPerMinuteThroughputEnabled": false,
                                     "offerMinimumThroughputParameters": {
-                                        "maxThroughputEverProvisioned": 500,
+                                        "maxThroughputEverProvisioned": 400,
                                         "maxConsumedStorageEverInKB": 0
-                                    },
-                                    "offerLastReplaceTimestamp": 1604118651
+                                    }
                                 },
-                                "id": "+1KO",
-                                "_rid": "+1KO",
-                                "_self": "offers/+1KO/",
-                                "_etag": "\"0000bb05-0000-0500-0000-5f9ce8b70000\"",
-                                "_ts": 1604118711
+                                "id": "VYd4",
+                                "_rid": "VYd4",
+                                "_self": "offers/VYd4/",
+                                "_etag": "\"0000e401-0000-0500-0000-6a1ef8890000\"",
+                                "_ts": 1780414601
                             }
                         ],
                         "_count": 1
@@ -638,7 +737,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47?api-version=2019-08-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/providers/Microsoft.DocumentDB/databaseAccounts/cctestcosmosdbc129bfa71a47?api-version=2025-10-15",
                 "body": null,
                 "headers": {}
             },
@@ -648,17 +747,26 @@
                     "message": "Ok"
                 },
                 "headers": {
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ],
                     "cache-control": [
                         "no-store, no-cache"
                     ],
                     "date": [
-                        "Sat, 31 Oct 2020 04:40:23 GMT"
+                        "Tue, 02 Jun 2026 16:08:45 GMT"
                     ],
                     "content-type": [
                         "application/json"
                     ],
                     "content-length": [
-                        "2324"
+                        "3342"
+                    ],
+                    "x-msedge-ref": [
+                        "Ref A: EFBD835CAAC24BA7AA5C553E719F2973 Ref B: BL2AA2011006040 Ref C: 2026-06-02T16:08:44Z"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
                     ]
                 },
                 "body": {
@@ -669,16 +777,17 @@
                         "type": "Microsoft.DocumentDB/databaseAccounts",
                         "kind": "GlobalDocumentDB",
                         "tags": {
-                            "test-store-throughput": "JZ07ANKIMdw=:4",
-                            "test-restore-throughput": "JZ07ANKIMdw=:4"
+                            "test-store-throughput": "yV8QAL3IfmQ=:4"
                         },
                         "systemData": {
-                            "createdAt": "2020-10-31T03:48:04.4977476Z"
+                            "createdAt": "2026-06-02T15:35:43.1591888+00:00"
                         },
                         "properties": {
                             "provisioningState": "Succeeded",
                             "documentEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
-                            "enableAutomaticFailover": false,
+                            "sqlEndpoint": "https://cctestcosmosdbc129bfa71a47.documents.azure.com:443/",
+                            "publicNetworkAccess": "Enabled",
+                            "enableAutomaticFailover": true,
                             "enableMultipleWriteLocations": false,
                             "enablePartitionKeyMonitor": false,
                             "isVirtualNetworkFilterEnabled": false,
@@ -687,16 +796,27 @@
                             "disableKeyBasedMetadataWriteAccess": false,
                             "enableFreeTier": false,
                             "enableAnalyticalStorage": false,
-                            "instanceId": "4649d200-f0d6-460e-8fd7-eac29464b96a",
-                            "createMode": "Default",
+                            "analyticalStorageConfiguration": {},
+                            "instanceId": "cd33901d-044f-474a-a5a8-c77629c7a17d",
                             "databaseAccountOfferType": "Standard",
-                            "ipRangeFilter": "67.185.99.110,104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26",
+                            "defaultIdentity": "FirstPartyIdentity",
+                            "networkAclBypass": "None",
+                            "disableLocalAuth": false,
+                            "enablePartitionMerge": false,
+                            "enablePerRegionPerPartitionAutoscale": true,
+                            "enableBurstCapacity": false,
+                            "enablePriorityBasedExecution": false,
+                            "defaultPriorityLevel": "High",
+                            "minimalTlsVersion": "Tls12",
+                            "enablePerPartitionAutomaticFailover": false,
                             "consistencyPolicy": {
                                 "defaultConsistencyLevel": "Session",
                                 "maxIntervalInSeconds": 5,
                                 "maxStalenessPrefix": 100
                             },
-                            "configurationOverrides": {},
+                            "configurationOverrides": {
+                                "EnablePerRegionPerPartitionAutoscaleOptIn": "True"
+                            },
                             "writeLocations": [
                                 {
                                     "id": "cctestcosmosdbc129bfa71a47-southcentralus",
@@ -736,13 +856,52 @@
                             ],
                             "cors": [],
                             "capabilities": [],
+                            "ipRules": [
+                                {
+                                    "ipAddressOrRange": "173.2.147.78"
+                                },
+                                {
+                                    "ipAddressOrRange": "104.42.195.92"
+                                },
+                                {
+                                    "ipAddressOrRange": "40.76.54.131"
+                                },
+                                {
+                                    "ipAddressOrRange": "52.176.6.30"
+                                },
+                                {
+                                    "ipAddressOrRange": "52.169.50.45"
+                                },
+                                {
+                                    "ipAddressOrRange": "52.187.184.26"
+                                }
+                            ],
                             "backupPolicy": {
                                 "type": "Periodic",
                                 "periodicModeProperties": {
                                     "backupIntervalInMinutes": 240,
-                                    "backupRetentionIntervalInHours": 8
+                                    "backupRetentionIntervalInHours": 8,
+                                    "backupStorageRedundancy": "Geo"
+                                }
+                            },
+                            "networkAclBypassResourceIds": [],
+                            "keysMetadata": {
+                                "primaryMasterKey": {
+                                    "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                },
+                                "secondaryMasterKey": {
+                                    "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                },
+                                "primaryReadonlyMasterKey": {
+                                    "generationTime": "2026-06-02T15:35:43.1591888+00:00"
+                                },
+                                "secondaryReadonlyMasterKey": {
+                                    "generationTime": "2026-06-02T15:35:43.1591888+00:00"
                                 }
                             }
+                        },
+                        "identity": {
+                            "type": "None"
                         }
                     }
                 }

--- a/uv.lock
+++ b/uv.lock
@@ -504,16 +504,16 @@ wheels = [
 
 [[package]]
 name = "azure-mgmt-cosmosdb"
-version = "6.4.0"
+version = "9.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-common" },
     { name = "azure-mgmt-core" },
     { name = "msrest" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/81/d6d8812775b253c698e29c4f0f4a983aa4111b874fa9a9f2ae153b9e515a/azure-mgmt-cosmosdb-6.4.0.zip", hash = "sha256:fb6b8ab80ab97214b94ae9e462ba1c459b68a3af296ffc26317ebd3ff500e00b", size = 344309, upload-time = "2021-06-22T02:47:24.021Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/e3/8687e481a34c83f5a6e6d9d3a084c8344920aaf6a505b19a299e58f20421/azure_mgmt_cosmosdb-9.9.0.tar.gz", hash = "sha256:4678bf042bdc208aa24fca71767ac29b6f2a2722ac7872608371a5922f3b6c37", size = 285338, upload-time = "2025-11-14T06:29:06.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/f7/2e28b1881382247cdbc150b0f19c58987c802815568ddd02284de5b1c15f/azure_mgmt_cosmosdb-6.4.0-py2.py3-none-any.whl", hash = "sha256:aa10e728be4706189173916e7ecb49da98a8b96fbacbec1d2b48ca6cdad3efc9", size = 290550, upload-time = "2021-06-22T02:47:21.431Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/6b/19a16013a805e506f5e775d79587859852b1a07dd6ae5b377ab541ef4692/azure_mgmt_cosmosdb-9.9.0-py3-none-any.whl", hash = "sha256:31322770c61fdca6bcd1444e9dad501a5a225879c152ec1fd57ab5c68901a1fa", size = 420362, upload-time = "2025-11-14T06:29:09.083Z" },
 ]
 
 [[package]]
@@ -1556,7 +1556,7 @@ requires-dist = [
     { name = "azure-mgmt-containerinstance", specifier = ">=7.0.0,<8.0.0" },
     { name = "azure-mgmt-containerregistry", specifier = ">=14.0.0,<15.0.0" },
     { name = "azure-mgmt-containerservice", specifier = ">=15.0.0,<16.0.0" },
-    { name = "azure-mgmt-cosmosdb", specifier = ">=6.1.0,<7.0.0" },
+    { name = "azure-mgmt-cosmosdb", specifier = ">=6.1.0,<10.0.0" },
     { name = "azure-mgmt-costmanagement", specifier = ">=1.0.0,<2.0.0" },
     { name = "azure-mgmt-databricks", specifier = "==1.0.0b1" },
     { name = "azure-mgmt-datafactory", specifier = ">=1.0.0,<2.0.0" },


### PR DESCRIPTION
Pick up new service model data, and avoid depending on a deprecated API
version.

After reviewing changelogs and re-recording tests, as far as I could tell this jump only required 1 code change (adjusting the matching logic of the `offer` filter).

Resolves https://github.com/cloud-custodian/cloud-custodian/issues/10701