### PR TITLE
[Bedrock] adding bedrock-mantle-project resource

### DIFF
--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -1,5 +1,6 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+import json
 
 from c7n.manager import resources
 from c7n.exceptions import PolicyValidationError
@@ -1024,3 +1025,44 @@ class UpdateGuardrail(BaseAction):
                 client.update_guardrail(**params)
             except client.exceptions.ResourceNotFoundException:
                 continue
+
+
+@resources.register('bedrock-mantle-project')
+class BedrockMantleProject(QueryResourceManager):
+    """Bedrock Mantle Project.
+
+    The bedrock-mantle control plane exposes no service sdk client;
+    projects are enumerated via the cloud control api, with tags
+    fetched in batch via the resource groups tagging api.
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: bedrock-mantle-project-untagged
+            resource: aws.bedrock-mantle-project
+            filters:
+              - type: value
+                key: Id
+                op: ne
+                value: default
+              - tag:Owner: absent
+    """
+    class resource_type(TypeInfo):
+        service = 'cloudcontrol'
+        enum_spec = ('list_resources', 'ResourceDescriptions',
+                     {'TypeName': 'AWS::BedrockMantle::Project'})
+        cfn_type = 'AWS::BedrockMantle::Project'
+        arn = 'Arn'
+        id = name = 'Id'
+        permission_prefix = 'bedrock-mantle'
+        permissions_enum = (
+            'cloudcontrol:ListResources',
+            'bedrock-mantle:ListProjects',
+            'bedrock-mantle:ListTagsForResource')
+        universal_taggable = object()
+
+    def augment(self, resources):
+        resources = [json.loads(r['Properties']) for r in resources]
+        return universal_augment(self, resources)

