### PR TITLE
aws - redshift delete - preserve invalid state warning details

### DIFF
--- a/c7n/resources/redshift.py
+++ b/c7n/resources/redshift.py
@@ -363,8 +363,8 @@ class Delete(BaseAction):
             except ClientError as e:
                 if e.response['Error']['Code'] == "InvalidClusterState":
                     self.log.warning(
-                        "Cannot delete cluster when not 'Available' state: %s",
-                        db['ClusterIdentifier'])
+                        "Cannot delete cluster %s: %s",
+                        db['ClusterIdentifier'], e)
                     continue
                 raise
 

--- a/tests/data/placebo/test_redshift_delete_lakehouse_registered/redshift.DeleteCluster_1.json
+++ b/tests/data/placebo/test_redshift_delete_lakehouse_registered/redshift.DeleteCluster_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Type": "Sender",
+            "Code": "InvalidClusterState",
+            "Message": "The cluster has an associated lakehouse glue catalog. Deregister it before you delete the cluster."
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_redshift_delete_lakehouse_registered/redshift.DescribeClusters_1.json
+++ b/tests/data/placebo/test_redshift_delete_lakehouse_registered/redshift.DescribeClusters_1.json
@@ -1,0 +1,113 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "ClusterIdentifier": "c7n-test-redshift",
+                "NodeType": "ra3.xlplus",
+                "ClusterStatus": "available",
+                "ClusterAvailabilityStatus": "Available",
+                "MasterUsername": "awsuser",
+                "DBName": "test",
+                "Endpoint": {
+                    "Address": "c7n-test-redshift.cbfpjoynzfab.us-east-1.redshift.amazonaws.com",
+                    "Port": 5439,
+                    "VpcEndpoints": [
+                        {
+                            "VpcEndpointId": "vpce-0965ac0d5c55b9741",
+                            "VpcId": "vpc-013f466175ab8b593",
+                            "NetworkInterfaces": [
+                                {
+                                    "NetworkInterfaceId": "eni-0f2ec15384f700f53",
+                                    "SubnetId": "subnet-0b6e72066ec785fa5",
+                                    "PrivateIpAddress": "10.0.0.72",
+                                    "AvailabilityZone": "us-east-1a"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "ClusterCreateTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 30,
+                    "hour": 0,
+                    "minute": 46,
+                    "second": 9,
+                    "microsecond": 713000
+                },
+                "AutomatedSnapshotRetentionPeriod": 1,
+                "ManualSnapshotRetentionPeriod": -1,
+                "ClusterSecurityGroups": [],
+                "VpcSecurityGroups": [
+                    {
+                        "VpcSecurityGroupId": "sg-01156922ad9c738e6",
+                        "Status": "active"
+                    }
+                ],
+                "ClusterParameterGroups": [
+                    {
+                        "ParameterGroupName": "c7n-test-redshift",
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ],
+                "ClusterSubnetGroupName": "c7n-test-redshift",
+                "VpcId": "vpc-013f466175ab8b593",
+                "AvailabilityZone": "us-east-1a",
+                "PreferredMaintenanceWindow": "sat:10:00-sat:10:30",
+                "PendingModifiedValues": {},
+                "ClusterVersion": "1.0",
+                "AllowVersionUpgrade": true,
+                "NumberOfNodes": 1,
+                "PubliclyAccessible": false,
+                "Encrypted": true,
+                "ClusterPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDF+uPvvhaW8bBZn7dJOYg+xeZwugJHGPSaX3BNKanddRTuBjqfB5YtV1DPvmPRwIBNlao5aHw0vC+0ztWekuZaI8Ez1dSBZjHRD278wtYeX7nMY1/uARd6brm7tDN35RdPiN9Q/+lsmjhUrPp9Oh4j7osYKTFvpq60phXhCCJeQOwGdsIEKlb5CjCEH+RUaahsui8sKlka7lAsfUZvzN1Zl6bJF0pIAvLG7psjj0WpErd4SFk2tTzYsnmlaaPkdlr0EojHxVficYYArKCnzpGDJDe4kjtO7xU5na64ywnK7yuRTc8VDoZfFqGpHPyZH/5f38Ucf1S/EikDbywmNUdZ Amazon-Redshift\n",
+                "ClusterNodes": [
+                    {
+                        "NodeRole": "SHARED",
+                        "PrivateIPAddress": "10.0.0.121",
+                        "PublicIPAddress": "54.237.232.38"
+                    }
+                ],
+                "ClusterRevisionNumber": "331388",
+                "Tags": [
+                    {
+                        "Key": "Project",
+                        "Value": "c7n-redshift"
+                    },
+                    {
+                        "Key": "Env",
+                        "Value": "test"
+                    }
+                ],
+                "KmsKeyId": "AWS_OWNED_KMS_KEY",
+                "EnhancedVpcRouting": false,
+                "IamRoles": [],
+                "MaintenanceTrackName": "current",
+                "DeferredMaintenanceWindows": [],
+                "NextMaintenanceWindowStartTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 4,
+                    "hour": 10,
+                    "minute": 0,
+                    "second": 0,
+                    "microsecond": 0
+                },
+                "AvailabilityZoneRelocationStatus": "disabled",
+                "ClusterNamespaceArn": "arn:aws:redshift:us-east-1:644160558196:namespace:ede75cf5-eb77-4045-9cb0-7ce836256680",
+                "AquaConfiguration": {
+                    "AquaStatus": "disabled",
+                    "AquaConfigurationStatus": "auto"
+                },
+                "MasterPasswordSecretArn": "arn:aws:secretsmanager:us-east-1:644160558196:secret:redshift!c7n-test-redshift-awsuser-5tJOpX",
+                "MultiAZ": "Disabled",
+                "LakehouseRegistrationStatus": "REGISTERED",
+                "CatalogArn": "arn:aws:glue:us-east-1:644160558196:catalog/c7n-test-catalog"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -179,6 +179,23 @@ class TestRedshift(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
+    def test_redshift_delete_lakehouse_registered(self):
+        factory = self.record_flight_data("test_redshift_delete_lakehouse_registered")
+        p = self.load_policy(
+            {
+                "name": "redshift-delete-lakehouse-registered",
+                "resource": "aws.redshift",
+                "filters": [{"ClusterIdentifier": "c7n-test-redshift"}],
+                "actions": [{"type": "delete", "skip-snapshot": True}],
+            },
+            session_factory=factory,
+        )
+
+        output = self.capture_logging("custodian.actions", level=logging.DEBUG)
+        p.run()
+        print(output.getvalue())
+        self.assertIn("The cluster has an associated lakehouse glue catalog", output.getvalue())
+
     def test_redshift_default_vpc(self):
         session_factory = self.replay_flight_data("test_redshift_default_vpc")
         p = self.load_policy(


### PR DESCRIPTION
The existing logic in the `aws.redshift` `delete` action includes some hardcoded text when it hits an `InvalidClusterState` error:

> Cannot delete cluster when not 'Available' state

This can be misleading if the cluster is already in `available` state and the `InvalidClusterState` has another cause (like an existing Lakehouse registration).

Since the underlying API response should have a more useful error, pass that through and add a test to demonstrate it.