### PR TITLE
escape spreadsheet formula characters in csv report output

### DIFF
--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -47,6 +47,24 @@ from c7n.utils import local_session, dumps, jmespath_search, jmespath_compile, g
 
 log = logging.getLogger('custodian.reports')
 
+# Leading characters that spreadsheet applications (Excel, LibreOffice, Google
+# Sheets) interpret as the start of a formula. Report cells are populated from
+# resource tags and attributes, which anyone able to tag a resource in the
+# account controls, so a value like ``=cmd|'/c calc'!A1`` runs when the report
+# is opened. csv quoting does not stop this; the cell has to be neutralized.
+CSV_INJECTION_PREFIXES = ('=', '+', '-', '@', '\t', '\r')
+
+
+def sanitize_csv_value(value):
+    """Prefix a quote to values a spreadsheet would otherwise treat as a formula."""
+    if isinstance(value, str) and value[:1] in CSV_INJECTION_PREFIXES:
+        return "'" + value
+    return value
+
+
+def sanitize_csv_rows(rows):
+    return [[sanitize_csv_value(v) for v in row] for row in rows]
+
 
 def strip_output_path(path, policy_name):
     """Remove the date portion from an object storage output path.
@@ -100,7 +118,7 @@ def report(policies, start_date, options, output_fh, raw_output_fh=None):
     if options.format == 'csv':
         writer = csv.writer(output_fh, formatter.headers(), quoting=csv.QUOTE_ALL)
         writer.writerow(formatter.headers())
-        writer.writerows(rows)
+        writer.writerows(sanitize_csv_rows(rows))
     elif options.format == 'json':
         print(dumps(records, indent=2))
     else:

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -57,7 +57,7 @@ CSV_INJECTION_PREFIXES = ('=', '+', '-', '@', '\t', '\r')
 
 def sanitize_csv_value(value):
     """Prefix a quote to values a spreadsheet would otherwise treat as a formula."""
-    if isinstance(value, str) and value[:1] in CSV_INJECTION_PREFIXES:
+    if isinstance(value, str) and value and value[0] in CSV_INJECTION_PREFIXES:
         return "'" + value
     return value
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,6 +1,11 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from c7n.reports.csvout import Formatter, strip_output_path
+from c7n.reports.csvout import (
+    Formatter,
+    sanitize_csv_rows,
+    sanitize_csv_value,
+    strip_output_path,
+)
 from .common import BaseTest, load_data
 
 
@@ -164,3 +169,33 @@ class TestMultiReport(BaseTest):
             strip_output_path(p, policy_name) == f"logs/{policy_name}"
             for p in output_paths
         ))
+
+
+class TestCsvSanitize(BaseTest):
+
+    def test_sanitize_csv_value(self):
+        self.assertEqual(sanitize_csv_value("=cmd|'/c calc'!A1"), "'=cmd|'/c calc'!A1")
+        self.assertEqual(sanitize_csv_value("+1+1"), "'+1+1")
+        self.assertEqual(sanitize_csv_value("-2+3"), "'-2+3")
+        self.assertEqual(sanitize_csv_value("@SUM(A1)"), "'@SUM(A1)")
+        self.assertEqual(sanitize_csv_value("\tHYPERLINK"), "'\tHYPERLINK")
+        # ordinary values and non-strings are returned untouched
+        self.assertEqual(sanitize_csv_value("i-0abc123"), "i-0abc123")
+        self.assertEqual(sanitize_csv_value(""), "")
+        self.assertEqual(sanitize_csv_value(5), 5)
+
+    def test_formula_tag_value_is_neutralized(self):
+        # a Name tag an attacker set on a resource reaches a report cell
+        p = self.load_policy({"name": "report-test-ec2", "resource": "ec2"})
+        formatter = Formatter(
+            p.resource_manager.resource_type,
+            extra_fields=["name=tag:Name"],
+            include_default_fields=False,
+        )
+        record = {
+            "LaunchTime": "2020-01-01T00:00:00+00:00",
+            "Tags": [{"Key": "Name", "Value": "=cmd|'/c calc'!A1"}],
+        }
+        rows = formatter.to_csv([record], unique=False)
+        self.assertEqual(rows, [["=cmd|'/c calc'!A1"]])
+        self.assertEqual(sanitize_csv_rows(rows), [["'=cmd|'/c calc'!A1"]])

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -34,7 +34,13 @@ from c7n.config import Config, Bag
 from c7n.loader import SourceLocator
 from c7n.policy import PolicyCollection, Policy, PolicyValidationError
 from c7n.provider import get_resource_class, clouds as cloud_providers
-from c7n.reports.csvout import Formatter, fs_record_set, record_set, strip_output_path
+from c7n.reports.csvout import (
+    Formatter,
+    fs_record_set,
+    record_set,
+    sanitize_csv_rows,
+    strip_output_path,
+)
 from c7n.resources import load_available, load_resources
 from c7n.schema import StructureParser
 from c7n.utils import (
@@ -461,7 +467,7 @@ def report(config, output, use, output_dir, accounts,
     rows = formatter.to_csv(records, unique=False)
     writer = csv.writer(output, formatter.headers(), quoting=csv.QUOTE_ALL)
     writer.writerow(formatter.headers())
-    writer.writerows(rows)
+    writer.writerows(sanitize_csv_rows(rows))
 
 
 def validate_basic(custodian_config, policy_file, fmt, check_mode, verbose):


### PR DESCRIPTION
Repro: tag a resource Name=`=cmd|'/c calc'!A1`, run `custodian report -f csv`, open the csv in Excel.
Cause: report() and c7n-org write Formatter rows to csv as-is, so a tag or attribute value reaches a cell unchanged. A leading =, +, -, @, tab or CR makes a spreadsheet evaluate the cell as a formula; QUOTE_ALL only controls csv field quoting, not that.
Fix: prefix a quote to those values at the two csv emit sites through one helper in csvout.py, so the cell opens as literal text instead of executing.

Tradeoff: a value that genuinely starts with one of those characters (a negative-number tag, for instance) gains a leading quote in the csv. The json and tabulate output paths are unchanged.