### PR TITLE
aws - memorydb - Adding db-parameter filter and parameter-group resource

### DIFF
--- a/c7n/resources/memorydb.py
+++ b/c7n/resources/memorydb.py
@@ -1,8 +1,11 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+import itertools
+
 import c7n.filters.vpc as net_filters
 from c7n.actions import BaseAction
+from c7n.filters import ValueFilter
 from c7n.filters.kms import KmsRelatedFilter
 from c7n.manager import resources
 from c7n.query import (
@@ -221,6 +224,73 @@ class KmsFilter(KmsRelatedFilter):
     RelatedIdsExpression = 'KmsKeyId'
 
 
+@MemoryDb.filter_registry.register('db-parameter')
+class MemoryDbParameterFilter(ValueFilter):
+    """Applies value type filter on set memorydb cluster parameter values.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: memorydb-approved-maxmemory-policy
+                resource: aws.memorydb
+                filters:
+                  - type: db-parameter
+                    key: maxmemory-policy
+                    op: in
+                    value: ["volatile-lru", "allkeys-lru"]
+    """
+
+    schema = type_schema('db-parameter', rinherit=ValueFilter.schema)
+    schema_alias = False
+    permissions = ('memorydb:DescribeClusters', 'memorydb:DescribeParameters',)
+    policy_annotation = 'c7n:MatchedDBParameter'
+
+    @staticmethod
+    def recast(val, datatype):
+        # memorydb reports parameters as string or integer datatypes
+        if datatype == 'integer' and val.isdigit():
+            return int(val)
+        return val
+
+    def handle_paramgroup_cache(self, param_groups):
+        pgcache = {}
+        cache = self.manager._cache
+        client = local_session(self.manager.session_factory).client('memorydb')
+
+        with cache:
+            for pg in sorted(param_groups):
+                cache_key = {
+                    'region': self.manager.config.region,
+                    'account_id': self.manager.config.account_id,
+                    'memorydb-pg': pg}
+                pg_values = cache.get(cache_key)
+                if pg_values is not None:
+                    pgcache[pg] = pg_values
+                    continue
+                paginator = client.get_paginator('describe_parameters')
+                param_list = list(itertools.chain(*[p['Parameters']
+                    for p in paginator.paginate(ParameterGroupName=pg)]))
+                pgcache[pg] = {
+                    p['Name']: self.recast(p['Value'], p['DataType'])
+                    for p in param_list if 'Value' in p}
+                cache.save(cache_key, pgcache[pg])
+        return pgcache
+
+    def process(self, resources, event=None):
+        results = []
+        parameter_group_list = {r['ParameterGroupName'] for r in resources}
+        paramcache = self.handle_paramgroup_cache(parameter_group_list)
+        for resource in resources:
+            pg_values = paramcache[resource['ParameterGroupName']]
+            if self.match(pg_values):
+                resource.setdefault(self.policy_annotation, []).append(
+                    self.data.get('key'))
+                results.append(resource)
+        return results
+
+
 @MemoryDb.filter_registry.register('security-group')
 class SecurityGroupFilter(net_filters.SecurityGroupFilter):
 
@@ -291,6 +361,25 @@ class MemoryDbSubnetGroup(QueryResourceManager):
         'describe': DescribeWithResourceTags,
         'config': ConfigSource
     }
+
+
+@resources.register('memorydb-parameter-group')
+class MemoryDbParameterGroup(QueryResourceManager):
+    """AWS MemoryDb Parameter Group"""
+
+    class resource_type(TypeInfo):
+        service = 'memorydb'
+        arn_type = 'parametergroup'
+        enum_spec = ('describe_parameter_groups',
+                     'ParameterGroups', None)
+        name = id = 'Name'
+        filter_name = 'ParameterGroupName'
+        filter_type = 'scalar'
+        cfn_type = 'AWS::MemoryDB::ParameterGroup'
+        universal_taggable = object()
+        permissions = ('memorydb:DescribeParameterGroups',)
+
+    source_mapping = {'describe': DescribeWithResourceTags}
 
 
 @MemoryDbSnapshot.action_registry.register('delete')

