### PR TITLE
escape untrusted uid before building ldap filter

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/ldap_lookup.py
+++ b/tools/c7n_mailer/c7n_mailer/ldap_lookup.py
@@ -13,6 +13,7 @@ else:
     have_sqlite = True
 from ldap3 import Connection
 from ldap3.core.exceptions import LDAPSocketOpenError
+from ldap3.utils.conv import escape_filter_chars
 
 
 class LdapLookup:
@@ -145,7 +146,7 @@ class LdapLookup:
                 cache_msg = "Got ldap metadata from local cache for: %s" % uid
                 self.log.debug(cache_msg)
                 return cache_result
-        ldap_filter = "(%s=%s)" % (self.uid_key, uid)
+        ldap_filter = "(%s=%s)" % (self.uid_key, escape_filter_chars(uid))
         ldap_results = self.search_ldap(self.base_dn, ldap_filter, attributes=self.attributes)
         if ldap_results:
             ldap_user_metadata = self.get_dict_from_ldap_object(self.connection.entries[0])

--- a/tools/c7n_mailer/tests/test_ldap.py
+++ b/tools/c7n_mailer/tests/test_ldap.py
@@ -69,6 +69,13 @@ class MailerLdapTest(unittest.TestCase):
         bill_metadata = self.ldap_lookup.get_metadata_from_dn(BILL[0])
         self.assertEqual(bill_metadata["mail"], BILL[1]["mail"][0])
 
+    def test_uid_wildcard_is_not_interpreted_as_filter(self):
+        # a uid sourced from a resource tag / event is attacker influenced,
+        # so an embedded '*' must be treated as a literal, not an ldap
+        # wildcard. there is no user whose uid is the literal string 'peter*'.
+        result = self.ldap_lookup.get_metadata_from_uid("peter*")
+        self.assertEqual(result, {})
+
     def test_to_addr_with_ldap_query(self):
         to_addr = self.ldap_lookup.get_email_to_addrs_from_uid("peter", manager=True)
         self.assertEqual(to_addr, ["peter@initech.com", "bill_lumberg@initech.com"])


### PR DESCRIPTION
reading through the mailer ldap path, `get_metadata_from_uid` builds its search filter with `"(%s=%s)" % (self.uid_key, uid)`. the `uid` isn't operator data, it comes from resource tag values and an iam `UserName` (`get_ldap_emails_from_resource`) and the event username (`get_event_owner_email`), so anyone who can set a tag on a scanned resource controls it. a value like `peter*` is interpreted as an ldap wildcard rather than a literal, which lets the filter match unintended directory entries and redirect the notification to whoever matches.

escaping `uid` with `ldap3`'s `escape_filter_chars` before interpolation keeps the assertion value literal. doing it in the lookup helper means every caller is covered without each having to remember to sanitise. added a regression test that looks up `peter*` and expects no match, it returns peter's record on the unpatched tree.
