### PR TITLE
chore: Switched from Makefile to justfile.

### DIFF
--- a/.github/composites/install/action.yaml
+++ b/.github/composites/install/action.yaml
@@ -19,6 +19,15 @@ runs:
         version: ${{ inputs.uv-version }}
         enable-cache: true
 
+    - name: Install just
+      shell: bash
+      run: |
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          choco install just -y
+        else
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        fi
+
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # ratchet:actions/setup-python@v5
       with:
@@ -69,7 +78,7 @@ runs:
         if [ -d ".venv" ]; then
           mv .venv .venv-old
         fi
-        make install
+        just install
 
     - name: Output UV Version
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,14 @@ jobs:
           terraform_wrapper: false
           # last OSS version
           terraform_version: "1.5.5"
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
       - name: Lint Check
         env:
           RUFF_OUTPUT_FORMAT: github
         run: |
-          make lint
+          just python lint
       - name: Check Workflows
         run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -64,12 +67,15 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-suffix: "analyzer"
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
       - name: Run Bandit
         run: |
-          make analyzer-bandit
+          just analyzer bandit
       - name: Run Semgrep
         run: |
-          make analyzer-semgrep
+          just analyzer semgrep
 
   Docs:
     runs-on: ubuntu-latest
@@ -102,7 +108,7 @@ jobs:
       - name: Build Docs
         shell: bash
         run: |
-          make sphinx
+          just docs html
 
       - name: Update Docs Cache
         # basically to prevent the docs cache from going stale as we're not keying
@@ -176,10 +182,10 @@ jobs:
         run: |
           if [[ "$COV_RUN" == "true" ]]
           then
-            make test-coverage COVERAGE_TYPE=term
+            COVERAGE_TYPE=term just python coverage
             uv run coverage xml
           else
-            make test
+            just python test
           fi
 
       - name: Upload Code Coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build Wheels
         shell: bash
         run: |
-          make pkg-build-wheel
+          just pkg build-wheel
 
       - name: Build ChangeLog
         shell: bash
@@ -62,7 +62,7 @@ jobs:
           set -euxo pipefail
           uv run python tools/dev/staging-clean.py
           uv run python tools/dev/devpkg.py gen-qa-requires -r . --output wheels-manifest.txt
-          make pkg-publish-wheel PKG_REPO=${{ env.PKG_REPO }}
+          PKG_REPO=${{ env.PKG_REPO }} just pkg publish
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v4
         with:
@@ -151,4 +151,4 @@ jobs:
 #      - name: Publish
 #        if: startsWith(github.ref, 'refs/tags/')
 #        run: |
-#          make pkg-publish PKG_REPO=pypi
+#          PKG_REPO=pypi just pkg publish

--- a/docs/source/aws/contribute.rst
+++ b/docs/source/aws/contribute.rst
@@ -10,7 +10,7 @@ Run the following commands in the root directory after cloning Cloud Custodian:
 
 .. code-block:: bash
 
-    make install
+    just install
     source bin/activate
 
 This creates a virtual env in your enlistment and installs all packages as editable.

--- a/docs/source/azure/advanced/contribute.rst
+++ b/docs/source/azure/advanced/contribute.rst
@@ -4,11 +4,11 @@ Developer Guide
 ===============
 
 The c7n developer install includes c7n_azure.  A shortcut for creating a virtual env for development is available
-in the makefile:
+using ``just``:
 
 .. code-block:: bash
 
-    $ make install
+    $ just install
     $ source bin/activate
 
 This creates a virtual env in your enlistment and installs all packages as editable.
@@ -80,8 +80,8 @@ Testing
 Tests for c7n_azure run automatically with other Custodian tests.  See :ref:`Testing for Developers <developer-tests>`
 for information on how to run.
 
