### PR TITLE
escape resource data in html mailer templates

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -60,8 +60,17 @@ def get_processor(mailer_config, logger):
     return processor
 
 
+def html_autoescape(template_name):
+    # Template names carry a .j2 suffix and html templates are named
+    # <name>.html.j2, matching the convention used to pick the mime subtype
+    # in get_mimetext_message.
+    if not template_name:
+        return False
+    return template_name.rsplit(".j2", 1)[0].endswith(("html", "htm"))
+
+
 def get_jinja_env(template_folders):
-    env = jinja2.Environment(trim_blocks=True, autoescape=False)  # nosec nosemgrep
+    env = jinja2.Environment(trim_blocks=True, autoescape=html_autoescape)  # nosec nosemgrep
     env.filters["yaml_safe"] = functools.partial(yaml.safe_dump, default_flow_style=False)
     env.filters["date_time_format"] = date_time_format
     env.filters["get_date_time_delta"] = get_date_time_delta

--- a/tools/c7n_mailer/tests/escape.html.j2
+++ b/tools/c7n_mailer/tests/escape.html.j2
@@ -1,0 +1,1 @@
+<html><body><p>{{ resources[0]['Tags'][0]['Value'] }}</p></body></html>

--- a/tools/c7n_mailer/tests/test_utils.py
+++ b/tools/c7n_mailer/tests/test_utils.py
@@ -386,6 +386,35 @@ class OtherTests(unittest.TestCase):
         )
         self.assertIsNotNone(body)
 
+    def test_html_autoescape_predicate(self):
+        self.assertTrue(utils.html_autoescape("default.html.j2"))
+        self.assertTrue(utils.html_autoescape("report.htm.j2"))
+        self.assertTrue(utils.html_autoescape("default.html"))
+        self.assertFalse(utils.html_autoescape("default.j2"))
+        self.assertFalse(utils.html_autoescape("report.txt.j2"))
+        self.assertFalse(utils.html_autoescape(None))
+
+    def test_get_rendered_jinja_html_escapes_resource_data(self):
+        resource = {"Tags": [{"Key": "Name", "Value": "<img src=x onerror=alert(1)>"}]}
+        message = {
+            "action": {"template": "escape.html"},
+            "policy": {"name": "p", "resource": "ec2"},
+            "account": "a",
+            "account_id": "1",
+            "region": "us-east-1",
+        }
+        body = utils.get_rendered_jinja(
+            ["test@test.com"],
+            message,
+            [resource],
+            logging.getLogger("c7n_mailer.utils.email"),
+            "template",
+            "default",
+            MAILER_CONFIG["templates_folders"],
+        )
+        self.assertNotIn("<img src=x onerror=alert(1)>", body)
+        self.assertIn("&lt;img src=x onerror=alert(1)&gt;", body)
+
     def test_get_date_age(self):
         now = datetime.utcnow().isoformat() + "Z"
         sleep(1.0)


### PR DESCRIPTION
get_jinja_env builds one jinja environment with autoescape=False for every delivery path, and the shipped default.html.j2 drops resource fields straight into markup (getTag(resource,'Name'), resource[col], and similar). Tag values and other resource attributes come from the scanned account, so a resource named <img src=x onerror=...> renders as live HTML in the notification an operator opens in their mail client.

Before: html templates emit attacker-set resource strings verbatim. After: the environment escapes interpolated values for *.html/*.htm templates while plain-text and slack templates stay byte-for-byte the same, so the guard sits on the one shared helper instead of each template. Tradeoff is that an html template wanting raw markup from a value now has to opt in with |safe, which matches how jinja autoescaping behaves everywhere else.