### PR TITLE
aws - tags - allow resource lookups in tag values

### DIFF
--- a/c7n/resources/keyspaces.py
+++ b/c7n/resources/keyspaces.py
@@ -68,13 +68,13 @@ Keyspace.filter_registry.register('marked-for-op', TagActionFilter)
 class TagKeyspace(Tag):
     permissions = ('cassandra:TagResource', 'cassandra:TagMultiRegionResource')
 
-    def process(self, resources):
-        client = self.get_client()
-        for r in resources:
-            client.tag_resource(
+    def process_resource_set(self, client, resource_set, tags):
+        cassandra_tags = [{'key': t['Key'], 'value': t['Value']} for t in tags]
+        for r in resource_set:
+            self.manager.retry(
+                client.tag_resource,
                 resourceArn=r['resourceArn'],
-                tags=[{'key': k, 'value': v} for k, v in self.data.get('tags', {}).items()]
-                )
+                tags=cassandra_tags)
 
 
 @Keyspace.action_registry.register('mark-for-op')
@@ -201,13 +201,13 @@ class Table(ChildResourceManager):
 class TagTable(Tag):
     permissions = ('cassandra:TagResource', 'cassandra:TagMultiRegionResource')
 
-    def process(self, resources):
-        client = self.get_client()
-        for r in resources:
-            client.tag_resource(
+    def process_resource_set(self, client, resource_set, tags):
+        cassandra_tags = [{'key': t['Key'], 'value': t['Value']} for t in tags]
+        for r in resource_set:
+            self.manager.retry(
+                client.tag_resource,
                 resourceArn=r['resourceArn'],
-                tags=[{'key': k, 'value': v} for k, v in self.data.get('tags', {}).items()]
-                )
+                tags=cassandra_tags)
 
 
 @Table.action_registry.register('mark-for-op')

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -967,19 +967,26 @@ class UniversalTag(Tag):
         tag = self.data.get('key') or tag
 
         # Support setting multiple tags in a single go with a mapping
-        tags = self.data.get('tags', {})
-
+        spec_map = dict(self.data.get('tags', {}))
         if msg:
-            tags[tag] = msg
-
-        self.interpolate_values(tags)
+            spec_map[tag] = msg
 
         batch_size = self.data.get('batch_size', self.batch_size)
         client = self.get_client()
 
-        _common_tag_processer(
-            self.executor_factory, batch_size, self.concurrency, client,
-            self.process_resource_set, self.id_key, resources, tags, self.log)
+        if not has_dynamic_tag_values(spec_map):
+            tags = dict(spec_map)
+            self.interpolate_values(tags)
+            _common_tag_processer(
+                self.executor_factory, batch_size, self.concurrency, client,
+                self.process_resource_set, self.id_key, resources, tags, self.log)
+            return
+
+        for resource_set, resolved in self._resolve_and_group(resources, spec_map):
+            _common_tag_processer(
+                self.executor_factory, batch_size, self.concurrency, client,
+                self.process_resource_set, self.id_key, resource_set, resolved,
+                self.log)
 
     def process_resource_set(self, client, resource_set, tags):
         arns = self.manager.get_arns(resource_set)

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -426,6 +426,24 @@ class TagCountFilter(Filter):
 
 class Tag(Action):
     """Tag an ec2 resource.
+
+    Tag values may be looked up per-resource from resource attributes:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: ec2-tag-owner
+            resource: aws.ec2
+            actions:
+              - type: tag
+                tags:
+                  Owner:
+                    type: resource
+                    key: "Tags[?Key=='team'].Value | [0]"
+                    default-value: unknown
+                  CostCenter:
+                    type: resource
+                    default-value: unassigned   # set only if CostCenter absent
     """
 
     batch_size = 25
@@ -437,9 +455,9 @@ class Tag(Action):
 
     schema = utils.type_schema(
         'tag', aliases=('mark',),
-        tags={'type': 'object'},
+        tags={'type': 'object', 'additionalProperties': tag_value_schema()},
         key={'type': 'string'},
-        value={'type': 'string'},
+        value=tag_value_schema(),
         tag={'type': 'string'},
     )
     schema_alias = True
