### PR TITLE
aws - lambda - trim-versions - fix retain-latest schema default

### DIFF
--- a/c7n/resources/awslambda.py
+++ b/c7n/resources/awslambda.py
@@ -555,7 +555,7 @@ class VersionTrim(Action):
     schema = type_schema(
         'trim-versions',
         **{'exclude-aliases': {'default': True, 'type': 'boolean'},
-           'retain-latest': {'default': True, 'type': 'boolean'},
+           'retain-latest': {'default': False, 'type': 'boolean'},
            'older-than': {'type': 'number'}})
 
     def process(self, resources):

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -201,6 +201,22 @@ class LambdaTest(BaseTest):
         assert '$LATEST' in versions
         assert set(versions) == {'$LATEST', '6', '12'}
 
+    def test_lambda_trim_versions_retain_latest_default(self):
+        # The advertised schema default for retain-latest must match the
+        # action's actual runtime default (process_lambda reads it as False)
+        # and its documented default. A stale schema default of True would
+        # mislead authors into omitting the flag while the numbered version
+        # is still deleted.
+        p = self.load_policy(
+            {
+                'name': 'lambda-check',
+                'resource': 'lambda',
+                'actions': [{'type': 'trim-versions'}]
+            })
+        action = p.resource_manager.actions[0]
+        assert action.schema['properties']['retain-latest']['default'] is False
+        assert action.data.get('retain-latest', False) is False
+
     def test_lambda_check_permission(self):
         # lots of pre-conditions, iam role with iam read only policy attached
         # and a permission boundary with deny on iam read access.


### PR DESCRIPTION
The `aws.lambda` `trim-versions` action advertises `retain-latest` with a schema default of `True`, but the code and the action's own docstring both treat the default as `False`:

- Schema: `'retain-latest': {'default': True, 'type': 'boolean'}` (`c7n/resources/awslambda.py`)
- Code: `retain_latest = self.data.get('retain-latest', False)`
- Docstring: `retain-latest: true # default false`

`jsonschema`'s `Draft7Validator` (used by c7n) does not inject schema defaults into policy data, so the real runtime default is `False`. The schema default of `True` is the outlier.

The practical effect is misleading `custodian schema` output. Someone inspecting `custodian schema aws.lambda.actions.trim-versions` sees `retain-latest` defaulting to `True` and may omit the flag, expecting the current numbered version to be retained, while `process_lambda` actually deletes it. Function availability is unaffected because the `$LATEST` alias still points at the last revision, as the docstring notes, but the explicit numbered version is gone.

Changes:

- Correct the `retain-latest` schema default to `False` so the machine-readable schema matches both the code and the documented behavior.
- Add a regression test asserting the advertised schema default (and the resolved action data default) for `retain-latest` is `False`.

This is a documentation-facing, non-behavioral change: no runtime behavior of the action changes, only the advertised schema default is brought in line with the code.

## Verification

- `.venv/bin/python -m pytest tests/test_lambda.py -q` -> 36 passed.
- Red/green: reverting the schema line to `True` makes the new `test_lambda_trim_versions_retain_latest_default` fail; restoring `False` passes.
- `uvx ruff@0.11 check c7n/resources/awslambda.py tests/test_lambda.py` -> All checks passed.
