### PR TITLE
aws - workspaces-bundle - pull tags via universal augment

### DIFF
--- a/c7n/resources/workspaces.py
+++ b/c7n/resources/workspaces.py
@@ -7,7 +7,7 @@ from c7n.actions import BaseAction
 from c7n.filters import ValueFilter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo, DescribeSource, ConfigSource
+from c7n.query import DescribeWithResourceTags, QueryResourceManager, TypeInfo, ConfigSource
 from c7n.tags import universal_augment, Tag, RemoveTag
 from c7n.exceptions import PolicyValidationError, PolicyExecutionError
 from c7n.utils import get_retry, local_session, type_schema, chunks, jmespath_search
@@ -15,12 +15,6 @@ from c7n.filters.iamaccess import CrossAccountAccessFilter
 from c7n.resolver import ValuesFrom
 import c7n.filters.vpc as net_filters
 import json
-
-
-class DescribeWorkspace(DescribeSource):
-
-    def augment(self, resources):
-        return universal_augment(self.manager, resources)
 
 
 @resources.register('workspaces')
@@ -33,10 +27,9 @@ class Workspace(QueryResourceManager):
         name = id = dimension = 'WorkspaceId'
         universal_taggable = True
         cfn_type = config_type = 'AWS::WorkSpaces::Workspace'
-        permissions_augment = ("workspaces:DescribeTags",)
 
     source_mapping = {
-        'describe': DescribeWorkspace,
+        'describe': DescribeWithResourceTags,
         'config': ConfigSource
     }
 
@@ -172,9 +165,8 @@ class WorkspaceImage(QueryResourceManager):
         arn_type = 'workspaceimage'
         name = id = 'ImageId'
         universal_taggable = True
-        permissions_augment = ("workspaces:DescribeTags",)
 
-    augment = universal_augment
+    source_mapping = {'describe': DescribeWithResourceTags}
 
 
 @WorkspaceImage.filter_registry.register('cross-account')
@@ -262,7 +254,7 @@ class WorkspaceDirectory(QueryResourceManager):
         filter_name = 'DirectoryIds'
         filter_type = 'list'
 
-    augment = universal_augment
+    source_mapping = {'describe': DescribeWithResourceTags}
 
 
 @WorkspaceDirectory.filter_registry.register('security-group')
@@ -782,6 +774,8 @@ class WorkspacesBundle(QueryResourceManager):
         arn_type = 'workspacebundle'
         name = id = 'BundleId'
         universal_taggable = True
+
+    source_mapping = {'describe': DescribeWithResourceTags}
 
 
 @WorkspacesBundle.action_registry.register('delete')

