### PR TITLE
core - fix match-resource key requirement in related filters

### DIFF
--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -11,7 +11,7 @@ class MatchResourceValidator:
 
     def validate(self):
         if self.data.get('match-resource'):
-            self.required_keys = set('key',)
+            self.required_keys = {'key'}
         return super(MatchResourceValidator, self).validate()
 
 

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -2437,6 +2437,18 @@ class SecurityGroupTest(BaseTest):
         except PolicyValidationError:
             self.fail("should pass validation")
 
+        self.assertRaises(
+            PolicyValidationError,
+            self.load_policy,
+            {'name': 'related-sg-no-key',
+             'resource': 'elb',
+             'filters': [
+                 {'type': 'security-group',
+                  'match-resource': True,
+                  'op': 'not-equal',
+                  'operator': 'or'}]},
+            validate=True)
+
     @functional
     def test_only_ports(self):
         factory = self.replay_flight_data("test_security_group_only_ports")


### PR DESCRIPTION

```markdown
### What this fixes

`MatchResourceValidator.validate` intends to make `key` a required field whenever a
related-resource filter (`security-group`, `subnet`, `vpc`, and friends) sets
`match-resource: true`. It does this by populating `self.required_keys`:

```python
def validate(self):
    if self.data.get('match-resource'):
        self.required_keys = set('key',)
    return super().validate()
```

The trailing comma here is inert: `set()` takes a single iterable argument, so
`set('key',)` is just `set('key')`, which iterates the string and produces
`{'k', 'e', 'y'}` rather than the intended `{'key'}`.

Downstream, `ValueFilter.validate` enforces the requirement with:

```python
if 'key' not in self.data and 'key' in self.required_keys:
    raise PolicyValidationError(...)
```

Because the literal `'key'` is never a member of `{'k', 'e', 'y'}`, this check never
fires. A `match-resource: true` filter that omits `key` is silently accepted at
validation time instead of raising `PolicyValidationError`, so the intended guard has
been a no-op.

### The fix

Build the set with a set literal so it contains the string `'key'`:

```python
self.required_keys = {'key'}
```

This changes validation only; runtime match behavior is untouched. A related filter
that already supplies `key` (or does not use `match-resource`) is unaffected.

### Test

Extended `SecurityGroupTest.test_match_resource_validator` with a negative case: a
`security-group` filter with `match-resource: true` and no `key` now asserts
`PolicyValidationError`. The existing positive (with-key) case is retained. The new
assertion fails on the current source and passes with the fix.
```

---

## Notes for whoever opens the PR

- The `set('key',)` -> `{'key'}` diff is one line in `c7n/filters/vpc.py`; the rest is
  the test addition in `tests/test_vpc.py` (+13/-1 total, 2 files).
- Provenance (context only, not for the PR body): introduced in 2019 by PR #3524
  ("aws - related resource match validation"); `git blame` on line 14 -> `67ebd447`.
- Upstream CI can be intermittently red on `main` for unrelated `c7n_awscc` reasons
  (see repo memory). Gate on the new test + `Lint`/`Docker`/`Analyzer` green, and
  cross-check `gh run list --branch main` / peer PRs before assuming a red run is this
  change.
