### PR TITLE
AWS - Add resource support for Bedrock Provisioned Throughput

### DIFF
--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -823,6 +823,51 @@ class InferenceProfileMetrics(MetricsFilter):
         return [{'Name': 'ModelId', 'Value': resource['inferenceProfileId']}]
 
 
+@resources.register('bedrock-provisioned-throughput')
+class BedrockProvisionedThroughput(QueryResourceManager):
+    """AWS Bedrock Provisioned Throughput
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: bedrock-provisioned-throughput-zero-invocations
+            resource: aws.bedrock-provisioned-throughput
+            filters:
+              - type: value
+                key: status
+                value: InService
+              - type: metrics
+                namespace: AWS/Bedrock
+                name: Invocations
+                statistics: Sum
+                days: 14
+                period: 86400
+                op: eq
+                value: 0
+                missing-value: 0
+    """
+    class resource_type(TypeInfo):
+        service = 'bedrock'
+        enum_spec = ('list_provisioned_model_throughputs',
+                     'provisionedModelSummaries', None)
+        name = 'provisionedModelName'
+        id = arn = 'provisionedModelArn'
+        arn_type = 'provisioned-model-throughput'
+        permission_prefix = 'bedrock'
+        universal_taggable = object()
+        permissions_augment = ("bedrock:ListTagsForResource",)
+
+    augment = universal_augment
+
+
+@BedrockProvisionedThroughput.filter_registry.register('metrics')
+class ProvisionedThroughputMetrics(MetricsFilter):
+    def get_dimensions(self, resource):
+        return [{'Name': 'ModelId', 'Value': resource['provisionedModelArn']}]
+
+
 @resources.register('bedrock-guardrail')
 class BedrockGuardrail(QueryResourceManager):
     class resource_type(TypeInfo):

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -42,6 +42,8 @@ ResourceMap = {
   "aws.bedrock-foundation-model": "c7n.resources.bedrock.BedrockFoundationModel",
   "aws.bedrock-knowledge-base": "c7n.resources.bedrock.BedrockKnowledgeBase",
   "aws.bedrock-model-invocation-job": "c7n.resources.bedrock.BedrockModelInvocationJob",
+  "aws.bedrock-provisioned-throughput":
+    "c7n.resources.bedrock.BedrockProvisionedThroughput",
   "aws.budget": "c7n.resources.budgets.Budget",
   "aws.cache-cluster": "c7n.resources.elasticache.ElastiCacheCluster",
   "aws.cache-snapshot": "c7n.resources.elasticache.ElastiCacheSnapshot",

--- a/tests/data/placebo/test_bedrock_provisioned_throughput/bedrock.ListProvisionedModelThroughputs_1.json
+++ b/tests/data/placebo/test_bedrock_provisioned_throughput/bedrock.ListProvisionedModelThroughputs_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "provisionedModelSummaries": [
+            {
+                "provisionedModelName": "my-provisioned-model",
+                "provisionedModelArn": "arn:aws:bedrock:us-east-2:644160558196:provisioned-model/9k2m1x3z7a2b",
+                "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0",
+                "desiredModelArn": "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0",
+                "foundationModelArn": "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0",
+                "modelUnits": 1,
+                "desiredModelUnits": 1,
+                "status": "InService",
+                "commitmentDuration": "OneMonth",
+                "commitmentExpirationTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 8,
+                    "day": 14,
+                    "hour": 19,
+                    "minute": 14,
+                    "second": 21,
+                    "microsecond": 0
+                },
+                "creationTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 5,
+                    "day": 12,
+                    "hour": 19,
+                    "minute": 14,
+                    "second": 21,
+                    "microsecond": 0
+                },
+                "lastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 5,
+                    "day": 12,
+                    "hour": 19,
+                    "minute": 14,
+                    "second": 21,
+                    "microsecond": 0
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_provisioned_throughput/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_bedrock_provisioned_throughput/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:bedrock:us-east-2:644160558196:provisioned-model/9k2m1x3z7a2b",
+                "Tags": [
+                    {
+                        "Key": "App",
+                        "Value": "Project1"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_bedrock_provisioned_throughput_metrics_filter/bedrock.ListProvisionedModelThroughputs_1.json
+++ b/tests/data/placebo/test_bedrock_provisioned_throughput_metrics_filter/bedrock.ListProvisionedModelThroughputs_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "provisionedModelSummaries": [
+            {
+                "provisionedModelName": "my-provisioned-model",
+                "provisionedModelArn": "arn:aws:bedrock:us-east-2:644160558196:provisioned-model/9k2m1x3z7a2b",
+                "modelArn": "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0",
+                "desiredModelArn": "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0",
+                "foundationModelArn": "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0",
+                "modelUnits": 1,
+                "desiredModelUnits": 1,
+                "status": "InService",
+                "commitmentDuration": "OneMonth",
+                "commitmentExpirationTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 8,
+                    "day": 14,
+                    "hour": 19,
+                    "minute": 14,
+                    "second": 21,
+                    "microsecond": 0
+                },
+                "creationTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 5,
+                    "day": 12,
+                    "hour": 19,
+                    "minute": 14,
+                    "second": 21,
+                    "microsecond": 0
+                },
+                "lastModifiedTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 5,
+                    "day": 12,
+                    "hour": 19,
+                    "minute": 14,
+                    "second": 21,
+                    "microsecond": 0
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_provisioned_throughput_metrics_filter/monitoring.GetMetricStatistics_1.json
+++ b/tests/data/placebo/test_bedrock_provisioned_throughput_metrics_filter/monitoring.GetMetricStatistics_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "Label": "Invocations",
+        "Datapoints": [
+            {
+                "Timestamp": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 1,
+                    "hour": 0,
+                    "minute": 0,
+                    "second": 0,
+                    "microsecond": 0
+                },
+                "Sum": 0.0,
+                "Unit": "Count"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_bedrock_provisioned_throughput_metrics_filter/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_bedrock_provisioned_throughput_metrics_filter/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:bedrock:us-east-2:644160558196:provisioned-model/9k2m1x3z7a2b",
+                "Tags": [
+                    {
+                        "Key": "App",
+                        "Value": "Project1"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -1204,3 +1204,57 @@ def test_bedrock_inference_profile_metrics(test):
     test.assertEqual(len(resources), 1)
     test.assertTrue('c7n.metrics' in resources[0])
     test.assertTrue('AWS/Bedrock.InputTokenCount.Sum.1' in resources[0]['c7n.metrics'])
+
+
+def test_bedrock_provisioned_throughput(test):
+    session_factory = test.replay_flight_data(
+        'test_bedrock_provisioned_throughput',
+        region='us-east-2'
+    )
+    p = test.load_policy(
+        {
+            'name': 'bedrock-provisioned-throughput',
+            'resource': 'aws.bedrock-provisioned-throughput',
+            'filters': [
+                {'type': 'value', 'key': 'status', 'value': 'InService'},
+                {'tag:App': 'Project1'},
+            ],
+        },
+        session_factory=session_factory,
+    )
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+    test.assertEqual(
+        resources[0]['provisionedModelArn'],
+        'arn:aws:bedrock:us-east-2:644160558196:provisioned-model/9k2m1x3z7a2b',
+    )
+
+
+def test_bedrock_provisioned_throughput_metrics_filter(test):
+    session_factory = test.replay_flight_data(
+        'test_bedrock_provisioned_throughput_metrics_filter',
+        region='us-east-2'
+    )
+    p = test.load_policy(
+        {
+            'name': 'bedrock-provisioned-throughput-metrics-filter',
+            'resource': 'aws.bedrock-provisioned-throughput',
+            'filters': [
+                {
+                    'type': 'metrics',
+                    'namespace': 'AWS/Bedrock',
+                    'name': 'Invocations',
+                    'statistics': 'Sum',
+                    'days': 14,
+                    'period': 86400,
+                    'op': 'eq',
+                    'value': 0,
+                    'missing-value': 0,
+                }
+            ],
+        },
+        session_factory=session_factory,
+    )
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+    test.assertTrue('c7n.metrics' in resources[0])


### PR DESCRIPTION
Register aws.bedrock-provisioned-throughput enumerating ListProvisionedModelThroughputs, with tagging (universal_taggable) and a metrics filter using the provisioned model ARN as the CloudWatch ModelId dimension.

Fixes #10869