@@ -462,24 +480,47 @@ class Tag(Action):
         tag = self.data.get('key') or tag
 
         # Support setting multiple tags in a single go with a mapping
-        tags = self.data.get('tags')
-
-        if tags is None:
-            tags = []
-        else:
-            tags = [{'Key': k, 'Value': v} for k, v in tags.items()]
-
+        spec_map = dict(self.data.get('tags') or {})
         if msg:
-            tags.append({'Key': tag, 'Value': msg})
-
-        self.interpolate_values(tags)
+            spec_map[tag] = msg
 
         batch_size = self.data.get('batch_size', self.batch_size)
-
         client = self.get_client()
-        _common_tag_processer(
-            self.executor_factory, batch_size, self.concurrency, client,
-            self.process_resource_set, self.id_key, resources, tags, self.log)
+
+        if not has_dynamic_tag_values(spec_map):
+            tags = [{'Key': k, 'Value': v} for k, v in spec_map.items()]
+            self.interpolate_values(tags)
+            _common_tag_processer(
+                self.executor_factory, batch_size, self.concurrency, client,
+                self.process_resource_set, self.id_key, resources, tags, self.log)
+            return
+
+        for resource_set, resolved in self._resolve_and_group(resources, spec_map):
+            tags = [{'Key': k, 'Value': v} for k, v in resolved.items()]
+            _common_tag_processer(
+                self.executor_factory, batch_size, self.concurrency, client,
+                self.process_resource_set, self.id_key, resource_set, tags, self.log)
+
+    def _resolve_and_group(self, resources, spec_map):
+        """Resolve tag values per resource and group by identical payload.
+
+        Returns a list of (resource_set, resolved_dict). Resources whose
+        payload is empty (all tags conditionally skipped) are dropped.
+        """
+        groups = {}
+        for r in resources:
+            current = resource_tag_keys(r)
+            resolved = {}
+            for name, spec in spec_map.items():
+                value = resolve_tag_value(spec, name, r, current)
+                if value is TAG_VALUE_SKIP:
+                    continue
+                resolved[name] = self.interpolate_single_value(value)
+            if not resolved:
+                continue
+            sig = tuple(sorted(resolved.items()))
+            groups.setdefault(sig, ([], resolved))[0].append(r)
+        return list(groups.values())
 
     def process_resource_set(self, client, resource_set, tags):
         mid = self.manager.get_model().id

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -23,9 +23,76 @@ from c7n.exceptions import PolicyValidationError, PolicyExecutionError
 from c7n.resources import load_resources
 from c7n.filters import Filter, OPERATORS
 from c7n.filters.offhours import Time
+from c7n.lookup import Lookup
 from c7n import deprecated, utils
 
 DEFAULT_TAG = "maid_status"
+
+
+# Sentinel: the resolver returns this to omit a tag from a resource's payload.
+TAG_VALUE_SKIP = object()
+
+
+def tag_value_schema():
+    """Schema for a single tag value.
+
+    Accepts a scalar, a resource lookup by key (with optional fallback), or a
+    conditional default with no key (write only when the tag is absent).
+    """
+    return {
+        'oneOf': [
+            {'type': ['string', 'number', 'boolean']},
+            {
+                'type': 'object',
+                'additionalProperties': False,
+                'required': ['type', 'key'],
+                'properties': {
+                    'type': {'enum': [Lookup.RESOURCE_SOURCE]},
+                    'key': {'type': 'string'},
+                    'default-value': {'type': 'string'},
+                },
+            },
+            {
+                'type': 'object',
+                'additionalProperties': False,
+                'required': ['type', 'default-value'],
+                'properties': {
+                    'type': {'enum': [Lookup.RESOURCE_SOURCE]},
+                    'default-value': {'type': 'string'},
+                },
+            },
+        ]
+    }
+
+
+def has_dynamic_tag_values(spec_map):
+    return any(Lookup.is_lookup(v) for v in spec_map.values())
+
+
+def resource_tag_keys(resource):
+    current = resource.get('Tags', [])
+    if isinstance(current, dict):
+        return set(current.keys())
+    keys = set()
+    for t in current or ():
+        if isinstance(t, dict) and 'Key' in t:
+            keys.add(t['Key'])
+    return keys
+
+
+def resolve_tag_value(spec, tag_name, resource, current_tag_keys):
+    """Resolve one tag value spec against a resource.
+
+    Returns the resolved value, or TAG_VALUE_SKIP to omit the tag.
+    """
+    if not Lookup.is_lookup(spec):
+        return spec
+    if 'key' in spec:
+        return Lookup.extract(spec, resource)
+    # Conditional default (no key): write only if the tag is absent.
+    if tag_name in current_tag_keys:
+        return TAG_VALUE_SKIP
+    return spec['default-value']
 
 
 def register_ec2_tags(filters, actions):

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -434,12 +434,16 @@ class Tag(Action):
         policies:
           - name: ec2-tag-owner
             resource: aws.ec2
