### PR TITLE
tools/ops - fix mugc schedule mode tag lookup (#10312)

### DIFF
--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -68,7 +68,7 @@ def region_gc(options, region, policy_config, policies):
                 # Is it a schedule mode policy function due to empty resource policy?
                 fn = client.get_function(FunctionName=n['FunctionName'])
                 if 'custodian-schedule' in fn.get('Tags', {}).keys():
-                    tag_value = fn.get['Tags']['custodian-schedule']
+                    tag_value = fn['Tags']['custodian-schedule']
                     tag_result = schedule_pattern.search(tag_value)
                     events.append(mu.EventBridgeScheduleSource({
                         'group-name': tag_result.group(2)

--- a/tools/ops/test_mugc.py
+++ b/tools/ops/test_mugc.py
@@ -1,0 +1,69 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import mock
+
+from botocore.exceptions import ClientError
+
+import mugc
+
+from c7n import mu
+
+
+class Options:
+
+    prefix = "custodian-"
+    policy_regex = "^custodian-.*"
+    present = False
+    dryrun = False
+
+
+class PolicyConfig:
+
+    assume_role = None
+    profile = None
+    external_id = None
+
+
+def test_region_gc_schedule_mode_function():
+    """Schedule-mode policy lambdas are garbage collected without error.
+
+    Regression test for #10312: an EventBridge schedule mode function has an
+    empty resource policy, so ``get_policy`` raises ResourceNotFoundException
+    and mugc falls back to reading the ``custodian-schedule`` tag from the
+    ``get_function`` response.
+    """
+    function_name = "custodian-test-app-mypolicy"
+
+    lambda_client = mock.MagicMock()
+    lambda_client.get_policy.side_effect = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException"}}, "GetPolicy")
+    lambda_client.get_function.return_value = {
+        "Tags": {"custodian-schedule": "name=custodian-test-app-mypolicy:group=mygroup"}
+    }
+
+    manager = mock.MagicMock()
+    manager.list_functions.return_value = [{
+        "FunctionName": function_name,
+        "Role": "arn:aws:iam::644160558196:role/mypolicy",
+        "Handler": "custodian_policy.run",
+        "Timeout": 900,
+        "MemorySize": 512,
+        "Description": "",
+        "Runtime": "python3.11",
+    }]
+
+    session_factory = mock.MagicMock()
+    session_factory.return_value.client.return_value = lambda_client
+
+    with mock.patch.object(mugc, "SessionFactory", return_value=session_factory), \
+            mock.patch.object(mugc.mu, "LambdaManager", return_value=manager):
+        mugc.region_gc(Options(), "us-east-1", PolicyConfig(), [])
+
+    manager.remove.assert_called_once()
+    removed = manager.remove.call_args.args[0]
+    assert removed.func_data["name"] == function_name
+    events = removed.func_data["events"]
+    assert len(events) == 1
+    assert isinstance(events[0], mu.EventBridgeScheduleSource)
+    assert events[0].data == {"group-name": "mygroup"}


### PR DESCRIPTION
```markdown

`mugc` raised `TypeError` when garbage collecting EventBridge schedule mode
policy lambdas, so it could not remove them at all.

On the fallback path for a function with an empty resource policy (schedule
mode), `region_gc` reads the `custodian-schedule` tag from the `get_function`
response. The guard on the preceding line calls `fn.get('Tags', {})` correctly,
but the next line subscripted the bound method object instead of the dict:

```python
tag_value = fn.get['Tags']['custodian-schedule']
```

`fn.get` is `dict.get` (a bound method); subscripting it raises
`TypeError: 'builtin_function_or_method' object is not subscriptable`. This
fires 100% of the time for schedule mode functions, since their empty resource
policy always sends `get_policy` down this `ResourceNotFoundException` branch.

## Fix

Index the response dict instead of the method:

```python
tag_value = fn['Tags']['custodian-schedule']
```

`fn` is the `get_function` response, and the `custodian-schedule` key's presence
is already confirmed by the preceding `if 'custodian-schedule' in
fn.get('Tags', {}).keys():` guard, so this is safe. No change on the success
path.

The bug was introduced in #9273 (EventBridge Scheduler mode for policy lambdas).

## Test

Adds `tools/ops/test_mugc.py::test_region_gc_schedule_mode_function`, which
mocks the Lambda client so `get_policy` raises `ResourceNotFoundException` and
`get_function` returns a `custodian-schedule` tag, runs `region_gc`, and asserts
an `EventBridgeScheduleSource` is built and passed to `manager.remove`. It fails
with the original `TypeError` before the fix and passes after.

Closes #10312
```

---

## Notes for the PR (not part of the body)
- Commit style matches repo history: `component - description (#NNNN)`
  (e.g. `tools/ops - aws iam permission generator for policies (#9964)`,
  `aws - add eventbridge scheduler mode for policy lambdas (#9273)`).
- No emojis, no em dashes, no local paths / automation hints anywhere.
- Lint: `uvx ruff@0.11 check tools/ops/mugc.py tools/ops/test_mugc.py` -> clean.
  (`tools/ops` is covered by CI `ruff check ... tools` but not in the black
  FMT_SET, so black does not apply here.)
- Tests: `.venv/bin/python -m pytest tools/ops/test_mugc.py
  tools/ops/test_policylambda.py -q -p no:terraform` -> 4 passed.
