### PR TITLE
feat: add k8s role-binding, cluster-role-binding resources and role-ref filter

### DIFF
--- a/tools/c7n_kube/c7n_kube/resources/rbac/rolebinding.py
+++ b/tools/c7n_kube/c7n_kube/resources/rbac/rolebinding.py
@@ -1,0 +1,31 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+from c7n_kube.query import QueryResourceManager, TypeInfo
+from c7n_kube.provider import resources
+
+
+@resources.register("cluster-role-binding")
+class ClusterRoleBinding(QueryResourceManager):
+    class resource_type(TypeInfo):
+        group = "RbacAuthorization"
+        canonical_group = "rbac.authorization.k8s.io"
+        version = "V1"
+        patch = "patch_cluster_role_binding"
+        delete = "delete_cluster_role_binding"
+        enum_spec = ("list_cluster_role_binding", "items", None)
+        plural = "clusterrolebindings"
+        namespaced = False
+
+
+@resources.register("role-binding")
+class RoleBinding(QueryResourceManager):
+    class resource_type(TypeInfo):
+        group = "RbacAuthorization"
+        canonical_group = "rbac.authorization.k8s.io"
+        version = "V1"
+        patch = "patch_namespaced_role_binding"
+        delete = "delete_namespaced_role_binding"
+        enum_spec = ("list_role_binding_for_all_namespaces", "items", None)
+        plural = "rolebindings"
+        namespaced = True

--- a/tools/c7n_kube/c7n_kube/resources/rbac/rolebinding.py
+++ b/tools/c7n_kube/c7n_kube/resources/rbac/rolebinding.py
@@ -1,6 +1,12 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 #
+from kubernetes.client.exceptions import ApiException
+
+from c7n.exceptions import PolicyExecutionError
+from c7n.filters import ValueFilter
+from c7n.utils import local_session, type_schema
+
 from c7n_kube.query import QueryResourceManager, TypeInfo
 from c7n_kube.provider import resources
 
@@ -29,3 +35,92 @@ class RoleBinding(QueryResourceManager):
         enum_spec = ("list_role_binding_for_all_namespaces", "items", None)
         plural = "rolebindings"
         namespaced = True
+
+
+class RoleRefFilter(ValueFilter):
+    """Filter role-bindings (or cluster-role-bindings) based on the permissions
+    defined in the role they reference (roleRef).
+
+    The filter fetches the ClusterRole or Role that the binding points to via
+    ``roleRef``, converts it to a plain dict, and then applies the standard
+    JMESPath ``key`` / ``value`` / ``op`` match against that role's data.
+
+    This lets you select bindings whose referenced role has specific permission
+    patterns, for example finding all bindings that grant wildcard resource access:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: role-bindings-with-wildcard-resources
+            resource: k8s.role-binding
+            filters:
+              - type: role-ref
+                key: "rules[?resources && contains(resources, '*')]"
+                op: ne
+                value: null
+
+          - name: role-bindings-with-wildcard-verbs
+            resource: k8s.cluster-role-binding
+            filters:
+              - type: role-ref
+                key: "rules[?verbs && contains(verbs, '*')]"
+                op: ne
+                value: null
+
+    The matched role data is also annotated on the binding resource under the
+    ``c7n:role-ref`` key for use in follow-up actions or notifications.
+    """
+
+    schema = type_schema("role-ref", rinherit=ValueFilter.schema)
+    annotation_key = "c7n:role-ref"
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client(
+            "RbacAuthorization", "V1"
+        )
+
+        cluster_roles = {
+            cr.metadata.name: cr for cr in client.list_cluster_role().items
+        }
+
+        try:
+            namespaced_roles = {
+                (r.metadata.namespace, r.metadata.name): r
+                for r in client.list_role_for_all_namespaces().items
+            }
+        except ApiException as e:
+            raise PolicyExecutionError(
+                "failed to list namespaced roles for role-ref filter: %s" % e
+            ) from e
+
+        result = []
+        for resource in resources:
+            role = self._resolve_role_ref(
+                binding=resource,
+                cluster_roles=cluster_roles,
+                namespaced_roles=namespaced_roles,
+            )
+            if role is None:
+                continue
+            role_dict = role.to_dict()
+            resource[self.annotation_key] = role_dict
+            if self.match(role_dict):
+                result.append(resource)
+        return result
+
+    def _resolve_role_ref(self, binding, cluster_roles, namespaced_roles):
+        role_ref = binding.get("role_ref") or {}
+        kind = role_ref.get("kind", "")
+        name = role_ref.get("name", "")
+        if not name:
+            return None
+        if kind == "ClusterRole":
+            return cluster_roles.get(name)
+        elif kind == "Role":
+            namespace = (binding.get("metadata") or {}).get("namespace", "")
+            return namespaced_roles.get((namespace, name))
+        return None
+
+
+RoleBinding.filter_registry.register("role-ref", RoleRefFilter)
+ClusterRoleBinding.filter_registry.register("role-ref", RoleRefFilter)

