### PR TITLE
docs - update governance docs and CoC references

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,5 @@
 # Governance for Cloud Custodian
-Cloud Custodian is governed with the goals of transparency, vendor neutrality, and scalable community leadership. All contributors are expected to follow the CNCF Code of Conduct.
+Cloud Custodian is governed with the goals of transparency, vendor neutrality, and scalable community leadership. All contributors are expected to follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 ## 1. Project Areas
 
 Cloud Custodian is organized into several functional areas, each responsible for a part of the project:
@@ -65,7 +65,7 @@ Failure to meet expectations may lead to emeritus designation or removal after c
 
 ## 7. Code of Conduct
 
-Cloud Custodian follows the CNCF Code of Conduct, which is published in `CODE_OF_CONDUCT.md` and linked across governance and contributor documents.
+Cloud Custodian follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md), linked across governance and contributor documents.
 
 ## 8. Transparency & Updates
 `GOVERNANCE.md` is located in the repository root. Updates are tracked in GitHub with dates and rationale.Any changes require review and approval by a majority of Core Maintainers through a pull request. This document is linked from the project’s main `README` and contribution guides.
@@ -75,4 +75,4 @@ Cloud Custodian follows the CNCF Code of Conduct, which is published in `CODE_OF
 - `README.md`  
 - `GOVERNANCE.md` (this document)  
 - `OWNERS.md` (area and core maintainers list)  
-- `CODE_OF_CONDUCT.md` (CNCF Code of Conduct link)
+- [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)

--- a/README.md
+++ b/README.md
@@ -286,7 +286,8 @@ potential vulnerability in Cloud Custodian please let the Cloud
 [Custodian Security Team](mailto:security@cloudcustodian.io) know with
 the details of the vulnerability. We'll send a confirmation email to
 acknowledge your report, and we'll send an additional email when we've
-identified the issue positively or negatively.
+identified the issue positively or negatively. See [SECURITY.md](SECURITY.md)
+for details.
 
 Code of Conduct
 ---------------
@@ -294,4 +295,12 @@ Code of Conduct
 This project adheres to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
 
 By participating, you are expected to honor this code.
+
+Governance
+----------
+
+Cloud Custodian is governed with the goals of transparency, vendor
+neutrality, and scalable community leadership. See [GOVERNANCE.md](GOVERNANCE.md)
+for details on project areas, maintainer roles, and decision-making, and
+[OWNERS.md](OWNERS.md) for the current list of maintainers.
 

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -38,3 +38,19 @@ as a large portion of our contributor community don't have familiarity with it.
 The contributor agreement signing  process is managed through the use of the Linux Foundation's EasyCLA opensource project
 and is automatically verified on any pull requests.
 
+
+Governance
+----------
+
+See `GOVERNANCE.md <https://github.com/cloud-custodian/cloud-custodian/blob/main/GOVERNANCE.md>`_
+for details on project areas, maintainer roles, and decision-making, and
+`OWNERS.md <https://github.com/cloud-custodian/cloud-custodian/blob/main/OWNERS.md>`_
+for the current list of maintainers.
+
+
+Security
+--------
+
+See `SECURITY.md <https://github.com/cloud-custodian/cloud-custodian/blob/main/SECURITY.md>`_
+for how to report a security related issue or vulnerability.
+


### PR DESCRIPTION
- Point to the CNCF code of conduct instead of a non-existent repo-local file
- Add cross-links to the top-level readme and contributor docs