### PR TITLE
gcp - loadbalancer-address - skip global addresses in set-labels action

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/actions/labels.py
+++ b/tools/c7n_gcp/c7n_gcp/actions/labels.py
@@ -74,8 +74,10 @@ class BaseLabelAction(MethodAction):
     @classmethod
     def register_resources(cls, registry, resource_class):
         if resource_class.resource_type.labels:
-            resource_class.action_registry.register('set-labels', SetLabelsAction)
-            resource_class.action_registry.register('mark-for-op', LabelDelayedAction)
+            if 'set-labels' not in resource_class.action_registry:
+                resource_class.action_registry.register('set-labels', SetLabelsAction)
+            if 'mark-for-op' not in resource_class.action_registry:
+                resource_class.action_registry.register('mark-for-op', LabelDelayedAction)
 
             resource_class.filter_registry.register('marked-for-op', LabelActionFilter)
 

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancer.py
@@ -3,7 +3,7 @@
 import re
 
 from c7n.utils import type_schema, local_session
-from c7n_gcp.actions import MethodAction
+from c7n_gcp.actions import MethodAction, SetLabelsAction
 from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo
 
@@ -91,6 +91,26 @@ class LoadBalancingAddressDelete(MethodAction):
             resources = [r for r in resources if 'region' in r]
 
         return resources
+
+
+@LoadBalancingAddress.action_registry.register('set-labels')
+class LoadBalancingAddressSetLabels(SetLabelsAction):
+
+    def process(self, resources):
+        missing_region = [r for r in resources if 'region' not in r]
+        if missing_region:
+            removed = ', '.join([r.get('name', '<unknown>') for r in missing_region])
+            self.log.warning(
+                "policy:%s action:%s skipped %d global addresses, use "
+                "gcp.loadbalancer-global-address to label them: %s",
+                self.manager.ctx.policy.name,
+                self.type,
+                len(missing_region),
+                removed,
+            )
+            resources = [r for r in resources if 'region' in r]
+
+        return super().process(resources)
 
 
 @resources.register('loadbalancer-url-map')

--- a/tools/c7n_gcp/tests/test_loadbalancer.py
+++ b/tools/c7n_gcp/tests/test_loadbalancer.py
@@ -95,6 +95,28 @@ class LoadBalancingAddressTest(BaseTest):
 
         self.assertEqual(len(result['items']["regions/{}".format(region)]['addresses']), 0)
 
+    def test_loadbalancer_address_set_labels_skips_global_addresses(self):
+        project_id = self.project_id
+        factory = self.replay_flight_data('lb-addresses-global-addresses',
+                                          project_id=project_id)
+        policy = self.load_policy(
+        {
+            'name': 'label-gcp-ip-addresses',
+            'resource': 'gcp.loadbalancer-address',
+            'filters': [{
+                'type': 'value',
+                'key': 'selfLink',
+                'op': 'regex',
+                'value': '.*/global/addresses/.*'}],
+            'actions': [{
+                'type': 'set-labels',
+                'labels': {'env': 'test'}}]
+        },
+        session_factory=factory)
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['name'], 'google-managed-services-default')
+
 
 class LoadBalancingUrlMapTest(BaseTest):
 


### PR DESCRIPTION
Fixes #10954. The aggregatedList enum returns both regional and global addresses, but parse_params only matches the regional selfLink shape, so set-labels crashed with an AttributeError whenever a global address was in the result set. Following the approach suggested in the issue, the labeling action now warns and skips global addresses, pointing at gcp.loadbalancer-global-address instead, same as the delete action already does for missing regions.