### PR TITLE
fix: isolate filter annotations from cached and shared resource dicts

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -1286,7 +1286,10 @@ class ListItemFilter(Filter):
                 )
             for idx, list_value in enumerate(list_values):
                 list_value['c7n:_id'] = idx
-            list_resources = frm.filter_resources(list_values, event)
+            # List-item manages ephemeral c7n:_id on list_values; skip the
+            # default deepcopy so cleanup and annotate_items stay consistent.
+            list_resources = frm.filter_resources(
+                list_values, event, copy_resources=False)
             matched_indicies = [r['c7n:_id'] for r in list_resources]
             for idx, list_value in enumerate(list_values):
                 list_value.pop('c7n:_id')

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -1,6 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from collections import deque
+import copy
 import logging
 
 from c7n import cache, deprecated
@@ -99,7 +100,11 @@ class ResourceManager:
             return klass(self.ctx, {'source': self.source_type})
         return klass(self.ctx, data or {})
 
-    def filter_resources(self, resources, event=None):
+    def filter_resources(self, resources, event=None, copy_resources=True):
+        # Filters annotate resource dicts in-place; copy so cached
+        # resource lists are not polluted across policy executions.
+        if copy_resources and resources:
+            resources = copy.deepcopy(resources)
         original = len(resources)
         if event and event.get('debug', False):
             self.log.info(

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 from c7n.ctx import ExecutionContext
 from c7n.filters import Filter
-from c7n.filters.core import trim_runtime
+from c7n.filters.core import ANNOTATION_KEY, trim_runtime
 from c7n.resources.ec2 import EC2
 from c7n.tags import Tag
 from .common import BaseTest, instance, Bag
@@ -136,6 +136,38 @@ class TestEC2Manager(BaseTest):
                 {"Values": ["CMDBEnvironment", "Owner"], "Name": "tag-key"},
             ]
         })
+
+    def test_filter_resources_does_not_mutate_input(self):
+        ec2 = self.load_policy({
+            'name': 'xyz', 'resource': 'aws.ec2',
+            'filters': [{"State.Name": "running"}]}).resource_manager
+        shared = [instance(State={'Name': 'running'})]
+        original = deepcopy(shared)
+        result = ec2.filter_resources(shared)
+        self.assertEqual(len(result), 1)
+        self.assertIn(ANNOTATION_KEY, result[0])
+        self.assertNotIn(ANNOTATION_KEY, shared[0])
+        self.assertEqual(shared, original)
+
+    def test_filter_resources_list_item_skips_copy(self):
+        """Nested list-item filtering must not deepcopy list elements."""
+        ec2 = self.load_policy({
+            'name': 'xyz', 'resource': 'aws.ec2',
+            'filters': [{
+                'type': 'list-item',
+                'key': 'Tags',
+                'attrs': [{'Key': 'Owner'}],
+            }],
+        }).resource_manager
+        resource = instance(Tags=[
+            {'Key': 'Owner', 'Value': 'team-a'},
+            {'Key': 'Env', 'Value': 'dev'},
+        ])
+        original_tags = deepcopy(resource['Tags'])
+        result = ec2.filter_resources([resource])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(resource['Tags'], original_tags)
+        self.assertNotIn('c7n:_id', result[0]['Tags'][0])
 
     def test_filters(self):
         ec2 = self.load_policy({

--- a/tools/c7n_azure/tests_azure/tests_resources/test_armresource.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_armresource.py
@@ -252,7 +252,9 @@ class ArmResourceTest(BaseTest):
             ]
         })
         p.run()
-        delete_action_mock.assert_called_with([self.fake_arm_resources[0]])
+        expected = dict(self.fake_arm_resources[0])
+        expected['c7n:MatchedFilters'] = ['name']
+        delete_action_mock.assert_called_with([expected])
 
     @patch('c7n_azure.query.ResourceQuery.filter',
         return_value=fake_arm_resources)
@@ -273,7 +275,9 @@ class ArmResourceTest(BaseTest):
             ]
         })
         p.run()
-        delete_action_mock.assert_called_with([self.fake_arm_resources[0]])
+        expected = dict(self.fake_arm_resources[0])
+        expected['c7n:MatchedFilters'] = ['name']
+        delete_action_mock.assert_called_with([expected])
 
     def test_arm_resource_resource_type_schema_validate(self):
         with self.sign_out_patch():

--- a/tools/c7n_left/tests/test_left.py
+++ b/tools/c7n_left/tests/test_left.py
@@ -2208,7 +2208,9 @@ resource "aws_ecs_task_definition" "test_task_def" {
     """)
     results = policy_env.run()
     assert results[0].resource["c7n:MatchedFilters"] == ["container_definitions"]
-    assert results[1].resource["c7n:MatchedFilters"] == ["container_definitions"]
+    assert results[1].resource["c7n:ListItemMatches"] == [
+        "from_json(container_definitions)[].environment[][0]",
+    ]
 
 
 @pytest.mark.xfail(reason="https://github.com/cloud-custodian/cloud-custodian/issues/9709")


### PR DESCRIPTION
## Summary

Filters annotate matched resources in-place with `c7n:MatchedFilters`. When multiple policies run against the same cached or shared resource objects, annotations from earlier policies leak into later results.

This change deep-copies resources at the start of `filter_resources()` so runtime annotations do not mutate cached describe results or shared resource lists.

## Problem

Cloud Custodian adds `c7n:MatchedFilters` directly onto resource dicts during filtering. The same objects are often reused:

- **Query cache** — `query.resources()` saves resources to cache, then filters them in-place
- **Multi-policy runs** — the same resource list is passed to each policy

Each policy appends its matched filter keys to the same dict. Later policies inherit annotations they never evaluated.

### Example: Kubernetes policy pack

Some policies target the `kube-apiserver` pod:

```yaml
filters:
  - type: value
    key: |
      metadata.namespace=='kube-system' &&
      metadata.labels.component=='kube-apiserver' &&
      contains(spec.containers[].command[],'kube-apiserver')
    value: true
  - or:
      - type: value
        key: spec.containers[].command[]
        value: "--anonymous-auth=true"
      - not:
          - type: value
            key: spec.containers[].command[]
            value: "--anonymous-auth=false"
```

**Before fix** — `c7n:MatchedFilters` on the matched pod contains **60+ entries** from unrelated policies in the same run (`spec.host_network`, TLS cipher-suite checks, audit-log settings, admission plugin rules, etc.):

```json
"c7n:MatchedFilters": [
  "spec && (spec.security_context && ...)",
  "spec.containers && length(spec.containers[?security_context.read_only_root_filesystem != `true`])",
  "spec.host_network",
  "spec.containers[].command[?starts_with(@, '--tls-cipher-suites=')][] | length(...)",
  "metadata.labels.component",
  "... 50+ more keys from other policies ..."
]
```

**After fix** — only the filter(s) from this policy:

```json
"c7n:MatchedFilters": [
  "metadata.namespace=='kube-system' && \nmetadata.labels.component=='kube-apiserver' && \ncontains(spec.containers[].command[],'kube-apiserver')\n"
]
```

The pod is the same; the annotation list is no longer polluted by every prior policy that touched the shared object.