+            filters:
+              - or:
+                - "tag:Owner": empty
+                - "tag:CostCenter": empty
             actions:
               - type: tag
                 tags:
                   Owner:
                     type: resource
-                    key: "Tags[?Key=='team'].Value | [0]"
+                    key: "Tags[?Key=='Team'].Value | [0]"  # set based on Team tag if available
                     default-value: unknown
                   CostCenter:
                     type: resource

--- a/tests/test_keyspaces.py
+++ b/tests/test_keyspaces.py
@@ -1,5 +1,6 @@
 from botocore.exceptions import ClientError
 import time
+from unittest.mock import MagicMock
 
 from .common import BaseTest
 from c7n.utils import local_session
@@ -143,3 +144,20 @@ class TestKeyspaceTable(BaseTest):
                 keyspaceName=resources[0]['keyspaceName'],
                 tableName=resources[0]['tableName']
             )
+
+
+class TestKeyspaceDynamicTag(BaseTest):
+    def test_keyspace_dynamic_tag(self):
+        mock_factory = MagicMock()
+        mock_factory.region = 'us-east-1'
+        tag_resource = mock_factory().client('keyspaces').tag_resource
+        tag_resource.return_value = {}
+        policy = self.load_policy(
+            {'name': 'ks', 'resource': 'keyspace',
+             'actions': [{'type': 'tag', 'tags': {
+                 'Name': {'type': 'resource', 'key': 'keyspaceName'}}}]},
+            session_factory=mock_factory)
+        policy.resource_manager.actions[0].process(
+            [{'keyspaceName': 'ks1', 'resourceArn': 'arn:ks1'}])
+        tag_resource.assert_called_once_with(
+            resourceArn='arn:ks1', tags=[{'key': 'Name', 'value': 'ks1'}])

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -7,6 +7,7 @@ import time
 from freezegun import freeze_time
 from unittest.mock import MagicMock, call
 
+from c7n import tags as tagmod
 from c7n.tags import universal_retry, coalesce_copy_user_tags
 from c7n.exceptions import PolicyExecutionError, PolicyValidationError
 from c7n.utils import yaml_load
@@ -603,3 +604,46 @@ class CopyRelatedResourceTag(BaseTest):
             ]
         }
         self.assertRaises(PolicyValidationError, self.load_policy, policy)
