### PR TITLE
azure - marked-for-op filter - fix KeyError on unparsable date tag

### DIFF
--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -393,7 +393,7 @@ class TagActionFilter(Filter):
             action_date = parse(action_date_str)
         except Exception:
             self.log.error("could not parse tag:%s value:%s on %s" % (
-                self.tag, v, i['InstanceId']))
+                self.tag, v, i.get('id', i.get('name'))))
             return False
 
         # current_date must match timezones with the parsed date string

--- a/tools/c7n_azure/tests_azure/tools_tags.py
+++ b/tools/c7n_azure/tests_azure/tools_tags.py
@@ -34,7 +34,6 @@ def get_resource(existing_tags):
                      'TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm'
     resource['name'] = 'cctestvm'
     resource['type'] = 'Microsoft.Compute/virtualMachines'
-    resource['InstanceId'] = "testInstance"
     return resource
 
 


### PR DESCRIPTION

---

### What this does

The Azure `marked-for-op` filter (`TagActionFilter`) crashes with
`KeyError: 'InstanceId'` on any Azure resource whose `custodian_status` tag holds
an unparsable date, aborting the entire policy run instead of skipping that one
resource.

In `tools/c7n_azure/c7n_azure/filters.py`, the `except` branch that fires when
`dateutil.parser.parse()` cannot parse the date logs the offending resource by
`i['InstanceId']`:

```python
try:
    action_date = parse(action_date_str)
except Exception:
    self.log.error("could not parse tag:%s value:%s on %s" % (
        self.tag, v, i['InstanceId']))
    return False
```

`InstanceId` is an AWS/EC2 key. Azure resources returned by the ARM API carry
`id` / `name` / `type` and never an `InstanceId`, so the error handler itself
raises `KeyError('InstanceId')`. What should have been a graceful "could not
parse tag" warning (followed by `return False` to skip the resource) becomes a
hard crash that takes down the whole policy.

This is a copy-paste artifact: the Azure `TagActionFilter` is adapted from the
AWS core version (`c7n/tags.py`), which was updated to read Azure tags
(`i.get('tags', {})`) but left the AWS-only `i['InstanceId']` in the error path.

### The fix

Log an identifier that always resolves for an Azure resource:

```python
    self.log.error("could not parse tag:%s value:%s on %s" % (
        self.tag, v, i.get('id', i.get('name'))))
```

`i.get('id', i.get('name'))` matches how identifiers are resolved elsewhere in
c7n_azure (e.g. `resource.get('id')` in `actions/base.py`). The parse logic is
untouched; the filter now logs the warning and skips the malformed resource as
intended.

### Tests

`tools/c7n_azure/tests_azure/test_filters_marked_for_op.py::TagsTest::test_misformatted_date_string`
already existed to cover the malformed-date path, but it only passed because the
shared test fixture (`tools_tags.get_resource`) injected a synthetic
`resource['InstanceId'] = "testInstance"` onto every resource, which masked the
crash. Removing that one synthetic key makes the fixture a realistic Azure
resource (`id`/`name`/`type` only) and turns the test into a genuine regression
guard: without the fix it raises `KeyError('InstanceId')`; with the fix it
passes.

Verified: the full c7n_azure tag/marked-for-op suite (every module that shares
the `tools_tags` fixture) passes (119 tests, 0 failures). ruff is clean on both
changed files.

---

## Diff (net +1 / -2, 2 files, 1 commit)

```diff
diff --git a/tools/c7n_azure/c7n_azure/filters.py b/tools/c7n_azure/c7n_azure/filters.py
index 27ebf97f..cf4f9758 100644
--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -393,7 +393,7 @@ class TagActionFilter(Filter):
             action_date = parse(action_date_str)
         except Exception:
             self.log.error("could not parse tag:%s value:%s on %s" % (
-                self.tag, v, i['InstanceId']))
+                self.tag, v, i.get('id', i.get('name'))))
             return False

diff --git a/tools/c7n_azure/tests_azure/tools_tags.py b/tools/c7n_azure/tests_azure/tools_tags.py
index dcf9ed4e..1b2aafe1 100644
--- a/tools/c7n_azure/tests_azure/tools_tags.py
+++ b/tools/c7n_azure/tests_azure/tools_tags.py
@@ -34,7 +34,6 @@ def get_resource(existing_tags):
                      'TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm'
     resource['name'] = 'cctestvm'
     resource['type'] = 'Microsoft.Compute/virtualMachines'
-    resource['InstanceId'] = "testInstance"
     return resource
```
