### PR TITLE
aws - iam-user - avoid quadratic dedup in policy filter

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -2089,8 +2089,9 @@ class UserPolicy(ValueFilter):
         matched = []
         for r in resources:
             for p in r['c7n:Policies']:
-                if self.match(p) and r not in matched:
+                if self.match(p):
                     matched.append(r)
+                    break
         return matched
 
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1111,6 +1111,26 @@ class IamUserTest(BaseTest):
         self.assertEqual(resources[1]["UserName"], "alphabet_soup_2")
         self.assertEqual(len(resources[1]["c7n:Policies"]), 2)
 
+    def test_iam_user_policy_dedup(self):
+        # A user with more than one matching policy must be returned exactly
+        # once, matched users keep their input order, and non-matching users
+        # are excluded. Guards the dedup behavior of UserPolicy.process.
+        self.patch(UserPolicy, "executor_factory", MainThreadExecutor)
+        f = UserPolicy(
+            {"type": "policy", "key": "PolicyName", "value": "AdministratorAccess"},
+            mock.MagicMock(),
+        )
+        admin = {"PolicyName": "AdministratorAccess"}
+        readonly = {"PolicyName": "ReadOnlyAccess"}
+        resources = [
+            {"UserName": "u1", "c7n:Policies": [admin, admin]},
+            {"UserName": "u2", "c7n:Policies": [readonly]},
+            {"UserName": "u3", "c7n:Policies": [readonly, admin]},
+        ]
+        with mock.patch.object(UserPolicy, "user_policies"):
+            matched = f.process(resources)
+        self.assertEqual([r["UserName"] for r in matched], ["u1", "u3"])
+
     def test_iam_user_access_key_filter(self):
         session_factory = self.replay_flight_data("test_iam_user_access_key_active")
         self.patch(UserAccessKey, "executor_factory", MainThreadExecutor)


### PR DESCRIPTION

`UserPolicy.process` (the `iam-user` `type: policy` filter) deduplicated matched
users with `r not in matched`, a linear scan of the growing result list on every
`(user, policy)` pair:

```python
matched = []
for r in resources:
    for p in r['c7n:Policies']:
        if self.match(p) and r not in matched:
            matched.append(r)
return matched
```

With many matching users this is `O(users^2 * policies_per_user)`. `iam-user` +
`type: policy` is a common compliance filter and large accounts can have
thousands of IAM users, so the `not in` scan becomes a noticeable cost.

A user only needs one matching policy to be included, so this appends the user on
the first match and breaks out of the inner policy loop; each user is appended at
most once and the linear scan is gone:

```python
matched = []
for r in resources:
    for p in r['c7n:Policies']:
        if self.match(p):
            matched.append(r)
            break
return matched
```

Output and ordering are unchanged: both versions append each user exactly once,
in `resources` order, iff the user has at least one matching policy, and exclude
non-matching users. `break` is a strict improvement because it also stops
scanning a user's remaining policies once a match is found.

Added `tests/test_iam.py::IamUserTest::test_iam_user_policy_dedup`, which builds
three users (one with two matching policies) and asserts the matched users are
returned once each in input order with the non-matching user excluded. It fails
if the dedup is removed and passes with this change.

### Testing

- `pytest tests/test_iam.py -k "not terraform"` -> 138 passed
- `ruff check c7n/resources/iam.py tests/test_iam.py` -> clean
