### PR TITLE
aws - bedrock inference profile - total tokens metric

### DIFF
--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -250,6 +250,14 @@ class MetricsFilter(Filter):
             dims.append({'Name': k, 'Value': v})
         return dims
 
+    def get_metric_data(self, client, params):
+        """Retrieve metric datapoints in the filter's normalized shape.
+
+        Resource-specific metric filters may override this method when the
+        metric is not available through GetMetricStatistics.
+        """
+        return client.get_metric_statistics(**params)['Datapoints']
+
     def process_resource_set(self, resource_set):
         client = local_session(
             self.manager.session_factory).client('cloudwatch')
@@ -284,8 +292,7 @@ class MetricsFilter(Filter):
             params[stats_key] = [self.statistics]
 
             if key not in collected_metrics:
-                collected_metrics[key] = client.get_metric_statistics(
-                    **params)['Datapoints']
+                collected_metrics[key] = self.get_metric_data(client, params)
 
             # In certain cases CloudWatch reports no data for a metric.
             # If the policy specifies a fill value for missing data, add

--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -924,8 +924,8 @@ class InferenceProfileMetrics(MetricsFilter):
             'StartTime': params['StartTime'],
             'EndTime': params['EndTime'],
         }
-        while True:
-            response = client.get_metric_data(**request)
+        paginator = client.get_paginator('get_metric_data')
+        for response in paginator.paginate(**request):
             for result in response.get('MetricDataResults', ()):
                 if result['Id'] != 'total':
                     continue
@@ -934,9 +934,6 @@ class InferenceProfileMetrics(MetricsFilter):
                     self.statistics: value,
                 } for timestamp, value in zip(
                     result.get('Timestamps', ()), result.get('Values', ())))
-            if 'NextToken' not in response:
-                break
-            request['NextToken'] = response['NextToken']
         return datapoints
 
 

--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -822,7 +822,7 @@ class DeleteBedrockInferenceProfile(BaseAction):
 class InferenceProfileMetrics(MetricsFilter):
     """Filter inference profiles by published or combined token usage.
 
-    ``TotalTokenCount`` is a Custodian-derived metric that sums Bedrock's
+    ``c7n:TotalTokenCount`` is a Custodian-derived metric that sums Bedrock's
     ``InputTokenCount`` and ``OutputTokenCount`` metrics. Its statistic is
     always ``Sum`` and defaults to that value when omitted.
 
@@ -844,7 +844,7 @@ class InferenceProfileMetrics(MetricsFilter):
             resource: aws.bedrock-inference-profile
             filters:
               - type: metrics
-                name: TotalTokenCount
+                name: c7n:TotalTokenCount
                 days: 1
                 period: 86400
                 period-start: start-of-day
@@ -862,20 +862,20 @@ class InferenceProfileMetrics(MetricsFilter):
             resource: aws.bedrock-inference-profile
             filters:
               - type: metrics
-                name: TotalTokenCount
+                name: c7n:TotalTokenCount
                 days: 7
                 period: 604800
                 period-start: start-of-day
                 value: 700000
                 op: greater-than
     """
-    TOTAL_TOKEN_COUNT = 'TotalTokenCount'
+    TOTAL_TOKEN_COUNT = 'c7n:TotalTokenCount'
 
     def validate(self):
         if (self.data['name'] == self.TOTAL_TOKEN_COUNT and
                 self.data.get('statistics', 'Sum') != 'Sum'):
             raise PolicyValidationError(
-                "metrics filter TotalTokenCount only supports the Sum statistic")
+                "metrics filter c7n:TotalTokenCount only supports the Sum statistic")
         return super().validate()
 
     def process(self, resources, event=None):

--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from c7n.manager import resources
+from c7n.exceptions import PolicyValidationError
 from c7n.query import QueryResourceManager, TypeInfo, DescribeSource, DescribeWithResourceTags
 from c7n.tags import RemoveTag, Tag, TagActionFilter, TagDelayedAction, universal_augment
 from c7n.utils import local_session, type_schema, QueryParser
@@ -819,8 +820,124 @@ class DeleteBedrockInferenceProfile(BaseAction):
 
 @BedrockApplicationInferenceProfile.filter_registry.register('metrics')
 class InferenceProfileMetrics(MetricsFilter):
