### PR TITLE
fix: avoid KeyError in marked-for-op on non-EC2 resources

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -309,8 +309,9 @@ class TagActionFilter(Filter):
         try:
             action_date = parse(action_date_str)
         except Exception:
+            rid = i.get(self.manager.get_model().id) if self.manager else None
             self.log.warning("could not parse tag:%s value:%s on %s" % (
-                tag, v, i['InstanceId']))
+                tag, v, rid))
             return False
 
         if action_date.tzinfo:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -832,6 +832,19 @@ class TestMarkedForAction(BaseFilterTest):
         ]:
             self.assertFilter({"type": "marked-for-op"}, ii, v)
 
+    def test_filter_unparseable_date_without_instance_id(self):
+        # marked-for-op is registered on many non-ec2 resources whose id key
+        # is not InstanceId. An unparseable date on such a resource should be
+        # logged and skipped, not raise KeyError('InstanceId').
+        resource = {
+            "Name": "my-secret",
+            "Tags": [
+                {"Key": "maid_status", "Value": "does not meet policy: stop@notadate"}
+            ],
+        }
+        f = filters.factory({"type": "marked-for-op", "op": "stop"})
+        self.assertFalse(f(resource))
+
 
 class EventFilterTest(BaseFilterTest):
 


### PR DESCRIPTION

### What this does

`marked-for-op` (the `TagActionFilter`) is a generic filter registered on many
resource types, not just EC2. When the status tag on a resource holds an
unparseable date, the parse-failure branch logs the resource id using a
hardcoded `i['InstanceId']`:

```python
try:
    action_date = parse(action_date_str)
except Exception:
    self.log.warning("could not parse tag:%s value:%s on %s" % (
        tag, v, i['InstanceId']))
    return False
```

`InstanceId` only exists on EC2 instances. The same filter is registered on
resources whose id key is different, for example `secretsmanager` (`Name`),
`opensearch-ingestion` (`PipelineName`), `dms`, `dynamodb-dax`, `emr`,
`elasticsearch`, and more. If one of those resources carries a status tag with a
date that `dateutil.parser.parse` cannot read (for example a hand-edited or
otherwise malformed `custodian_status` value), the filter raises
`KeyError('InstanceId')` and the whole policy crashes, instead of logging that
the value could not be parsed and skipping the resource.

### The fix

Resolve the resource id from the resource manager's model id key instead of the
hardcoded `InstanceId`, matching the idiom already used throughout this module
(`self.manager.get_model().id`). Read it with `.get()` so a resource that is
missing the key still logs cleanly, and fall back to `None` when no manager is
attached (for example when the filter is constructed directly). Only the
log line changes; the return value (`False`) and control flow are unchanged.

For EC2 the model id is `InstanceId`, so the logged value is identical to
before for the original case. For every other resource type the log now shows
the correct id and no longer crashes.

### Testing

Added a regression test in `tests/test_filters.py`
(`TestMarkedForAction.test_filter_unparseable_date_without_instance_id`) that
runs `marked-for-op` with an unparseable date on a resource that has no
`InstanceId` key and asserts it is skipped rather than raising. Before this
change the test fails with `KeyError: 'InstanceId'`; after it, it passes.

Ran locally:
- `pytest tests/test_filters.py::TestMarkedForAction` -> passes
- `pytest tests/test_filters.py tests/test_tags.py` -> passes
- Spot-checked resources that register `marked-for-op` (ec2, secretsmanager,
  dms, elasticsearch, sqs, rds) -> pass
- `ruff check c7n/tags.py tests/test_filters.py` -> clean