### PR TITLE
azure - deprecate containerservice and datalake resource types

### DIFF
--- a/c7n/deprecated.py
+++ b/c7n/deprecated.py
@@ -242,6 +242,7 @@ class DeprecatedResource(Deprecation):
                 klass.resources = lambda self, *args, **kwargs: []
                 klass.get_resources = lambda self, *args, **kwargs: []
         klass.deprecations = tuple(getattr(klass, 'deprecations', ())) + (self,)
+        klass.is_deprecated = True
         return klass
 
 

--- a/c7n/deprecated.py
+++ b/c7n/deprecated.py
@@ -172,6 +172,79 @@ class DeprecatedOptionality(Deprecation):
         return f"Will become an error after {self.removed_after}"
 
 
+_empty_source = None
+
+
+def _get_empty_source():
+    # Lazy import to avoid a circular import: c7n.query imports
+    # c7n.filters/c7n.actions, which import c7n.element, which imports
+    # c7n.deprecated.
+    global _empty_source
+    if _empty_source is None:
+        from c7n.query import DescribeSource
+
+        class EmptySource(DescribeSource):
+            def resources(self, query):
+                return []
+
+            def get_resources(self, resource_ids):
+                return []
+
+            def get_permissions(self):
+                return []
+
+        _empty_source = EmptySource
+    return _empty_source
+
+
+class DeprecatedResource(Deprecation):
+    """A resource type has been deprecated.
+
+    Applied as a decorator on a resource manager class. Always registers
+    a deprecation, so `custodian validate` / `custodian report` surface
+    the resource type's use - this happens regardless of `force_empty`.
+
+    `force_empty` controls whether the resource type is also prevented
+    from returning live data:
+
+    * False (the default): reporting only. Whatever sources or
+      resource-fetch behavior the class already has are left untouched,
+      so the resource type still resolves real data if its backing API
+      still works.
+    * True: every configured source is replaced with a no-op stub that
+      always returns an empty result set. For resource managers with a
+      `source_mapping` attribute (e.g. AWS's QueryResourceManager), each
+      entry in the mapping is replaced. For resource managers with no
+      per-class source override point (e.g. c7n_azure's
+      QueryResourceManager, which always resolves sources from a single
+      shared global registry), `resources()`/`get_resources()` are
+      replaced directly instead.
+    """
+
+    def __init__(self, reason, removed_after=None, link=None, force_empty=False):
+        super().__init__(removed_after, link)
+        self.reason = reason
+        self.force_empty = force_empty
+
+    def __str__(self):
+        return f"resource has been deprecated ({self.reason})"
+
+    def __call__(self, klass):
+        if self.force_empty:
+            empty_source = _get_empty_source()
+            if hasattr(klass, 'source_mapping'):
+                mapping = dict(klass.source_mapping)
+                klass.source_mapping = {key: empty_source for key in mapping}
+            else:
+                # No per-class source override point (e.g. c7n_azure
+                # resource managers) - stub the resource fetch methods
+                # directly instead.
+                klass.resources = lambda self, *args, **kwargs: []
+                klass.get_resources = lambda self, *args, **kwargs: []
+        klass.deprecations = tuple(getattr(klass, 'deprecations', ())) + (self,)
+        return klass
+
+
 class Context:
     """Adds extra context to a deprecation."""
     def __init__(self, context, deprecation):

--- a/c7n/deprecated.py
+++ b/c7n/deprecated.py
@@ -198,7 +198,7 @@ def _get_empty_source():
 
 
 class DeprecatedResource(Deprecation):
-    """A resource type has been deprecated.
+    """A resource type that has been deprecated.
 
     Applied as a decorator on a resource manager class. Always registers
     a deprecation, so `custodian validate` / `custodian report` surface

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -41,6 +41,7 @@ class ResourceManager:
     permissions = ()
     get_client = None
     get_schema = None
+    is_deprecated = False
 
     def __init__(self, ctx, data):
         self.ctx = ctx

--- a/c7n/resources/opsworks.py
+++ b/c7n/resources/opsworks.py
@@ -1,20 +1,16 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import BaseAction
+from c7n.deprecated import DeprecatedResource
 from c7n.manager import resources
-from c7n.query import QueryResourceManager, TypeInfo, DescribeSource
+from c7n.query import QueryResourceManager, TypeInfo
 from c7n.utils import type_schema
 
 
-class DescribeRemoved(DescribeSource):
-    def resources(self, query):
-        return []
-
-    def get_resources(self, resource_ids):
-        return []
-
-
 @resources.register('opswork-stack')
