### PR TITLE
aws- Payment Cryptography -cross-account filter implementation

### DIFF
--- a/c7n/resources/pmtcrypt.py
+++ b/c7n/resources/pmtcrypt.py
@@ -3,6 +3,7 @@
 
 from c7n.manager import resources
 from c7n import query
+from c7n.filters import CrossAccountAccessFilter
 from c7n.utils import local_session, type_schema
 from c7n.tags import Tag, RemoveTag
 from c7n.actions import BaseAction
@@ -31,6 +32,39 @@ class PmtcryptKey(query.QueryResourceManager):
             'KeyArn', 'Key')
 
     source_mapping = {"describe": PmtcryptKeyDescribe, }
+
+
+@PmtcryptKey.filter_registry.register('cross-account')
+class PmtcryptKeyCrossAccount(CrossAccountAccessFilter):
+    """Filter payment-cryptography-key by its resource based policy for
+    cross account access.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: payment-cryptography-key-cross-account
+                resource: payment-cryptography-key
+                filters:
+                  - type: cross-account
+    """
+
+    policy_annotation = 'c7n:AccessPolicy'
+    permissions = ('payment-cryptography:GetResourcePolicy',)
+
+    def process(self, resources, event=None):
+        self.client = local_session(
+            self.manager.session_factory).client('payment-cryptography')
+        return super().process(resources, event)
+
+    def get_resource_policy(self, r):
+        if self.policy_annotation in r:
+            return r[self.policy_annotation]
+        result = self.manager.retry(
+            self.client.get_resource_policy, ResourceArn=r['KeyArn'])
+        r[self.policy_annotation] = p = result.get('Policy')
+        return p
 
 
 @PmtcryptKey.action_registry.register('tag')

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.GetResourcePolicy_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.GetResourcePolicy_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/ltn2kegms2cvxmhe",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"ExternalAccess\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:root\"},\"Action\":\"payment-cryptography:GetKey\",\"Resource\":\"*\"}]}",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.GetResourcePolicy_2.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.GetResourcePolicy_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/vhwflzja45wd3hqj",
+        "Policy": "{}",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.ListKeys_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.ListKeys_1.json
@@ -1,0 +1,54 @@
+{
+    "status_code": 200,
+    "data": {
+        "Keys": [
+            {
+                "KeyArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/ltn2kegms2cvxmhe",
+                "KeyState": "CREATE_COMPLETE",
+                "KeyAttributes": {
+                    "KeyUsage": "TR31_P0_PIN_ENCRYPTION_KEY",
+                    "KeyClass": "SYMMETRIC_KEY",
+                    "KeyAlgorithm": "TDES_3KEY",
+                    "KeyModesOfUse": {
+                        "Encrypt": true,
+                        "Decrypt": true,
+                        "Wrap": true,
+                        "Unwrap": true,
+                        "Generate": false,
+                        "Sign": false,
+                        "Verify": false,
+                        "DeriveKey": false,
+                        "NoRestrictions": false
+                    }
+                },
+                "KeyCheckValue": "1BCEBA",
+                "Exportable": true,
+                "Enabled": true
+            },
+            {
+                "KeyArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/vhwflzja45wd3hqj",
+                "KeyState": "CREATE_COMPLETE",
+                "KeyAttributes": {
+                    "KeyUsage": "TR31_C0_CARD_VERIFICATION_KEY",
+                    "KeyClass": "SYMMETRIC_KEY",
+                    "KeyAlgorithm": "TDES_2KEY",
+                    "KeyModesOfUse": {
+                        "Encrypt": false,
+                        "Decrypt": false,
+                        "Wrap": false,
+                        "Unwrap": false,
+                        "Generate": true,
+                        "Sign": false,
+                        "Verify": true,
+                        "DeriveKey": false,
+                        "NoRestrictions": false
+                    }
+                },
+                "KeyCheckValue": "786C13",
+                "Exportable": true,
+                "Enabled": true
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.ListTagsForResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "Department",
+                "Value": "International"
+            },
+            {
+                "Key": "Owner",
+                "Value": "DarthVader"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account/controlplane.payment-cryptography.ListTagsForResource_2.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "Department",
+                "Value": "International"
+            },
+            {
+                "Key": "Owner",
+                "Value": "Pratyush"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.GetResourcePolicy_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.GetResourcePolicy_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/ltn2kegms2cvxmhe",
+        "Policy": "{}",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.GetResourcePolicy_2.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.GetResourcePolicy_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/vhwflzja45wd3hqj",
+        "Policy": "{}",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.ListKeys_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.ListKeys_1.json
@@ -1,0 +1,54 @@
+{
+    "status_code": 200,
+    "data": {
+        "Keys": [
+            {
+                "KeyArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/ltn2kegms2cvxmhe",
+                "KeyState": "CREATE_COMPLETE",
+                "KeyAttributes": {
+                    "KeyUsage": "TR31_P0_PIN_ENCRYPTION_KEY",
+                    "KeyClass": "SYMMETRIC_KEY",
+                    "KeyAlgorithm": "TDES_3KEY",
+                    "KeyModesOfUse": {
+                        "Encrypt": true,
+                        "Decrypt": true,
+                        "Wrap": true,
+                        "Unwrap": true,
+                        "Generate": false,
+                        "Sign": false,
+                        "Verify": false,
+                        "DeriveKey": false,
+                        "NoRestrictions": false
+                    }
+                },
+                "KeyCheckValue": "1BCEBA",
+                "Exportable": true,
+                "Enabled": true
+            },
+            {
+                "KeyArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/vhwflzja45wd3hqj",
+                "KeyState": "CREATE_COMPLETE",
+                "KeyAttributes": {
+                    "KeyUsage": "TR31_C0_CARD_VERIFICATION_KEY",
+                    "KeyClass": "SYMMETRIC_KEY",
+                    "KeyAlgorithm": "TDES_2KEY",
+                    "KeyModesOfUse": {
+                        "Encrypt": false,
+                        "Decrypt": false,
+                        "Wrap": false,
+                        "Unwrap": false,
+                        "Generate": true,
+                        "Sign": false,
+                        "Verify": true,
+                        "DeriveKey": false,
+                        "NoRestrictions": false
+                    }
+                },
+                "KeyCheckValue": "786C13",
+                "Exportable": true,
+                "Enabled": true
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.ListTagsForResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "Department",
+                "Value": "International"
+            },
+            {
+                "Key": "Owner",
+                "Value": "DarthVader"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_empty/controlplane.payment-cryptography.ListTagsForResource_2.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "Department",
+                "Value": "International"
+            },
+            {
+                "Key": "Owner",
+                "Value": "Pratyush"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.GetResourcePolicy_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.GetResourcePolicy_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/ltn2kegms2cvxmhe",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SameAccountAccess\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"payment-cryptography:GetKey\",\"Resource\":\"*\"}]}",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.GetResourcePolicy_2.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.GetResourcePolicy_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/vhwflzja45wd3hqj",
+        "Policy": "{}",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.ListKeys_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.ListKeys_1.json
@@ -1,0 +1,54 @@
+{
+    "status_code": 200,
+    "data": {
+        "Keys": [
+            {
+                "KeyArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/ltn2kegms2cvxmhe",
+                "KeyState": "CREATE_COMPLETE",
+                "KeyAttributes": {
+                    "KeyUsage": "TR31_P0_PIN_ENCRYPTION_KEY",
+                    "KeyClass": "SYMMETRIC_KEY",
+                    "KeyAlgorithm": "TDES_3KEY",
+                    "KeyModesOfUse": {
+                        "Encrypt": true,
+                        "Decrypt": true,
+                        "Wrap": true,
+                        "Unwrap": true,
+                        "Generate": false,
+                        "Sign": false,
+                        "Verify": false,
+                        "DeriveKey": false,
+                        "NoRestrictions": false
+                    }
+                },
+                "KeyCheckValue": "1BCEBA",
+                "Exportable": true,
+                "Enabled": true
+            },
+            {
+                "KeyArn": "arn:aws:payment-cryptography:us-east-1:644160558196:key/vhwflzja45wd3hqj",
+                "KeyState": "CREATE_COMPLETE",
+                "KeyAttributes": {
+                    "KeyUsage": "TR31_C0_CARD_VERIFICATION_KEY",
+                    "KeyClass": "SYMMETRIC_KEY",
+                    "KeyAlgorithm": "TDES_2KEY",
+                    "KeyModesOfUse": {
+                        "Encrypt": false,
+                        "Decrypt": false,
+                        "Wrap": false,
+                        "Unwrap": false,
+                        "Generate": true,
+                        "Sign": false,
+                        "Verify": true,
+                        "DeriveKey": false,
+                        "NoRestrictions": false
+                    }
+                },
+                "KeyCheckValue": "786C13",
+                "Exportable": true,
+                "Enabled": true
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.ListTagsForResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "Department",
+                "Value": "International"
+            },
+            {
+                "Key": "Owner",
+                "Value": "DarthVader"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_pmtcrypt_key_cross_account_same/controlplane.payment-cryptography.ListTagsForResource_2.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "Department",
+                "Value": "International"
+            },
+            {
+                "Key": "Owner",
+                "Value": "Pratyush"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_pmtcrypt.py
+++ b/tests/test_pmtcrypt.py
@@ -44,6 +44,53 @@ class PmtcryptTest(BaseTest):
         tags = client.list_tags_for_resource(ResourceArn=resources[0]["KeyArn"])["Tags"]
         self.assertEqual(len(tags), 0)
 
+    def test_cross_account(self):
+        session_factory = self.replay_flight_data(
+            "test_pmtcrypt_key_cross_account"
+        )
+        p = self.load_policy(
+            {
+                "name": "pmtcrypt-key-cross-account",
+                "resource": "payment-cryptography-key",
+                "filters": [{"type": "cross-account"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertTrue(resources[0]["CrossAccountViolations"])
+
+    def test_cross_account_same_account(self):
+        session_factory = self.replay_flight_data(
+            "test_pmtcrypt_key_cross_account_same"
+        )
+        p = self.load_policy(
+            {
+                "name": "pmtcrypt-key-cross-account-same",
+                "resource": "payment-cryptography-key",
+                "filters": [{"type": "cross-account"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        # policy grants only the owning account -> not a violation
+        self.assertEqual(len(resources), 0)
+
+    def test_cross_account_empty(self):
+        session_factory = self.replay_flight_data(
+            "test_pmtcrypt_key_cross_account_empty"
+        )
+        p = self.load_policy(
+            {
+                "name": "pmtcrypt-key-cross-account-empty",
+                "resource": "payment-cryptography-key",
+                "filters": [{"type": "cross-account"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
     def test_delete_(self):
         session_factory = self.replay_flight_data(
             "test_payment-cryptography_delete"


### PR DESCRIPTION
This PR adds a cross-account filter to the payment-cryptography-key resource. It checks each key's resource-based policy (via `GetResourcePolicy`) for access granted to principals outside the account, org, or allowlist.

  - Keys with no resource policy return {} from the API and are not flagged.
  - Multi-region replica keys always return {} (the policy is in the primary key), so they are never flagged 