-If you'd like to run tests at the command line or in your IDE then reference `Makefile` to see the required
-environment variables and command lines for running `pytest`.
+If you'd like to run tests at the command line or in your IDE then reference ``just/python.just`` for the
+environment variables and command lines for running ``pytest``.
 
 
 Test framework
@@ -141,7 +141,7 @@ For long standing operations cassette can be modified to reduce test execution t
 Running tests
 ~~~~~~~~~~~~~
 
-You can use `make test` to run all tests or instead you can use `pytest` and run only Azure tests (or only specific set of tests). Running recorded tests still requires some authentication, it is possible to use fake data for authorization token and subscription id.
+You can use ``just python test`` to run all tests or instead you can use ``pytest`` and run only Azure tests (or only specific set of tests). Running recorded tests still requires some authentication, it is possible to use fake data for authorization token and subscription id.
 
 .. code-block:: bash
 

--- a/docs/source/developer/documentation.rst
+++ b/docs/source/developer/documentation.rst
@@ -80,11 +80,11 @@ Within docstrings, ``rst`` directives allow for highlighting code examples:
 Render the Documentation
 ------------------------
 
-To build the documentation use the make target:
+To build the documentation use the just recipe:
 
 .. code-block:: shell
 
-    make sphinx
+    just docs html
 
 Builds are cached locally and incremental.
 

--- a/docs/source/developer/installing.rst
+++ b/docs/source/developer/installing.rst
@@ -8,7 +8,7 @@ Installing Prerequisites
 
 Cloud Custodian supports Python 3.7 and above. To work on Custodian's code base, you will need:
 
-* A make/C toolchain
+* A C toolchain and the `just <https://just.systems/>`_ command runner
 * A supported release of Python 3
 * Some basic Python tools
 
@@ -134,7 +134,7 @@ Now that the repository is set up, perform a developer installation using UV:
 
 .. code-block:: bash
 
-    make install
+    just install
 
 This creates a sandboxed "virtual environment" ("venv") inside the ``cloud-custodian``
 directory, and installs the full suite of Cloud Custodian packages.
@@ -143,7 +143,7 @@ You can run tests via UV as well:
 
 .. code-block:: bash
 
-    make test
+    just python test
 
 To run executables from your UV environment, precede them with ``uv run``:
 
@@ -161,7 +161,7 @@ development environment by default:
     custodian schema
 
 You'll also be able to invoke `pytest <https://docs.pytest.org/en/latest/>`_ directly
-with the arguments of your choosing, though that requires mimicking ``make test``'s
+with the arguments of your choosing, though that requires mimicking ``just python test``'s
 environment preparation:
 
 .. code-block:: bash

--- a/docs/source/developer/packaging.rst
+++ b/docs/source/developer/packaging.rst
@@ -25,18 +25,18 @@ management activities.
 
 Usage
 -----
-We maintain several makefile targets that can be used to front end
+We maintain several ``just`` recipes that can be used to front end
 uv.
 
-  - `make install` installs custodian using uv.
+  - ``just install`` installs custodian using uv.
 
-  - `make pkg-increment` update all project versions
+  - ``just pkg increment`` update all project versions
 
-  - `make pkg-rebase` update dependencies across projects
+  - ``just pkg update`` update dependencies across projects
 
-  - `make pkg-build-wheel` build wheels and lint for all projects
+  - ``just pkg build-wheel`` build wheels and lint for all projects
 
-  - `make pkg-publish-wheel` publish previously built wheels for all projects
+  - ``just pkg publish`` publish previously built wheels for all projects
 
 
 Caveats

--- a/docs/source/developer/release.rst
+++ b/docs/source/developer/release.rst
@@ -9,8 +9,8 @@ Prerequisites / Assumptions
 * Releases are built and published using the ``main`` branch
 * The release process documented here should come _after_ a "release preparation" pull request gets merged. That pull request should:
 
-  * Increment package versions (via ``make pkg-increment``)
-  * Update dependencies (via ``make pkg-rebase``)
+  * Increment package versions (via ``just pkg increment``)
+  * Update dependencies (via ``just pkg update``)
   * Resolve any test breakages related to those dependency updates
 
 .. note::