--- a/tools/c7n_kube/c7n_kube/resources/rbac/rolebinding.py
+++ b/tools/c7n_kube/c7n_kube/resources/rbac/rolebinding.py
@@ -75,13 +75,9 @@ class RoleRefFilter(ValueFilter):
     annotation_key = "c7n:role-ref"
 
     def process(self, resources, event=None):
-        client = local_session(self.manager.session_factory).client(
-            "RbacAuthorization", "V1"
-        )
+        client = local_session(self.manager.session_factory).client("RbacAuthorization", "V1")
 
-        cluster_roles = {
-            cr.metadata.name: cr for cr in client.list_cluster_role().items
-        }
+        cluster_roles = {cr.metadata.name: cr for cr in client.list_cluster_role().items}
 
         try:
             namespaced_roles = {

--- a/tools/c7n_kube/c7n_kube/resources/resource_map.py
+++ b/tools/c7n_kube/c7n_kube/resources/resource_map.py
@@ -20,5 +20,7 @@ ResourceMap = {
     "k8s.volume": "c7n_kube.resources.core.volume.PersistentVolume",
     "k8s.volume-claim": "c7n_kube.resources.core.volume.PersistentVolumeClaim",
     "k8s.cluster-role": "c7n_kube.resources.rbac.role.ClusterRole",
+    "k8s.cluster-role-binding": "c7n_kube.resources.rbac.rolebinding.ClusterRoleBinding",
     "k8s.role": "c7n_kube.resources.rbac.role.NamespacedRole",
+    "k8s.role-binding": "c7n_kube.resources.rbac.rolebinding.RoleBinding",
 }

--- a/tools/c7n_kube/tests/data/flights/ClusterRoleBindingTest.test_cluster_role_binding_query.yaml
+++ b/tools/c7n_kube/tests/data/flights/ClusterRoleBindingTest.test_cluster_role_binding_query.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Swagger-Codegen/10.0.1/python
+    method: GET
+    uri: https://ghost/apis/rbac.authorization.k8s.io/v1/clusterrolebindings
+  response:
+    body:
+      string: '{"kind":"ClusterRoleBindingList","apiVersion":"rbac.authorization.k8s.io/v1","metadata":{"resourceVersion":"1156146"},"items":[{"metadata":{"name":"cluster-admin","uid":"6c9e0f2b-1d4a-4b8b-9f3e-1a2b3c4d5e6f","resourceVersion":"175","creationTimestamp":"2022-10-10T15:02:29Z","labels":{"kubernetes.io/bootstrapping":"rbac-defaults"},"annotations":{"rbac.authorization.kubernetes.io/autoupdate":"true"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"cluster-admin"},"subjects":[{"kind":"Group","apiGroup":"rbac.authorization.k8s.io","name":"system:masters"}]},{"metadata":{"name":"cert-manager-cainjector","uid":"7d8e1f3c-2e5b-4c9c-a04f-2b3c4d5e6f70","resourceVersion":"15745","creationTimestamp":"2022-10-10T18:46:55Z","labels":{"app":"cainjector","app.kubernetes.io/component":"cainjector","app.kubernetes.io/instance":"cert-manager","app.kubernetes.io/name":"cainjector"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"cert-manager-cainjector"},"subjects":[{"kind":"ServiceAccount","name":"cert-manager-cainjector","namespace":"cert-manager"}]},{"metadata":{"name":"system:controller:token-cleaner","uid":"8e9f2a4d-3f6c-4d0d-b15a-3c4d5e6f7081","resourceVersion":"183","creationTimestamp":"2022-10-10T15:02:29Z","labels":{"kubernetes.io/bootstrapping":"rbac-defaults"},"annotations":{"rbac.authorization.kubernetes.io/autoupdate":"true"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"system:controller:token-cleaner"},"subjects":[{"kind":"ServiceAccount","name":"token-cleaner","namespace":"kube-system"}]}]}
+
+        '
+    headers:
+      Audit-Id:
+      - 8b6b7a2e-1234-4f3c-91ad-abcdef012345
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 25 Oct 2022 13:31:34 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - 6934332f-22cd-43ef-a389-9620e5d58cb6
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - 2ff72234-6653-4ad6-9a50-8b48c49c6a7e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tools/c7n_kube/tests/data/flights/ClusterRoleBindingTest.test_cluster_role_binding_role_ref_filter.yaml
+++ b/tools/c7n_kube/tests/data/flights/ClusterRoleBindingTest.test_cluster_role_binding_role_ref_filter.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: null
+    headers: &id001
+      Accept: application/json
+      Content-Type: application/json
+      User-Agent: Swagger-Codegen/10.0.1/python
+    method: GET
+    uri: https://ghost/apis/rbac.authorization.k8s.io/v1/clusterrolebindings
+  response:
+    body:
+      string: '{"kind": "ClusterRoleBindingList", "apiVersion": "rbac.authorization.k8s.io/v1",
+        "items": [{"metadata": {"name": "cluster-admin"}, "roleRef": {"apiGroup":
+        "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "cluster-admin"},
+        "subjects": [{"kind": "User", "name": "test-user"}]}, {"metadata": {"name":
+        "cert-manager-cainjector"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole", "name": "cert-manager-cainjector"}, "subjects": [{"kind":
+        "User", "name": "test-user"}]}, {"metadata": {"name": "system:controller:token-cleaner"},
+        "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole",
+        "name": "system:controller:token-cleaner"}, "subjects": [{"kind": "User",
+        "name": "test-user"}]}]}
+
+
+        '
+    headers: &id002
+      Cache-Control: no-cache, private
+      Content-Type: application/json
+      Date: Tue, 25 Oct 2022 13:31:34 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: *id001
+    method: GET
+    uri: https://ghost/apis/rbac.authorization.k8s.io/v1/clusterroles
+  response:
+    body:
+      string: '{"kind": "ClusterRoleList", "apiVersion": "rbac.authorization.k8s.io/v1",
+        "items": [{"metadata": {"name": "cluster-admin"}, "rules": [{"verbs": ["*"],
+        "apiGroups": ["*"], "resources": ["*"]}]}, {"metadata": {"name": "cert-manager-cainjector"},
+        "rules": [{"verbs": ["get"], "apiGroups": [""], "resources": ["events"]}]},
+        {"metadata": {"name": "system:controller:token-cleaner"}, "rules": [{"verbs":
+        ["delete"], "apiGroups": [""], "resources": ["secrets"]}]}]}
+
+
+        '
+    headers: *id002
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: *id001
+    method: GET
+    uri: https://ghost/apis/rbac.authorization.k8s.io/v1/roles
+  response:
+    body:
+      string: '{"kind": "RoleList", "apiVersion": "rbac.authorization.k8s.io/v1",
+        "items": []}
+
+
+        '
+    headers: *id002
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tools/c7n_kube/tests/data/flights/RoleBindingTest.test_role_binding_query.yaml
+++ b/tools/c7n_kube/tests/data/flights/RoleBindingTest.test_role_binding_query.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Swagger-Codegen/10.0.1/python
+    method: GET
+    uri: https://ghost/apis/rbac.authorization.k8s.io/v1/rolebindings
+  response:
+    body:
+      string: '{"kind":"RoleBindingList","apiVersion":"rbac.authorization.k8s.io/v1","metadata":{"resourceVersion":"1156147"},"items":[{"metadata":{"name":"cert-manager-cainjector:leaderelection","namespace":"kube-system","uid":"9f0a3b5e-4a7d-4e1e-c26b-4d5e6f708192","resourceVersion":"15746","creationTimestamp":"2022-10-10T18:46:55Z","labels":{"app":"cainjector","app.kubernetes.io/component":"cainjector","app.kubernetes.io/instance":"cert-manager","app.kubernetes.io/name":"cainjector"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"cert-manager-cainjector:leaderelection"},"subjects":[{"kind":"ServiceAccount","name":"cert-manager-cainjector","namespace":"cert-manager"}]},{"metadata":{"name":"system::leader-locking-kube-controller-manager","namespace":"kube-system","uid":"a0b1c4d6-5b8e-4f2f-d37c-5e6f708192a3","resourceVersion":"184","creationTimestamp":"2022-10-10T15:02:29Z","labels":{"kubernetes.io/bootstrapping":"rbac-defaults"},"annotations":{"rbac.authorization.kubernetes.io/autoupdate":"true"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"system::leader-locking-kube-controller-manager"},"subjects":[{"kind":"User","apiGroup":"rbac.authorization.k8s.io","name":"system:kube-controller-manager"}]},{"metadata":{"name":"cert-manager-webhook:dynamic-serving","namespace":"cert-manager","uid":"b1c2d5e7-6c9f-403f-e48d-6f708192a3b4","resourceVersion":"15747","creationTimestamp":"2022-10-10T18:46:55Z","labels":{"app":"webhook","app.kubernetes.io/component":"webhook","app.kubernetes.io/instance":"cert-manager","app.kubernetes.io/name":"webhook"}},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"cert-manager-webhook:dynamic-serving"},"subjects":[{"kind":"ServiceAccount","name":"cert-manager-webhook","namespace":"cert-manager"}]}]}
+
+        '
+    headers:
+      Audit-Id:
+      - c2d3e4f5-6789-4a1b-92cd-bcdef1234567
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 25 Oct 2022 13:31:34 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - 6934332f-22cd-43ef-a389-9620e5d58cb6
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - 2ff72234-6653-4ad6-9a50-8b48c49c6a7e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tools/c7n_kube/tests/data/flights/RoleBindingTest.test_role_binding_role_ref_filter.yaml
+++ b/tools/c7n_kube/tests/data/flights/RoleBindingTest.test_role_binding_role_ref_filter.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: null
+    headers: &id001
+      Accept: application/json
+      Content-Type: application/json
+      User-Agent: Swagger-Codegen/10.0.1/python
+    method: GET
+    uri: https://ghost/apis/rbac.authorization.k8s.io/v1/rolebindings
+  response:
+    body:
+      string: '{"kind": "RoleBindingList", "apiVersion": "rbac.authorization.k8s.io/v1",
+        "items": [{"metadata": {"name": "wildcard-binding", "namespace": "kube-system"},
+        "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name":
+        "wildcard-role"}, "subjects": [{"kind": "ServiceAccount", "name": "test-sa",
+        "namespace": "kube-system"}]}, {"metadata": {"name": "scoped-binding", "namespace":
+        "kube-system"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind":
+        "Role", "name": "scoped-role"}, "subjects": [{"kind": "ServiceAccount", "name":
+        "test-sa", "namespace": "kube-system"}]}, {"metadata": {"name": "webhook-binding",
+        "namespace": "cert-manager"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role", "name": "webhook-role"}, "subjects": [{"kind": "ServiceAccount",
+        "name": "test-sa", "namespace": "cert-manager"}]}]}
+
+
+        '
+    headers: &id002
+      Cache-Control: no-cache, private
+      Content-Type: application/json
+      Date: Tue, 25 Oct 2022 13:31:34 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: *id001
+    method: GET
+    uri: https://ghost/apis/rbac.authorization.k8s.io/v1/clusterroles
+  response:
+    body:
+      string: '{"kind": "ClusterRoleList", "apiVersion": "rbac.authorization.k8s.io/v1",
+        "items": []}
+
+
+        '
+    headers: *id002
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: *id001
+    method: GET
+    uri: https://ghost/apis/rbac.authorization.k8s.io/v1/roles
+  response:
+    body:
+      string: '{"kind": "RoleList", "apiVersion": "rbac.authorization.k8s.io/v1",
+        "items": [{"metadata": {"name": "wildcard-role", "namespace": "kube-system"},
+        "rules": [{"verbs": ["*"], "apiGroups": ["*"], "resources": ["*"]}]}, {"metadata":
+        {"name": "scoped-role", "namespace": "kube-system"}, "rules": [{"verbs": ["get"],
+        "apiGroups": [""], "resources": ["configmaps"]}]}, {"metadata": {"name": "webhook-role",
+        "namespace": "cert-manager"}, "rules": [{"verbs": ["get"], "apiGroups": [""],
+        "resources": ["secrets"]}]}]}
+
+
+        '
+    headers: *id002
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tools/c7n_kube/tests/test_rolebinding.py
+++ b/tools/c7n_kube/tests/test_rolebinding.py
@@ -1,0 +1,34 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from common_kube import KubeTest
+
+
+class ClusterRoleBindingTest(KubeTest):
+    def test_cluster_role_binding_query(self):
+        factory = self.replay_flight_data()
+        # factory = self.record_flight_data()
+        p = self.load_policy(
+            {"name": "cluster-role-bindings", "resource": "k8s.cluster-role-binding"},
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 3)
+        sorted_resources = sorted([r["metadata"]["name"] for r in resources])
+        assert "cluster-admin" in sorted_resources
+        assert "cert-manager-cainjector" in sorted_resources
+        assert "system:controller:token-cleaner" in sorted_resources
+
+
+class RoleBindingTest(KubeTest):
+    def test_role_binding_query(self):
+        factory = self.replay_flight_data()
+        p = self.load_policy(
+            {"name": "role-bindings", "resource": "k8s.role-binding"},
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 3)
+        sorted_resources = sorted([r["metadata"]["name"] for r in resources])
+        assert "cert-manager-cainjector:leaderelection" in sorted_resources
+        assert "system::leader-locking-kube-controller-manager" in sorted_resources
+        assert "cert-manager-webhook:dynamic-serving" in sorted_resources

