### PR TITLE
chore: improve cloud-custodian maintenance path

### DIFF
--- a/tests/test_zpill.py
+++ b/tests/test_zpill.py
@@ -1,0 +1,68 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
+from io import BytesIO
+
+import pytest
+from botocore.response import StreamingBody
+
+from tests.zpill import deserialize, serialize, utc
+
+
+class TestSerialize:
+
+    def test_serialize_datetime(self):
+        dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=utc)
+        result = serialize(dt)
+        assert result == {
+            "__class__": "datetime",
+            "year": 2023,
+            "month": 1,
+            "day": 1,
+            "hour": 12,
+            "minute": 0,
+            "second": 0,
+            "microsecond": 0,
+        }
+
+    def test_serialize_bytes(self):
+        result = serialize(b"hello")
+        assert result == "aGVsbG8="
+
+    def test_serialize_unknown_type(self):
+        with pytest.raises(TypeError, match="not serializable"):
+            serialize("hello")
+
+
+class TestDeserialize:
+
+    def test_deserialize_datetime(self):
+        obj = {"__class__": "datetime", "year": 2023, "month": 1, "day": 1}
+        result = deserialize(obj)
+        assert isinstance(result, datetime)
+        assert result == datetime(2023, 1, 1, tzinfo=utc)
+
+    def test_deserialize_datetime_with_module_does_not_mutate_input(self):
+        """Ensure deserialize pops __module__ from its working copy, not the original dict."""
+        obj = {
+            "__class__": "datetime",
+            "__module__": "datetime",
+            "year": 2023,
+            "month": 1,
+            "day": 1,
+        }
+        original = dict(obj)
+        result = deserialize(obj)
+        assert isinstance(result, datetime)
+        assert obj == original
+
+    def test_deserialize_streaming_body(self):
+        obj = {"__class__": "StreamingBody", "body": b"dGVzdA=="}
+        result = deserialize(obj)
+        assert isinstance(result, StreamingBody)
+        assert result.read() == b"test"
+
+    def test_deserialize_unrecognized_returns_as_is(self):
+        obj = {"foo": "bar"}
+        result = deserialize(obj)
+        assert result == {"foo": "bar"}

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -59,8 +59,8 @@ def deserialize(obj):
     class_name = None
     if "__class__" in target:
         class_name = target.pop("__class__")
-    if "__module__" in obj:
-        obj.pop("__module__")
+    if "__module__" in target:
+        target.pop("__module__")
     # Use getattr(module, class_name) for custom types if needed
     if class_name == "datetime":
         return datetime(tzinfo=utc, **target)


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/zpill.py, tests/common.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.