@@ -45,7 +45,7 @@ Download the release artifacts into a clean working copy:
 
 .. code-block::
 
-    make release-get-artifacts
+    just pkg get-artifacts
 
 Open the Changelog (``release.md``) in a text editor and adjust accordingly so that it makes sense for humans.
 
@@ -68,7 +68,7 @@ Publish Wheel
 
 .. code-block::
 
-    make pkg-publish-wheel PKG_REPO=prodpypi
+    PKG_REPO=prodpypi just pkg publish
 
 Announce
 --------

--- a/docs/source/developer/tests.rst
+++ b/docs/source/developer/tests.rst
@@ -10,13 +10,13 @@ Unit tests can be run with:
 
 .. code-block:: bash
 
-   $ make test
+   $ just python test
 
 Linting can be run with:
 
 .. code-block:: bash
 
-  $ make lint
+  $ just python lint
 
 Individual package tests can be targeted with pytest:
 

--- a/docs/source/gcp/contribute.rst
+++ b/docs/source/gcp/contribute.rst
@@ -4,11 +4,11 @@ Developer Guide
 =================
 
 The c7n developer install includes c7n_gcp.  A shortcut for creating a virtual env for development is available
-in the makefile:
+using ``just``:
 
 .. code-block:: bash
 
-    make install
+    just install
     source bin/activate
 
 This creates a virtual env in your enlistment and installs all packages as editable.

--- a/docs/source/oci/testing.rst
+++ b/docs/source/oci/testing.rst
@@ -6,7 +6,7 @@ Tests for c7n_oci run automatically with other Cloud Custodian tests.  See :ref:
 Running Tests
 ~~~~~~~~~~~~~
 
-You can use ``make test`` to run all tests or instead you can use ``pytest`` and run only Oracle Cloud Infrastructure (OCI) tests.
+You can use ``just python test`` to run all tests or instead you can use ``pytest`` and run only Oracle Cloud Infrastructure (OCI) tests.
 
 
 Functional (live) Tests

--- a/just/analyzer.just
+++ b/just/analyzer.just
@@ -1,0 +1,30 @@
+set working-directory := ".."
+
+@_default:
+    just --list analyzer
+
+# Directories analysed by both bandit and semgrep.
+# B105 (hardcoded password) is skipped — see https://github.com/PyCQA/bandit/issues/1350
+ANALYZE_DIRS := "tools/c7n_azure/c7n_azure \
+    tools/c7n_gcp/c7n_gcp \
+    tools/c7n_oci/c7n_oci \
+    tools/c7n_left/c7n_left \
+    tools/c7n_guardian/c7n_guardian \
+    tools/c7n_org/c7n_org \
+    tools/c7n_mailer/c7n_mailer \
+    tools/c7n_policystream/policystream.py \
+    tools/c7n_trailcreator/c7n_trailcreator \
+    c7n"
+
+# Run bandit static analysis (skips B101, B105, B311).
+@bandit:
+    uvx bandit -i -s B101,B105,B311 -r {{ANALYZE_DIRS}}
+
+# Run semgrep security audit.
+@semgrep:
+    uvx semgrep --error --verbose --config p/security-audit {{ANALYZE_DIRS}}
+
+# Run all static analyzers.
+@all:
+    just analyzer bandit
+    just analyzer semgrep

