### PR TITLE
aws - ec2 - ssm-compliance - honor advertised default for states

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1180,7 +1180,7 @@ class SsmCompliance(Filter):
         filters = [
             {
                 'Key': 'Status',
-                'Values': self.data['states'],
+                'Values': self.data.get('states', ['NON_COMPLIANT']),
                 'Type': 'EQUAL'
             },
             {

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -499,6 +499,26 @@ class TestSsm(BaseTest):
             [r['InstanceId'] for r in resources],
             ['i-0dea82d960d56dc1d', 'i-0ba3874e85bb97244'])
 
+    def test_ssm_compliance_states_default(self):
+        session_factory = self.replay_flight_data('test_ec2_ssm_compliance_filter')
+        policy = self.load_policy({
+            'name': 'ec2-ssm-compliance',
+            'resource': 'aws.ec2',
+            'filters': [
+                {'type': 'ssm-compliance',
+                 'compliance_types': [
+                     'Association',
+                     'Patch'
+                 ]}]},
+            session_factory=session_factory,
+            config={'region': 'us-east-2'})
+        resources = policy.run()
+        self.assertEqual(len(resources), 2)
+        self.assertTrue('c7n:ssm-compliance' in resources[0])
+        self.assertEqual(
+            [r['InstanceId'] for r in resources],
+            ['i-0dea82d960d56dc1d', 'i-0ba3874e85bb97244'])
+
     def test_ssm_inventory(self):
         session_factory = self.replay_flight_data("test_ec2_ssm_inventory_filter")
         p = self.load_policy(


### PR DESCRIPTION

The `ssm-compliance` filter on `aws.ec2` advertises a schema default of
`['NON_COMPLIANT']` for its optional `states` field, but `process()` read the
value with a hard subscript, `self.data['states']`. Custodian validates policies
with a plain `Draft7Validator`, which does not inject schema defaults into the
policy data, so a policy that omits `states` passes validation and then raises
`KeyError: 'states'` at runtime. The advertised default never applies and the
filter fails closed with a crash.

The `states` field is optional (only `compliance_types` is in `required`), the
docstring example lists `NON_COMPLIANT`, and the schema declares
`'default': ['NON_COMPLIANT']`, so the intended behavior when `states` is omitted
is clearly to filter on `NON_COMPLIANT`.

### Change

Read the value defensively so the advertised default is honored instead of
crashing:

```python
# c7n/resources/ec2.py, SsmCompliance.process()
'Values': self.data.get('states', ['NON_COMPLIANT']),
```

The literal matches the schema default declared a few lines above, so behavior is
unchanged for policies that set `states`, and policies that omit it now default to
`NON_COMPLIANT` as documented rather than raising.

### Reproduction

A minimal policy that omits `states`:

```yaml
policies:
  - name: ec2-ssm-compliance
    resource: aws.ec2
    filters:
      - type: ssm-compliance
        compliance_types:
          - Association
          - Patch
```

Before this change the filter raises `KeyError: 'states'`; after it, the filter
runs and defaults the `Status` filter to `['NON_COMPLIANT']`.

### Tests

Added `tests/test_ec2.py::TestSsm::test_ssm_compliance_states_default`, which runs
the `ssm-compliance` filter with only `compliance_types` (no `states`) and asserts
it does not raise and produces the expected matches. It fails with
`KeyError: 'states'` on the current code and passes with the fix.

```
pytest tests/test_ec2.py::TestSsm -q      # 4 passed
pytest tests/test_ec2.py -q               # 113 passed
ruff check c7n tests tools                # All checks passed
```