+
+
+class ResolveTagValueTest(BaseTest):
+    def test_static_passthrough(self):
+        self.assertEqual(
+            tagmod.resolve_tag_value("plain", "K", {}, set()), "plain")
+
+    def test_lookup_with_key_hit(self):
+        r = {"State": {"Name": "running"}}
+        spec = {"type": "resource", "key": "State.Name"}
+        self.assertEqual(tagmod.resolve_tag_value(spec, "K", r, set()), "running")
+
+    def test_lookup_with_key_miss_uses_default(self):
+        spec = {"type": "resource", "key": "Nope", "default-value": "dv"}
+        self.assertEqual(tagmod.resolve_tag_value(spec, "K", {}, set()), "dv")
+
+    def test_lookup_with_key_miss_no_default_raises(self):
+        spec = {"type": "resource", "key": "Nope"}
+        with self.assertRaises(Exception):
+            tagmod.resolve_tag_value(spec, "K", {}, set())
+
+    def test_conditional_tag_absent_writes_default(self):
+        spec = {"type": "resource", "default-value": "dv"}
+        self.assertEqual(
+            tagmod.resolve_tag_value(spec, "Owner", {}, set()), "dv")
+
+    def test_conditional_tag_present_skips(self):
+        spec = {"type": "resource", "default-value": "dv"}
+        self.assertIs(
+            tagmod.resolve_tag_value(spec, "Owner", {}, {"Owner"}),
+            tagmod.TAG_VALUE_SKIP)
+
+    def test_resource_tag_keys_list_and_dict(self):
+        self.assertEqual(
+            tagmod.resource_tag_keys({"Tags": [{"Key": "A", "Value": "1"}]}), {"A"})
+        self.assertEqual(
+            tagmod.resource_tag_keys({"Tags": {"B": "2"}}), {"B"})
+        self.assertEqual(tagmod.resource_tag_keys({}), set())
+
+    def test_has_dynamic(self):
+        self.assertFalse(tagmod.has_dynamic_tag_values({"A": "x"}))
+        self.assertTrue(
+            tagmod.has_dynamic_tag_values({"A": {"type": "resource", "key": "k"}}))

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -647,3 +647,59 @@ class ResolveTagValueTest(BaseTest):
         self.assertFalse(tagmod.has_dynamic_tag_values({"A": "x"}))
         self.assertTrue(
             tagmod.has_dynamic_tag_values({"A": {"type": "resource", "key": "k"}}))
+
+
+class DynamicTagTest(BaseTest):
+    def _run(self, resources, tags, resource='ec2'):
+        mock_factory = MagicMock()
+        mock_factory.region = 'us-east-1'
+        create_tags = mock_factory().client(resource).create_tags
+        create_tags.return_value = {}
+        policy = self.load_policy(
+            {"name": "d", "resource": resource,
+             "actions": [{"type": "tag", "tags": tags}]},
+            session_factory=mock_factory)
+        policy.resource_manager.actions[0].process(resources)
+        return create_tags
+
+    def test_lookup_key_hit(self):
+        create_tags = self._run(
+            [{"InstanceId": "i-1", "State": {"Name": "running"}}],
+            {"St": {"type": "resource", "key": "State.Name"}})
+        create_tags.assert_called_once_with(
+            Resources=["i-1"], Tags=[{"Key": "St", "Value": "running"}], DryRun=False)
+
+    def test_lookup_key_miss_default(self):
+        create_tags = self._run(
+            [{"InstanceId": "i-1"}],
+            {"St": {"type": "resource", "key": "Nope", "default-value": "dv"}})
+        create_tags.assert_called_once_with(
+            Resources=["i-1"], Tags=[{"Key": "St", "Value": "dv"}], DryRun=False)
+
+    def test_conditional_skip_and_write_group_separately(self):
+        create_tags = self._run(
+            [{"InstanceId": "i-has", "Tags": [{"Key": "Owner", "Value": "x"}]},
+             {"InstanceId": "i-missing"}],
+            {"Owner": {"type": "resource", "default-value": "dv"}})
+        # i-has -> skipped (empty payload, no call); i-missing -> Owner=dv
+        create_tags.assert_called_once_with(
+            Resources=["i-missing"], Tags=[{"Key": "Owner", "Value": "dv"}],
+            DryRun=False)
+
+    def test_dynamic_grouping_two_payloads(self):
+        create_tags = self._run(
+            [{"InstanceId": "i-1", "State": {"Name": "running"}},
+             {"InstanceId": "i-2", "State": {"Name": "stopped"}},
+             {"InstanceId": "i-3", "State": {"Name": "running"}}],
+            {"St": {"type": "resource", "key": "State.Name"}})
+        self.assertEqual(create_tags.call_count, 2)
+        by_value = {c.kwargs["Tags"][0]["Value"]: set(c.kwargs["Resources"])
+                    for c in create_tags.call_args_list}
+        self.assertEqual(by_value["running"], {"i-1", "i-3"})
+        self.assertEqual(by_value["stopped"], {"i-2"})
+
+    def test_static_fast_path_single_call(self):
+        create_tags = self._run(
+            [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}], {"K": "v"})
+        create_tags.assert_called_once_with(
+            Resources=["i-1", "i-2"], Tags=[{"Key": "K", "Value": "v"}], DryRun=False)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -703,3 +703,32 @@ class DynamicTagTest(BaseTest):
             [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}], {"K": "v"})
         create_tags.assert_called_once_with(
             Resources=["i-1", "i-2"], Tags=[{"Key": "K", "Value": "v"}], DryRun=False)
