### PR TITLE
[WAFv2] using us-east-1 for CLOUDFRONT scope logging calls

### DIFF
--- a/c7n/resources/waf.py
+++ b/c7n/resources/waf.py
@@ -10,6 +10,15 @@ from c7n.exceptions import PolicyValidationError
 from c7n.resources.aws import shape_validate
 
 
+def wafv2_scope_region(scope, default_region):
+    """Region to use for wafv2 API calls given a WebACL's Scope.
+
+    CLOUDFRONT WebACLs are global resources addressed via us-east-1; all other
+    (REGIONAL) WebACLs use the policy's region.
+    """
+    return 'us-east-1' if scope == 'CLOUDFRONT' else default_region
+
+
 class DescribeRegionalWaf(DescribeSource):
     def get_permissions(self):
         perms = super().get_permissions()
@@ -202,16 +211,21 @@ class WAFV2LoggingFilter(ValueFilter):
     annotation_key = 'c7n:WafV2LoggingConfiguration'
 
     def process(self, resources, event=None):
-        client = local_session(self.manager.session_factory).client(
-            'wafv2', region_name=self.manager.region
-        )
-        logging_confs = client.list_logging_configurations(Scope='REGIONAL')[
-            'LoggingConfigurations'
-        ]
         resource_map = {r['ARN']: r for r in resources}
-        for lc in logging_confs:
-            if lc['ResourceArn'] in resource_map:
-                resource_map[lc['ResourceArn']][self.annotation_key] = lc
+        # CLOUDFRONT logging configs are only listable from us-east-1 with the
+        # CLOUDFRONT scope; query each scope present against its matching region.
+        scopes = {r.get('Scope') or 'REGIONAL' for r in resources}
+        for scope in scopes:
+            region = wafv2_scope_region(scope, self.manager.region)
+            client = local_session(self.manager.session_factory).client(
+                'wafv2', region_name=region
+            )
+            logging_confs = client.list_logging_configurations(Scope=scope)[
+                'LoggingConfigurations'
+            ]
+            for lc in logging_confs:
+                if lc['ResourceArn'] in resource_map:
+                    resource_map[lc['ResourceArn']][self.annotation_key] = lc
 
         resources = list(resource_map.values())
 
@@ -292,13 +306,21 @@ class WAFV2SetLogging(BaseAction):
         return self
 
     def process(self, resources):
-        client = local_session(self.manager.session_factory).client(
-            'wafv2', region_name=self.manager.region
-        )
         destination = self.data['destination']
         attributes = self.data.get('attributes', {})
+        # CLOUDFRONT WebACLs are global resources whose ARNs live in us-east-1;
+        # PutLoggingConfiguration must target that region regardless of the policy
+        # region.
+        clients = {}
 
         for r in resources:
+            region = wafv2_scope_region(r.get('Scope'), self.manager.region)
+            if region not in clients:
+                clients[region] = local_session(
+                    self.manager.session_factory
+                ).client('wafv2', region_name=region)
+            client = clients[region]
+
             resource_arn = r['ARN']
             logging_config = {
                 'ResourceArn': resource_arn,

--- a/tests/test_waf.py
+++ b/tests/test_waf.py
@@ -111,6 +111,51 @@ class WAFTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1, f"Expected 1 resource, got {len(resources)}")
 
+    def test_wafv2_set_logging_cloudfront(self):
+        session_factory = self.replay_flight_data("test_wafv2_set_logging_enabled")
+
+        wafv2_regions = []
+
+        def spy_factory(*args, **kw):
+            session = session_factory(*args, **kw)
+            real_client = session.client
+
+            def client(*cargs, **ckw):
+                if cargs and cargs[0] == 'wafv2':
+                    region = ckw.get('region_name')
+                    if region is None and len(cargs) > 1:
+                        region = cargs[1]
+                    wafv2_regions.append(region)
+                return real_client(*cargs, **ckw)
+
+            session.client = client
+            return session
+
+        if hasattr(session_factory, 'region'):
+            spy_factory.region = session_factory.region
+
+        policy = {
+                "name": "enable-wafv2-cloudfront-logging",
+                "resource": "aws.wafv2",
+                "query": [{"Scope": "CLOUDFRONT"}],
+                "filters": [{"Name": "noncompliant_waf"}],
+                "actions": [
+                    {
+                        "type": "set-logging",
+                        "destination": "arn:aws:s3:::aws-waf-logs-test-custodian-creation",
+                    }
+                ],
+            }
+        p = self.load_policy(policy,
+                             session_factory=spy_factory,
+                             config={"region": "us-west-2"})
+
+        resources = p.run()
+        self.assertEqual(len(resources), 1, f"Expected 1 resource, got {len(resources)}")
+        self.assertEqual(resources[0]["Scope"], "CLOUDFRONT")
+        self.assertIn("us-east-1", wafv2_regions)
+        self.assertNotIn("us-west-2", wafv2_regions)
+
     def test_wafv2_set_logging_invalid_destination(self):
         session_factory = self.replay_flight_data("test_wafv2_set_logging_invalid_destination")
 


### PR DESCRIPTION
 Currently, `set-logging` on `aws.wafv2` fails with `WAFInvalidParameterException` when remediating CLOUDFRONT-scoped WebACLs from any region other than `us-east-1`. CLOUDFRONT WebACLs are global resources addressed via `us-east-1`, but`WAFV2SetLogging.process()` (and `WAFV2LoggingFilter.process()`) was set to`self.manager.region`, so the calls are being sent to the policy's region and rejected.


- This PR adds `wafv2_scope_region(scope, default_region)` which maps `CLOUDFRONT -> us-east-1`, everything else -> policy region (the same rule  used in `WafV2ResourceQuery` and `DescribeWafV2.augment`). The logging filter also now queries each scope against its  matching region instead of always assuming REGIONAL."
- Added test_wafv2_set_logging_cloudfront, which runs a CLOUDFRONT policy in us-west-2 and asserts the call is routed to us-east-1 (reused existing flight data).
