### PR TITLE
perf(sqs): use set for dead-letter redrive membership check

### DIFF
--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -473,10 +473,10 @@ class DeadLetterFilter(Filter):
         all_resources = self.manager.get_resource_manager("sqs").resources()
         all_queue_arn_map = {r['QueueArn']: r for r in all_resources}
         queue_arn_map = {r['QueueArn']: r for r in resources}
-        has_redrive = []
+        has_redrive = set()
         for r in all_resources:
             if r.get("RedrivePolicy"):
-                has_redrive.append(r['QueueArn'])
+                has_redrive.add(r['QueueArn'])
         result = []
         # dead letter queues must exist in the same region and account as the
         # original queue so it should be safe to look for them in our existing

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -873,3 +873,10 @@ class QueueTests(BaseTest):
         )
         resources = policy.run()
         self.assertEqual(len(resources), 2)
+        self.assertEqual(
+            sorted(r["QueueArn"] for r in resources),
+            [
+                "arn:aws:sqs:us-east-1:644160558196:bar_dlq",
+                "arn:aws:sqs:us-east-1:644160558196:test-dlq",
+            ],
+        )


### PR DESCRIPTION

The `dead-letter` filter for `aws.sqs` (`DeadLetterFilter.process`) inspects
every SQS queue in the region, collects the ARNs of queues that carry a
`RedrivePolicy` into `has_redrive`, and then iterates the queues again testing
`r['QueueArn'] in has_redrive`.

`has_redrive` was a `list`, so each membership test is O(n) and the filter as a
whole is O(queues^2). On accounts with many SQS queues this is noticeably slow.

This changes `has_redrive` to a `set`, making the membership check O(1) and the
filter O(queues). It also lines up with the hash-based lookups already built a
couple of lines above (`all_queue_arn_map` / `queue_arn_map`), so the idiom is
consistent within the method.

Behavior is unchanged: `QueueArn` values are unique (they are the keys of
`all_queue_arn_map`) and the result is already de-duplicated via `set(result)`,
so a set and a list yield identical membership results.

I extended `tests/test_sqs.py::test_sqs_deadletter_filter` to assert the exact
target ARNs the filter returns (`bar_dlq`, `test-dlq`), not just the count, so
the returned set is pinned. It reuses the existing recorded flight data (no new
cassette).

Testing:
- `pytest tests/test_sqs.py -k deadletter` -> passes
- `pytest tests/test_sqs.py` -> 26 passed
- `ruff check c7n/resources/sqs.py tests/test_sqs.py` -> clean