+    """Filter inference profiles by published or combined token usage.
+
+    ``TotalTokenCount`` is a Custodian-derived metric that sums Bedrock's
+    ``InputTokenCount`` and ``OutputTokenCount`` metrics. Its statistic is
+    always ``Sum`` and defaults to that value when omitted.
+
+    A completed daily total can be selected with ``days: 1``, ``period:
+    86400``, and ``period-start: start-of-day``. For a single completed
+    seven-day aggregate use ``days: 7`` and ``period: 604800``. Using a period
+    of 86400 over seven days produces seven datapoints, all of which must meet
+    the configured comparison.
+
+    :example:
+
+    Match profiles whose total token consumption for the last completed day
+    exceeds 100,000 tokens:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: bedrock-daily-token-usage
+            resource: aws.bedrock-inference-profile
+            filters:
+              - type: metrics
+                name: TotalTokenCount
+                days: 1
+                period: 86400
+                period-start: start-of-day
+                value: 100000
+                op: greater-than
+
+    :example:
+
+    Match a single completed seven-day aggregate above 700,000 tokens:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: bedrock-weekly-token-usage
+            resource: aws.bedrock-inference-profile
+            filters:
+              - type: metrics
+                name: TotalTokenCount
+                days: 7
+                period: 604800
+                period-start: start-of-day
+                value: 700000
+                op: greater-than
+    """
+    TOTAL_TOKEN_COUNT = 'TotalTokenCount'
+
+    def validate(self):
+        if (self.data['name'] == self.TOTAL_TOKEN_COUNT and
+                self.data.get('statistics', 'Sum') != 'Sum'):
+            raise PolicyValidationError(
+                "metrics filter TotalTokenCount only supports the Sum statistic")
+        return super().validate()
+
+    def process(self, resources, event=None):
+        if self.data['name'] == self.TOTAL_TOKEN_COUNT:
+            self.data.setdefault('statistics', 'Sum')
+        return super().process(resources, event)
+
+    def get_permissions(self):
+        if self.data.get('name') == self.TOTAL_TOKEN_COUNT:
+            return ('cloudwatch:GetMetricData',)
+        return self.permissions
+
     def get_dimensions(self, resource):
         return [{'Name': 'ModelId', 'Value': resource['inferenceProfileId']}]
