### PR TITLE
azure - add machine-learning-job resource

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/arm.py
+++ b/tools/c7n_azure/c7n_azure/resources/arm.py
@@ -24,7 +24,8 @@ arm_tags_unsupported = ['microsoft.network/dnszones/',
                         'microsoft.sql/servers/databases',
                         'microsoft.storage/storageaccounts/blobservices/containers',
                         'microsoft.cognitiveservices/accounts/deployments',
-                        'microsoft.cognitiveservices/accounts/projects/connections']
+                        'microsoft.cognitiveservices/accounts/projects/connections',
+                        'microsoft.machinelearningservices/workspaces/jobs']
 
 
 class ArmTypeInfo(TypeInfo, metaclass=TypeMeta):

--- a/tools/c7n_azure/c7n_azure/resources/machine_learning_job.py
+++ b/tools/c7n_azure/c7n_azure/resources/machine_learning_job.py
@@ -42,7 +42,6 @@ class MachineLearningJob(ChildArmResourceManager):
         resource_type = 'Microsoft.MachineLearningServices/workspaces/jobs'
         default_report_fields = (
             'name',
-            'location',
             'resourceGroup',
             '"c7n:parent-id"'
         )

--- a/tools/c7n_azure/c7n_azure/resources/machine_learning_job.py
+++ b/tools/c7n_azure/c7n_azure/resources/machine_learning_job.py
@@ -1,0 +1,55 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ChildArmResourceManager
+
+
+@resources.register('machine-learning-job')
+class MachineLearningJob(ChildArmResourceManager):
+    """Azure Machine Learning Job Resource
+
+    Jobs are child resources of a Machine Learning workspace
+    (``Microsoft.MachineLearningServices/workspaces/jobs``). They are enumerated
+    per workspace using the ``Jobs_List`` API.
+
+    :example:
+
+    Find sweep jobs whose maximum number of concurrent trials exceeds 10.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: ml-sweep-jobs-over-parallelism-limit
+            resource: azure.machine-learning-job
+            filters:
+              - type: value
+                key: properties.jobType
+                value: Sweep
+              - type: value
+                key: properties.limits.maxConcurrentTrials
+                op: gt
+                value: 10
+
+    """
+
+    class resource_type(ChildArmResourceManager.resource_type):
+        doc_groups = ['AI + Machine Learning']
+        service = 'azure.mgmt.machinelearningservices'
+        client = 'MachineLearningServicesMgmtClient'
+        enum_spec = ('jobs', 'list', None)
+        parent_manager_name = 'machine-learning-workspace'
+        resource_type = 'Microsoft.MachineLearningServices/workspaces/jobs'
+        default_report_fields = (
+            'name',
+            'location',
+            'resourceGroup',
+            '"c7n:parent-id"'
+        )
+
+        @classmethod
+        def extra_args(cls, parent_resource):
+            return {
+                'resource_group_name': parent_resource['resourceGroup'],
+                'workspace_name': parent_resource['name'],
+            }

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -67,6 +67,7 @@ ResourceMap = {
     "azure.loadbalancer": "c7n_azure.resources.load_balancer.LoadBalancer",
     "azure.logic-app-workflow": "c7n_azure.resources.logic_app.LogicAppWorkflow",
     "azure.machine-learning-workspace": "c7n_azure.resources.machine_learning_workspace.MachineLearningWorkspace", # noqa
+    "azure.machine-learning-job": "c7n_azure.resources.machine_learning_job.MachineLearningJob",
     "azure.mariadb": "c7n_azure.resources.mariadb.MariaDB",
     "azure.monitor-log-profile": "c7n_azure.resources.monitor_logprofile.MonitorLogprofile",
     "azure.mariadb-server": "c7n_azure.resources.mariadb_server.MariaDBServer",

--- a/tools/c7n_azure/tests_azure/cassettes/MachineLearningJobTest.machine-learning-jobs.json
+++ b/tools/c7n_azure/tests_azure/cassettes/MachineLearningJobTest.machine-learning-jobs.json
@@ -62,6 +62,7 @@
                                 "properties": {
                                     "jobType": "Sweep",
                                     "limits": {
+                                        "jobLimitsType": "Sweep",
                                         "maxConcurrentTrials": 20
                                     }
                                 }

--- a/tools/c7n_azure/tests_azure/cassettes/MachineLearningJobTest.machine-learning-jobs.json
+++ b/tools/c7n_azure/tests_azure/cassettes/MachineLearningJobTest.machine-learning-jobs.json
@@ -1,0 +1,75 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.MachineLearningServices/workspaces?api-version=2020-08-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": ["application/json; charset=utf-8"],
+                    "cache-control": ["no-cache"]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_machine-learning-job/providers/Microsoft.MachineLearningServices/workspaces/cctest-mlws",
+                                "name": "cctest-mlws",
+                                "type": "Microsoft.MachineLearningServices/workspaces",
+                                "location": "eastus",
+                                "tags": {},
+                                "properties": {
+                                    "friendlyName": "cctest-mlws",
+                                    "provisioningState": "Succeeded"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_machine-learning-job/providers/Microsoft.MachineLearningServices/workspaces/cctest-mlws/jobs?api-version=2023-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-type": ["application/json; charset=utf-8"],
+                    "cache-control": ["no-cache"]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_machine-learning-job/providers/Microsoft.MachineLearningServices/workspaces/cctest-mlws/jobs/cctest-sweep-job",
+                                "name": "cctest-sweep-job",
+                                "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+                                "properties": {
+                                    "jobType": "Sweep",
+                                    "limits": {
+                                        "maxConcurrentTrials": 20
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/templates/machine-learning-job.json
+++ b/tools/c7n_azure/tests_azure/templates/machine-learning-job.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "uniqueId": {
+            "type": "string"
+        }
+    },
+    "variables": {
+        "storageAccountName": "[concat('cctestmlws', parameters('uniqueId'))]",
+        "keyVaultName": "[concat('cctestmlws', parameters('uniqueId'))]",
+        "appInsightsName": "[concat('cctestmlws', parameters('uniqueId'))]",
+        "workspaceName": "cctest-mlws",
+        "jobName": "cctest-sweep-job"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2023-01-01",
+            "name": "[variables('storageAccountName')]",
+            "location": "eastus",
+            "sku": {
+                "name": "Standard_LRS"
+            },
+            "kind": "StorageV2",
+            "properties": {
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": false
+            }
+        },
+        {
+            "type": "Microsoft.KeyVault/vaults",
+            "apiVersion": "2023-02-01",
+            "name": "[variables('keyVaultName')]",
+            "location": "eastus",
+            "properties": {
+                "tenantId": "[subscription().tenantId]",
+                "sku": {
+                    "family": "A",
+                    "name": "standard"
+                },
+                "accessPolicies": []
+            }
+        },
+        {
+            "type": "Microsoft.Insights/components",
+            "apiVersion": "2020-02-02",
+            "name": "[variables('appInsightsName')]",
+            "location": "eastus",
+            "kind": "web",
+            "properties": {
+                "Application_Type": "web"
+            }
+        },
+        {
+            "type": "Microsoft.MachineLearningServices/workspaces",
+            "apiVersion": "2023-04-01",
+            "name": "[variables('workspaceName')]",
+            "location": "eastus",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "friendlyName": "[variables('workspaceName')]",
+                "storageAccount": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "keyVault": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                "applicationInsights": "[resourceId('Microsoft.Insights/components', variables('appInsightsName'))]"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                "[resourceId('Microsoft.Insights/components', variables('appInsightsName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+            "apiVersion": "2023-04-01",
+            "name": "[format('{0}/{1}', variables('workspaceName'), variables('jobName'))]",
+            "properties": {
+                "jobType": "Sweep",
+                "limits": {
+                    "maxConcurrentTrials": 20
+                }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.MachineLearningServices/workspaces', variables('workspaceName'))]"
+            ]
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/templates/machine-learning-job.json
+++ b/tools/c7n_azure/tests_azure/templates/machine-learning-job.json
@@ -79,6 +79,7 @@
             "properties": {
                 "jobType": "Sweep",
                 "limits": {
+                    "jobLimitsType": "Sweep",
                     "maxConcurrentTrials": 20
                 }
             },

--- a/tools/c7n_azure/tests_azure/tests_resources/test_machine_learning_job.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_machine_learning_job.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ..azure_common import BaseTest, arm_template, cassette_name
+from c7n_azure.resources.machine_learning_job import MachineLearningJob
 
 
 class MachineLearningJobTest(BaseTest):
@@ -12,6 +13,12 @@ class MachineLearningJobTest(BaseTest):
             'resource': 'azure.machine-learning-job'
         }, validate=True)
         self.assertTrue(p)
+
+        for action in ('tag', 'untag', 'auto-tag-user', 'auto-tag-date',
+                       'tag-trim', 'mark-for-op'):
+            self.assertNotIn(action, MachineLearningJob.action_registry)
+        self.assertNotIn('marked-for-op', MachineLearningJob.filter_registry)
+        self.assertNotIn('location', MachineLearningJob.resource_type.default_report_fields)
 
     @arm_template('machine-learning-job.json')
     @cassette_name('machine-learning-jobs')

--- a/tools/c7n_azure/tests_azure/tests_resources/test_machine_learning_job.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_machine_learning_job.py
@@ -1,0 +1,47 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from ..azure_common import BaseTest, arm_template, cassette_name
+
+
+class MachineLearningJobTest(BaseTest):
+
+    def test_machine_learning_job_schema_validate(self):
+        p = self.load_policy({
+            'name': 'find-all-machine-learning-jobs',
+            'resource': 'azure.machine-learning-job'
+        }, validate=True)
+        self.assertTrue(p)
+
+    @arm_template('machine-learning-job.json')
+    @cassette_name('machine-learning-jobs')
+    def test_machine_learning_job_query(self):
+        p = self.load_policy({
+            'name': 'find-all-machine-learning-jobs',
+            'resource': 'azure.machine-learning-job',
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('cctest-sweep-job', resources[0]['name'])
+        self.assertIn('/jobs/', resources[0]['id'])
+
+    @arm_template('machine-learning-job.json')
+    @cassette_name('machine-learning-jobs')
+    def test_machine_learning_job_filter_sweep_parallelism(self):
+        p = self.load_policy({
+            'name': 'ml-sweep-jobs-over-parallelism-limit',
+            'resource': 'azure.machine-learning-job',
+            'filters': [{
+                'type': 'value',
+                'key': 'properties.jobType',
+                'value': 'Sweep'
+            }, {
+                'type': 'value',
+                'key': 'properties.limits.maxConcurrentTrials',
+                'op': 'gt',
+                'value': 10
+            }],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('cctest-sweep-job', resources[0]['name'])


### PR DESCRIPTION
Adds `azure.machine-learning-job` as a child resource of
`machine-learning-workspace`, enumerating
`Microsoft.MachineLearningServices/workspaces/jobs` per workspace via the
`Jobs_List` API. This lets policies inspect ML jobs (training, sweep, etc.)
and filter job fields such as `properties.limits.maxConcurrentTrials`.

Implemented as a `ChildArmResourceManager`, mirroring the existing
`ai-foundry-project` resource:

- `enum_spec = ('jobs', 'list', None)`
- `parent_manager_name = 'machine-learning-workspace'`
- `extra_args` passes `resource_group_name` + `workspace_name` from the parent.

Example - find sweep jobs whose maximum concurrent trials exceeds 10:

```yaml
policies:
  - name: ml-sweep-jobs-over-parallelism-limit
    resource: azure.machine-learning-job
    filters:
      - type: value
        key: properties.jobType
        value: Sweep
      - type: value
        key: properties.limits.maxConcurrentTrials
        op: gt
        value: 10
```

Tests: schema validation, query enumeration, and a sweep-parallelism value
filter, backed by a recorded cassette and an ARM template. New tests pass;
workspace + AI-foundry + provider regression pass.

Closes #10832
