### PR TITLE
feat(appflow): add activate and deactivate actions

### DIFF
--- a/c7n/resources/appflow.py
+++ b/c7n/resources/appflow.py
@@ -84,6 +84,87 @@ AppFlow.action_registry.register('mark-for-op', TagDelayedAction)
 AppFlow.filter_registry.register('marked-for-op', TagActionFilter)
 
 
+@AppFlow.action_registry.register('deactivate')
+class DeactivateAppFlowResource(BaseAction):
+    """Action to deactivate (stop) an AppFlow flow.
+
+    This deactivates schedule and event-triggered flows. On-demand flows
+    cannot be deactivated and will raise an error.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: deactivate-app-flow
+                resource: app-flow
+                filters:
+                  - type: value
+                    key: flowStatus
+                    value: Active
+                  - type: value
+                    key: triggerType
+                    value: Scheduled
+                actions:
+                  - deactivate
+    """
+
+    permissions = ('appflow:StopFlow',)
+    schema = type_schema('deactivate')
+
+    def process(self, resources):
+        client = local_session(
+            self.manager.session_factory).client('appflow')
+        for r in resources:
+            self.manager.retry(
+                client.stop_flow,
+                flowName=r['flowName'],
+                ignore_err_codes=(
+                    'ResourceNotFoundException',
+                    'UnsupportedOperationException',
+                )
+            )
+
+
+@AppFlow.action_registry.register('activate')
+class ActivateAppFlowResource(BaseAction):
+    """Action to activate (start) an AppFlow flow.
+
+    For on-demand flows, this runs the flow immediately. For schedule
+    and event-triggered flows, this activates the flow.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: activate-app-flow
+                resource: app-flow
+                filters:
+                  - type: value
+                    key: flowStatus
+                    value: Draft
+                actions:
+                  - activate
+    """
+
+    permissions = ('appflow:StartFlow',)
+    schema = type_schema('activate')
+
+    def process(self, resources):
+        client = local_session(
+            self.manager.session_factory).client('appflow')
+        for r in resources:
+            self.manager.retry(
+                client.start_flow,
+                flowName=r['flowName'],
+                ignore_err_codes=(
+                    'ResourceNotFoundException',
+                    'ConflictException',
+                )
+            )
+
+
 @AppFlow.action_registry.register('delete')
 class DeleteAppFlowResource(BaseAction):
     """Action to delete an AppFlow

--- a/tests/data/placebo/test_appflow_activate/appflow.DescribeFlow_1.json
+++ b/tests/data/placebo/test_appflow_activate/appflow.DescribeFlow_1.json
@@ -1,0 +1,74 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "flowArn": "arn:aws:appflow:us-east-1:644160558196:flow/scheduled-flow",
+        "flowName": "scheduled-flow",
+        "kmsArn": "arn:aws:kms:us-east-1:644160558196:key/5a53ba7b-bcae-442d-8f6a-b2e78315d6d3",
+        "flowStatus": "Suspended",
+        "sourceFlowConfig": {
+            "connectorType": "S3",
+            "sourceConnectorProperties": {
+                "S3": {
+                    "bucketName": "test-bucket",
+                    "bucketPrefix": "preflow"
+                }
+            }
+        },
+        "destinationFlowConfigList": [
+            {
+                "connectorType": "S3",
+                "destinationConnectorProperties": {
+                    "S3": {
+                        "bucketName": "test-bucket",
+                        "s3OutputFormatConfig": {
+                            "fileType": "JSON",
+                            "prefixConfig": {},
+                            "aggregationConfig": {
+                                "aggregationType": "None"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "triggerConfig": {
+            "triggerType": "Scheduled",
+            "triggerProperties": {
+                "Scheduled": {
+                    "scheduleExpression": "rate(1hour)"
+                }
+            }
+        },
+        "tasks": [
+            {
+                "sourceFields": ["field1"],
+                "connectorOperator": {"S3": "NO_OP"},
+                "destinationField": "field1",
+                "taskType": "Map",
+                "taskProperties": {}
+            }
+        ],
+        "createdAt": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 2,
+            "day": 23,
+            "hour": 11,
+            "minute": 5,
+            "second": 40,
+            "microsecond": 852000
+        },
+        "lastUpdatedAt": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 2,
+            "day": 23,
+            "hour": 11,
+            "minute": 5,
+            "second": 40,
+            "microsecond": 852000
+        },
+        "tags": {}
+    }
+}

--- a/tests/data/placebo/test_appflow_activate/appflow.ListFlows_1.json
+++ b/tests/data/placebo/test_appflow_activate/appflow.ListFlows_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "flows": [
+            {
+                "flowArn": "arn:aws:appflow:us-east-1:644160558196:flow/scheduled-flow",
+                "flowName": "scheduled-flow",
+                "flowStatus": "Suspended",
+                "sourceConnectorType": "S3",
+                "destinationConnectorType": "S3",
+                "triggerType": "Scheduled",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 2,
+                    "day": 23,
+                    "hour": 11,
+                    "minute": 5,
+                    "second": 40,
+                    "microsecond": 852000
+                },
+                "lastUpdatedAt": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 2,
+                    "day": 23,
+                    "hour": 11,
+                    "minute": 5,
+                    "second": 40,
+                    "microsecond": 852000
+                },
+                "tags": {}
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_appflow_activate/appflow.StartFlow_1.json
+++ b/tests/data/placebo/test_appflow_activate/appflow.StartFlow_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "flowArn": "arn:aws:appflow:us-east-1:644160558196:flow/scheduled-flow",
+        "flowStatus": "Active",
+        "executionId": "examplead-flow-execution-id"
+    }
+}

--- a/tests/data/placebo/test_appflow_deactivate/appflow.DescribeFlow_1.json
+++ b/tests/data/placebo/test_appflow_deactivate/appflow.DescribeFlow_1.json
@@ -1,0 +1,74 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "flowArn": "arn:aws:appflow:us-east-1:644160558196:flow/scheduled-flow",
+        "flowName": "scheduled-flow",
+        "kmsArn": "arn:aws:kms:us-east-1:644160558196:key/5a53ba7b-bcae-442d-8f6a-b2e78315d6d3",
+        "flowStatus": "Active",
+        "sourceFlowConfig": {
+            "connectorType": "S3",
+            "sourceConnectorProperties": {
+                "S3": {
+                    "bucketName": "test-bucket",
+                    "bucketPrefix": "preflow"
+                }
+            }
+        },
+        "destinationFlowConfigList": [
+            {
+                "connectorType": "S3",
+                "destinationConnectorProperties": {
+                    "S3": {
+                        "bucketName": "test-bucket",
+                        "s3OutputFormatConfig": {
+                            "fileType": "JSON",
+                            "prefixConfig": {},
+                            "aggregationConfig": {
+                                "aggregationType": "None"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "triggerConfig": {
+            "triggerType": "Scheduled",
+            "triggerProperties": {
+                "Scheduled": {
+                    "scheduleExpression": "rate(1hour)"
+                }
+            }
+        },
+        "tasks": [
+            {
+                "sourceFields": ["field1"],
+                "connectorOperator": {"S3": "NO_OP"},
+                "destinationField": "field1",
+                "taskType": "Map",
+                "taskProperties": {}
+            }
+        ],
+        "createdAt": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 2,
+            "day": 23,
+            "hour": 11,
+            "minute": 5,
+            "second": 40,
+            "microsecond": 852000
+        },
+        "lastUpdatedAt": {
+            "__class__": "datetime",
+            "year": 2021,
+            "month": 2,
+            "day": 23,
+            "hour": 11,
+            "minute": 5,
+            "second": 40,
+            "microsecond": 852000
+        },
+        "tags": {}
+    }
+}

--- a/tests/data/placebo/test_appflow_deactivate/appflow.ListFlows_1.json
+++ b/tests/data/placebo/test_appflow_deactivate/appflow.ListFlows_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "flows": [
+            {
+                "flowArn": "arn:aws:appflow:us-east-1:644160558196:flow/scheduled-flow",
+                "flowName": "scheduled-flow",
+                "flowStatus": "Active",
+                "sourceConnectorType": "S3",
+                "destinationConnectorType": "S3",
+                "triggerType": "Scheduled",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 2,
+                    "day": 23,
+                    "hour": 11,
+                    "minute": 5,
+                    "second": 40,
+                    "microsecond": 852000
+                },
+                "lastUpdatedAt": {
+                    "__class__": "datetime",
+                    "year": 2021,
+                    "month": 2,
+                    "day": 23,
+                    "hour": 11,
+                    "minute": 5,
+                    "second": 40,
+                    "microsecond": 852000
+                },
+                "tags": {}
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_appflow_deactivate/appflow.StopFlow_1.json
+++ b/tests/data/placebo/test_appflow_deactivate/appflow.StopFlow_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "flowArn": "arn:aws:appflow:us-east-1:644160558196:flow/scheduled-flow",
+        "flowStatus": "Suspended"
+    }
+}

--- a/tests/test_appflow.py
+++ b/tests/test_appflow.py
@@ -52,6 +52,48 @@ class AppFlowTests(BaseTest):
         call = appflow.describe_flow(flowName=flow_name)
         self.assertEqual({}, call.get('tags'))
 
+    def test_appflow_deactivate(self):
+        session_factory = self.replay_flight_data('test_appflow_deactivate')
+        p = self.load_policy(
+            {
+                'name': 'app-flow-deactivate',
+                'resource': 'app-flow',
+                'filters': [{
+                    'type': 'value',
+                    'key': 'flowStatus',
+                    'value': 'Active'
+                }],
+                'actions': [{
+                    'type': 'deactivate'
+                }]
+            },
+            session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual(resources[0]['flowStatus'], 'Active')
+
+    def test_appflow_activate(self):
+        session_factory = self.replay_flight_data('test_appflow_activate')
+        p = self.load_policy(
+            {
+                'name': 'app-flow-activate',
+                'resource': 'app-flow',
+                'filters': [{
+                    'type': 'value',
+                    'key': 'flowStatus',
+                    'value': 'Suspended'
+                }],
+                'actions': [{
+                    'type': 'activate'
+                }]
+            },
+            session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual(resources[0]['flowStatus'], 'Suspended')
+
     def test_appflow_delete(self):
         session_factory = self.replay_flight_data('test_appflow_delete')
         p = self.load_policy(


### PR DESCRIPTION
Adds `activate` and `deactivate` actions to the `app-flow` resource.

**What:**
- `activate` — calls `start_flow` to resume suspended flows or trigger on-demand flows
- `deactivate` — calls `stop_flow` to pause scheduled/event-triggered flows

**Why:**
Users managing scheduled or event-triggered AppFlow flows currently can only delete them.
This adds the ability to pause and resume flows via policy, useful for cost control and
incident response without destroying the flow configuration.

**Testing:**
- Unit tests with placebo flight data — all 5 AppFlow tests passing
