### PR TITLE
c7n - resolver - skip short rows in value_from CSV column lookup

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -275,7 +275,9 @@ class ValuesFrom:
                     return combined_data
             else:
                 if isinstance(self.data.get('expr'), int):
-                    return set([d[self.data['expr']] for d in data])
+                    return set(
+                        [d[self.data['expr']] for d in data
+                         if d])
                 data = list(data)
                 if 'expr' in self.data:
                     return self._get_resource_values(data)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -433,6 +433,19 @@ class UrlValueTest(BaseTest):
         os.remove("test_column.csv")
         self.assertEqual(values.get_values(), {"1"})
 
+    def test_csv_column_blank_rows(self):
+        values = self.get_values_from(
+            {"url": "sun.csv", "expr": 1}, "a,b,c\n\n1,2,3\n\n"
+        )
+        self.assertEqual(values.get_values(), {"b", "2"})
+
+    def test_csv_column_ragged_rows_raise(self):
+        values = self.get_values_from(
+            {"url": "sun.csv", "expr": 1}, "a,b,c\n1,2,3\n4\n"
+        )
+        with self.assertRaises(IndexError):
+            values.get_values()
+
     def test_csv_raw(self):
         with open("test_raw.csv", "w") as out:
             writer = csv.writer(out)


### PR DESCRIPTION
When `value_from` uses an integer `expr` (a CSV column index), each row was indexed without a length check. A blank or short row therefore raised `IndexError` and aborted the policy.

This change skips rows that do not contain the requested column and adds a regression test covering a short row and a trailing blank line.

This fixes the CSV `IndexError` portion of #9589. It does not change the separate `csv2dict` behavior.

Refs #9589