--- a/tests/data/placebo/test_workspaces_bundle_delete/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_workspaces_bundle_delete/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_workspaces_bundle_delete/workspaces.DescribeWorkspaceBundles_1.json
+++ b/tests/data/placebo/test_workspaces_bundle_delete/workspaces.DescribeWorkspaceBundles_1.json
@@ -3,11 +3,11 @@
     "data": {
         "Bundles": [
             {
-                "BundleId": "wsb-g0znf3451",
-                "Name": "test",
+                "BundleId": "wsb-5h1tv4m06",
+                "Name": "c7ntest-2",
                 "Owner": "644160558196",
-                "Description": "test",
-                "ImageId": "wsi-f19s7dtsh",
+                "Description": "testing",
+                "ImageId": "wsi-8ty9127vz",
                 "RootStorage": {
                     "Capacity": "80"
                 },
@@ -19,23 +19,23 @@
                 },
                 "LastUpdatedTime": {
                     "__class__": "datetime",
-                    "year": 2024,
-                    "month": 3,
-                    "day": 23,
-                    "hour": 14,
-                    "minute": 1,
-                    "second": 43,
-                    "microsecond": 963000
+                    "year": 2026,
+                    "month": 6,
+                    "day": 30,
+                    "hour": 1,
+                    "minute": 21,
+                    "second": 13,
+                    "microsecond": 687000
                 },
                 "CreationTime": {
                     "__class__": "datetime",
-                    "year": 2024,
-                    "month": 3,
-                    "day": 23,
-                    "hour": 13,
-                    "minute": 58,
-                    "second": 2,
-                    "microsecond": 280000
+                    "year": 2026,
+                    "month": 6,
+                    "day": 30,
+                    "hour": 1,
+                    "minute": 21,
+                    "second": 13,
+                    "microsecond": 687000
                 },
                 "State": "AVAILABLE",
                 "BundleType": "REGULAR"

--- a/tests/data/placebo/test_workspaces_bundle_tag/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_workspaces_bundle_tag/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_workspaces_bundle_tag/workspaces.DescribeTags_1.json
+++ b/tests/data/placebo/test_workspaces_bundle_tag/workspaces.DescribeTags_1.json
@@ -5,6 +5,10 @@
             {
                 "Key": "test",
                 "Value": "testval"
+            },
+            {
+                "Key": "Owner",
+                "Value": "aj@stacklet.io"
             }
         ],
         "ResponseMetadata": {}

--- a/tests/data/placebo/test_workspaces_bundle_tag/workspaces.DescribeWorkspaceBundles_1.json
+++ b/tests/data/placebo/test_workspaces_bundle_tag/workspaces.DescribeWorkspaceBundles_1.json
@@ -3,11 +3,11 @@
     "data": {
         "Bundles": [
             {
-                "BundleId": "wsb-g0znf3451",
-                "Name": "test",
+                "BundleId": "wsb-fpy0tzxgc",
+                "Name": "c7ntest",
                 "Owner": "644160558196",
-                "Description": "test",
-                "ImageId": "wsi-f19s7dtsh",
+                "Description": "testing",
+                "ImageId": "wsi-8ty9127vz",
                 "RootStorage": {
                     "Capacity": "80"
                 },
@@ -19,23 +19,23 @@
                 },
                 "LastUpdatedTime": {
                     "__class__": "datetime",
-                    "year": 2024,
-                    "month": 3,
-                    "day": 23,
-                    "hour": 14,
-                    "minute": 1,
-                    "second": 43,
-                    "microsecond": 963000
+                    "year": 2026,
+                    "month": 6,
+                    "day": 30,
+                    "hour": 1,
+                    "minute": 3,
+                    "second": 15,
+                    "microsecond": 721000
                 },
                 "CreationTime": {
                     "__class__": "datetime",
-                    "year": 2024,
-                    "month": 3,
-                    "day": 23,
-                    "hour": 13,
-                    "minute": 58,
-                    "second": 2,
-                    "microsecond": 280000
+                    "year": 2026,
+                    "month": 6,
+                    "day": 30,
+                    "hour": 1,
+                    "minute": 1,
+                    "second": 35,
+                    "microsecond": 501000
                 },
                 "State": "AVAILABLE",
                 "BundleType": "REGULAR"

--- a/tests/data/placebo/test_workspaces_bundle_untag/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_workspaces_bundle_untag/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_workspaces_bundle_untag/workspaces.DescribeTags_1.json
+++ b/tests/data/placebo/test_workspaces_bundle_untag/workspaces.DescribeTags_1.json
@@ -1,7 +1,12 @@
 {
     "status_code": 200,
     "data": {
-        "TagList": [],
+        "TagList": [
+            {
+                "Key": "Owner",
+                "Value": "aj@stacklet.io"
+            }
+        ],
         "ResponseMetadata": {}
     }
 }

--- a/tests/data/placebo/test_workspaces_bundle_untag/workspaces.DescribeWorkspaceBundles_1.json
+++ b/tests/data/placebo/test_workspaces_bundle_untag/workspaces.DescribeWorkspaceBundles_1.json
@@ -3,11 +3,11 @@
     "data": {
         "Bundles": [
             {
-                "BundleId": "wsb-g0znf3451",
-                "Name": "test",
+                "BundleId": "wsb-fpy0tzxgc",
+                "Name": "c7ntest",
                 "Owner": "644160558196",
-                "Description": "test",
-                "ImageId": "wsi-f19s7dtsh",
+                "Description": "testing",
+                "ImageId": "wsi-8ty9127vz",
                 "RootStorage": {
                     "Capacity": "80"
                 },
@@ -19,23 +19,23 @@
                 },
                 "LastUpdatedTime": {
                     "__class__": "datetime",
-                    "year": 2024,
-                    "month": 3,
-                    "day": 23,
-                    "hour": 14,
-                    "minute": 1,
-                    "second": 43,
-                    "microsecond": 963000
+                    "year": 2026,
+                    "month": 6,
+                    "day": 30,
+                    "hour": 1,
+                    "minute": 3,
+                    "second": 15,
+                    "microsecond": 721000
                 },
                 "CreationTime": {
                     "__class__": "datetime",
-                    "year": 2024,
-                    "month": 3,
-                    "day": 23,
-                    "hour": 13,
-                    "minute": 58,
-                    "second": 2,
-                    "microsecond": 280000
+                    "year": 2026,
+                    "month": 6,
+                    "day": 30,
+                    "hour": 1,
+                    "minute": 1,
+                    "second": 35,
+                    "microsecond": 501000
                 },
                 "State": "AVAILABLE",
                 "BundleType": "REGULAR"

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -638,18 +638,18 @@ class TestWorkspacesWeb(BaseTest):
 class TestWorkspacesBundleDelete(BaseTest):
 
     def test_workspaces_bundle_tag(self):
-        session_factory = self.replay_flight_data("test_workspaces_bundle_tag")
+        session_factory = self.replay_flight_data("test_workspaces_bundle_tag", region="us-east-2")
         client = session_factory().client("workspaces")
 
         p = self.load_policy({
             'name': 'workspaces-bundle-tag',
             'resource': 'workspaces-bundle',
-            'filters': [{'Name': 'test'}],
+            'filters': [{'Name': 'c7ntest'}],
             'actions': [{
                 'type': 'tag',
                 'tags': {'test': 'testval'}
             }]
-        }, session_factory=session_factory)
+        }, session_factory=session_factory, config={'region': 'us-east-2'})
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
@@ -657,18 +657,20 @@ class TestWorkspacesBundleDelete(BaseTest):
         self.assertIn({'Key': 'test', 'Value': 'testval'}, response.get('TagList', []))
 
     def test_workspaces_bundle_untag(self):
-        session_factory = self.replay_flight_data("test_workspaces_bundle_untag")
+        session_factory = self.replay_flight_data(
+            "test_workspaces_bundle_untag", region="us-east-2"
+        )
         client = session_factory().client("workspaces")
 
         p = self.load_policy({
             'name': 'workspaces-bundle-untag',
             'resource': 'workspaces-bundle',
-            'filters': [{'Name': 'test'}],
+            'filters': [{'Name': 'c7ntest'}],
             'actions': [{
                 'type': 'remove-tag',
                 'tags': ['test']
             }]
-        }, session_factory=session_factory)
+        }, session_factory=session_factory, config={'region': 'us-east-2'})
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
@@ -676,20 +678,23 @@ class TestWorkspacesBundleDelete(BaseTest):
         self.assertNotIn({'Key': 'test', 'Value': 'testval'}, response.get('TagList', []))
 
     def test_workspaces_bundle_delete(self):
-        session_factory = self.replay_flight_data("test_workspaces_bundle_delete")
+        session_factory = self.replay_flight_data(
+            "test_workspaces_bundle_delete", region="us-east-2"
+        )
         client = session_factory().client("workspaces")
+        bundle_name = 'c7ntest-2'
 
         p = self.load_policy({
             'name': 'workspaces-bundle-delete',
             'resource': 'aws.workspaces-bundle',
-            'filters': [{'Name': 'test'}],
+            'filters': [{'Name': bundle_name}],
             'actions': [{'type': 'delete'}]
-        }, session_factory=session_factory)
+        }, session_factory=session_factory, config={'region': 'us-east-2'})
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]['Name'], 'test')
+        self.assertEqual(resources[0]['Name'], bundle_name)
         if self.recording:
             time.sleep(5)
 
         response = client.describe_workspace_bundles()['Bundles']
