### PR TITLE
core - reduce filter - fix discard-percent leaking across groups

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -1149,13 +1149,15 @@ class ReduceFilter(BaseValueFilter):
         if 'group-by' in self.data or 'order' in self.data:
             ordered = self.reorder(ordered, key=lambda r: groups[r]['sortkey'])
         for g in ordered:
-            # discard X first
+            # discard X first, computing the per-group count fresh so a larger
+            # group's discard doesn't leak into subsequent, smaller groups
+            gdrop = drop
             if droppct > 0:
                 n = int(droppct / 100 * len(groups[g]['resources']))
-                if n > drop:
-                    drop = n
-            if drop > 0:
-                groups[g]['resources'] = groups[g]['resources'][drop:]
+                if n > gdrop:
+                    gdrop = n
+            if gdrop > 0:
+                groups[g]['resources'] = groups[g]['resources'][gdrop:]
 
             # then limit the remaining
             count = len(groups[g]['resources'])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1437,6 +1437,30 @@ class TestReduceFilter(BaseFilterTest):
         self.assertEqual(len(rs), 3)
         self.assertEqual([r['InstanceId'] for r in rs], ['D', 'E', 'F'])
 
+    def test_discard_percent_by_group(self):
+        # discard-percent must be computed per group; a larger group's discard
+        # count should not leak into subsequent, smaller groups
+        resources = [
+            dict(InstanceId="A", Group="big", Id="1"),
+            dict(InstanceId="B", Group="big", Id="2"),
+            dict(InstanceId="C", Group="big", Id="3"),
+            dict(InstanceId="D", Group="big", Id="4"),
+            dict(InstanceId="E", Group="small", Id="5"),
+            dict(InstanceId="F", Group="small", Id="6"),
+        ]
+        f = filters.factory(
+            {
+                "type": "reduce",
+                "group-by": "Group",
+                "sort-by": "Id",
+                "order": "asc",
+                "discard-percent": 50,
+            }
+        )
+        rs = f.process(resources)
+        # big (4 items) discards 2 -> C, D; small (2 items) discards 1 -> F
+        self.assertEqual([r['InstanceId'] for r in rs], ['C', 'D', 'F'])
+
     def test_discard_and_limit(self):
         resources = self.instances()
         f = filters.factory(


### PR DESCRIPTION

```markdown
### What this fixes

The `reduce` filter's `discard-percent` option is meant to be applied per group,
the same way `limit`, `limit-percent`, and grouping already are. Right now, when a
policy also uses `group-by`, the percent-derived discard count computed for one
group leaks into the groups processed after it.

In `ReduceFilter.limit`, `drop` is read once from the configured `discard` value
before the per-group loop and then reassigned in place to the percentage count for
the current group:

```python
drop = self.data.get('discard', 0)
...
for g in ordered:
    if droppct > 0:
        n = int(droppct / 100 * len(groups[g]['resources']))
        if n > drop:
            drop = n          # <- mutates the loop-carried value
    if drop > 0:
        groups[g]['resources'] = groups[g]['resources'][drop:]
```

Because `drop` is never reset per group, once a larger group bumps it up, every
subsequent (smaller) group is sliced with that larger count and loses too many
resources.

### Example

Six resources, grouped into `big` (4) and `small` (2), with `discard-percent: 50`:

- Expected: `big` discards 2 (keeps 2), `small` discards 1 (keeps 1).
- Actual: `big` sets `drop = 2`; `small` then discards 2 of its 2 resources, so its
  surviving resource is wrongly dropped.

### The fix

Compute a fresh per-group discard count (`gdrop`) from the configured `discard`
floor each iteration instead of mutating it. This keeps the existing single-group
semantics exactly (discard the greater of the fixed `discard` count and the
per-group percentage), and stops one group's count from affecting the next.

### Tests

Added `tests/test_filters.py::TestReduceFilter::test_discard_percent_by_group`,
which groups differently sized groups with `discard-percent` and asserts each group
is discarded proportionally. It fails on the current code and passes with the fix.
The existing `TestReduceFilter` cases (including `test_discard`,
`test_discard_percent`, and `test_discard_and_limit`) continue to pass.
```

---

## Notes for the PR mechanics (not part of the body)

- Do NOT `git commit -s`: the project uses CNCF EasyCLA, not DCO. The EasyCLA bot
  authorizes the PR; Anas signs it through the bot link on the PR.
- Commit/PR title use the repo-dominant `<area> - <summary>` style
  (`core - support Azure Blob...`, `aws - security-hub...`).
- No PR template exists in the repo (`.github/` ships only `ISSUE_TEMPLATE`), so the
  body above is freeform, matching the house style of recent bugfix PRs
  (concise problem statement + fix + tests).