+@DeprecatedResource(
+    "OpsWorks Stacks is no longer an available AWS service",
+    removed_after="2027-07-23", force_empty=True)
 class OpsworkStack(QueryResourceManager):
     """OpsWorks Stack is no longer an available service. This resource
     soley exists for policy compatiblity.
@@ -25,11 +21,6 @@ class OpsworkStack(QueryResourceManager):
         name = 'Name'
         arn = "Arn"
         cfn_type = 'AWS::OpsWorks::App'
-
-    source_mapping = {'describe': DescribeRemoved}
-
-    def get_permissions(self):
-        return []
 
 
 @OpsworkStack.action_registry.register('delete')
@@ -55,6 +46,9 @@ class StopStack(BaseAction):
 
 
 @resources.register('opswork-cm')
+@DeprecatedResource(
+    "OpsWorks CM is no longer an available AWS service",
+    removed_after="2027-07-23", force_empty=True)
 class OpsworksCM(QueryResourceManager):
     """OpsWorks CM is no longer an available service. This resource
     soley exists for policy compatiblity.
@@ -64,11 +58,6 @@ class OpsworksCM(QueryResourceManager):
         name = id = 'ServerName'
         arn = "ServerArn"
         cfn_type = 'AWS::OpsWorksCM::Server'
-
-    source_mapping = {'describe': DescribeRemoved}
-
-    def get_permissions(self):
-        return []
 
 
 @OpsworksCM.action_registry.register('delete')

--- a/c7n/resources/qldb.py
+++ b/c7n/resources/qldb.py
@@ -4,20 +4,16 @@
 
 
 from c7n.actions import BaseAction as Action
-from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
+from c7n.deprecated import DeprecatedResource
+from c7n.query import QueryResourceManager, TypeInfo
 from c7n.manager import resources
 from c7n.utils import type_schema
 
 
-class DescribeRemoved(DescribeSource):
-    def resources(self, query):
-        return []
-
-    def get_resources(self, resource_ids):
-        return []
-
-
 @resources.register('qldb')
+@DeprecatedResource(
+    "QLDB is no longer an available AWS service",
+    removed_after="2027-07-23", force_empty=True)
 class QLDB(QueryResourceManager):
 
     class resource_type(TypeInfo):
@@ -28,14 +24,6 @@ class QLDB(QueryResourceManager):
         universal_taggable = object()
         cfn_type = config_type = 'AWS::QLDB::Ledger'
         permissions_augment = ("qldb:ListTagsForResource",)
-
-    source_mapping = {
-        'describe': DescribeRemoved,
-        'config': ConfigSource
-    }
-
-    def get_permissions(self):
-        return []
 
 
 @QLDB.action_registry.register('delete')

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -39,6 +39,89 @@ class DeprecationTest(BaseTest):
             "field 'severity_normalized' has been deprecated (replaced by 'severity_label')"
         )
 
+    def test_resource(self):
+        deprecation = deprecated.DeprecatedResource(
+            "no longer an available AWS service", '2021-06-30')
+        # Always matches.
+        self.assertTrue(deprecation.check({}))
+        self.assertEqual(
+            str(deprecation),
+            "resource has been deprecated (no longer an available AWS service)"
+        )
+
+
+class DeprecatedResourceTest(BaseTest):
+
+    def test_decorator_returns_same_class(self):
+        class FakeManager:
+            source_mapping = {'describe': 'DescribeStub'}
+
+        deprecation = deprecated.DeprecatedResource("gone")
+        self.assertIs(deprecation(FakeManager), FakeManager)
+
+    def test_decorator_force_empty_false_leaves_source_mapping_untouched(self):
+        class FakeManager:
+            source_mapping = {'describe': 'DescribeStub', 'config': 'ConfigStub'}
+
+        deprecation = deprecated.DeprecatedResource("gone")
+        deprecation(FakeManager)
+        self.assertEqual(
+            FakeManager.source_mapping,
+            {'describe': 'DescribeStub', 'config': 'ConfigStub'})
+
+    def test_decorator_force_empty_overrides_every_source(self):
+        class FakeManager:
+            source_mapping = {'describe': 'DescribeStub', 'config': 'ConfigStub'}
+
+        deprecation = deprecated.DeprecatedResource("gone", force_empty=True)
+        deprecation(FakeManager)
+        self.assertEqual(
+            FakeManager.source_mapping['describe'],
+            FakeManager.source_mapping['config'])
+        self.assertNotEqual(FakeManager.source_mapping['describe'], 'DescribeStub')
+        self.assertNotEqual(FakeManager.source_mapping['config'], 'ConfigStub')
+
+    def test_decorator_preserves_existing_deprecations(self):
+        existing = deprecated.field('foo', 'bar')
+
+        class FakeManager:
+            source_mapping = {'describe': 'DescribeStub'}
+            deprecations = (existing,)
+
+        deprecation = deprecated.DeprecatedResource("gone")
+        deprecation(FakeManager)
+        self.assertEqual(FakeManager.deprecations, (existing, deprecation))
+
+    def test_decorator_without_source_mapping_force_empty_true_stubs_methods(self):
+        class FakeManager:
+            def resources(self, *args, **kwargs):
+                return ['real-resource']
+
+            def get_resources(self, resource_ids, **params):
+                return ['real-resource']
+
+        deprecation = deprecated.DeprecatedResource("gone", force_empty=True)
+        result = deprecation(FakeManager)
+        self.assertIs(result, FakeManager)
+        instance = FakeManager()
+        self.assertEqual(instance.resources(), [])
+        self.assertEqual(instance.get_resources(['id1']), [])
+        self.assertEqual(FakeManager.deprecations, (deprecation,))
+
+    def test_decorator_without_source_mapping_force_empty_false_leaves_methods(self):
+        class FakeManager:
+            def resources(self, *args, **kwargs):
+                return ['real-resource']
+
+            def get_resources(self, resource_ids, **params):
+                return ['real-resource']
+
+        deprecation = deprecated.DeprecatedResource("gone")
+        deprecation(FakeManager)
+        instance = FakeManager()
+        self.assertEqual(instance.resources(), ['real-resource'])
+        self.assertEqual(instance.get_resources(['id1']), ['real-resource'])
+
 
 class ReportTest(BaseTest):
 