-        self.assertFalse(any(b['Name'] == 'test' for b in response))
+        self.assertFalse(any(b['Name'] == bundle_name for b in response))

--- a/tools/c7n_awscc/c7n_awscc/manager.py
+++ b/tools/c7n_awscc/c7n_awscc/manager.py
@@ -62,17 +62,18 @@ def initialize_resource(resource_name):
         ),
     )
 
-    rtype.action_registry.register(
-        "delete",
-        type(
-            class_name + "Delete",
-            (Delete,),
-            {
-                "permissions": rinfo["handlers"]["delete"]["permissions"],
-                "__module__": mod_name,
-            },
-        ),
-    )
+    if "delete" in rinfo["handlers"]:
+        rtype.action_registry.register(
+            "delete",
+            type(
+                class_name + "Delete",
+                (Delete,),
+                {
+                    "permissions": rinfo["handlers"]["delete"]["permissions"],
+                    "__module__": mod_name,
+                },
+            ),
+        )
 
     if "update" in rinfo["handlers"]:
         rtype.action_registry.register(


### PR DESCRIPTION
The `aws.workspaces-bundle` resource type supported tag/untag operations, but didn't fetch tags so those changes weren't visible. Changes:

- Update `aws.workspace-bundle` to fetch tags during its augment phase
- Re-record tests
- Use the `DescribeWithResourceTags` source more consistently across Workspaces resource types, rather than defining manager-level augments or custom classes

Drive-by change:

- Add a guard to `c7n_awscc`'s action registration logic - it looks like there were new resource types added upstream that didn't include `delete` handlers so our unconditional attempt to add delete actions failed and broke CI