--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -1058,7 +1058,7 @@ class BedrockMantleProject(QueryResourceManager):
         id = name = 'Id'
         permission_prefix = 'bedrock-mantle'
         permissions_enum = (
-            'cloudcontrol:ListResources',
+            'cloudformation:ListResources',
             'bedrock-mantle:ListProjects',
             'bedrock-mantle:ListTagsForResource')
         universal_taggable = object()

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -41,6 +41,7 @@ ResourceMap = {
   "aws.bedrock-custom-model": "c7n.resources.bedrock.BedrockCustomModel",
   "aws.bedrock-foundation-model": "c7n.resources.bedrock.BedrockFoundationModel",
   "aws.bedrock-knowledge-base": "c7n.resources.bedrock.BedrockKnowledgeBase",
+  "aws.bedrock-mantle-project": "c7n.resources.bedrock.BedrockMantleProject",
   "aws.bedrock-model-invocation-job": "c7n.resources.bedrock.BedrockModelInvocationJob",
   "aws.budget": "c7n.resources.budgets.Budget",
   "aws.cache-cluster": "c7n.resources.elasticache.ElastiCacheCluster",

--- a/tests/data/placebo/test_bedrock_mantle_project_query/cloudcontrolapi.ListResources_1.json
+++ b/tests/data/placebo/test_bedrock_mantle_project_query/cloudcontrolapi.ListResources_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "TypeName": "AWS::BedrockMantle::Project",
+        "ResourceDescriptions": [
+            {
+                "Identifier": "arn:aws:bedrock-mantle:us-east-1:644160558196:project/default",
+                "Properties": "{\"Id\":\"default\",\"Arn\":\"arn:aws:bedrock-mantle:us-east-1:644160558196:project/default\"}"
+            },
+            {
+                "Identifier": "arn:aws:bedrock-mantle:us-east-1:644160558196:project/proj_u5ohxk75k3ehgtswbmcc",
+                "Properties": "{\"Id\":\"proj_u5ohxk75k3ehgtswbmcc\",\"Arn\":\"arn:aws:bedrock-mantle:us-east-1:644160558196:project/proj_u5ohxk75k3ehgtswbmcc\"}"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_bedrock_mantle_project_query/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_bedrock_mantle_project_query/tagging.GetResources_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:bedrock-mantle:us-east-1:644160558196:project/proj_u5ohxk75k3ehgtswbmcc",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "c7n"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "test"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_bedrock_mantle_project_untagged/cloudcontrolapi.ListResources_1.json
+++ b/tests/data/placebo/test_bedrock_mantle_project_untagged/cloudcontrolapi.ListResources_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "TypeName": "AWS::BedrockMantle::Project",
+        "ResourceDescriptions": [
+            {
+                "Identifier": "arn:aws:bedrock-mantle:us-east-1:644160558196:project/default",
+                "Properties": "{\"Id\":\"default\",\"Arn\":\"arn:aws:bedrock-mantle:us-east-1:644160558196:project/default\"}"
+            },
+            {
+                "Identifier": "arn:aws:bedrock-mantle:us-east-1:644160558196:project/proj_u5ohxk75k3ehgtswbmcc",
+                "Properties": "{\"Id\":\"proj_u5ohxk75k3ehgtswbmcc\",\"Arn\":\"arn:aws:bedrock-mantle:us-east-1:644160558196:project/proj_u5ohxk75k3ehgtswbmcc\"}"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_bedrock_mantle_project_untagged/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_bedrock_mantle_project_untagged/tagging.GetResources_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:bedrock-mantle:us-east-1:644160558196:project/proj_u5ohxk75k3ehgtswbmcc",
+                "Tags": [
+                    {
+                        "Key": "Owner",
+                        "Value": "c7n"
+                    },
+                    {
+                        "Key": "Environment",
+                        "Value": "test"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -1255,3 +1255,62 @@ def test_bedrock_inference_profile_bad_statistics(test):
                 }],
             },
         )
+
+
+class BedrockMantleProject(BaseTest):
+
+    def test_bedrock_mantle_project_query(self):
+        if C7N_FUNCTIONAL:
+            session_factory = self.record_flight_data(
+                'test_bedrock_mantle_project_query', region='us-east-1')
+        else:
+            session_factory = self.replay_flight_data(
+                'test_bedrock_mantle_project_query', region='us-east-1')
+        p = self.load_policy(
+            {
+                'name': 'mantle-project-tagged',
+                'resource': 'aws.bedrock-mantle-project',
+                'filters': [{'tag:Owner': 'c7n'}],
+            },
+            session_factory=session_factory,
+            config={'region': 'us-east-1'},
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertTrue(resources[0]['Arn'].startswith(
+            'arn:aws:bedrock-mantle:us-east-1:'))
+        self.assertTrue(resources[0]['Id'].startswith('proj_'))
+        tags = {t['Key']: t['Value'] for t in resources[0]['Tags']}
+        self.assertEqual(tags['Owner'], 'c7n')
+
+    def test_bedrock_mantle_project_untagged(self):
+        # the account default project carries no tags; the tagging
+        # api augment must still set an empty Tags list so absent
+        # tag filters match rather than error.
+        if C7N_FUNCTIONAL:
+            session_factory = self.record_flight_data(
+                'test_bedrock_mantle_project_untagged', region='us-east-1')
+        else:
+            session_factory = self.replay_flight_data(
+                'test_bedrock_mantle_project_untagged', region='us-east-1')
+        p = self.load_policy(
+            {
+                'name': 'mantle-project-untagged',
+                'resource': 'aws.bedrock-mantle-project',
+                'filters': [
+                    {'Id': 'default'},
+                    {'tag:Owner': 'absent'},
+                ],
+            },
+            session_factory=session_factory,
+            config={'region': 'us-east-1'},
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['Tags'], [])
+        self.assertEqual(
+            sorted(p.get_permissions()),
+            ['bedrock-mantle:ListProjects',
+             'bedrock-mantle:ListTagsForResource',
+             'cloudcontrol:ListResources',
+             'tag:GetResources'])

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -1312,5 +1312,5 @@ class BedrockMantleProject(BaseTest):
             sorted(p.get_permissions()),
             ['bedrock-mantle:ListProjects',
              'bedrock-mantle:ListTagsForResource',
-             'cloudcontrol:ListResources',
+             'cloudformation:ListResources',
              'tag:GetResources'])


### PR DESCRIPTION
This PR adds a new resource aws.bedrock-mantle-project for Amazon Bedrock Mantle projects

Bedrock Mantle (the OpenAI/Anthropic-SDK-compatible endpoint at bedrock-mantle.{region}.api.aws) has no boto3 service client, the control plane is reachable from the AWS SDKs only through the Cloud Control API. That leaves custodian unable to enumerate Mantle resources or write policy against them today. Projects are Mantle's only Cloud-Control-managed type (AWS::BedrockMantle::Project) and its only taggable resource.