### PR TITLE
aws - security-hub - fix post-finding FIPS md5 usage

### DIFF
--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -514,10 +514,9 @@ class PostFinding(Action):
         if existing_finding_id:
             finding_id = existing_finding_id
         else:
-            # for fips compliance we need to explicit pass the usage param but it doesn't
-            # exist on python 3.8, directly pass when we drop 3.8 support.
-            params = (sys.version_info.major > 3 and sys.version_info.minor > 8) and {
-                'usedforsecurity': False} or {}
+            # for fips compliance we need to explicitly pass the usage param but it
+            # doesn't exist on python 3.8; guard on version until we drop 3.8 support.
+            params = {'usedforsecurity': False} if sys.version_info >= (3, 9) else {}
             finding_id = '{}/{}/{}/{}'.format(
                 self.manager.config.region,
                 self.manager.config.account_id,

--- a/c7n/resources/securityhub.py
+++ b/c7n/resources/securityhub.py
@@ -7,7 +7,6 @@ from dateutil.tz import tzutc
 import json
 import hashlib
 import logging
-import sys
 
 from c7n import deprecated, query
 from c7n.actions import Action
@@ -514,19 +513,16 @@ class PostFinding(Action):
         if existing_finding_id:
             finding_id = existing_finding_id
         else:
-            # for fips compliance we need to explicitly pass the usage param but it
-            # doesn't exist on python 3.8; guard on version until we drop 3.8 support.
-            params = {'usedforsecurity': False} if sys.version_info >= (3, 9) else {}
             finding_id = '{}/{}/{}/{}'.format(
                 self.manager.config.region,
                 self.manager.config.account_id,
                 # we use md5 for id, equiv to using crc32
                 hashlib.md5(  # nosec nosemgrep
                     json.dumps(policy.data).encode('utf8'),
-                    **params).hexdigest(),
+                    usedforsecurity=False).hexdigest(),
                 hashlib.md5(  # nosec nosemgrep
                     json.dumps(list(sorted([r[model.id] for r in resources]))).encode('utf8'),
-                    **params).hexdigest()
+                    usedforsecurity=False).hexdigest()
             )
         finding = {
             "SchemaVersion": self.FindingVersion,

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -5,8 +5,10 @@ from c7n.exceptions import PolicyValidationError
 from c7n.resources.aws import shape_validate
 from .common import BaseTest, event_data
 
+import hashlib
 import logging
 import time
+from unittest import mock
 
 LambdaFindingId = "us-east-2/644160558196/81cc9d38b8f8ebfd260ecc81585b4bc9/9f5932aa97900b5164502f41ae393d23" # NOQA
 
@@ -129,6 +131,37 @@ class SecurityHubTest(BaseTest):
         resource = post_finding.format_resource(
             {'Name': 'xyz', 'CreationDate': 'xtf'})
         self.assertEqual(resource['Id'], "arn:aws:s3:::xyz")
+
+    def test_post_finding_id_fips_usedforsecurity(self):
+        # A new finding id is built from hashlib.md5; for FIPS compliance the
+        # usedforsecurity=False flag must actually be passed (on Python >= 3.9).
+        policy = self.load_policy({
+            'name': 's3',
+            'resource': 's3',
+            'actions': [
+                {'type': 'post-finding',
+                 'types': [
+                     "Software and Configuration Checks/AWS Security Best Practices/Network Reachability"  # NOQA
+                 ]}]})
+        post_finding = policy.resource_manager.actions[0]
+
+        real_md5 = hashlib.md5
+        seen_kwargs = []
+
+        def spy_md5(*args, **kwargs):
+            seen_kwargs.append(kwargs)
+            return real_md5(*args)
+
+        with mock.patch(
+                'c7n.resources.securityhub.hashlib.md5', side_effect=spy_md5):
+            finding = post_finding.get_finding(
+                [{'Name': 'xyz'}], None, '2018-01-01T00:00:00Z',
+                '2018-01-01T00:00:00Z')
+
+        self.assertTrue(finding['Id'])
+        self.assertTrue(seen_kwargs)
+        self.assertTrue(
+            all(kw.get('usedforsecurity') is False for kw in seen_kwargs))
 
     def test_security_hub_master_filter(self):
         factory = self.replay_flight_data('test_security_hub_master_filter')

--- a/tests/test_securityhub.py
+++ b/tests/test_securityhub.py
@@ -134,7 +134,7 @@ class SecurityHubTest(BaseTest):
 
     def test_post_finding_id_fips_usedforsecurity(self):
         # A new finding id is built from hashlib.md5; for FIPS compliance the
-        # usedforsecurity=False flag must actually be passed (on Python >= 3.9).
+        # usedforsecurity=False flag must be passed.
         policy = self.load_policy({
             'name': 's3',
             'resource': 's3',


### PR DESCRIPTION
The `post-finding` action builds Security Hub finding IDs with `hashlib.md5`. On FIPS-enabled hosts this requires `usedforsecurity=False`, but the existing version guard was always false on supported Python versions.

Pass `usedforsecurity=False` directly now that Python 3.8 is no longer supported. Add a regression test asserting both MD5 calls receive the flag.

Testing:

- `uv run pytest tests/test_securityhub.py -q` (21 passed)
- `uv run ruff check c7n/resources/securityhub.py tests/test_securityhub.py`