--- a/just/data.just
+++ b/just/data.just
@@ -1,0 +1,25 @@
+set working-directory := ".."
+
+@_default:
+    just --list data
+
+# Regenerate all data sets: terraform, AWS, and GCP.
+@update:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # terraform data sets
+    (cd tools/c7n_left/scripts && uv run python get_taggable.py \
+        --module-path taggable_providers/latest \
+        --module-path taggable_providers/azurerm-previous \
+        --output ../c7n_left/data/taggable.json)
+
+    # aws data sets
+    uv run python tools/dev/data_cftypedb.py -f tests/data/cfn-types.json
+    uv run python tools/dev/data_updatearnref.py > tests/data/arn-types.json
+    uv run python tools/dev/data_iamdb.py -f tests/data/iam-actions.json
+    uv run python tools/dev/data_awspartitions.py > c7n/data/aws_region_partition_map.json
+
+    # gcp data sets
+    uv run python tools/dev/data_gcpiamdb.py -f tools/c7n_gcp/tests/data/iam-permissions.json
+    uv run python tools/dev/data_gcpregion.py -f tools/c7n_gcp/c7n_gcp/regions.json

--- a/just/docker.just
+++ b/just/docker.just
@@ -1,0 +1,15 @@
+set working-directory := ".."
+
+@_default:
+    just --list docker
+
+IMAGE     := env_var_or_default("IMAGE", "c7n")
+IMAGE_TAG := env_var_or_default("IMAGE_TAG", "latest")
+
+# Build the Docker image (IMAGE=c7n IMAGE_TAG=latest).
+@build:
+    docker build -f docker/{{IMAGE}} -t {{IMAGE}}:{{IMAGE_TAG}} .
+
+# Regenerate Dockerfiles from the template script.
+@gen:
+    uv run tools/dev/dockerpkg.py generate

--- a/just/docs.just
+++ b/just/docs.just
@@ -1,0 +1,12 @@
+set working-directory := ".."
+
+@_default:
+    just --list docs
+
+# Build HTML documentation with Sphinx.
+@html:
+    make -f docs/Makefile.sphinx html
+
+# Clean Sphinx build artefacts.
+@clean:
+    make -f docs/Makefile.sphinx clean