--- a/tools/c7n_kube/tests/test_rolebinding.py
+++ b/tools/c7n_kube/tests/test_rolebinding.py
@@ -18,6 +18,30 @@ class ClusterRoleBindingTest(KubeTest):
         assert "cert-manager-cainjector" in sorted_resources
         assert "system:controller:token-cleaner" in sorted_resources
 
+    def test_cluster_role_binding_role_ref_filter(self):
+        factory = self.replay_flight_data()
+        p = self.load_policy(
+            {
+                "name": "cluster-role-bindings-wildcard",
+                "resource": "k8s.cluster-role-binding",
+                "filters": [
+                    {
+                        "type": "role-ref",
+                        "key": "length(rules[?resources && contains(resources, '*')])",
+                        "op": "gt",
+                        "value": 0,
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["metadata"]["name"], "cluster-admin")
+        self.assertEqual(
+            resources[0]["c7n:role-ref"]["metadata"]["name"], "cluster-admin"
+        )
+
 
 class RoleBindingTest(KubeTest):
     def test_role_binding_query(self):
@@ -32,3 +56,27 @@ class RoleBindingTest(KubeTest):
         assert "cert-manager-cainjector:leaderelection" in sorted_resources
         assert "system::leader-locking-kube-controller-manager" in sorted_resources
         assert "cert-manager-webhook:dynamic-serving" in sorted_resources
+
+    def test_role_binding_role_ref_filter(self):
+        factory = self.replay_flight_data()
+        p = self.load_policy(
+            {
+                "name": "role-bindings-wildcard",
+                "resource": "k8s.role-binding",
+                "filters": [
+                    {
+                        "type": "role-ref",
+                        "key": "length(rules[?resources && contains(resources, '*')])",
+                        "op": "gt",
+                        "value": 0,
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["metadata"]["name"], "wildcard-binding")
+        self.assertEqual(
+            resources[0]["c7n:role-ref"]["metadata"]["name"], "wildcard-role"
+        )

--- a/tools/c7n_kube/tests/test_rolebinding.py
+++ b/tools/c7n_kube/tests/test_rolebinding.py
@@ -38,9 +38,7 @@ class ClusterRoleBindingTest(KubeTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["metadata"]["name"], "cluster-admin")
-        self.assertEqual(
-            resources[0]["c7n:role-ref"]["metadata"]["name"], "cluster-admin"
-        )
+        self.assertEqual(resources[0]["c7n:role-ref"]["metadata"]["name"], "cluster-admin")
 
 
 class RoleBindingTest(KubeTest):
@@ -77,6 +75,4 @@ class RoleBindingTest(KubeTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["metadata"]["name"], "wildcard-binding")
-        self.assertEqual(
-            resources[0]["c7n:role-ref"]["metadata"]["name"], "wildcard-role"
-        )
+        self.assertEqual(resources[0]["c7n:role-ref"]["metadata"]["name"], "wildcard-role")


### PR DESCRIPTION
Adds `RoleBinding` and `ClusterRoleBinding` as queryable resource types in the `c7n_kube` provider, so Cloud Custodian policies can inspect and audit Kubernetes RBAC bindings the same way they already can for `Role`/`ClusterRole`.