### PR TITLE
aws - emr-serverless - augment applications with get_application details

### DIFF
--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -327,9 +327,15 @@ class DeleteEMRSecurityConfiguration(BaseAction):
 class DescribeEMRServerlessApp(DescribeSource):
 
     def augment(self, resources):
-        return universal_augment(
-            self.manager,
-            super().augment(resources))
+        resources = super().augment(resources)
+        client = local_session(self.manager.session_factory).client('emr-serverless')
+        results = []
+        for r in resources:
+            detail = self.manager.retry(
+                client.get_application, applicationId=r['id'])['application']
+            r.update(detail)
+            results.append(r)
+        return universal_augment(self.manager, results)
 
 
 @resources.register('emr-serverless-app')
@@ -346,6 +352,7 @@ class EMRServerless(QueryResourceManager):
         id = 'id'
         date = "createdAt"
         cfn_type = 'AWS::EMRServerless::Application'
+        permissions_augment = ('emr-serverless:GetApplication',)
 
     source_mapping = {
         'describe': DescribeEMRServerlessApp,

--- a/tests/data/placebo/test_emr_serverless_augment/emr-serverless.GetApplication_1.json
+++ b/tests/data/placebo/test_emr_serverless_augment/emr-serverless.GetApplication_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "application": {
+            "applicationId": "00f7bot3h1dbr009",
+            "id": "00f7bot3h1dbr009",
+            "name": "test-emr-serverless",
+            "arn": "arn:aws:emr-serverless:us-east-1:644160558196:/applications/00f7bot3h1dbr009",
+            "releaseLabel": "emr-6.9.0",
+            "type": "Spark",
+            "state": "CREATED",
+            "stateDetails": "Application created by user.",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "architecture": "X86_64",
+            "autoStartConfiguration": {
+                "enabled": true
+            },
+            "autoStopConfiguration": {
+                "enabled": true,
+                "idleTimeoutMinutes": 15
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_emr_serverless_augment/emr-serverless.ListApplications_1.json
+++ b/tests/data/placebo/test_emr_serverless_augment/emr-serverless.ListApplications_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "applications": [
+            {
+                "id": "00f7bot3h1dbr009",
+                "name": "test-emr-serverless",
+                "arn": "arn:aws:emr-serverless:us-east-1:644160558196:/applications/00f7bot3h1dbr009",
+                "releaseLabel": "emr-6.9.0",
+                "type": "Spark",
+                "state": "CREATED",
+                "stateDetails": "Application created by user.",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 1,
+                    "day": 24,
+                    "hour": 13,
+                    "minute": 12,
+                    "second": 37,
+                    "microsecond": 610000
+                },
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2023,
+                    "month": 1,
+                    "day": 24,
+                    "hour": 13,
+                    "minute": 12,
+                    "second": 37,
+                    "microsecond": 610000
+                },
+                "architecture": "X86_64"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_emr_serverless_augment/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_emr_serverless_augment/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:emr-serverless:us-east-1:644160558196:/applications/00f7bot3h1dbr009",
+                "Tags": []
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_emr_serverless_delete/emr-serverless.GetApplication_1.json
+++ b/tests/data/placebo/test_emr_serverless_delete/emr-serverless.GetApplication_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "application": {
+            "applicationId": "00f7bp174ejqb109",
+            "id": "00f7bp174ejqb109",
+            "name": "test-emr-serverless",
+            "arn": "arn:aws:emr-serverless:us-east-1:644160558196:/applications/00f7bp174ejqb109",
+            "releaseLabel": "emr-6.9.0",
+            "type": "Spark",
+            "state": "CREATED",
+            "stateDetails": "Application created by user.",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "architecture": "X86_64",
+            "autoStartConfiguration": {
+                "enabled": true
+            },
+            "autoStopConfiguration": {
+                "enabled": true,
+                "idleTimeoutMinutes": 15
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_emr_serverless_markop/emr-serverless.GetApplication_1.json
+++ b/tests/data/placebo/test_emr_serverless_markop/emr-serverless.GetApplication_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "application": {
+            "applicationId": "00f7bp174ejqb109",
+            "id": "00f7bp174ejqb109",
+            "name": "test-emr-serverless",
+            "arn": "arn:aws:emr-serverless:us-east-1:644160558196:/applications/00f7bp174ejqb109",
+            "releaseLabel": "emr-6.9.0",
+            "type": "Spark",
+            "state": "CREATED",
+            "stateDetails": "Application created by user.",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "architecture": "X86_64",
+            "autoStartConfiguration": {
+                "enabled": true
+            },
+            "autoStopConfiguration": {
+                "enabled": true,
+                "idleTimeoutMinutes": 15
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_emr_serverless_remove_tag/emr-serverless.GetApplication_1.json
+++ b/tests/data/placebo/test_emr_serverless_remove_tag/emr-serverless.GetApplication_1.json
@@ -10,7 +10,7 @@
             "releaseLabel": "emr-6.9.0",
             "type": "Spark",
             "state": "CREATED",
-            "stateDetails": "Application created by user",
+            "stateDetails": "Application created by user.",
             "createdAt": {
                 "__class__": "datetime",
                 "year": 2023,

--- a/tests/data/placebo/test_emr_serverless_remove_tag/emr-serverless.GetApplication_1.json
+++ b/tests/data/placebo/test_emr_serverless_remove_tag/emr-serverless.GetApplication_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "application": {
+            "applicationId": "00f7bot3h1dbr009",
+            "id": "00f7bot3h1dbr009",
+            "name": "test-emr-serverless",
+            "arn": "arn:aws:emr-serverless:us-east-1:644160558196:/applications/00f7bot3h1dbr009",
+            "releaseLabel": "emr-6.9.0",
+            "type": "Spark",
+            "state": "CREATED",
+            "stateDetails": "Application created by user.",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "architecture": "X86_64",
+            "autoStartConfiguration": {
+                "enabled": true
+            },
+            "autoStopConfiguration": {
+                "enabled": true,
+                "idleTimeoutMinutes": 15
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_emr_serverless_remove_tag/emr-serverless.GetApplication_1.json
+++ b/tests/data/placebo/test_emr_serverless_remove_tag/emr-serverless.GetApplication_1.json
@@ -10,7 +10,7 @@
             "releaseLabel": "emr-6.9.0",
             "type": "Spark",
             "state": "CREATED",
-            "stateDetails": "Application created by user.",
+            "stateDetails": "Application created by user",
             "createdAt": {
                 "__class__": "datetime",
                 "year": 2023,

--- a/tests/data/placebo/test_emr_serverless_tag/emr-serverless.GetApplication_1.json
+++ b/tests/data/placebo/test_emr_serverless_tag/emr-serverless.GetApplication_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "application": {
+            "applicationId": "00f7bot3h1dbr009",
+            "id": "00f7bot3h1dbr009",
+            "name": "test-emr-serverless",
+            "arn": "arn:aws:emr-serverless:us-east-1:644160558196:/applications/00f7bot3h1dbr009",
+            "releaseLabel": "emr-6.9.0",
+            "type": "Spark",
+            "state": "CREATED",
+            "stateDetails": "Application created by user.",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2023,
+                "month": 1,
+                "day": 24,
+                "hour": 13,
+                "minute": 12,
+                "second": 37,
+                "microsecond": 610000
+            },
+            "architecture": "X86_64",
+            "autoStartConfiguration": {
+                "enabled": true
+            },
+            "autoStopConfiguration": {
+                "enabled": true,
+                "idleTimeoutMinutes": 15
+            }
+        }
+    }
+}

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -305,6 +305,27 @@ class TestEMRServerless(BaseTest):
         applications = client.list_applications()['applications']
         self.assertEqual(len(applications), 0)
 
+    def test_emr_serverless_augment(self):
+        session_factory = self.replay_flight_data("test_emr_serverless_augment")
+        p = self.load_policy(
+            {
+                "name": "emr-serverless-augment",
+                "resource": "aws.emr-serverless-app",
+                "filters": [
+                    {"type": "value",
+                     "key": "autoStopConfiguration.idleTimeoutMinutes",
+                     "value": 15}
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]["autoStopConfiguration"],
+            {"enabled": True, "idleTimeoutMinutes": 15},
+        )
+
     def test_emr_serverless_markop(self):
         session_factory = self.replay_flight_data("test_emr_serverless_markop")
         p = self.load_policy(


### PR DESCRIPTION
Closes #10841

  `aws.emr-serverless-app` enumerates via `list_applications`, which only returns an application summary (id, name, arn, type, state, releaseLabel, timestamps, architecture). Detail fields such as `autoStopConfiguration`, `autoStartConfiguration`, `initialCapacity`, `maximumCapacity`, `networkConfiguration`, etc. are only available from `get_application`, so they could not be filtered on.

  This augments each application with `get_application` during resource enumeration, making those fields available to `value` filters. For example, filtering on the auto-stop idle timeout:

  ```yaml
  policies:
    - name: emr-serverless-short-idle-timeout
      resource: aws.emr-serverless-app
      filters:
        - type: value
          key: autoStopConfiguration.idleTimeoutMinutes
          value: 15
```
  - Adds the emr-serverless:GetApplication permission via
  permissions_augment.
  - Adds a test covering the augmented autoStopConfiguration field and
  updates existing EMR Serverless flight data with GetApplication
  responses.

