### PR TITLE
azure - keyvault-key - hoist key-type set out of the filter loop

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault_keys.py
@@ -145,6 +145,7 @@ class KeyTypeFilter(Filter):
 
     def _process_resource_set(self, resources, event):
         matched = []
+        key_types = {t.lower() for t in self.data.get('key-types', ())}
         for resource in resources:
             try:
                 if 'c7n:kty' not in resource:
@@ -154,7 +155,7 @@ class KeyTypeFilter(Filter):
 
                     resource['c7n:kty'] = key.key.kty.lower()
 
-                if resource['c7n:kty'] in [t.lower() for t in self.data['key-types']]:
+                if resource['c7n:kty'] in key_types:
                     matched.append(resource)
             except Exception as error:
                 log.warning(error)

--- a/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py
@@ -67,6 +67,27 @@ class KeyVaultKeyTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertTrue(resources[0]['c7n:kty'].lower(), 'rsa')
 
+    def test_key_vault_keys_type_filters_by_type(self):
+        # Keys already carry 'c7n:kty' so no service call is made; this exercises
+        # the in-memory matching in KeyTypeFilter across a set of keys.
+        resources = [
+            {'id': 'https://kv.vault.azure.net/keys/rsa-key', 'c7n:kty': 'rsa'},
+            {'id': 'https://kv.vault.azure.net/keys/ec-key', 'c7n:kty': 'ec'},
+            {'id': 'https://kv.vault.azure.net/keys/rsa-hsm-key', 'c7n:kty': 'rsa-hsm'},
+        ]
+        p = self.load_policy({
+            'name': 'test-key-vault',
+            'resource': 'azure.keyvault-key',
+            'filters': [
+                {'type': 'key-type', 'key-types': ['RSA', 'RSA-HSM']}
+            ]
+        }, validate=True)
+        matched = p.resource_manager.filters[0].process(resources)
+        self.assertEqual(
+            sorted(r['c7n:kty'] for r in matched),
+            ['rsa', 'rsa-hsm']
+        )
+
     def test_key_vault_keys_rotation(self):
         p = self.load_policy({
             'name': 'test-key-vault',


### PR DESCRIPTION

`KeyTypeFilter._process_resource_set` in the Key Vault `key-type` filter rebuilt the
list of allowed key types on every key inside the per-resource loop:

```python
if resource['c7n:kty'] in [t.lower() for t in self.data['key-types']]:
```

That list only depends on the filter's static `key-types` configuration, so it is
invariant across the whole resource set, yet it was reconstructed (and every allowed
type re-lowercased) once per key. Membership was also tested against a `list`, so each
check was a linear scan.

This hoists the allowed set out of the loop and computes it once, using a `set` so the
membership test is O(1):

```python
key_types = {t.lower() for t in self.data.get('key-types', ())}
for resource in resources:
    ...
    if resource['c7n:kty'] in key_types:
        matched.append(resource)
```

Behavior is unchanged for valid policies. Using `self.data.get('key-types', ())`
preserves the existing behavior for a `key-type` filter configured without
`key-types` (the schema does not require it): the allowed set is empty and nothing
matches, without raising. Previously the missing key raised `KeyError` per resource,
which was swallowed by the surrounding `except Exception` (and logged a warning each
time) and likewise matched nothing.

### Testing

Added `test_key_vault_keys_type_filters_by_type`, which asserts the filter matches
the configured key types case-insensitively (`['RSA', 'RSA-HSM']` matches keys whose
`c7n:kty` is `rsa`/`rsa-hsm` and excludes `ec`). The keys in the test already carry
`c7n:kty`, so the in-memory matching is exercised directly with no service call.

```
tools/c7n_azure/tests_azure/tests_resources/test_keyvault_keys.py  ->  7 passed
```

Ruff clean on the changed files.
