### PR TITLE
aws - iam-policy - detect list-form Action/Resource in has-allow-all

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1527,8 +1527,8 @@ class AllowAllIamPolicies(Filter):
             resource_val = [resource_val] if isinstance(resource_val, str) else resource_val
 
             if ('Condition' not in s and
-                    action == ['*'] and
-                    resource_val == ['*'] and
+                    action is not None and '*' in action and
+                    resource_val is not None and '*' in resource_val and
                     s.get('Effect') == "Allow"):
                 return True
         return False

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1519,14 +1519,17 @@ class AllowAllIamPolicies(Filter):
             statements = [statements]
 
         for s in statements:
+            # Action/Resource are valid as either a bare string ("*") or a
+            # list (["*"]); normalize to a list so both forms are detected.
+            action = s.get('Action')
+            action = [action] if isinstance(action, str) else action
+            resource_val = s.get('Resource')
+            resource_val = [resource_val] if isinstance(resource_val, str) else resource_val
+
             if ('Condition' not in s and
-                    'Action' in s and
-                    isinstance(s['Action'], str) and
-                    s['Action'] == "*" and
-                    'Resource' in s and
-                    isinstance(s['Resource'], str) and
-                    s['Resource'] == "*" and
-                    s['Effect'] == "Allow"):
+                    action == ['*'] and
+                    resource_val == ['*'] and
+                    s.get('Effect') == "Allow"):
                 return True
         return False
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1747,12 +1747,24 @@ class IamPolicy(BaseTest):
         })
         self.assertTrue(f.has_allow_all_policy(client, resource))
 
