### PR TITLE
gcp - recommender - fix concatenated usage commitment recommender id

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/filters/recommender.json
+++ b/tools/c7n_gcp/c7n_gcp/filters/recommender.json
@@ -39,10 +39,10 @@
     "category": "Cost",
     "permission_prefix": "recommender.cloudsqlOverprovisionedInstanceRecommendations"
   },
-  "google.compute.commitment.UsageCommitmentRecommendergoogle.cloudbilling.commitment.SpendBasedCommitmentRecommender": {
+  "google.compute.commitment.UsageCommitmentRecommender": {
     "name": "Committed use discount recommender",
     "resource": "gcp.compute-project",
-    "id": "google.compute.commitment.UsageCommitmentRecommendergoogle.cloudbilling.commitment.SpendBasedCommitmentRecommender",
+    "id": "google.compute.commitment.UsageCommitmentRecommender",
     "description": "Reduce costs thru commitments",
     "category": "Cost",
     "permission_prefix": "recommender.usageCommitmentRecommendations"

--- a/tools/c7n_gcp/tests/test_compute.py
+++ b/tools/c7n_gcp/tests/test_compute.py
@@ -4,6 +4,7 @@
 import re
 import time
 
+from c7n_gcp.filters.recommender import get_recommender_data
 from c7n_gcp.resources.compute import Snapshot
 from gcp_common import BaseTest, event_data
 from googleapiclient.errors import HttpError
@@ -811,6 +812,25 @@ class ProjectTest(BaseTest):
 
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['name'], project_id)
+
+    def test_recommend_usage_commitment_id(self):
+        # https://github.com/cloud-custodian/cloud-custodian/issues/10707
+        # The committed use discount recommender entry had a second recommender
+        # id accidentally concatenated onto its key/id, producing an id the
+        # Recommender API rejects and making the real id unusable in a policy.
+        data = get_recommender_data()
+        rec_id = 'google.compute.commitment.UsageCommitmentRecommender'
+        self.assertIn(rec_id, data)
+        self.assertEqual(data[rec_id]['id'], rec_id)
+        self.assertEqual(data[rec_id]['resource'], 'gcp.compute-project')
+
+        # the documented id validates against gcp.compute-project
+        p = self.load_policy(
+            {'name': 'gcp-compute-project-usage-commitment',
+             'resource': 'gcp.compute-project',
+             'filters': [{'type': 'recommend', 'id': rec_id}]},
+            validate=True)
+        self.assertEqual(len(p.resource_manager.filters), 1)
 
 
 class TestInstanceGroupManager(BaseTest):


### PR DESCRIPTION
The committed use discount recommender entry in
`tools/c7n_gcp/c7n_gcp/filters/recommender.json` had a second recommender id
accidentally concatenated (with no separator) onto both its object key and its
inner `id` field:

```
google.compute.commitment.UsageCommitmentRecommender
google.cloudbilling.commitment.SpendBasedCommitmentRecommender
```

joined into
`google.compute.commitment.UsageCommitmentRecommendergoogle.cloudbilling.commitment.SpendBasedCommitmentRecommender`.

This made the recommender unusable either way, exactly as reported in #10707:

- Using the combined id builds the path
  `.../recommenders/google.compute.commitment.UsageCommitmentRecommendergoogle.cloudbilling.commitment.SpendBasedCommitmentRecommender/recommendations`,
  which the Recommender API rejects with `HTTP 400 "Request contains an invalid argument."`.
- Using the real, documented id
  `google.compute.commitment.UsageCommitmentRecommender` fails policy validation
  (`recommendation id ... is not valid for gcp.compute-project`), because the data
  table only knew the concatenated key.

The entry's `resource` (`gcp.compute-project`) and `permission_prefix`
(`recommender.usageCommitmentRecommendations`) already correspond to the compute
usage commitment recommender, so this restores the key and `id` to that single
valid recommender id. Per Google's recommender docs, the resource-based CUD
recommender (`google.compute.commitment.UsageCommitmentRecommender`) and the
spend-based one (`google.cloudbilling.commitment.SpendBasedCommitmentRecommender`)
are two distinct recommenders; the spend-based one targets a billing account
rather than a compute project, and is intentionally not added here (see the
discussion in #10707 about it not fitting the current recommender assumptions).

Per review feedback, the static unit test was dropped in favor of the data fix
alone. A recorded flight test can land separately if useful (see also #10935).

Closes #10707