+
+
+class DynamicUniversalTagTest(BaseTest):
+    def _run(self, resources, tags, resource='rds'):
+        mock_factory = MagicMock()
+        mock_factory.region = 'us-east-1'
+        tag_resources = mock_factory().client('resourcegroupstaggingapi').tag_resources
+        tag_resources.return_value = {}
+        policy = self.load_policy(
+            {"name": "d", "resource": resource,
+             "actions": [{"type": "tag", "tags": tags}]},
+            session_factory=mock_factory)
+        policy.resource_manager.actions[0].process(resources)
+        return tag_resources
+
+    def test_universal_lookup_hit(self):
+        tag_resources = self._run(
+            [{"DBInstanceIdentifier": "x", "DBInstanceArn": "arn:x",
+              "Engine": "postgres"}],
+            {"Eng": {"type": "resource", "key": "Engine"}})
+        tag_resources.assert_called_once_with(
+            ResourceARNList=["arn:x"], Tags={"Eng": "postgres"})
+
+    def test_universal_static_fast_path(self):
+        tag_resources = self._run(
+            [{"DBInstanceIdentifier": "x", "DBInstanceArn": "arn:x"}],
+            {"K": "v"})
+        tag_resources.assert_called_once_with(
+            ResourceARNList=["arn:x"], Tags={"K": "v"})

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -704,6 +704,17 @@ class DynamicTagTest(BaseTest):
         create_tags.assert_called_once_with(
             Resources=["i-1", "i-2"], Tags=[{"Key": "K", "Value": "v"}], DryRun=False)
 
+    @freeze_time("2022-06-27 12:34:56")
+    def test_placeholder_interpolated_in_default_value(self):
+        create_tags = self._run(
+            [{"InstanceId": "i-1"}],
+            {"Stamp": {"type": "resource", "key": "Nope",
+                       "default-value": "created-{now}-in-{region}"}})
+        create_tags.assert_called_once_with(
+            Resources=["i-1"],
+            Tags=[{"Key": "Stamp", "Value": "created-2022-06-27 12:34:56-in-us-east-1"}],
+            DryRun=False)
+
 
 class DynamicUniversalTagTest(BaseTest):
     def _run(self, resources, tags, resource='rds'):


### PR DESCRIPTION
This is a reworking of #8955 that takes a different approach to avoid some of the concerns from that PR. The core goal is the same - allow dynamic per-resource tagging for AWS. The implementation sticks closer to established patterns though:

- Allow tag values to be mappings rather than plain strings
- In the mapping case, use the dynamic `Lookup` pattern already used by GCP & Azure
  - Preserve bulk tagging API call count reductions where possible, by building groups of common new tag values
  - Allow `type: resource` + `default-value: <fallback value>` _without_ defining a `key` to serve the "set a default value for a tag, but don't overwrite an existing value" case

Example policy:

```yaml
policies:
  - name: ec2-set-default-tags
    filters:
      - or:
        - "tag:Owner": empty
        - "tag:CostCenter": empty
    resource: aws.ec2
    actions:
      - type: tag
        tags:
          Owner:
            type: resource
            key: "Tags[?Key=='Team'].Value | [0]"  # set based on a Team tag value if possible
            default-value: unknown                 # fallback if there's no Team tag
          CostCenter:
            type: resource
            default-value: unassigned  # set only if CostCenter absent

```

Relates to #5011 (but does not cover the "get tag values from other sources" piece)
Closes #10857