### PR TITLE
AWS - resource: kms-key - Added last-usage filter for KMS Keys

### DIFF
--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -494,6 +494,142 @@ class LastRotation(ValueFilter):
         return results
 
 
+@Key.filter_registry.register('last-usage')
+class LastUsage(ValueFilter):
+    """Filters KMS keys by their last usage information.
+
+    Uses the ``GetKeyLastUsage`` API to determine when a key was last used
+    for a cryptographic operation, enabling identification of stale or
+    unused keys.
+
+    The ``KeyLastUsage`` response contains the last tracked cryptographic
+    operation, its timestamp, and the associated CloudTrail event ID.
+    If the key has never been used since tracking began, ``KeyLastUsage``
+    will be empty.
+
+    Only successful cryptographic operations are tracked. Non-cryptographic
+    operations (e.g., ``DescribeKey``, ``ListKeys``) are not recorded.
+
+    For more details, see:
+    https://docs.aws.amazon.com/kms/latest/developerguide/monitoring-keys-determining-usage.html
+
+    .. warning::
+
+       Do not use ``GetKeyLastUsage`` as the sole indicator when scheduling
+       a key for deletion. Instead, first disable the key and monitor
+       CloudTrail for ``DisabledException`` entries, as there could be
+       infrequent workflows that depend on the key.
+
+    :example:
+
+    Find keys not used in the last 30 days:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: kms-unused-keys-30-days
+                resource: kms-key
+                filters:
+                  - type: last-usage
+                    key: Timestamp
+                    value: 30
+                    value_type: age
+                    op: gte
+
+    Find keys that have never been used since tracking began:
+
+    .. code-block:: yaml
+
+              - name: kms-never-used-keys
+                resource: kms-key
+                filters:
+                  - type: last-usage
+                    key: Timestamp
+                    value: absent
+
+    Find keys last used for a specific operation:
+
+    .. code-block:: yaml
+
+              - name: kms-keys-used-for-decrypt
+                resource: kms-key
+                filters:
+                  - type: last-usage
+                    key: Operation
+                    value: Decrypt
+
+    """
+
+    # Tracked cryptographic operations returned by GetKeyLastUsage.
+    # Reference: https://docs.aws.amazon.com/kms/latest/developerguide/
+    #   monitoring-keys-determining-usage.html#determining-usage-key-last-usage-tracking
+    TRACKED_OPERATIONS = [
+        'Decrypt',
+        'DeriveSharedSecret',
+        'Encrypt',
+        'GenerateDataKey',
+        'GenerateDataKeyPair',
+        'GenerateDataKeyPairWithoutPlaintext',
+        'GenerateDataKeyWithoutPlaintext',
+        'GenerateMac',
+        'ReEncrypt',
+        'Sign',
+        'Verify',
+        'VerifyMac',
+    ]
+
+    schema = type_schema('last-usage', rinherit=ValueFilter.schema)
+    schema_alias = False
+    permissions = ('kms:GetKeyLastUsage',)
+    annotation_key = 'c7n:LastUsage'
+
+    def validate(self):
+        """Validate filter configuration.
+
+        If filtering by Operation, ensure the value is a recognized
+        tracked cryptographic operation.
+        """
+        attrs = dict(self.data)
+        attrs.pop('type', None)
+        if attrs.get('key') == 'Operation' and attrs.get('op', 'eq') == 'eq':
+            op_value = attrs.get('value')
+            if op_value and op_value not in self.TRACKED_OPERATIONS:
+                raise ValueError(
+                    f"Invalid Operation value '{op_value}'. "
+                    f"Valid operations: {', '.join(self.TRACKED_OPERATIONS)}"
+                )
+        return self
+
+    def get_last_usage(self, client, key_id):
+        """Retrieve last usage info for a KMS key.
+
+        Returns the ``KeyLastUsage`` dict from the API response,
+        or an empty dict if the key has never been used, or None
+        if an error occurred.
+        """
+        last_usage = None
+        try:
+            result = client.get_key_last_usage(KeyId=key_id)
+            # Empty dict means key has not been used since tracking began
+            last_usage = result.get('KeyLastUsage') or {}
+        except ClientError as err:
+            self.log.warning(err)
+        return last_usage
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('kms')
+        results = []
+
+        for r in resources:
+            if self.annotation_key not in r:
+                r[self.annotation_key] = self.get_last_usage(client, r['KeyId'])
+
+            if self.match(r[self.annotation_key]):
+                results.append(r)
+
+        return results
+
+
 @Key.action_registry.register("schedule-deletion")
 class KmsKeyScheduleDeletion(BaseAction):
     """Schedule KMS key deletion

--- a/tests/data/placebo/test_kms_last_usage/kms.DescribeKey_1.json
+++ b/tests/data/placebo/test_kms_last_usage/kms.DescribeKey_1.json
@@ -1,0 +1,27 @@
+{
+  "status_code": 200,
+  "data": {
+    "KeyMetadata": {
+      "Origin": "AWS_KMS",
+      "KeyId": "9a2e037b-c775-4bb0-a74f-85619da32b74",
+      "Description": "",
+      "KeyManager": "CUSTOMER",
+      "Enabled": true,
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "KeyState": "Enabled",
+      "CreationDate": {
+        "hour": 19,
+        "__class__": "datetime",
+        "month": 7,
+        "second": 29,
+        "microsecond": 216000,
+        "year": 2025,
+        "day": 29,
+        "minute": 25
+      },
+      "Arn": "arn:aws:kms:us-east-1:644160558196:key/9a2e037b-c775-4bb0-a74f-85619da32b74",
+      "AWSAccountId": "644160558196"
+    },
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage/kms.GetKeyLastUsage_1.json
+++ b/tests/data/placebo/test_kms_last_usage/kms.GetKeyLastUsage_1.json
@@ -1,0 +1,42 @@
+{
+  "status_code": 200,
+  "data": {
+    "KeyId": "9a2e037b-c775-4bb0-a74f-85619da32b74",
+    "KeyLastUsage": {
+      "Operation": "Decrypt",
+      "Timestamp": {
+        "hour": 7,
+        "__class__": "datetime",
+        "month": 5,
+        "second": 19,
+        "microsecond": 721000,
+        "year": 2026,
+        "day": 1,
+        "minute": 6
+      },
+      "CloudTrailEventId": "73595a59-3b0c-3fab-a33b-98452d4d6e88",
+      "KmsRequestId": "2fd736ba-80c8-4638-a4d9-b02fcf2cbf98"
+    },
+    "TrackingStartDate": {
+      "hour": 0,
+      "__class__": "datetime",
+      "month": 4,
+      "second": 0,
+      "microsecond": 0,
+      "year": 2026,
+      "day": 23,
+      "minute": 0
+    },
+    "KeyCreationDate": {
+      "hour": 19,
+      "__class__": "datetime",
+      "month": 7,
+      "second": 29,
+      "microsecond": 216000,
+      "year": 2025,
+      "day": 29,
+      "minute": 25
+    },
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage/kms.ListAliases_1.json
+++ b/tests/data/placebo/test_kms_last_usage/kms.ListAliases_1.json
@@ -1,0 +1,8 @@
+{
+  "status_code": 200,
+  "data": {
+    "Aliases": [],
+    "Truncated": false,
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage/kms.ListKeys_1.json
+++ b/tests/data/placebo/test_kms_last_usage/kms.ListKeys_1.json
@@ -1,0 +1,13 @@
+{
+  "status_code": 200,
+  "data": {
+    "Keys": [
+      {
+        "KeyArn": "arn:aws:kms:us-east-1:644160558196:key/9a2e037b-c775-4bb0-a74f-85619da32b74",
+        "KeyId": "9a2e037b-c775-4bb0-a74f-85619da32b74"
+      }
+    ],
+    "ResponseMetadata": {},
+    "Truncated": false
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_kms_last_usage/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+  "status_code": 200,
+  "data": {
+    "PaginationToken": "",
+    "ResourceTagMappingList": [],
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage_never_used/kms.DescribeKey_1.json
+++ b/tests/data/placebo/test_kms_last_usage_never_used/kms.DescribeKey_1.json
@@ -1,0 +1,27 @@
+{
+  "status_code": 200,
+  "data": {
+    "KeyMetadata": {
+      "Origin": "AWS_KMS",
+      "KeyId": "abcd1234-5678-90ab-cdef-1234567890ab",
+      "Description": "",
+      "KeyManager": "CUSTOMER",
+      "Enabled": true,
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "KeyState": "Enabled",
+      "CreationDate": {
+        "hour": 10,
+        "__class__": "datetime",
+        "month": 5,
+        "second": 0,
+        "microsecond": 0,
+        "year": 2026,
+        "day": 1,
+        "minute": 0
+      },
+      "Arn": "arn:aws:kms:us-east-1:644160558196:key/abcd1234-5678-90ab-cdef-1234567890ab",
+      "AWSAccountId": "644160558196"
+    },
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage_never_used/kms.GetKeyLastUsage_1.json
+++ b/tests/data/placebo/test_kms_last_usage_never_used/kms.GetKeyLastUsage_1.json
@@ -1,0 +1,28 @@
+{
+  "status_code": 200,
+  "data": {
+    "KeyId": "abcd1234-5678-90ab-cdef-1234567890ab",
+    "KeyLastUsage": {},
+    "TrackingStartDate": {
+      "hour": 0,
+      "__class__": "datetime",
+      "month": 4,
+      "second": 0,
+      "microsecond": 0,
+      "year": 2026,
+      "day": 23,
+      "minute": 0
+    },
+    "KeyCreationDate": {
+      "hour": 10,
+      "__class__": "datetime",
+      "month": 5,
+      "second": 0,
+      "microsecond": 0,
+      "year": 2026,
+      "day": 1,
+      "minute": 0
+    },
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage_never_used/kms.ListAliases_1.json
+++ b/tests/data/placebo/test_kms_last_usage_never_used/kms.ListAliases_1.json
@@ -1,0 +1,8 @@
+{
+  "status_code": 200,
+  "data": {
+    "Aliases": [],
+    "Truncated": false,
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage_never_used/kms.ListKeys_1.json
+++ b/tests/data/placebo/test_kms_last_usage_never_used/kms.ListKeys_1.json
@@ -1,0 +1,13 @@
+{
+  "status_code": 200,
+  "data": {
+    "Keys": [
+      {
+        "KeyArn": "arn:aws:kms:us-east-1:644160558196:key/abcd1234-5678-90ab-cdef-1234567890ab",
+        "KeyId": "abcd1234-5678-90ab-cdef-1234567890ab"
+      }
+    ],
+    "ResponseMetadata": {},
+    "Truncated": false
+  }
+}

--- a/tests/data/placebo/test_kms_last_usage_never_used/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_kms_last_usage_never_used/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+  "status_code": 200,
+  "data": {
+    "PaginationToken": "",
+    "ResourceTagMappingList": [],
+    "ResponseMetadata": {}
+  }
+}

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -180,6 +180,68 @@ class KMSTest(BaseTest):
         self.assertIn("AccessDenied", log.getvalue())
         self.assertEqual(len(resources), 2)
 
+    def test_last_usage(self):
+        session_factory = self.replay_flight_data("test_kms_last_usage")
+        p = self.load_policy(
+            {
+                "name": "kms-last-usage",
+                "resource": "kms-key",
+                "filters": [
+                    {
+                        "type": "last-usage",
+                        "key": "Timestamp",
+                        "value": 30,
+                        "value_type": "age",
+                        "op": "gte",
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        with freeze_time("2026-06-07T00:00:00+00:00"):
+            resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertIn("c7n:LastUsage", resources[0])
+        self.assertIn("Timestamp", resources[0]["c7n:LastUsage"])
+        self.assertEqual(resources[0]["c7n:LastUsage"]["Operation"], "Decrypt")
+
+    def test_last_usage_never_used(self):
+        session_factory = self.replay_flight_data("test_kms_last_usage_never_used")
+        p = self.load_policy(
+            {
+                "name": "kms-never-used",
+                "resource": "kms-key",
+                "filters": [
+                    {
+                        "type": "last-usage",
+                        "key": "Timestamp",
+                        "value": "absent",
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["c7n:LastUsage"], {})
+
+    def test_last_usage_invalid_operation(self):
+        self.assertRaises(
+            ValueError,
+            self.load_policy,
+            {
+                "name": "kms-invalid-operation",
+                "resource": "kms-key",
+                "filters": [
+                    {
+                        "type": "last-usage",
+                        "key": "Operation",
+                        "value": "InvalidOp",
+                    }
+                ],
+            },
+        )
+
     def test_key_rotation_exception_unsupportedopp(self):
         region = "us-west-2"
         session_factory = self.replay_flight_data(


### PR DESCRIPTION
## Feature Overview

Adds a new `last-usage` filter for KMS Keys that leverages the AWS [`GetKeyLastUsage`](https://docs.aws.amazon.com/kms/latest/APIReference/API_GetKeyLastUsage.html) API (released April 2026). This enables governance policies to identify stale or never-used KMS keys.

This is an enhancement of #10781.

The filter supports:
- **Age-based filtering** — find keys not used in N days
- **Never-used detection** — identify keys that have never performed a cryptographic operation
- **Operation-specific filtering** — target keys by their last operation type
- **Resource annotation** — adds `c7n:LastUsage` annotation to each processed key containing the last usage metadata (Timestamp, Operation, CloudTrailEventId, KmsRequestId)

## Example Policies

### Customer-managed CMK keys unused for up to 365 days

```yaml
policies:
  - name: kms-cmk-unused-365-days
    resource: aws.kms-key
    filters:
      - type: value
        key: KeyManager
        value: CUSTOMER
      - type: last-usage
        key: Timestamp
        value_type: age
        value: 365
        op: gte
```

### Keys never used

```yaml
policies:
  - name: kms-keys-never-used
    resource: aws.kms-key
    filters:
      - type: value
        key: KeyManager
        value: CUSTOMER
      - type: last-usage
        key: Timestamp
        value: absent
```

### Keys last used for Decrypt operation

```yaml
policies:
  - name: kms-keys-last-decrypt
    resource: aws.kms-key
    filters:
      - type: last-usage
        key: Operation
        value: Decrypt
```

## Supported Operations

The supported operations are taken from the AWS documentation:
[`GetKeyLastUsage` API Reference](https://docs.aws.amazon.com/kms/latest/APIReference/API_GetKeyLastUsage.html)

`Encrypt`, `Decrypt`, `GenerateDataKey`, `GenerateDataKeyWithoutPlaintext`, `GenerateDataKeyPair`, `GenerateDataKeyPairWithoutPlaintext`, `ReEncrypt`, `Sign`, `Verify`, `GenerateMac`, `VerifyMac`, `DeriveSharedSecret`

## Testing

- 3 unit tests covering: age-based filtering, never-used keys, and invalid operation validation
- Live-tested against AWS account with customer-managed keys