### PR TITLE
Allow c7n cli to use a --vars-file parameter to inject variables when expanding them

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -196,6 +196,7 @@ def _key_val_pair(value):
         raise argparse.ArgumentTypeError(msg)
     return value
 
+
 def _valid_path(value):
     """
     Type checker to ensure that --vars-file is a path to a file

--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -9,6 +9,7 @@ import argparse
 import importlib
 import logging
 import os
+import pathlib
 import pdb
 import sys
 import traceback
@@ -74,10 +75,9 @@ def _default_options(p, exclude=[]):
     output.add_argument("--debug", default=False, help=argparse.SUPPRESS,
                         action="store_true")
 
-    if 'vars' not in exclude:
-        # p.add_argument('--vars', default=None,
-        #               help='Vars file to substitute into policy')
-        p.set_defaults(vars=None)
+    if 'vars-file' not in exclude:
+        p.add_argument('--vars-file', default=None, type=_valid_path,
+                      help='Vars file to substitute into policy')
 
     if 'log-group' not in exclude:
         p.add_argument(
@@ -193,6 +193,16 @@ def _key_val_pair(value):
     """
     if '=' not in value:
         msg = 'values must be of the form `header=field`'
+        raise argparse.ArgumentTypeError(msg)
+    return value
+
+def _valid_path(value):
+    """
+    Type checker to ensure that --vars-file is a path to a file
+    """
+    path = pathlib.Path(value)
+    if not path.is_file():
+        msg = 'vars-file must point to a file'
         raise argparse.ArgumentTypeError(msg)
     return value
 

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -50,7 +50,7 @@ def policy_command(f):
         options.region = ""
         for fp in options.configs:
             try:
-                collection = policy_load(options, fp, validate=validate, vars=vars)
+                collection = policy_load(options, fp, validate=validate)
             except IOError:
                 log.error('policy file does not exist ({})'.format(fp))
                 errors += 1
@@ -123,7 +123,7 @@ def policy_command(f):
 
         # Variable expansion and non schema validation (not optional)
         for p in policies:
-            p.expand_variables(p.get_variables())
+            p.expand_variables(p.get_variables(variables=vars))
             p.validate()
 
         return f(options, list(policies))
@@ -133,11 +133,11 @@ def policy_command(f):
 
 def _load_vars(options):
     vars = None
-    if options.vars:
+    if options.vars_file:
         try:
-            vars = load_file(options.vars)
+            vars = load_file(options.vars_file)
         except IOError as e:
-            log.error('Problem loading vars file "{}": {}'.format(options.vars, e.strerror))
+            log.error('Problem loading vars file "{}": {}'.format(options.vars_file, e.strerror))
             sys.exit(1)
 
     # TODO - provide builtin vars here (such as account)

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -1,6 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from collections import Counter, defaultdict
+from collections.abc import Mapping
 from datetime import timedelta, datetime
 from functools import wraps
 import json
@@ -123,7 +124,7 @@ def policy_command(f):
 
         # Variable expansion and non schema validation (not optional)
         for p in policies:
-            p.expand_variables(p.get_variables(variables=vars))
+            p.expand_variables(p.get_variables(variables=dict(vars or {})))
             p.validate()
 
         return f(options, list(policies))
@@ -136,8 +137,10 @@ def _load_vars(options):
     if options.vars_file:
         try:
             vars = load_file(options.vars_file)
-        except IOError as e:
-            log.error('Problem loading vars file "{}": {}'.format(options.vars_file, e.strerror))
+            if not isinstance(vars, Mapping):
+                raise ValueError("Invalid vars file type")
+        except (IOError, yaml.YAMLError, ValueError) as e:
+            log.error('Problem loading vars file "{}": {}'.format(options.vars_file, e))
             sys.exit(1)
 
     # TODO - provide builtin vars here (such as account)

--- a/c7n/config.py
+++ b/c7n/config.py
@@ -32,6 +32,7 @@ class Config(Bag):
             'region': os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'),
             'regions': (),
             'cache': '',
+            'vars_file': None,
             'profile': None,
             'account_id': None,
             'assume_role': None,

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -62,9 +62,9 @@ class CustodianTestCore:
         return fh.name
 
     def write_raw_file(self, contents, format="yaml"):
-        """Write a policy file to disk in the specified format.
+        """Write a raw string to disk.
 
