### PR TITLE
aws - vpc-endpoint - add delete action

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -2820,6 +2820,19 @@ class VpcEndpoint(query.QueryResourceManager):
         cfn_type = config_type = "AWS::EC2::VPCEndpoint"
 
 
+@VpcEndpoint.action_registry.register('delete')
+class DeleteVpcEndpoint(BaseAction):
+
+    schema = type_schema('delete')
+    permissions = ('ec2:DeleteVpcEndpoints',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('ec2')
+        for resource_set in chunks(resources, 25):
+            client.delete_vpc_endpoints(
+                VpcEndpointIds=[r['VpcEndpointId'] for r in resource_set])
+
+
 @VpcEndpoint.filter_registry.register('metrics')
 class VpcEndpointMetricsFilter(MetricsFilter):
 

--- a/tests/data/placebo/test_vpc_endpoint_delete/ec2.DeleteVpcEndpoints_1.json
+++ b/tests/data/placebo/test_vpc_endpoint_delete/ec2.DeleteVpcEndpoints_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Unsuccessful": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_endpoint_delete/ec2.DescribeVpcEndpoints_1.json
+++ b/tests/data/placebo/test_vpc_endpoint_delete/ec2.DescribeVpcEndpoints_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "VpcEndpoints": [
+            {
+                "VpcEndpointId": "vpce-0f0a1d8b9f7c1a2b3",
+                "VpcEndpointType": "Interface",
+                "VpcId": "vpc-0a1b2c3d4e5f60718",
+                "ServiceName": "com.amazonaws.us-east-1.ssm",
+                "State": "available",
+                "PolicyDocument": "{\"Statement\":[{\"Action\":\"*\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Resource\":\"*\"}]}",
+                "RouteTableIds": [],
+                "SubnetIds": [
+                    "subnet-0123456789abcdef0"
+                ],
+                "Groups": [
+                    {
+                        "GroupId": "sg-0123456789abcdef0",
+                        "GroupName": "default"
+                    }
+                ],
+                "PrivateDnsEnabled": true,
+                "RequesterManaged": false,
+                "NetworkInterfaceIds": [
+                    "eni-0123456789abcdef0"
+                ],
+                "DnsEntries": [],
+                "OwnerId": "644160558196",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "c7n-test"
+                    }
+                ],
+                "CreationTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 5,
+                    "hour": 12,
+                    "minute": 0,
+                    "second": 0,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_vpc_endpoint_delete/ec2.DescribeVpcEndpoints_2.json
+++ b/tests/data/placebo/test_vpc_endpoint_delete/ec2.DescribeVpcEndpoints_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "VpcEndpoints": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/vpc_endpoint_delete/main.tf
+++ b/tests/terraform/vpc_endpoint_delete/main.tf
@@ -1,0 +1,44 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block       = "10.0.0.0/16"
+  instance_tenancy = "default"
+
+  tags = {
+    Name = "c7n-test"
+  }
+}
+
+resource "aws_subnet" "main" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "c7n-test"
+  }
+}
+
+resource "aws_security_group" "main" {
+  name_prefix = "c7n-test"
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "c7n-test"
+  }
+}
+
+resource "aws_vpc_endpoint" "main" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.us-east-1.ssm"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.main.id]
+  security_group_ids  = [aws_security_group.main.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "c7n-test"
+  }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -3871,6 +3871,32 @@ class EndpointTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["c7n:matched-security-groups"], ["sg-6c7fa917"])
 
+    def test_endpoint_delete_action(self):
+        factory = self.replay_flight_data("test_vpc_endpoint_delete")
+        p = self.load_policy(
+            {
+                "name": "endpoint-delete",
+                "resource": "vpc-endpoint",
+                "filters": [{"tag:Name": "c7n-test"}],
+                "actions": ["delete"],
+            },
+            session_factory=factory,
+        )
+        self.assertEqual(
+            p.resource_manager.actions[0].get_permissions(),
+            ("ec2:DeleteVpcEndpoints",))
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["VpcEndpointId"], "vpce-0f0a1d8b9f7c1a2b3")
+
+        client = factory(region="us-east-1").client("ec2")
+        endpoints = client.describe_vpc_endpoints(
+            Filters=[{"Name": "vpc-endpoint-id", "Values": [resources[0]["VpcEndpointId"]]}]
+        )[
+            "VpcEndpoints"
+        ]
+        self.assertFalse(endpoints)
+
     def test_endpoint_cross_account(self):
         session_factory = self.replay_flight_data('test_vpce_cross_account')
         p = self.load_policy(


### PR DESCRIPTION
I have added delete action to the vpc endpoint resource. 
```
policies:
  - name: vpce-sg-tag-check
     tags:
        - periodic
       resource: aws.vpc-endpoint
       description: |
            Identify VPC endpoint for OpenSearch Serverless that have specific tag
       filters:
          - type: value
             key: ServiceName
             op: contains
             value: "aoss"
           - type: security-group
              key: "tag:,<key>:resource-type"
              op: ne
              value: aoss
       actions:
          - type: delete
          - type: notify
```