### PR TITLE
azure - output - normalize path separators for nested blob keys

### DIFF
--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -71,8 +71,9 @@ class AzureStorageOutput(DirectoryOutput):
     def upload(self):
         for root, dirs, files in os.walk(self.root_dir):
             for f in files:
-                blob_name = self.join(self.file_prefix, root[len(self.root_dir):], f)
-                blob_name.strip('/')
+                rel_path = root[len(self.root_dir):].replace(os.sep, '/')
+                blob_name = self.join(self.file_prefix, rel_path, f)
+                blob_name = blob_name.strip('/')
                 try:
                     self.blob_service.create_blob_from_path(
                         self.container,

--- a/tools/c7n_azure/tests_azure/test_output.py
+++ b/tools/c7n_azure/tests_azure/test_output.py
@@ -66,6 +66,31 @@ class OutputTest(BaseTest):
             fh.name
         )
 
+    def test_azure_output_upload_nested(self):
+        # Files in nested directories must produce forward-slash blob keys on
+        # every platform. On Windows os.walk yields OS-native separators, so the
+        # relative path fragment has to be normalized before it is used as a
+        # blob name.
+        AzureStorageOutput.get_blob_client_wrapper = gm = mock.MagicMock()
+        gm.return_value = None, "logs", 'xyz'
+
+        output = self.get_azure_output()
+
+        output.blob_service = mock.MagicMock()
+        output.blob_service.create_blob_from_path = m = mock.MagicMock()
+
+        # Simulate a Windows walk over a nested output tree by using backslash
+        # separators for both root_dir and the walked path.
+        output.root_dir = output.root_dir.replace(os.sep, "\\")
+        fake_walk = [(output.root_dir + "\\sub", [], ["foo.txt"])]
+        with mock.patch("c7n_azure.output.os.walk", return_value=fake_walk), \
+                mock.patch("c7n_azure.output.os.sep", "\\"):
+            output.upload()
+
+        blob_name = m.call_args[0][1]
+        self.assertEqual(blob_name, "xyz/sub/foo.txt")
+        self.assertNotIn("\\", blob_name)
+
     def test_azure_output_get_default_output_dir(self):
         AzureStorageOutput.get_blob_client_wrapper = gm = mock.MagicMock()
         gm.return_value = None, "logs", 'xyz'


### PR DESCRIPTION

```
`AzureStorageOutput.upload` builds each blob name from `os.walk` output. For a
file in a nested subdirectory on Windows, the relative-path fragment
`root[len(self.root_dir):]` contains the OS-native backslash separator, and
`join()` only strips forward slashes, so the resulting blob key kept the
backslash (for example `xyz\sub\foo.txt`). Azure Blob virtual directories are
delimited by `/`, so the backslash ends up as part of the object name instead
of a directory boundary.

On POSIX this path is already correct (`os.sep` is `/`), so this is effectively
a Windows-only fix. While here, I also restored the result of the trailing
`strip('/')` back to `blob_name`; it had been discarded (a no-op) since output
switched to `join()`.

Changes:

- Normalize the relative-path fragment with `os.sep` -> `/` before joining, so
  nested blob keys are always `/`-delimited.
- Assign `blob_name = blob_name.strip('/')` instead of discarding the stripped
  value.
- Add `test_azure_output_upload_nested`, which walks a nested tree with
  Windows-style separators and asserts the blob key is a clean POSIX path
  (`xyz/sub/foo.txt`, no backslash). It fails before the fix and passes after.

The shared `join()` static method is left unchanged (it is used elsewhere).
```