-        # list form with more than just "*": not a bare allow-all statement
+        # list form with extra entries alongside "*": still allow-all, since
+        # "*" in either list already grants access to everything regardless
+        # of the other (redundant) entries.
         client = get_policy_version({
             'Statement': [{
                 'Effect': 'Allow',
                 'Action': ['*'],
                 'Resource': ['*', 'arn:aws:s3:::some-bucket'],
+            }]
+        })
+        self.assertTrue(f.has_allow_all_policy(client, resource))
+
+        # list form without "*" in either list: not allow-all
+        client = get_policy_version({
+            'Statement': [{
+                'Effect': 'Allow',
+                'Action': ['s3:GetObject'],
+                'Resource': ['arn:aws:s3:::some-bucket'],
             }]
         })
         self.assertFalse(f.has_allow_all_policy(client, resource))

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -25,6 +25,7 @@ from c7n.resources.iam import (
     UserMfaDevice,
     UsedIamPolicies,
     UnusedIamPolicies,
+    AllowAllIamPolicies,
     UsedInstanceProfiles,
     UnusedInstanceProfiles,
     UsedIamRole,
@@ -1709,6 +1710,52 @@ class IamPolicy(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_iam_has_allow_all_policies_list_form(self):
+        # Regression test: Action/Resource are valid in IAM policy JSON as
+        # either a bare string ("*") or a single-element list (["*"]). The
+        # filter previously only matched the string form via
+        # isinstance(..., str), silently missing an equally common
+        # full-admin policy written with list syntax.
+        f = AllowAllIamPolicies(data={}, manager=None)
+        resource = {'Arn': 'arn:aws:iam::644160558196:policy/ListFormAdmin',
+                    'DefaultVersionId': 'v1'}
+
+        def get_policy_version(document):
+            client = mock.MagicMock()
+            client.get_policy_version.return_value = {
+                'PolicyVersion': {'Document': document}}
+            return client
+
+        # list-form Action/Resource: must be detected as allow-all
+        client = get_policy_version({
+            'Statement': [{
+                'Effect': 'Allow',
+                'Action': ['*'],
+                'Resource': ['*'],
+            }]
+        })
+        self.assertTrue(f.has_allow_all_policy(client, resource))
+
+        # mixed string/list form: must also be detected
+        client = get_policy_version({
+            'Statement': [{
+                'Effect': 'Allow',
+                'Action': '*',
+                'Resource': ['*'],
+            }]
+        })
+        self.assertTrue(f.has_allow_all_policy(client, resource))
+
+        # list form with more than just "*": not a bare allow-all statement
+        client = get_policy_version({
+            'Statement': [{
+                'Effect': 'Allow',
+                'Action': ['*'],
+                'Resource': ['*', 'arn:aws:s3:::some-bucket'],
+            }]
+        })
+        self.assertFalse(f.has_allow_all_policy(client, resource))
 
 
 @terraform('iam_user_group', teardown=terraform.TEARDOWN_IGNORE)


### PR DESCRIPTION
## Problem

The `has-allow-all` filter (`aws.iam-policy`) is meant to catch full-admin IAM
policy statements (`Action: "*"`, `Resource: "*"`, `Effect: "Allow"`, no
`Condition`), implementing CIS AWS check 1.24. It only matches the bare-string
form of `Action`/`Resource`:

```json
{"Effect": "Allow", "Action": "*", "Resource": "*"}
```

IAM policy JSON equally allows (and IAM console/many IaC tools commonly
generate) the list form:

```json
{"Effect": "Allow", "Action": ["*"], "Resource": ["*"]}
```

which `has-allow-all` silently misses entirely. A full-admin policy written
with list syntax passes the filter undetected, with no YAML-level
workaround (the filter takes no parameters, and the policy document isn't
persisted onto the resource for a fallback `value` filter).

## Root cause

```python
def has_allow_all_policy(self, client, resource):
    ...
    for s in statements:
        if ('Condition' not in s and
                'Action' in s and
                isinstance(s['Action'], str) and
                s['Action'] == "*" and
                'Resource' in s and
                isinstance(s['Resource'], str) and
                s['Resource'] == "*" and
                s['Effect'] == "Allow"):
            return True
    return False
```

`isinstance(s['Action'], str)` / `isinstance(s['Resource'], str)` only match
the string form. When a statement uses the list form, the `isinstance`
check is `False` and the whole condition short-circuits to `False`, so the
statement is never flagged.

## Fix

Normalize `Action`/`Resource` to a list before comparing, and match on
containment of `"*"` rather than exact equality to `["*"]`. This catches
both the string and list forms, and also catches list-form statements that
mix `"*"` with other (redundant) entries, e.g. `Resource: ["*",
"arn:aws:s3:::bucket"]` — since `"*"` already grants access to everything,
the extra entries don't narrow the statement, so it's still a bare
allow-all in effect:

```python
action = s.get('Action')
action = [action] if isinstance(action, str) else action
resource_val = s.get('Resource')
resource_val = [resource_val] if isinstance(resource_val, str) else resource_val

if ('Condition' not in s and
        action is not None and '*' in action and
        resource_val is not None and '*' in resource_val and
        s.get('Effect') == "Allow"):
    return True
```

## Testing

Added `test_iam_has_allow_all_policies_list_form` in `tests/test_iam.py`,
unit-testing `has_allow_all_policy()` directly (mocked IAM client) against:
- list-form `Action`/`Resource` (`["*"]`/`["*"]`) -> detected
- mixed string/list form (`Action: "*"`, `Resource: ["*"]`) -> detected
- list form with an extra entry alongside `"*"` (`Resource: ["*",
  "arn:..."]`) -> still detected, since `"*"` already grants access to
  everything
- list form with no `"*"` in either list -> not flagged

Confirmed the new tests fail against the unpatched code and pass after the
fix.

## Impact

Found while reviewing an internal auto-remediation policy that relies on
`has-allow-all` to catch and delete full-admin IAM policies in non-prod
accounts. Any full-admin policy authored with list-syntax `Action`/
`Resource` (the IAM console's own JSON editor produces this form for
multi-statement/generated policies) currently passes this filter
completely undetected, with no way to catch it via policy YAML alone.

## Related

Fixes #5136 (open since 2019, same repro as above).