-        Input a dictionary and a format. Valid formats are `yaml` and `json`
+        Input a string and a format/suffix.
         Returns the file path.
         """
         fh = tempfile.NamedTemporaryFile(mode="w+b", suffix="." + format, delete=False)

--- a/c7n/testing.py
+++ b/c7n/testing.py
@@ -61,6 +61,19 @@ class CustodianTestCore:
         self.addCleanup(fh.close)
         return fh.name
 
+    def write_raw_file(self, contents, format="yaml"):
+        """Write a policy file to disk in the specified format.
+
+        Input a dictionary and a format. Valid formats are `yaml` and `json`
+        Returns the file path.
+        """
+        fh = tempfile.NamedTemporaryFile(mode="w+b", suffix="." + format, delete=False)
+        fh.write(contents.encode("utf8"))
+        fh.flush()
+        self.addCleanup(os.unlink, fh.name)
+        self.addCleanup(fh.close)
+        return fh.name
+
     def get_test_config(self, **kw):
         temp_dir = self.get_temp_dir()
         return Config.empty(output_dir=temp_dir, **kw)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 import os
+import pathlib
 import sys
 import argparse
 
@@ -85,6 +86,16 @@ class UtilsTest(BaseTest):
         self.assertRaises(ArgumentTypeError, cli._key_val_pair, "invalid option")
         param = "day=today"
         self.assertIs(cli._key_val_pair(param), param)
+
+    def test_valid_path(self):
+        self.assertRaises(ArgumentTypeError, cli._valid_path, "invalid option")
+        param = "mock_path"
+        self.patch(pathlib.Path, "is_file", lambda x: True)
+        self.assertIs(cli._valid_path(param), param)
+        self.patch(pathlib.Path, "is_file", lambda x: False)
+        with self.assertRaises(ArgumentTypeError) as context:
+            cli._valid_path(param)
+        self.assertEqual(str(context.exception), 'vars-file must point to a file')
 
 
 class VersionTest(CliTest):
@@ -536,6 +547,71 @@ class RunTest(CliTest):
                 temp_dir,
                 yaml_file,
             ]
+        )
+
+    def test_vars_file(self):
+        session_factory = self.replay_flight_data(
+            "test_ec2_state_transition_age_filter"
+        )
+
+        from c7n.policy import PolicyCollection
+
+        self.patch(
+            PolicyCollection,
+            "session_factory",
+            staticmethod(lambda x=None: session_factory),
+        )
+
+        temp_dir = self.get_temp_dir()
+        policy_name = "ec2-vars-file"
+        yaml_file = self.write_policy_file(
+            {
+                "policies": [
+                    {
+                        "name": policy_name,
+                        "resource": "ec2",
+                        "filters": [{"State.Name": "{injected_from_vars}"}],
+                    }
+                ]
+            }
+        )
+        vars_file = self.write_policy_file({"injected_from_vars": "running"}, format="json")
+
+        self.run_and_expect_success(
+            [
+                "custodian",
+                "run",
+                "--vars-file",
+                vars_file,
+                "-s",
+                temp_dir,
+                yaml_file,
+            ]
+        )
+
+        # The "{injected_from_vars}" placeholder only matches the two running instances
+        # in the flight data once it is expanded from the vars file.
+        with open(os.path.join(temp_dir, policy_name, "resources.json")) as fh:
+            resources = json.load(fh)
+        self.assertEqual(len(resources), 2)
+
+    def test_vars_file_invalid_path(self):
+        yaml_file = self.write_policy_file(
+            {
+                "policies": [
+                    {"name": "ec2-vars-missing", "resource": "ec2"}
+                ]
+            }
+        )
+        self.run_and_expect_failure(
+            [
+                "custodian",
+                "run",
+                "--vars-file",
+                "does-not-exist.json",
+                yaml_file,
+            ],
+            2,
         )
 
     def test_error(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -614,6 +614,32 @@ class RunTest(CliTest):
             2,
         )
 
+    def test_vars_file_bad_contents(self):
+        temp_dir = self.get_temp_dir()
+        yaml_file = self.write_policy_file(
+            {"policies": [{"name": "ec2-vars-missing", "resource": "ec2"}]}
+        )
+        bad_yaml_list = [
+            "- list",  # not mapping type
+            "key2: bad-key: value",  # not valid yaml
+        ]
+        for bad_yaml in bad_yaml_list:
+            vars_file = self.write_raw_file(bad_yaml)
+            self.run_and_expect_failure(
+                [
+                    "custodian",
+                    "run",
+                    "--vars-file",
+                    vars_file,
+                    "-s",
+                    temp_dir,
+                    "--cache",
+                    temp_dir + "/cache",
+                    yaml_file,
+                ],
+                1,
+            )
+
     def test_error(self):
         from c7n.policy import Policy
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -56,6 +56,7 @@ class HandleTest(BaseTest):
              'regions': ['us-east-1'],
              'cache_period': 0,
              'log_group': None,
+             'vars_file': None,
              'metrics': None})
 
     def setupLambdaEnv(


### PR DESCRIPTION
### Summary

Enable `vars-file` as a parameter in c7n cli, and expand those variables as part of the framework expansion in Policy.expand_variables. This is the same mechanism that c7n-org expands it's custom account vars (https://github.com/cloud-custodian/cloud-custodian/blob/main/tools/c7n_org/c7n_org/cli.py#L1245).

### History

This was originally done in 2020, but reverted almost immediately. Kapil recommended that any work to restore use a similar mechanism to how c7n-org works (https://github.com/cloud-custodian/cloud-custodian/pull/1229#issuecomment-577233730), so this is an attempt to get the functionality to enable injection of vars at `custodian run` time without needing to modify policy config files. Another concern https://github.com/cloud-custodian/cloud-custodian/pull/5262#issuecomment-577422833 was that the previous way would overwrite the exposed framework variables, this change inverts that order by starting with the injected variables and overwriting with the standard variables. https://github.com/cloud-custodian/cloud-custodian/blob/main/c7n/policy.py#L1259.

### Question for discussion

c7n-org has logic to make sure all variables that are not expanded at runtime are filled in as part of it's validation (https://github.com/cloud-custodian/cloud-custodian/pull/10474), should that logic be moved to a common file and used here or should that be a later effort? I chose not to include it as it could potentially cause current items to fail validation and I want to be sure before that logic got added.

### Alternatives considered

Ultimately I was looking to add a `source_region` variable for use with notifications and s3 bucket names, to handle a case where the `region` variable (i.e. the region being targeted) was not the same region that we want notifications to a SNS/SQS to be sent to. If the approach for this PR is rejected, then I'd consider adding a new default CLI and adding it as one of the Policy standard frame work variables and also in Notifications.