--- a/just/pkg.just
+++ b/just/pkg.just
@@ -1,0 +1,65 @@
+set working-directory := ".."
+
+@_default:
+    just --list pkg
+
+PKG_SET := "tools/c7n_gcp tools/c7n_kube tools/c7n_openstack tools/c7n_mailer \
+    tools/c7n_policystream tools/c7n_org tools/c7n_sphinxext tools/c7n_awscc \
+    tools/c7n_tencentcloud tools/c7n_azure tools/c7n_oci tools/c7n_left"
+
+# Package index to publish to (default: testpypi).
+PKG_REPO := env_var_or_default("PKG_REPO", "testpypi")
+
+# Version component to bump (default: patch).
+PKG_INCREMENT := env_var_or_default("PKG_INCREMENT", "patch")
+
+# Remove all dist/ and build/ artefacts across the workspace.
+@clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -f release.md wheels-manifest.txt
+    rm -f dist/*
+    for pkg in {{PKG_SET}}; do
+        rm -f "$pkg/dist/"*
+    done
+    rm -Rf build/*
+    for pkg in {{PKG_SET}}; do
+        rm -Rf "$pkg/build/"*
+    done
+
+# Upgrade all locked dependencies.
+@update:
+    uv sync --all-packages \
+        --group dev \
+        --group addons \
+        --group lint \
+        --extra gcp --extra azure \
+        --upgrade
+
+# Show outdated dependencies.
+@show-update:
+    uv tree --outdated --no-default-groups
+
+# Bump version for all packages (PKG_INCREMENT=patch|minor|major).
+@increment:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    uv version --bump {{PKG_INCREMENT}}
+    for pkg in {{PKG_SET}}; do
+        (cd "$pkg" && uv version --bump {{PKG_INCREMENT}})
+    done
+    uv run tools/dev/devpkg.py gen-version-file -p . -f c7n/version.py
+
+# Build wheels for all packages (runs clean first).
+@build-wheel: clean
+    uv build --all-packages --wheel
+    uv run tools/dev/freezeuvwheel.py dist uv.lock
+    uv run twine check --strict dist/*.whl
+
+# Publish wheels to PKG_REPO.
+@publish:
+    uv run twine upload -r {{PKG_REPO}} dist/*
+
+# Download release artefacts from the GitHub release action (runs clean first).
+@get-artifacts: clean
+    uv run tools/dev/get_release_artifacts.py

--- a/just/python.just
+++ b/just/python.just
@@ -1,0 +1,50 @@
+set working-directory := ".."
+
+@_default:
+    just --list python
+
+# Subset of packages that use black for formatting.
+FMT_SET := "tools/c7n_left tools/c7n_mailer tools/c7n_oci tools/c7n_kube tools/c7n_awscc"
+
+# Ruff + black lint checks (no modifications).
+@lint:
+    uv run --no-project ruff check c7n tests tools
+    uv run --no-project black --check {{FMT_SET}}
+    terraform fmt -check -recursive .
+
+# Apply ruff + black auto-fixes and terraform formatting.
+@format:
+    uv run black {{FMT_SET}}
+    uv run ruff check --fix c7n tests tools
+    terraform fmt -recursive .
+
+# Run the full test suite.
+@test *ARGS:
+    uv run pytest -n auto {{ARGS}} tests tools
+
+# Coverage report format: html (default), term, xml, etc.
+COVERAGE_TYPE := env_var_or_default("COVERAGE_TYPE", "html")
+
+# Run the test suite with coverage report.
+@coverage *ARGS:
+    uv run pytest -n auto \
+        --cov-config .coveragerc \
+        --cov-report {{COVERAGE_TYPE}} \
+        --cov c7n \
+        --cov tools/c7n_azure/c7n_azure \
+        --cov tools/c7n_gcp/c7n_gcp \
+        --cov tools/c7n_kube/c7n_kube \
+        --cov tools/c7n_left/c7n_left \
+        --cov tools/c7n_mailer/c7n_mailer \
+        --cov tools/c7n_policystream/c7n_policystream \
+        --cov tools/c7n_tencentcloud/c7n_tencentcloud \
+        --cov tools/c7n_oci/c7n_oci \
+        tests tools {{ARGS}}
+
+# Run functional tests against a real AWS environment (provisions real resources).
+@test-functional *ARGS:
+    C7N_FUNCTIONAL=yes AWS_DEFAULT_REGION=us-east-2 pytest tests -m functional {{ARGS}}
+
+# Run functional tests against a real Azure environment (provisions real resources).
+@test-functional-azure *ARGS:
+    C7N_FUNCTIONAL=yes uv run pytest tools/c7n_azure/tests_azure -k terraform -m functional {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,25 @@
+# https://just.systems/
+set dotenv-load := false
+
+@_default:
+    just --list
+
+# Install all dependencies (dev, addons, lint groups; gcp + azure extras).
+@install:
+    uv sync --all-packages --locked \
+        --group dev \
+        --group addons \
+        --group lint \
+        --extra gcp --extra azure
+
+# Remove all build artefacts (docs + packages).
+@clean:
+    just docs clean
+    just pkg clean
+
+mod analyzer "just/analyzer.just"
+mod data     "just/data.just"
+mod docker   "just/docker.just"
+mod docs     "just/docs.just"
+mod pkg      "just/pkg.just"
+mod python   "just/python.just"


### PR DESCRIPTION
## what

Switches Cloud Custodian from the existing `Makefile` to a modular `justfile`.

## why

This came up on the C7N Slack, & I already had scripts/migration tools from other similar conversions to help. This provides at least an example of what things might look like, as well as help scope the work to be done.

A portion of this was implemented with the assistance of Claude.

## testing

- [x] Hand-tested

## docs

The existing documentation & `README` were updated.

## notes

- Due to the deeper hierarchy of the `tools/` directory, I have not looked to see if further work would be required to support everything within.
- I left the existing `Makefile` in-place, so as not to disrupt other scripts, & for comparison for now.