--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -234,6 +234,7 @@ ResourceMap = {
   "aws.memorydb-user": "c7n.resources.memorydb.MemoryDbUser",
   "aws.memorydb-acl": "c7n.resources.memorydb.MemoryDbAcl",
   "aws.memorydb-subnet-group": "c7n.resources.memorydb.MemoryDbSubnetGroup",
+  "aws.memorydb-parameter-group": "c7n.resources.memorydb.MemoryDbParameterGroup",
   "aws.message-broker": "c7n.resources.mq.MessageBroker",
   "aws.message-config": "c7n.resources.mq.MessageConfig",
   "aws.mirror-session": "c7n.resources.vpc.TrafficMirrorSession",

--- a/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.DescribeClusters_1.json
+++ b/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.DescribeClusters_1.json
@@ -1,0 +1,54 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "Name": "c7n-test-memorydb",
+                "Status": "available",
+                "NumberOfShards": 1,
+                "ClusterEndpoint": {
+                    "Address": "clustercfg.c7n-test-memorydb.qgcgte.memorydb.us-east-1.amazonaws.com",
+                    "Port": 6379
+                },
+                "NodeType": "db.t4g.small",
+                "EngineVersion": "7.1",
+                "EnginePatchVersion": "7.1.0",
+                "ParameterGroupName": "c7n-test-custom-params",
+                "ParameterGroupStatus": "in-sync",
+                "SubnetGroupName": "test-subnet",
+                "TLSEnabled": false,
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:cluster/c7n-test-memorydb",
+                "SnapshotRetentionLimit": 0,
+                "MaintenanceWindow": "sat:03:30-sat:04:30",
+                "SnapshotWindow": "04:30-05:30",
+                "ACLName": "open-access",
+                "AutoMinorVersionUpgrade": true,
+                "DataTiering": "false"
+            },
+            {
+                "Name": "test-cluster-default",
+                "Status": "available",
+                "NumberOfShards": 1,
+                "ClusterEndpoint": {
+                    "Address": "clustercfg.test-cluster-default.qgcgte.memorydb.us-east-1.amazonaws.com",
+                    "Port": 6379
+                },
+                "NodeType": "db.t4g.small",
+                "EngineVersion": "7.1",
+                "EnginePatchVersion": "7.1.0",
+                "ParameterGroupName": "default.memorydb-redis7",
+                "ParameterGroupStatus": "in-sync",
+                "SubnetGroupName": "test-subnet",
+                "TLSEnabled": true,
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:cluster/test-cluster-default",
+                "SnapshotRetentionLimit": 1,
+                "MaintenanceWindow": "mon:10:00-mon:11:00",
+                "SnapshotWindow": "07:30-08:30",
+                "ACLName": "open-access",
+                "AutoMinorVersionUpgrade": true,
+                "DataTiering": "false"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.DescribeParameters_1.json
+++ b/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.DescribeParameters_1.json
@@ -1,0 +1,32 @@
+{
+    "status_code": 200,
+    "data": {
+        "Parameters": [
+            {
+                "Name": "activedefrag",
+                "Value": "yes",
+                "Description": "Enabled active memory defragmentation",
+                "DataType": "string",
+                "AllowedValues": "yes,no",
+                "MinimumEngineVersion": "7.0.5"
+            },
+            {
+                "Name": "maxmemory-policy",
+                "Value": "volatile-lru",
+                "Description": "Max memory policy",
+                "DataType": "string",
+                "AllowedValues": "volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu,volatile-random,allkeys-random,volatile-ttl,noeviction",
+                "MinimumEngineVersion": "7.0.5"
+            },
+            {
+                "Name": "timeout",
+                "Value": "0",
+                "Description": "Close connection if client is idle for a given number of seconds, or never if 0",
+                "DataType": "integer",
+                "AllowedValues": "0,20-",
+                "MinimumEngineVersion": "7.0.5"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.DescribeParameters_2.json
+++ b/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.DescribeParameters_2.json
@@ -1,0 +1,32 @@
+{
+    "status_code": 200,
+    "data": {
+        "Parameters": [
+            {
+                "Name": "activedefrag",
+                "Value": "no",
+                "Description": "Enabled active memory defragmentation",
+                "DataType": "string",
+                "AllowedValues": "yes,no",
+                "MinimumEngineVersion": "7.0.5"
+            },
+            {
+                "Name": "maxmemory-policy",
+                "Value": "noeviction",
+                "Description": "Max memory policy",
+                "DataType": "string",
+                "AllowedValues": "volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu,volatile-random,allkeys-random,volatile-ttl,noeviction",
+                "MinimumEngineVersion": "7.0.5"
+            },
+            {
+                "Name": "timeout",
+                "Value": "0",
+                "Description": "Close connection if client is idle for a given number of seconds, or never if 0",
+                "DataType": "integer",
+                "AllowedValues": "0,20-",
+                "MinimumEngineVersion": "7.0.5"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.ListTags_1.json
+++ b/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.ListTags_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.ListTags_2.json
+++ b/tests/data/placebo/test_memorydb_db_parameter_filter/memory-db.ListTags_2.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_parameter_group/memory-db.DescribeParameterGroups_1.json
+++ b/tests/data/placebo/test_memorydb_parameter_group/memory-db.DescribeParameterGroups_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "ParameterGroups": [
+            {
+                "Name": "c7n-test-custom-params",
+                "Family": "memorydb_redis7",
+                "Description": "c7n db-parameter filter test",
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:parametergroup/c7n-test-custom-params"
+            },
+            {
+                "Name": "default.memorydb-redis7",
+                "Family": "memorydb_redis7",
+                "Description": "Default parameter group for memorydb_redis7",
+                "ARN": "arn:aws:memorydb:us-east-1:644160558196:parametergroup/default.memorydb-redis7"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_memorydb_parameter_group/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_memorydb_parameter_group/tagging.GetResources_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_memorydb.py
+++ b/tests/test_memorydb.py
@@ -212,6 +212,40 @@ class MemoryDbTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['Name'], 'test-cluster-2')
 
+    def test_memorydb_db_parameter_filter(self):
+        session_factory = self.replay_flight_data('test_memorydb_db_parameter_filter')
+        p = self.load_policy(
+            {
+                'name': 'memorydb-approved-maxmemory-policy',
+                'resource': 'memorydb',
+                'filters': [
+                    {
+                        'type': 'db-parameter',
+                        'key': 'maxmemory-policy',
+                        'op': 'in',
+                        'value': ['volatile-lru', 'allkeys-lru'],
+                    }
+                ],
+            }, session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['Name'], 'c7n-test-memorydb')
+        self.assertEqual(
+            resources[0]['c7n:MatchedDBParameter'], ['maxmemory-policy'])
+
+    def test_memorydb_parameter_group(self):
+        session_factory = self.replay_flight_data('test_memorydb_parameter_group')
+        p = self.load_policy(
+            {
+                'name': 'memorydb-param-group',
+                'resource': 'aws.memorydb-parameter-group',
+            }, session_factory=session_factory
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+        self.assertEqual(resources[0]['Name'], 'c7n-test-custom-params')
+
     def test_memorydb_snapshot(self):
         factory = self.replay_flight_data("test_memory_db_snapshot")
         p = self.load_policy({


### PR DESCRIPTION
 This PR adds parameter group support for MemoryDB, enabling policies that enforce custom parameter values on clusters (eviction policy, timeouts, etc).  It adds a `db-parameter` filter on `aws.memorydb` and a new `aws.memorydb-parameter-group` resource.