### PR TITLE
aws - bedrock-custom-model - add deployments and provisioned-throughputs filters

### DIFF
--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -7,7 +7,7 @@ from c7n.tags import RemoveTag, Tag, TagActionFilter, TagDelayedAction, universa
 from c7n.utils import local_session, type_schema, QueryParser
 from c7n.actions import BaseAction
 from c7n.filters.kms import KmsRelatedFilter
-from c7n.filters import MetricsFilter
+from c7n.filters import Filter, MetricsFilter
 from c7n.resources.aws import shape_schema, shape_validate, Arn
 
 
@@ -217,6 +217,106 @@ class BedrockCustomModelKmsFilter(KmsRelatedFilter):
 
     """
     RelatedIdsExpression = 'modelKmsKeyArn'
+
+
+@BedrockCustomModel.filter_registry.register('deployments')
+class ModelDeploymentsFilter(Filter):
+    """Filter custom models by their custom model deployments.
+
+    Queries ``ListCustomModelDeployments`` for deployments referencing the
+    model, optionally scoped server-side by ``status``. Matches
+    ``value: present`` if any matching deployment is found, or
+    ``value: absent`` if none is found.
+
+    :example:
+
+    Find custom models with no active deployment:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: bedrock-custom-model-no-active-deployment
+            resource: aws.bedrock-custom-model
+            filters:
+              - type: deployments
+                status: Active
+                value: absent
+    """
+    schema = type_schema(
+        'deployments',
+        status={'enum': ['Creating', 'Active', 'Failed']},
+        value={'enum': ['present', 'absent']},
+        required=['value'])
+    permissions = ('bedrock:ListCustomModelDeployments',)
+    annotation_key = 'c7n:deployments'
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('bedrock')
+        params = {}
+        if 'status' in self.data:
+            params['statusEquals'] = self.data['status']
+        want_present = self.data['value'] == 'present'
+        results = []
+        for r in resources:
+            deployments = self.manager.retry(
+                client.get_paginator('list_custom_model_deployments').paginate(
+                    modelArnEquals=r['modelArn'], **params
+                ).build_full_result
+            )['modelDeploymentSummaries']
+            r[self.annotation_key] = deployments
+            if bool(deployments) == want_present:
+                results.append(r)
+        return results
+
+
+@BedrockCustomModel.filter_registry.register('provisioned-throughputs')
+class ModelProvisionedThroughputsFilter(Filter):
+    """Filter custom models by their provisioned model throughputs.
+
+    Queries ``ListProvisionedModelThroughputs`` for throughputs referencing
+    the model, optionally scoped server-side by ``status``. Matches
+    ``value: present`` if any matching provisioned throughput is found, or
+    ``value: absent`` if none is found.
+
+    :example:
+
+    Find custom models with no in-service provisioned throughput:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: bedrock-custom-model-no-provisioned-throughput
+            resource: aws.bedrock-custom-model
+            filters:
+              - type: provisioned-throughputs
+                status: InService
+                value: absent
+    """
+    schema = type_schema(
+        'provisioned-throughputs',
+        status={'enum': ['Creating', 'InService', 'Updating', 'Failed']},
+        value={'enum': ['present', 'absent']},
+        required=['value'])
+    permissions = ('bedrock:ListProvisionedModelThroughputs',)
+    annotation_key = 'c7n:provisioned-throughputs'
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('bedrock')
+        params = {}
+        if 'status' in self.data:
+            params['statusEquals'] = self.data['status']
+        want_present = self.data['value'] == 'present'
+        results = []
+        for r in resources:
+            throughputs = self.manager.retry(
+                client.get_paginator('list_provisioned_model_throughputs').paginate(
+                    modelArnEquals=r['modelArn'], **params
+                ).build_full_result
+            )['provisionedModelSummaries']
+            r[self.annotation_key] = throughputs
+            if bool(throughputs) == want_present:
+                results.append(r)
+        return results
 
 
 class DescribeBedrockCustomizationJob(DescribeSource):

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.CreateCustomModelDeployment_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.CreateCustomModelDeployment_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 202,
+    "data": {
+        "ResponseMetadata": {},
+        "customModelDeploymentArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model-deployment/c6v9z95m1cwb"
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.DeleteCustomModelDeployment_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.DeleteCustomModelDeployment_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.GetCustomModelDeployment_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.GetCustomModelDeployment_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "customModelDeploymentArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model-deployment/c6v9z95m1cwb",
+        "modelDeploymentName": "c7n-test-custom-model-deployment",
+        "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-3-70b-instruct-v1:0:128k/atcpdot5kavs",
+        "createdAt": {
+            "__class__": "datetime",
+            "year": 2026,
+            "month": 7,
+            "day": 24,
+            "hour": 20,
+            "minute": 0,
+            "second": 48,
+            "microsecond": 375000
+        },
+        "status": "Creating",
+        "lastUpdatedAt": {
+            "__class__": "datetime",
+            "year": 2026,
+            "month": 7,
+            "day": 24,
+            "hour": 20,
+            "minute": 0,
+            "second": 48,
+            "microsecond": 375000
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.GetCustomModelDeployment_2.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.GetCustomModelDeployment_2.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "customModelDeploymentArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model-deployment/c6v9z95m1cwb",
+        "modelDeploymentName": "c7n-test-custom-model-deployment",
+        "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-3-70b-instruct-v1:0:128k/atcpdot5kavs",
+        "createdAt": {
+            "__class__": "datetime",
+            "year": 2026,
+            "month": 7,
+            "day": 24,
+            "hour": 20,
+            "minute": 0,
+            "second": 48,
+            "microsecond": 375000
+        },
+        "status": "Active",
+        "lastUpdatedAt": {
+            "__class__": "datetime",
+            "year": 2026,
+            "month": 7,
+            "day": 24,
+            "hour": 20,
+            "minute": 8,
+            "second": 47,
+            "microsecond": 647000
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.GetCustomModel_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.GetCustomModel_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-3-70b-instruct-v1:0:128k/atcpdot5kavs",
+        "modelName": "c7n-llama33-clever-leopard",
+        "jobArn": "arn:aws:bedrock:us-west-2:644160558196:model-customization-job/meta.llama3-3-70b-instruct-v1:0:128k/vt6ui6wum0mn",
+        "baseModelArn": "arn:aws:bedrock:us-west-2::foundation-model/meta.llama3-3-70b-instruct-v1:0:128k",
+        "customizationType": "FINE_TUNING",
+        "hyperParameters": {
+            "batchSize": "1",
+            "learningRate": "0.00005",
+            "epochCount": "1"
+        },
+        "trainingDataConfig": {
+            "s3Uri": "s3://c7n-bedrock-llama33-clever-leopard/train.jsonl"
+        },
+        "outputDataConfig": {
+            "s3Uri": "s3://c7n-bedrock-llama33-output-clever-leopard/output/"
+        },
+        "trainingMetrics": {
+            "trainingLoss": -1.0
+        },
+        "validationMetrics": [],
+        "creationTime": {
+            "__class__": "datetime",
+            "year": 2026,
+            "month": 7,
+            "day": 24,
+            "hour": 15,
+            "minute": 18,
+            "second": 35,
+            "microsecond": 468000
+        },
+        "modelStatus": "Active"
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.GetCustomModel_2.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.GetCustomModel_2.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-1-8b-instruct-v1:0:128k/liyn3ip5ckui",
+        "modelName": "c7n-llama-ft-emerging-marmoset",
+        "jobArn": "arn:aws:bedrock:us-west-2:644160558196:model-customization-job/meta.llama3-1-8b-instruct-v1:0:128k/gsfk5r3l6cor",
+        "baseModelArn": "arn:aws:bedrock:us-west-2::foundation-model/meta.llama3-1-8b-instruct-v1:0:128k",
+        "customizationType": "FINE_TUNING",
+        "hyperParameters": {
+            "batchSize": "1",
+            "learningRate": "0.00005",
+            "epochCount": "1"
+        },
+        "trainingDataConfig": {
+            "s3Uri": "s3://c7n-bedrock-llama-ft-emerging-marmoset/train.jsonl"
+        },
+        "outputDataConfig": {
+            "s3Uri": "s3://c7n-bedrock-llama-ft-output-emerging-marmoset/output/"
+        },
+        "trainingMetrics": {
+            "trainingLoss": -1.0
+        },
+        "validationMetrics": [],
+        "creationTime": {
+            "__class__": "datetime",
+            "year": 2026,
+            "month": 7,
+            "day": 22,
+            "hour": 14,
+            "minute": 45,
+            "second": 1,
+            "microsecond": 978000
+        },
+        "modelStatus": "Active"
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.ListCustomModelDeployments_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.ListCustomModelDeployments_1.json
@@ -1,0 +1,34 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "modelDeploymentSummaries": [
+            {
+                "customModelDeploymentArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model-deployment/c6v9z95m1cwb",
+                "customModelDeploymentName": "c7n-test-custom-model-deployment",
+                "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-3-70b-instruct-v1:0:128k/atcpdot5kavs",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 24,
+                    "hour": 20,
+                    "minute": 0,
+                    "second": 48,
+                    "microsecond": 375000
+                },
+                "status": "Active",
+                "lastUpdatedAt": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 24,
+                    "hour": 20,
+                    "minute": 8,
+                    "second": 47,
+                    "microsecond": 647000
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.ListCustomModels_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.ListCustomModels_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "modelSummaries": [
+            {
+                "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-3-70b-instruct-v1:0:128k/atcpdot5kavs",
+                "modelName": "c7n-llama33-clever-leopard",
+                "creationTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 24,
+                    "hour": 15,
+                    "minute": 18,
+                    "second": 35,
+                    "microsecond": 468000
+                },
+                "baseModelArn": "arn:aws:bedrock:us-west-2::foundation-model/meta.llama3-3-70b-instruct-v1:0:128k",
+                "baseModelName": "",
+                "customizationType": "FINE_TUNING",
+                "ownerAccountId": "644160558196",
+                "modelStatus": "Active"
+            },
+            {
+                "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-1-8b-instruct-v1:0:128k/liyn3ip5ckui",
+                "modelName": "c7n-llama-ft-emerging-marmoset",
+                "creationTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 22,
+                    "hour": 14,
+                    "minute": 45,
+                    "second": 1,
+                    "microsecond": 978000
+                },
+                "baseModelArn": "arn:aws:bedrock:us-west-2::foundation-model/meta.llama3-1-8b-instruct-v1:0:128k",
+                "baseModelName": "",
+                "customizationType": "FINE_TUNING",
+                "ownerAccountId": "644160558196",
+                "modelStatus": "Active"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.ListTagsForResource_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": []
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_bedrock_custom_model_deployments_filter/bedrock.ListTagsForResource_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": []
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.GetCustomModel_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.GetCustomModel_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-3-70b-instruct-v1:0:128k/atcpdot5kavs",
+        "modelName": "c7n-llama33-clever-leopard",
+        "jobArn": "arn:aws:bedrock:us-west-2:644160558196:model-customization-job/meta.llama3-3-70b-instruct-v1:0:128k/vt6ui6wum0mn",
+        "baseModelArn": "arn:aws:bedrock:us-west-2::foundation-model/meta.llama3-3-70b-instruct-v1:0:128k",
+        "customizationType": "FINE_TUNING",
+        "hyperParameters": {
+            "batchSize": "1",
+            "learningRate": "0.00005",
+            "epochCount": "1"
+        },
+        "trainingDataConfig": {
+            "s3Uri": "s3://c7n-bedrock-llama33-clever-leopard/train.jsonl"
+        },
+        "outputDataConfig": {
+            "s3Uri": "s3://c7n-bedrock-llama33-output-clever-leopard/output/"
+        },
+        "trainingMetrics": {
+            "trainingLoss": -1.0
+        },
+        "validationMetrics": [],
+        "creationTime": {
+            "__class__": "datetime",
+            "year": 2026,
+            "month": 7,
+            "day": 24,
+            "hour": 15,
+            "minute": 18,
+            "second": 35,
+            "microsecond": 468000
+        },
+        "modelStatus": "Active"
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.GetCustomModel_2.json
+++ b/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.GetCustomModel_2.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-1-8b-instruct-v1:0:128k/liyn3ip5ckui",
+        "modelName": "c7n-llama-ft-emerging-marmoset",
+        "jobArn": "arn:aws:bedrock:us-west-2:644160558196:model-customization-job/meta.llama3-1-8b-instruct-v1:0:128k/gsfk5r3l6cor",
+        "baseModelArn": "arn:aws:bedrock:us-west-2::foundation-model/meta.llama3-1-8b-instruct-v1:0:128k",
+        "customizationType": "FINE_TUNING",
+        "hyperParameters": {
+            "batchSize": "1",
+            "learningRate": "0.00005",
+            "epochCount": "1"
+        },
+        "trainingDataConfig": {
+            "s3Uri": "s3://c7n-bedrock-llama-ft-emerging-marmoset/train.jsonl"
+        },
+        "outputDataConfig": {
+            "s3Uri": "s3://c7n-bedrock-llama-ft-output-emerging-marmoset/output/"
+        },
+        "trainingMetrics": {
+            "trainingLoss": -1.0
+        },
+        "validationMetrics": [],
+        "creationTime": {
+            "__class__": "datetime",
+            "year": 2026,
+            "month": 7,
+            "day": 22,
+            "hour": 14,
+            "minute": 45,
+            "second": 1,
+            "microsecond": 978000
+        },
+        "modelStatus": "Active"
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListCustomModelDeployments_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListCustomModelDeployments_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "modelDeploymentSummaries": []
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListCustomModels_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListCustomModels_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "modelSummaries": [
+            {
+                "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-3-70b-instruct-v1:0:128k/atcpdot5kavs",
+                "modelName": "c7n-llama33-clever-leopard",
+                "creationTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 24,
+                    "hour": 15,
+                    "minute": 18,
+                    "second": 35,
+                    "microsecond": 468000
+                },
+                "baseModelArn": "arn:aws:bedrock:us-west-2::foundation-model/meta.llama3-3-70b-instruct-v1:0:128k",
+                "baseModelName": "",
+                "customizationType": "FINE_TUNING",
+                "ownerAccountId": "644160558196",
+                "modelStatus": "Active"
+            },
+            {
+                "modelArn": "arn:aws:bedrock:us-west-2:644160558196:custom-model/meta.llama3-1-8b-instruct-v1:0:128k/liyn3ip5ckui",
+                "modelName": "c7n-llama-ft-emerging-marmoset",
+                "creationTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 7,
+                    "day": 22,
+                    "hour": 14,
+                    "minute": 45,
+                    "second": 1,
+                    "microsecond": 978000
+                },
+                "baseModelArn": "arn:aws:bedrock:us-west-2::foundation-model/meta.llama3-1-8b-instruct-v1:0:128k",
+                "baseModelName": "",
+                "customizationType": "FINE_TUNING",
+                "ownerAccountId": "644160558196",
+                "modelStatus": "Active"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListProvisionedModelThroughputs_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListProvisionedModelThroughputs_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "provisionedModelSummaries": []
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListTagsForResource_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": []
+    }
+}

--- a/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_bedrock_custom_model_orphaned/bedrock.ListTagsForResource_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": []
+    }
+}

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -425,6 +425,34 @@ class BedrockCustomModel(BaseTest):
         self.assertEqual(len(tags), 1)
         self.assertEqual(tags, [{'key': 'foo', 'value': 'bar'}])
 
+    def test_bedrock_custom_model_deployments_filter_schema(self):
+        session_factory = self.replay_flight_data('test_bedrock_custom_model')
+        p = self.load_policy(
+            {
+                'name': 'bedrock-custom-model-no-active-deployment',
+                'resource': 'bedrock-custom-model',
+                'filters': [
+                    {'type': 'deployments', 'status': 'Active', 'value': 'absent'},
+                ],
+            },
+            session_factory=session_factory,
+        )
+        self.assertTrue(p)
+
+    def test_bedrock_custom_model_provisioned_throughputs_filter_schema(self):
+        session_factory = self.replay_flight_data('test_bedrock_custom_model')
+        p = self.load_policy(
+            {
+                'name': 'bedrock-custom-model-no-provisioned-throughput',
+                'resource': 'bedrock-custom-model',
+                'filters': [
+                    {'type': 'provisioned-throughputs', 'status': 'InService', 'value': 'absent'},
+                ],
+            },
+            session_factory=session_factory,
+        )
+        self.assertTrue(p)
+
     def test_bedrock_custom_model_delete(self):
         session_factory = self.replay_flight_data('test_bedrock_custom_model_delete')
         p = self.load_policy(

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -1,6 +1,8 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import time
+import pytest
 from .common import ACCOUNT_ID, BaseTest, event_data
 from botocore.exceptions import ClientError
 from pytest_terraform import terraform
@@ -1232,3 +1234,135 @@ def test_bedrock_inference_profile_metrics(test):
     test.assertEqual(len(resources), 1)
     test.assertTrue('c7n.metrics' in resources[0])
     test.assertTrue('AWS/Bedrock.InputTokenCount.Sum.1' in resources[0]['c7n.metrics'])
+
+
+# The deployments filter can only be exercised (present case) against a custom
+# model whose base model is eligible for on-demand custom model deployment.
+# Nova families are eligible in us-east-1 but their fine-tuning jobs would not
+# complete in the test account, so a prebuilt Llama 3.3 70B custom model in
+# us-west-2 (also on-demand-eligible) is used as a long-lived fixture ("pet").
+# See specs/10843-aws-bedrock-deployment-filters/llama-3-3-70b-custom-model/.
+# The model-id suffix is stable across record/replay; only the 12-digit account
+# segment differs (ACCOUNT_ID on replay, the real account when recording).
+CUSTOM_MODEL_REGION = "us-west-2"
+CUSTOM_MODEL_ID = "meta.llama3-3-70b-instruct-v1:0:128k/atcpdot5kavs"
+
+
+def _custom_model_arn(account_id):
+    return (f"arn:aws:bedrock:{CUSTOM_MODEL_REGION}:{account_id}"
+            f":custom-model/{CUSTOM_MODEL_ID}")
+
+
+def wait_for_custom_model_deployment_active(client, deployment_arn, test):
+    status = None
+    for _ in range(60):
+        status = client.get_custom_model_deployment(
+            customModelDeploymentIdentifier=deployment_arn)['status']
+        if status == 'Active':
+            return
+        if status == 'Failed':
+            raise RuntimeError(f'custom model deployment {deployment_arn} failed')
+        if test.recording:
+            time.sleep(20)
+    raise RuntimeError(
+        f'custom model deployment {deployment_arn} did not become Active: {status}')
+
+
+@pytest.fixture
+def create_custom_model_deployment(test):
+    """Create an on-demand custom model deployment for a test, clean it up after.
+
+    Builds its client from ``test.session_factory``, which the test must set
+    (via ``record_flight_data``/``replay_flight_data``) before calling the
+    yielded function, so the create and poll calls record/replay with the rest
+    of the test. Yields ``(model_arn) -> deployment_arn`` which creates the
+    deployment and waits for it to become ``Active``.
+    """
+    created = []
+
+    def _create(model_arn, name="c7n-test-custom-model-deployment"):
+        client = test.session_factory().client(
+            'bedrock', region_name=CUSTOM_MODEL_REGION)
+        deployment_arn = client.create_custom_model_deployment(
+            modelDeploymentName=name, modelArn=model_arn)['customModelDeploymentArn']
+        created.append((client, deployment_arn))
+        wait_for_custom_model_deployment_active(client, deployment_arn, test)
+        return deployment_arn
+
+    try:
+        yield _create
+    finally:
+        for client, deployment_arn in created:
+            try:
+                client.delete_custom_model_deployment(
+                    customModelDeploymentIdentifier=deployment_arn)
+            except client.exceptions.ResourceNotFoundException:
+                pass
+
+
+def test_bedrock_custom_model_deployments_filter(test, create_custom_model_deployment):
+    test.session_factory = test.replay_flight_data(
+        'test_bedrock_custom_model_deployments_filter', region=CUSTOM_MODEL_REGION)
+
+    account_id = ACCOUNT_ID
+    if C7N_FUNCTIONAL:
+        account_id = test.session_factory().client(
+            'sts', region_name=CUSTOM_MODEL_REGION).get_caller_identity()['Account']
+    model_arn = _custom_model_arn(account_id)
+
+    # Populate an on-demand deployment on the fixture model; its create/poll
+    # calls are recorded via the same session used below.
+    create_custom_model_deployment(model_arn)
+
+    present = test.load_policy(
+        {
+            'name': 'bedrock-custom-model-active-deployment',
+            'resource': 'aws.bedrock-custom-model',
+            'filters': [
+                {'modelArn': model_arn},
+                {'type': 'deployments', 'status': 'Active', 'value': 'present'},
+            ],
+        },
+        session_factory=test.session_factory,
+        config={'region': CUSTOM_MODEL_REGION},
+    )
+    resources = present.run()
+    test.assertEqual(len(resources), 1)
+    test.assertEqual(resources[0]['modelArn'], model_arn)
+    test.assertEqual(len(resources[0]['c7n:deployments']), 1)
+    test.assertEqual(resources[0]['c7n:deployments'][0]['status'], 'Active')
+
+
+def test_bedrock_custom_model_orphaned(test):
+    # An "orphaned" custom model: Active, but with neither an Active on-demand
+    # deployment nor an InService provisioned throughput -- the issue's target
+    # for cleanup. Exercises the absent branch of both filters at once. Needs
+    # no resource creation: the fixture model has neither serving path.
+    test.session_factory = test.replay_flight_data(
+        'test_bedrock_custom_model_orphaned', region=CUSTOM_MODEL_REGION)
+
+    account_id = ACCOUNT_ID
+    if C7N_FUNCTIONAL:
+        account_id = test.session_factory().client(
+            'sts', region_name=CUSTOM_MODEL_REGION).get_caller_identity()['Account']
+    model_arn = _custom_model_arn(account_id)
+
+    policy = test.load_policy(
+        {
+            'name': 'bedrock-custom-model-orphaned',
+            'resource': 'aws.bedrock-custom-model',
+            'filters': [
+                {'modelArn': model_arn},
+                {'type': 'deployments', 'status': 'Active', 'value': 'absent'},
+                {'type': 'provisioned-throughputs', 'status': 'InService',
+                 'value': 'absent'},
+            ],
+        },
+        session_factory=test.session_factory,
+        config={'region': CUSTOM_MODEL_REGION},
+    )
+    resources = policy.run()
+    test.assertEqual(len(resources), 1)
+    test.assertEqual(resources[0]['modelArn'], model_arn)
+    test.assertEqual(resources[0]['c7n:deployments'], [])
+    test.assertEqual(resources[0]['c7n:provisioned-throughputs'], [])


### PR DESCRIPTION
Closes #10843

## What

Adds two filters to `aws.bedrock-custom-model`:

- **`deployments`** — queries `ListCustomModelDeployments` for the model and
  matches `value: present`/`absent`, optionally scoped by `status`
  (`Creating`/`Active`/`Failed`).
- **`provisioned-throughputs`** — queries `ListProvisionedModelThroughputs`
  for the model and matches `value: present`/`absent`, optionally scoped by
  `status` (`Creating`/`InService`/`Updating`/`Failed`).

Together these let a policy flag "orphaned" custom models — `Active` models
that are old yet have neither an active on-demand deployment nor an in-service
provisioned throughput — as cleanup candidates, per the issue's example:

```yaml
policies:
  - name: bedrock-orphaned-custom-models
    resource: aws.bedrock-custom-model
    filters:
      - type: value
        key: modelStatus
        value: Active
      - type: deployments
        status: Active
        value: absent
      - type: provisioned-throughputs
        status: InService
        value: absent
```

Each filter makes one paginated list call per resource, scoped server-side by
`modelArnEquals` and the optional `status`, wrapped in the manager retry for
throttling.

## API verification

Verified param names, result keys, and status enums against the botocore
`bedrock` service model, and the two serving paths against the docs:

- `ListCustomModelDeployments` — https://docs.aws.amazon.com/bedrock/latest/APIReference/API_ListCustomModelDeployments.html
- `ListProvisionedModelThroughputs` — https://docs.aws.amazon.com/bedrock/latest/APIReference/API_ListProvisionedModelThroughputs.html
- On-demand deployment vs provisioned throughput serving paths — https://docs.aws.amazon.com/bedrock/latest/userguide/deploy-custom-model-on-demand.html and https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html

## Testing

Recorded (placebo flight data) against real custom models:

- `test_bedrock_custom_model_deployments_filter` — **present** case: creates a
  real on-demand custom model deployment (via a `create_custom_model_deployment`
  pytest fixture that records its own create/poll/delete calls) on a fine-tuned
  Llama 3.3 70B model, asserts the filter matches with an `Active` deployment.
- `test_bedrock_custom_model_orphaned` — the issue's use case: `deployments`
  **absent** AND `provisioned-throughputs` **absent** against an orphaned model.
- Schema-validation tests for both filters.

Note: these two behavioral tests run in `us-west-2` (where the fixture custom
models exist) rather than the file's usual `us-east-1`.

## Deferred

- **`provisioned-throughputs` present case is not yet tested live** — it
  requires purchasing a provisioned throughput, which is gated on a
  (currently-zero, adjustable) model-units service quota. The filter itself is
  implemented and its absent case is covered; the present-case recording will
  be added once quota is granted.