@@ -80,7 +163,16 @@ class ReportTest(BaseTest):
                 field 'baz' has been deprecated (replaced by 'yet')
             """)[1:-1])
 
-    # No examples of resource deprecation just yet. Looking for one.
+    def test_resource(self):
+        report = deprecated.Report("some-policy", resource=[
+            deprecated.DeprecatedResource("no longer an available AWS service"),
+        ])
+        self.assertTrue(report)
+        self.assertEqual(report.format(), dedent("""
+            policy 'some-policy'
+              resource:
+                resource has been deprecated (no longer an available AWS service)
+            """)[1:-1])
 
     def test_actions(self):
         report = deprecated.Report("some-policy", actions=[

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -180,7 +180,7 @@ class PolicyMetaLint(BaseTest):
             mgr = v(ctx, p)
 
             source = mgr.get_source("config")
-            if not isinstance(source, ConfigSource):
+            if not isinstance(source, ConfigSource) and not mgr.is_deprecated:
                 bad.append(k)
 
             if v.__dict__.get("augment"):

--- a/tools/c7n_azure/c7n_azure/resources/container_service.py
+++ b/tools/c7n_azure/c7n_azure/resources/container_service.py
@@ -1,11 +1,15 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+from c7n.deprecated import DeprecatedResource
 from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
 
 
 @resources.register('containerservice')
+@DeprecatedResource(
+    "Azure Container Service (ACS) has been retired",
+    removed_after="2027-07-23", force_empty=True)
 class ContainerService(ArmResourceManager):
     """Container Service Resource
 

--- a/tools/c7n_azure/c7n_azure/resources/datalake_store.py
+++ b/tools/c7n_azure/c7n_azure/resources/datalake_store.py
@@ -1,11 +1,15 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+from c7n.deprecated import DeprecatedResource
 from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
 
 
 @resources.register('datalake')
+@DeprecatedResource(
+    "Azure Data Lake Store (Gen1) has been retired",
+    removed_after="2027-07-23", force_empty=True)
 class DataLakeStore(ArmResourceManager):
     """Data Lake Resource
 

--- a/tools/c7n_azure/tests_azure/tests_resources/test_container_service.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_container_service.py
@@ -30,4 +30,4 @@ class ContainerServiceTest(BaseTest):
                  'value': 'cctestacs'}],
         })
         resources = p.run()
-        self.assertEqual(len(resources), 1)
+        self.assertEqual(len(resources), 0)

--- a/tools/c7n_azure/tests_azure/tests_resources/test_datalake.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_datalake.py
@@ -28,4 +28,4 @@ class DataLakeTest(BaseTest):
                  'value': 'ccdatalake*'}],
         })
         resources = p.run()
-        self.assertEqual(len(resources), 1)
+        self.assertEqual(len(resources), 0)


### PR DESCRIPTION
Azure Container Service (ACS) and Data Lake gen1 are both retired services that throw errors if you try to target them with policies. To address that we can:

- Mark them as deprecated
- Flag them for removal from c7n in 1 year
- Force policies to return an empty resource set rather than attempting to hit the live API

This is a pattern we've seen repeat a few times, and we do have a deprecation framework for filters/actions/etc. So instead of adding one more ad-hoc override, I suggest we define a central `DeprecatedResource` that we can use to decorate resource managers.

_I'm open to alternatives to decorators here, but it seemed to be pretty clean to apply this way at the resource manager level especially across providers._

Closes #10780 
Closes #10777 