### PR TITLE
aws - mu - strip read-only fields from ConfigRule before PutConfigRule update

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -1820,6 +1820,24 @@ class ConfigRule(AWSEventBase):
     """
     client_service = 'config'
 
+    # Fields that AWS Config's DescribeConfigRules response includes for an
+    # existing rule, but that are output-only / system-managed and can be
+    # rejected by PutConfigRule if echoed back verbatim on an update, e.g.:
+    #
+    #   InvalidParameterValueException: AWS Config populates the
+    #   RuleEvaluationVisibility field for ServiceLinkedConfigRule. Try
+    #   again without populating the RuleEvaluationVisibility field.
+    #
+    # This has been observed for ordinary customer-owned CUSTOM_LAMBDA
+    # rules that use EvaluationModes, not just true service-linked rules,
+    # so we always strip these before merging our own params back in.
+    readonly_fields = (
+        'ConfigRuleArn',
+        'ConfigRuleId',
+        'CreatedBy',
+        'RuleEvaluationVisibility',
+    )
+
     def __repr__(self):
         return "<ConfigRule>"
 
@@ -1897,6 +1915,8 @@ class ConfigRule(AWSEventBase):
 
         if rule and self.delta(rule, params):
             log.debug("Updating config rule for %s" % self)
+            for f in self.readonly_fields:
+                rule.pop(f, None)
             rule.update(params)
             return LambdaRetry(self.client.put_config_rule, ConfigRule=rule)
         elif rule:

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -24,6 +24,7 @@ from c7n.mu import (
     get_exec_options,
     normalize_arn,
     BucketLambdaNotification,
+    ConfigRule,
     LambdaFunction,
     LambdaManager,
     PolicyLambda,
@@ -216,6 +217,67 @@ class PolicyLambdaProvision(Publish):
                                     'MessageType': 'ScheduledNotification'}],
                  'SourceIdentifier': 'arn:aws:lambda:us-east-1:644160558196:function:CloudCustodian'} # noqa
              })
+
+    def test_config_rule_update_strips_readonly_fields(self):
+        # Regression test: AWS Config's DescribeConfigRules response for an
+        # existing rule includes output-only / system-managed fields
+        # (ConfigRuleArn, ConfigRuleId, CreatedBy, RuleEvaluationVisibility)
+        # that PutConfigRule can reject if echoed back verbatim on update,
+        # even for an ordinary customer-owned CUSTOM_LAMBDA rule that
+        # happens to use EvaluationModes, e.g.:
+        #
+        #   InvalidParameterValueException: AWS Config populates the
+        #   RuleEvaluationVisibility field for ServiceLinkedConfigRule.
+        #   Try again without populating the RuleEvaluationVisibility
+        #   field.
+        #
+        # ConfigRule.add() previously did `rule.update(params)` and PUT
+        # the entire merged dict back, round-tripping those fields.
+        from c7n.resources.kinesis import KinesisStream
+        self.patch(KinesisStream.resource_type, 'config_type', None)
+
+        p = self.load_policy({
+            'name': 'configx',
+            'resource': 'aws.kinesis',
+            'mode': {
+                'schedule': 'Three_Hours',
+                'type': 'config-poll-rule'}})
+        mu_policy = PolicyLambda(p)
+        mu_policy.arn = "arn:aws:lambda:us-east-1:644160558196:function:CloudCustodian"
+
+        rule_mgr = ConfigRule(p.data['mode'], lambda: None)
+        rule_mgr._client = mock.MagicMock()
+
+        # A live rule as AWS Config would return it via DescribeConfigRules,
+        # including the read-only fields that must not be sent back.
+        existing_rule = {
+            'ConfigRuleName': 'custodian-configx',
+            'ConfigRuleArn': 'arn:aws:config:us-east-1:644160558196:config-rule/config-rule-abcdef',
+            'ConfigRuleId': 'config-rule-abcdef',
+            'ConfigRuleState': 'ACTIVE',
+            'CreatedBy': '',
+            'Description': 'stale description',
+            'Source': {
+                'Owner': 'CUSTOM_LAMBDA',
+                'SourceIdentifier': mu_policy.arn,
+                'SourceDetails': [{'EventSource': 'aws.config',
+                                    'MessageType': 'ScheduledNotification'}]},
+            'MaximumExecutionFrequency': 'Three_Hours',
+            'EvaluationModes': [{'Mode': 'DETECTIVE'}],
+            'RuleEvaluationVisibility': 'EXTERNAL',
+        }
+        rule_mgr.get = mock.MagicMock(return_value=dict(existing_rule))
+
+        rule_mgr.add(mu_policy, existing=True)
+
+        rule_mgr.client.put_config_rule.assert_called_once()
+        sent_rule = rule_mgr.client.put_config_rule.call_args.kwargs['ConfigRule']
+
+        for readonly_field in ConfigRule.readonly_fields:
+            self.assertNotIn(readonly_field, sent_rule)
+        self.assertEqual(sent_rule['ConfigRuleName'], 'custodian-configx')
+        # fields we do manage should still make it through
+        self.assertEqual(sent_rule['MaximumExecutionFrequency'], 'Three_Hours')
 
     def test_config_rule_evaluation(self):
         session_factory = self.replay_flight_data("test_config_rule_evaluate")


### PR DESCRIPTION
## Problem

`ConfigRule.add()` fails to redeploy/update existing custom Config rules that use `EvaluationModes`, with:

```
InvalidParameterValueException: AWS Config populates the RuleEvaluationVisibility
field for ServiceLinkedConfigRule. Try again without populating the
RuleEvaluationVisibility field.
```

This happens for ordinary customer-owned `CUSTOM_LAMBDA` rules deployed by Custodian itself — not true AWS service-linked rules — as long as the rule has `EvaluationModes` set (which `DescribeConfigRules` always returns once a rule has been evaluated in that mode).

## Root cause

```python
def add(self, func, existing):
    rule = self.get(func.name)
    params = self.get_rule_params(func)

    if rule and self.delta(rule, params):
        log.debug("Updating config rule for %s" % self)
        rule.update(params)
        return LambdaRetry(self.client.put_config_rule, ConfigRule=rule)
    ...
```

`rule` here is the *entire* live `DescribeConfigRules` response for the existing rule, including several output-only / system-managed fields: `ConfigRuleArn`, `ConfigRuleId`, `CreatedBy`, and `RuleEvaluationVisibility`. `rule.update(params)` merges our desired params into that dict, and the *whole thing* — including those read-only fields — gets PUT back verbatim.

This has always technically been a round-trip of fields the caller doesn't manage, but it only recently started causing hard failures because AWS Config tightened server-side validation of `RuleEvaluationVisibility` on `PutConfigRule`, rejecting it even though `DescribeConfigRules` still returns it. Since `RuleEvaluationVisibility` isn't referenced anywhere else in the c7n codebase (it's never intentionally read or set — only passively carried through this merge), stripping it (and the other read-only identity fields, to be safe against future validation changes) fixes the update path without any behavior change to what Custodian actually manages.

## Fix

In `ConfigRule.add()`, drop the known output-only fields from the fetched `rule` dict before merging in `params`:

```python
readonly_fields = (
    'ConfigRuleArn',
    'ConfigRuleId',
    'CreatedBy',
    'RuleEvaluationVisibility',
)
...
if rule and self.delta(rule, params):
    log.debug("Updating config rule for %s" % self)
    for f in self.readonly_fields:
        rule.pop(f, None)
    rule.update(params)
    return LambdaRetry(self.client.put_config_rule, ConfigRule=rule)
```

## Testing

Added `test_config_rule_update_strips_readonly_fields` in `tests/test_mu.py`, which builds a synthetic `DescribeConfigRules`-shaped existing rule (with `RuleEvaluationVisibility`, `EvaluationModes`, etc. present, matching what AWS Config actually returns for `EvaluationModes`-based rules) and asserts none of the read-only fields are present in the dict passed to `put_config_rule`, while fields Custodian does manage (`ConfigRuleName`, `MaximumExecutionFrequency`, etc.) still are.

Confirmed the new test fails against the unpatched code with the exact symptom (`ConfigRuleArn`/`RuleEvaluationVisibility` present in the outgoing payload) and passes after the fix. Full `tests/test_mu.py` suite passes.

## Impact

We hit this in production trying to redeploy/update ~2000+ existing AWS Config custom rules across accounts — every update attempt failed with the error above, even though the rules themselves were healthy and `ACTIVE`. The only workaround was deleting and recreating the rule (forcing the create path instead of the broken update path), which is disruptive at scale. This fix restores normal in-place updates.

## Related

- #10008 and #7539 are prior `c7n/mu.py` `ConfigRule` fixes for other AWS Config API tightening (`Scope` on periodic rules, Lambda state waiter) — same failure shape (silent AWS-side validation change breaking `PutConfigRule`), different field.
- #8193 (still open) adds explicit `EvaluationModes`/proactive support to `get_rule_params()`. It's the reason `RuleEvaluationVisibility` shows up in `DescribeConfigRules` in the first place, but it doesn't touch the `add()` update/merge path this PR fixes, so the two are complementary, not overlapping.