+
+    def get_metric_data(self, client, params):
+        if self.metric != self.TOTAL_TOKEN_COUNT:
+            return super().get_metric_data(client, params)
+
+        metric_stat = {
+            'Namespace': params['Namespace'],
+            'Dimensions': params['Dimensions'],
+        }
+        queries = []
+        for query_id, metric_name in (
+                ('input', 'InputTokenCount'), ('output', 'OutputTokenCount')):
+            queries.append({
+                'Id': query_id,
+                'MetricStat': {
+                    'Metric': dict(metric_stat, MetricName=metric_name),
+                    'Period': params['Period'],
+                    'Stat': 'Sum',
+                },
+                'ReturnData': False,
+            })
+        queries.append({
+            'Id': 'total',
+            'Expression': 'input + output',
+            'Label': self.TOTAL_TOKEN_COUNT,
+            'ReturnData': True,
+        })
+
+        datapoints = []
+        request = {
+            'MetricDataQueries': queries,
+            'StartTime': params['StartTime'],
+            'EndTime': params['EndTime'],
+        }
+        while True:
+            response = client.get_metric_data(**request)
+            for result in response.get('MetricDataResults', ()):
+                if result['Id'] != 'total':
+                    continue
+                datapoints.extend({
+                    'Timestamp': timestamp,
+                    self.statistics: value,
+                } for timestamp, value in zip(
+                    result.get('Timestamps', ()), result.get('Values', ())))
+            if 'NextToken' not in response:
+                break
+            request['NextToken'] = response['NextToken']
+        return datapoints
 
 
 @resources.register('bedrock-guardrail')

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_1.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_1.json
@@ -1,0 +1,47 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "inferenceProfileSummaries": [
+            {
+                "inferenceProfileName": "c7n-token-metrics-default-cedc",
+                "description": "Cloud Custodian combined token metrics test",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 30,
+                    "microsecond": 86045
+                },
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 30,
+                    "microsecond": 86045
+                },
+                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "models": [
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "modelArn": "arn:aws:bedrock:us-west-2::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
+                    }
+                ],
+                "inferenceProfileId": "16iwuych65w4",
+                "status": "ACTIVE",
+                "type": "APPLICATION"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_1.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_1.json
@@ -4,29 +4,29 @@
         "ResponseMetadata": {},
         "inferenceProfileSummaries": [
             {
-                "inferenceProfileName": "c7n-token-metrics-default-cedc",
+                "inferenceProfileName": "c7n-token-metrics-default-bf98",
                 "description": "Cloud Custodian combined token metrics test",
                 "createdAt": {
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
+                    "day": 21,
                     "hour": 19,
-                    "minute": 3,
-                    "second": 30,
-                    "microsecond": 86045
+                    "minute": 13,
+                    "second": 39,
+                    "microsecond": 417684
                 },
                 "updatedAt": {
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
+                    "day": 21,
                     "hour": 19,
-                    "minute": 3,
-                    "second": 30,
-                    "microsecond": 86045
+                    "minute": 13,
+                    "second": 39,
+                    "microsecond": 417684
                 },
-                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/06vsfs68yb4g",
                 "models": [
                     {
                         "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
@@ -38,7 +38,7 @@
                         "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
                     }
                 ],
-                "inferenceProfileId": "16iwuych65w4",
+                "inferenceProfileId": "06vsfs68yb4g",
                 "status": "ACTIVE",
                 "type": "APPLICATION"
             }

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_2.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_2.json
@@ -1,0 +1,47 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "inferenceProfileSummaries": [
+            {
+                "inferenceProfileName": "c7n-token-metrics-default-cedc",
+                "description": "Cloud Custodian combined token metrics test",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 30,
+                    "microsecond": 86045
+                },
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 30,
+                    "microsecond": 86045
+                },
+                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "models": [
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "modelArn": "arn:aws:bedrock:us-west-2::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
+                    }
+                ],
+                "inferenceProfileId": "16iwuych65w4",
+                "status": "ACTIVE",
+                "type": "APPLICATION"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_2.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_2.json
@@ -4,29 +4,29 @@
         "ResponseMetadata": {},
         "inferenceProfileSummaries": [
             {
-                "inferenceProfileName": "c7n-token-metrics-default-cedc",
+                "inferenceProfileName": "c7n-token-metrics-default-bf98",
                 "description": "Cloud Custodian combined token metrics test",
                 "createdAt": {
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
+                    "day": 21,
                     "hour": 19,
-                    "minute": 3,
-                    "second": 30,
-                    "microsecond": 86045
+                    "minute": 13,
+                    "second": 39,
+                    "microsecond": 417684
                 },
                 "updatedAt": {
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
+                    "day": 21,
                     "hour": 19,
-                    "minute": 3,
-                    "second": 30,
-                    "microsecond": 86045
+                    "minute": 13,
+                    "second": 39,
+                    "microsecond": 417684
                 },
-                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/06vsfs68yb4g",
                 "models": [
                     {
                         "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
@@ -38,7 +38,7 @@
                         "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
                     }
                 ],
-                "inferenceProfileId": "16iwuych65w4",
+                "inferenceProfileId": "06vsfs68yb4g",
                 "status": "ACTIVE",
                 "type": "APPLICATION"
             }

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_3.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_3.json
@@ -1,0 +1,47 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "inferenceProfileSummaries": [
+            {
+                "inferenceProfileName": "c7n-token-metrics-default-cedc",
+                "description": "Cloud Custodian combined token metrics test",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 30,
+                    "microsecond": 86045
+                },
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 30,
+                    "microsecond": 86045
+                },
+                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "models": [
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "modelArn": "arn:aws:bedrock:us-west-2::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
+                    }
+                ],
+                "inferenceProfileId": "16iwuych65w4",
+                "status": "ACTIVE",
+                "type": "APPLICATION"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_3.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_3.json
@@ -4,29 +4,29 @@
         "ResponseMetadata": {},
         "inferenceProfileSummaries": [
             {
-                "inferenceProfileName": "c7n-token-metrics-default-cedc",
+                "inferenceProfileName": "c7n-token-metrics-default-bf98",
                 "description": "Cloud Custodian combined token metrics test",
                 "createdAt": {
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
+                    "day": 21,
                     "hour": 19,
-                    "minute": 3,
-                    "second": 30,
-                    "microsecond": 86045
+                    "minute": 13,
+                    "second": 39,
+                    "microsecond": 417684
                 },
                 "updatedAt": {
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
+                    "day": 21,
                     "hour": 19,
-                    "minute": 3,
-                    "second": 30,
-                    "microsecond": 86045
+                    "minute": 13,
+                    "second": 39,
+                    "microsecond": 417684
                 },
-                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/06vsfs68yb4g",
                 "models": [
                     {
                         "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
@@ -38,7 +38,7 @@
                         "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
                     }
                 ],
-                "inferenceProfileId": "16iwuych65w4",
+                "inferenceProfileId": "06vsfs68yb4g",
                 "status": "ACTIVE",
                 "type": "APPLICATION"
             }

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_4.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_4.json
@@ -1,0 +1,47 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "inferenceProfileSummaries": [
+            {
+                "inferenceProfileName": "c7n-token-metrics-default-cedc",
+                "description": "Cloud Custodian combined token metrics test",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 30,
+                    "microsecond": 86045
+                },
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 19,
+                    "minute": 3,
+                    "second": 30,
+                    "microsecond": 86045
+                },
+                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "models": [
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "modelArn": "arn:aws:bedrock:us-west-2::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
+                    }
+                ],
+                "inferenceProfileId": "16iwuych65w4",
+                "status": "ACTIVE",
+                "type": "APPLICATION"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_4.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/bedrock.ListInferenceProfiles_4.json
@@ -4,29 +4,29 @@
         "ResponseMetadata": {},
         "inferenceProfileSummaries": [
             {
-                "inferenceProfileName": "c7n-token-metrics-default-cedc",
+                "inferenceProfileName": "c7n-token-metrics-default-bf98",
                 "description": "Cloud Custodian combined token metrics test",
                 "createdAt": {
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
+                    "day": 21,
                     "hour": 19,
-                    "minute": 3,
-                    "second": 30,
-                    "microsecond": 86045
+                    "minute": 13,
+                    "second": 39,
+                    "microsecond": 417684
                 },
                 "updatedAt": {
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
+                    "day": 21,
                     "hour": 19,
-                    "minute": 3,
-                    "second": 30,
-                    "microsecond": 86045
+                    "minute": 13,
+                    "second": 39,
+                    "microsecond": 417684
                 },
-                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "inferenceProfileArn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/06vsfs68yb4g",
                 "models": [
                     {
                         "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
@@ -38,7 +38,7 @@
                         "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
                     }
                 ],
-                "inferenceProfileId": "16iwuych65w4",
+                "inferenceProfileId": "06vsfs68yb4g",
                 "status": "ACTIVE",
                 "type": "APPLICATION"
             }

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricData_1.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricData_1.json
@@ -4,21 +4,21 @@
         "MetricDataResults": [
             {
                 "Id": "total",
-                "Label": "TotalTokenCount",
+                "Label": "c7n:TotalTokenCount",
                 "Timestamps": [
                     {
                         "__class__": "datetime",
                         "year": 2026,
                         "month": 7,
-                        "day": 10,
-                        "hour": 15,
-                        "minute": 0,
+                        "day": 21,
+                        "hour": 14,
+                        "minute": 13,
                         "second": 0,
                         "microsecond": 0
                     }
                 ],
                 "Values": [
-                    10.0
+                    15.0
                 ],
                 "StatusCode": "Complete"
             }

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricData_1.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricData_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "MetricDataResults": [
+            {
+                "Id": "total",
+                "Label": "TotalTokenCount",
+                "Timestamps": [
+                    {
+                        "__class__": "datetime",
+                        "year": 2026,
+                        "month": 7,
+                        "day": 10,
+                        "hour": 15,
+                        "minute": 0,
+                        "second": 0,
+                        "microsecond": 0
+                    }
+                ],
+                "Values": [
+                    10.0
+                ],
+                "StatusCode": "Complete"
+            }
+        ],
+        "Messages": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricData_2.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricData_2.json
@@ -4,21 +4,21 @@
         "MetricDataResults": [
             {
                 "Id": "total",
-                "Label": "TotalTokenCount",
+                "Label": "c7n:TotalTokenCount",
                 "Timestamps": [
                     {
                         "__class__": "datetime",
                         "year": 2026,
                         "month": 7,
-                        "day": 10,
-                        "hour": 15,
-                        "minute": 0,
+                        "day": 21,
+                        "hour": 14,
+                        "minute": 13,
                         "second": 0,
                         "microsecond": 0
                     }
                 ],
                 "Values": [
-                    10.0
+                    15.0
                 ],
                 "StatusCode": "Complete"
             }

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricData_2.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricData_2.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "MetricDataResults": [
+            {
+                "Id": "total",
+                "Label": "TotalTokenCount",
+                "Timestamps": [
+                    {
+                        "__class__": "datetime",
+                        "year": 2026,
+                        "month": 7,
+                        "day": 10,
+                        "hour": 15,
+                        "minute": 0,
+                        "second": 0,
+                        "microsecond": 0
+                    }
+                ],
+                "Values": [
+                    10.0
+                ],
+                "StatusCode": "Complete"
+            }
+        ],
+        "Messages": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricStatistics_1.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricStatistics_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "InputTokenCount",
+        "Datapoints": [
+            {
+                "Timestamp": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 15,
+                    "minute": 0,
+                    "second": 0,
+                    "microsecond": 0
+                },
+                "Sum": 7.0,
+                "Unit": "Count"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricStatistics_1.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricStatistics_1.json
@@ -8,9 +8,9 @@
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
-                    "hour": 15,
-                    "minute": 0,
+                    "day": 21,
+                    "hour": 14,
+                    "minute": 13,
                     "second": 0,
                     "microsecond": 0
                 },

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricStatistics_2.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricStatistics_2.json
@@ -8,13 +8,13 @@
                     "__class__": "datetime",
                     "year": 2026,
                     "month": 7,
-                    "day": 10,
-                    "hour": 15,
-                    "minute": 0,
+                    "day": 21,
+                    "hour": 14,
+                    "minute": 13,
                     "second": 0,
                     "microsecond": 0
                 },
-                "Sum": 3.0,
+                "Sum": 8.0,
                 "Unit": "Count"
             }
         ],

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricStatistics_2.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/monitoring.GetMetricStatistics_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "OutputTokenCount",
+        "Datapoints": [
+            {
+                "Timestamp": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 10,
+                    "hour": 15,
+                    "minute": 0,
+                    "second": 0,
+                    "microsecond": 0
+                },
+                "Sum": 3.0,
+                "Unit": "Count"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/tagging.GetResources_1.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/tagging.GetResources_2.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/tagging.GetResources_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/tagging.GetResources_3.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/tagging.GetResources_3.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/bedrock_inference_profile_token_metrics/tagging.GetResources_4.json
+++ b/tests/data/placebo/bedrock_inference_profile_token_metrics/tagging.GetResources_4.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/bedrock_inference_profile_token_metrics/README.md
+++ b/tests/terraform/bedrock_inference_profile_token_metrics/README.md
@@ -1,0 +1,24 @@
+# Bedrock inference profile token metrics recording
+
+This fixture creates the application inference profile. The runtime invocation
+is an ephemeral operation that Terraform cannot represent, so `setup.py` emits
+real input and output token metrics before flight data is recorded.
+
+To re-record:
+
+1. Temporarily add `replay=False` to the
+   `@terraform("bedrock_inference_profile_token_metrics")` decorator and use
+   `record_flight_data("bedrock_inference_profile_token_metrics")`.
+2. Put a breakpoint at the start of the test, after pytest-terraform applies
+   this fixture. Run the focused test with `-s -p no:env`.
+3. At the breakpoint, run `./setup.py` from this directory. It reads the
+   Terraform-created profile name and region from the sibling
+   `tf_resources.json`, resolves the live ARN and ID through Bedrock, passes the
+   ARN to Bedrock Runtime, and uses the ID for the CloudWatch `ModelId`
+   dimension. Wait for it to report that both metrics are available, then
+   continue the test.
+4. Restore `replay_flight_data`, remove `replay=False` and the breakpoint, and
+   rerun the focused test in replay mode.
+
+pytest-terraform manages Terraform teardown. Replay runs never execute the
+setup script, and the invocation creates no resource requiring teardown.

--- a/tests/terraform/bedrock_inference_profile_token_metrics/main.tf
+++ b/tests/terraform/bedrock_inference_profile_token_metrics/main.tf
@@ -1,0 +1,25 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "random_id" "suffix" {
+  byte_length = 2
+}
+
+resource "aws_bedrock_inference_profile" "token_metrics" {
+  name        = "c7n-token-metrics-${terraform.workspace}-${random_id.suffix.hex}"
+  description = "Cloud Custodian combined token metrics test"
+
+  model_source {
+    copy_from = "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/us.amazon.nova-lite-v1:0"
+  }
+}
+
+output "inference_profile_arn" {
+  value = aws_bedrock_inference_profile.token_metrics.arn
+}

--- a/tests/terraform/bedrock_inference_profile_token_metrics/setup.py
+++ b/tests/terraform/bedrock_inference_profile_token_metrics/setup.py
@@ -13,30 +13,28 @@ import boto3
 TIMEOUT = 900
 
 
-def main():
+def load_profile():
     resources_path = Path(__file__).with_name('tf_resources.json')
     resources = json.loads(resources_path.read_text())
-    profile = resources['resources']['aws_bedrock_inference_profile']['token_metrics']
-    profile_name = profile['name']
-    region = profile['region']
+    return resources['resources']['aws_bedrock_inference_profile']['token_metrics']
 
+
+def find_inference_profile(profile_name, region):
     bedrock = boto3.client('bedrock', region_name=region)
     request = {'typeEquals': 'APPLICATION'}
-    inference_profile = None
     while True:
         response = bedrock.list_inference_profiles(**request)
         inference_profile = next((
             p for p in response['inferenceProfileSummaries']
             if p['inferenceProfileName'] == profile_name), None)
-        if inference_profile or 'nextToken' not in response:
-            break
+        if inference_profile:
+            return inference_profile
+        if 'nextToken' not in response:
+            raise RuntimeError(f'could not find inference profile {profile_name!r}')
         request['nextToken'] = response['nextToken']
-    if inference_profile is None:
-        raise RuntimeError(f'could not find inference profile {profile_name!r}')
 
-    inference_profile_arn = inference_profile['inferenceProfileArn']
-    inference_profile_id = inference_profile['inferenceProfileId']
 
+def emit_token_metrics(inference_profile_arn, region):
     runtime = boto3.client('bedrock-runtime', region_name=region)
     runtime.converse(
         modelId=inference_profile_arn,
@@ -47,6 +45,8 @@ def main():
         inferenceConfig={'maxTokens': 8, 'temperature': 0},
     )
 
+
+def wait_for_token_metrics(inference_profile_id, region):
     cloudwatch = boto3.client('cloudwatch', region_name=region)
     deadline = time.monotonic() + TIMEOUT
     while time.monotonic() < deadline:
@@ -68,6 +68,13 @@ def main():
             return
         time.sleep(15)
     raise TimeoutError('timed out waiting for Bedrock token metrics')
+
+
+def main():
+    profile = load_profile()
+    inference_profile = find_inference_profile(profile['name'], profile['region'])
+    emit_token_metrics(inference_profile['inferenceProfileArn'], profile['region'])
+    wait_for_token_metrics(inference_profile['inferenceProfileId'], profile['region'])
 
 
 if __name__ == '__main__':

--- a/tests/terraform/bedrock_inference_profile_token_metrics/setup.py
+++ b/tests/terraform/bedrock_inference_profile_token_metrics/setup.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+"""Emit token metrics for an application inference profile and await them."""
+
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import time
+
+import boto3
+
+TIMEOUT = 900
+
+
+def main():
+    resources_path = Path(__file__).with_name('tf_resources.json')
+    resources = json.loads(resources_path.read_text())
+    profile = resources['resources']['aws_bedrock_inference_profile']['token_metrics']
+    profile_name = profile['name']
+    region = profile['region']
+
+    bedrock = boto3.client('bedrock', region_name=region)
+    request = {'typeEquals': 'APPLICATION'}
+    inference_profile = None
+    while True:
+        response = bedrock.list_inference_profiles(**request)
+        inference_profile = next((
+            p for p in response['inferenceProfileSummaries']
+            if p['inferenceProfileName'] == profile_name), None)
+        if inference_profile or 'nextToken' not in response:
+            break
+        request['nextToken'] = response['nextToken']
+    if inference_profile is None:
+        raise RuntimeError(f'could not find inference profile {profile_name!r}')
+
+    inference_profile_arn = inference_profile['inferenceProfileArn']
+    inference_profile_id = inference_profile['inferenceProfileId']
+
+    runtime = boto3.client('bedrock-runtime', region_name=region)
+    runtime.converse(
+        modelId=inference_profile_arn,
+        messages=[{
+            'role': 'user',
+            'content': [{'text': 'Reply with the single word hello.'}],
+        }],
+        inferenceConfig={'maxTokens': 8, 'temperature': 0},
+    )
+
+    cloudwatch = boto3.client('cloudwatch', region_name=region)
+    deadline = time.monotonic() + TIMEOUT
+    while time.monotonic() < deadline:
+        end = datetime.now(timezone.utc)
+        available = []
+        for metric in ('InputTokenCount', 'OutputTokenCount'):
+            response = cloudwatch.get_metric_statistics(
+                Namespace='AWS/Bedrock',
+                MetricName=metric,
+                Dimensions=[{'Name': 'ModelId', 'Value': inference_profile_id}],
+                StartTime=end - timedelta(hours=1),
+                EndTime=end,
+                Period=60,
+                Statistics=['Sum'],
+            )
+            available.append(bool(response['Datapoints']))
+        if all(available):
+            print('InputTokenCount and OutputTokenCount are available.')
+            return
+        time.sleep(15)
+    raise TimeoutError('timed out waiting for Bedrock token metrics')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/terraform/bedrock_inference_profile_token_metrics/tf_resources.json
+++ b/tests/terraform/bedrock_inference_profile_token_metrics/tf_resources.json
@@ -1,0 +1,63 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {
+        "inference_profile_arn": {
+            "value": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+            "type": "string"
+        }
+    },
+    "resources": {
+        "aws_caller_identity": {
+            "current": {
+                "account_id": "644160558196",
+                "arn": "arn:aws:sts::644160558196:assumed-role/AWSReservedSSO_admin_1ca370fb35bf6b13/caleb.syring@sixfeetup.com",
+                "id": "644160558196",
+                "user_id": "AROAXGZAMH754FNWODWUX:caleb.syring@sixfeetup.com"
+            }
+        },
+        "aws_bedrock_inference_profile": {
+            "token_metrics": {
+                "arn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+                "created_at": "2026-07-10T19:03:30Z",
+                "description": "Cloud Custodian combined token metrics test",
+                "id": "16iwuych65w4",
+                "model_source": [
+                    {
+                        "copy_from": "arn:aws:bedrock:us-east-1:644160558196:inference-profile/us.amazon.nova-lite-v1:0"
+                    }
+                ],
+                "models": [
+                    {
+                        "model_arn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "model_arn": "arn:aws:bedrock:us-west-2::foundation-model/amazon.nova-lite-v1:0"
+                    },
+                    {
+                        "model_arn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
+                    }
+                ],
+                "name": "c7n-token-metrics-default-cedc",
+                "region": "us-east-1",
+                "status": "ACTIVE",
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "type": "APPLICATION",
+                "updated_at": "2026-07-10T19:03:30Z"
+            }
+        },
+        "random_id": {
+            "suffix": {
+                "b64_std": "ztw=",
+                "b64_url": "ztw",
+                "byte_length": 2,
+                "dec": "52956",
+                "hex": "cedc",
+                "id": "ztw",
+                "keepers": null,
+                "prefix": null
+            }
+        }
+    }
+}

--- a/tests/terraform/bedrock_inference_profile_token_metrics/tf_resources.json
+++ b/tests/terraform/bedrock_inference_profile_token_metrics/tf_resources.json
@@ -2,7 +2,7 @@
     "pytest-terraform": 1,
     "outputs": {
         "inference_profile_arn": {
-            "value": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
+            "value": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/06vsfs68yb4g",
             "type": "string"
         }
     },
@@ -10,17 +10,17 @@
         "aws_caller_identity": {
             "current": {
                 "account_id": "644160558196",
-                "arn": "arn:aws:sts::644160558196:assumed-role/AWSReservedSSO_admin_1ca370fb35bf6b13/caleb.syring@sixfeetup.com",
+                "arn": "arn:aws:sts::644160558196:assumed-role/AWSReservedSSO_admin_1ca370fb35bf6b13/kody.mullins@sixfeetup.com",
                 "id": "644160558196",
-                "user_id": "AROAXGZAMH754FNWODWUX:caleb.syring@sixfeetup.com"
+                "user_id": "AROAXGZAMH754FNWODWUX:kody.mullins@sixfeetup.com"
             }
         },
         "aws_bedrock_inference_profile": {
             "token_metrics": {
-                "arn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/16iwuych65w4",
-                "created_at": "2026-07-10T19:03:30Z",
+                "arn": "arn:aws:bedrock:us-east-1:644160558196:application-inference-profile/06vsfs68yb4g",
+                "created_at": "2026-07-21T19:13:39Z",
                 "description": "Cloud Custodian combined token metrics test",
-                "id": "16iwuych65w4",
+                "id": "06vsfs68yb4g",
                 "model_source": [
                     {
                         "copy_from": "arn:aws:bedrock:us-east-1:644160558196:inference-profile/us.amazon.nova-lite-v1:0"
@@ -37,24 +37,24 @@
                         "model_arn": "arn:aws:bedrock:us-east-2::foundation-model/amazon.nova-lite-v1:0"
                     }
                 ],
-                "name": "c7n-token-metrics-default-cedc",
+                "name": "c7n-token-metrics-default-bf98",
                 "region": "us-east-1",
                 "status": "ACTIVE",
                 "tags": null,
                 "tags_all": {},
                 "timeouts": null,
                 "type": "APPLICATION",
-                "updated_at": "2026-07-10T19:03:30Z"
+                "updated_at": "2026-07-21T19:13:39Z"
             }
         },
         "random_id": {
             "suffix": {
-                "b64_std": "ztw=",
-                "b64_url": "ztw",
+                "b64_std": "v5g=",
+                "b64_url": "v5g",
                 "byte_length": 2,
-                "dec": "52956",
-                "hex": "cedc",
-                "id": "ztw",
+                "dec": "49048",
+                "hex": "bf98",
+                "id": "v5g",
                 "keepers": null,
                 "prefix": null
             }

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -1224,10 +1224,10 @@ def test_bedrock_inference_profile_token_metrics(
             point['Sum'] for point in resources[0]['c7n.metrics'][annotation_key]
         ) > 0
 
-    total_policy, resources = run_metric_policy('TotalTokenCount', statistics=None)
+    total_policy, resources = run_metric_policy('c7n:TotalTokenCount', statistics=None)
     assert len(resources) == 1
     assert resources[0]['inferenceProfileArn'] == profile_arn
-    total_key = 'AWS/Bedrock.TotalTokenCount.Sum.1'
+    total_key = 'AWS/Bedrock.c7n:TotalTokenCount.Sum.1'
     assert total_key in resources[0]['c7n.metrics']
     observed_total = max(
         point['Sum'] for point in resources[0]['c7n.metrics'][total_key])
@@ -1235,13 +1235,13 @@ def test_bedrock_inference_profile_token_metrics(
     assert 'cloudwatch:GetMetricData' in total_policy.get_permissions()
     assert 'cloudwatch:GetMetricStatistics' not in total_policy.get_permissions()
 
-    _, resources = run_metric_policy('TotalTokenCount', value=observed_total + 1)
+    _, resources = run_metric_policy('c7n:TotalTokenCount', value=observed_total + 1)
     assert resources == []
 
 
 def test_bedrock_inference_profile_bad_statistics(test):
     with pytest.raises(
-        PolicyValidationError, match="TotalTokenCount only supports the Sum statistic"
+        PolicyValidationError, match="c7n:TotalTokenCount only supports the Sum statistic"
     ):
         test.load_policy(
             {
@@ -1249,7 +1249,7 @@ def test_bedrock_inference_profile_bad_statistics(test):
                 'resource': 'aws.bedrock-inference-profile',
                 'filters': [{
                     'type': 'metrics',
-                    'name': 'TotalTokenCount',
+                    'name': 'c7n:TotalTokenCount',
                     'statistics': 'Average',
                     'value': 0,
                 }],

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -3,7 +3,9 @@
 import logging
 from .common import ACCOUNT_ID, BaseTest, event_data
 from botocore.exceptions import ClientError
+import pytest
 from pytest_terraform import terraform
+from c7n.exceptions import PolicyValidationError
 from c7n.testing import C7N_FUNCTIONAL
 
 
@@ -1178,29 +1180,78 @@ def test_bedrock_guardrail_update(test, bedrock_guardrail_update):
     test.assertEqual(word_policy['managedWordLists'][0]['type'], 'PROFANITY')
 
 
-def test_bedrock_inference_profile_metrics(test):
+@terraform('bedrock_inference_profile_token_metrics')
+def test_bedrock_inference_profile_token_metrics(
+        test, bedrock_inference_profile_token_metrics):
+    profile_arn = bedrock_inference_profile_token_metrics.outputs[
+        'inference_profile_arn']['value']
+
     session_factory = test.replay_flight_data(
-        'test_bedrock_inference_profile_metrics_filter',
-        region='us-east-2'
-    )
-    p = test.load_policy(
-        {
-            'name': 'bedrock-inference-profile-metrics-filter',
-            'resource': 'aws.bedrock-inference-profile',
-            'filters': [
-                {
+        'bedrock_inference_profile_token_metrics', region='us-east-1')
+
+    def run_metric_policy(metric_name, value=0, statistics='Sum'):
+        metric_filter = {
+            'type': 'metrics',
+            'name': metric_name,
+            'days': 1,
+            'period': 300,
+            'value': value,
+            'op': 'greater-than',
+        }
+        if statistics is not None:
+            metric_filter['statistics'] = statistics
+        policy = test.load_policy(
+            {
+                'name': 'bedrock-inference-profile-token-metrics',
+                'resource': 'aws.bedrock-inference-profile',
+                'filters': [
+                    {'inferenceProfileArn': profile_arn},
+                    metric_filter,
+                ],
+            },
+            session_factory=session_factory,
+            config={'region': 'us-east-1'},
+        )
+        return policy, policy.run()
+
+    for metric_name in ('InputTokenCount', 'OutputTokenCount'):
+        _, resources = run_metric_policy(metric_name)
+        assert len(resources) == 1
+        assert resources[0]['inferenceProfileArn'] == profile_arn
+        annotation_key = 'AWS/Bedrock.%s.Sum.1' % metric_name
+        assert annotation_key in resources[0]['c7n.metrics']
+        assert max(
+            point['Sum'] for point in resources[0]['c7n.metrics'][annotation_key]
+        ) > 0
+
+    total_policy, resources = run_metric_policy('TotalTokenCount', statistics=None)
+    assert len(resources) == 1
+    assert resources[0]['inferenceProfileArn'] == profile_arn
+    total_key = 'AWS/Bedrock.TotalTokenCount.Sum.1'
+    assert total_key in resources[0]['c7n.metrics']
+    observed_total = max(
+        point['Sum'] for point in resources[0]['c7n.metrics'][total_key])
+    assert observed_total > 0
+    assert 'cloudwatch:GetMetricData' in total_policy.get_permissions()
+    assert 'cloudwatch:GetMetricStatistics' not in total_policy.get_permissions()
+
+    _, resources = run_metric_policy('TotalTokenCount', value=observed_total + 1)
+    assert resources == []
+
+
+def test_bedrock_inference_profile_bad_statistics(test):
+    with pytest.raises(
+        PolicyValidationError, match="TotalTokenCount only supports the Sum statistic"
+    ):
+        test.load_policy(
+            {
+                'name': 'bedrock-inference-profile-invalid-total-statistic',
+                'resource': 'aws.bedrock-inference-profile',
+                'filters': [{
                     'type': 'metrics',
-                    'name': 'InputTokenCount',
-                    'statistics': 'Sum',
-                    'days': 1,
-                    'value': 10000,
-                    'op': 'greater-than',
-                }
-            ]
-        },
-        session_factory=session_factory,
-    )
-    resources = p.run()
-    test.assertEqual(len(resources), 1)
-    test.assertTrue('c7n.metrics' in resources[0])
-    test.assertTrue('AWS/Bedrock.InputTokenCount.Sum.1' in resources[0]['c7n.metrics'])
+                    'name': 'TotalTokenCount',
+                    'statistics': 'Average',
+                    'value': 0,
+                }],
+            },
+        )


### PR DESCRIPTION
## aws - bedrock inference profile - total tokens metric

### What
Resolves #10834 by adding a Custodian-derived `TotalTokenCount` metric to the `metrics` filter on `aws.bedrock-inference-profile`. It sums Bedrock's `InputTokenCount` and `OutputTokenCount` CloudWatch metrics via metric math, letting policies match on combined token consumption in a single filter.

### Why
Bedrock publishes input and output token counts as separate CloudWatch metrics with no combined series. Alerting on total usage previously required two filters and manual reconciliation.

### How
- Introduces a small `get_metric_data(client, params)` seam on the base `MetricsFilter`. The default preserves existing behavior (`GetMetricStatistics`); resource filters can override it for metrics unavailable through that API.
- `InferenceProfileMetrics` overrides the seam for `TotalTokenCount`, issuing a `GetMetricData` call with an `input + output` math expression (paginated).
- `TotalTokenCount` only supports the `Sum` statistic (defaulted, and validated), and reports the `cloudwatch:GetMetricData` permission instead of `cloudwatch:GetMetricStatistics`.

### Usage
```yaml
policies:
  - name: bedrock-daily-token-usage
    resource: aws.bedrock-inference-profile
    filters:
      - type: metrics
        name: TotalTokenCount
        days: 1
        period: 86400
        period-start: start-of-day
        value: 100000
        op: greater-than
```

### Testing
- New terraform fixture (`bedrock_inference_profile_token_metrics`) with a `setup.py` that drives a real Bedrock invocation to generate token metrics, plus a re-record `README.md`.
- Replay test asserts raw `Input`/`Output` metrics, the derived total, the negative match case, and the permission set.
- Added validation test for the unsupported-statistic error.
- Backward compatibility for the base-filter refactor confirmed against the general metrics and shield-metrics subclass tests.