### PR TITLE
azure - tags - resolve resource lookups in tag values

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions/tagging.py
+++ b/tools/c7n_azure/c7n_azure/actions/tagging.py
@@ -39,6 +39,19 @@ class Tag(AzureBaseAction):
            - type: tag
              tag: Environment
              value: Test
+
+        - name: azure-tag-from-resource-attr
+          resource: azure.vm
+          description: |
+            Tag all existing virtual machines with values taken from the resource
+          actions:
+           - type: tag
+             tags:
+               Environment: Test
+               ResourceName:
+                type: resource
+                key: name
+                default-value: name_not_found
     """
 
     schema = utils.type_schema(
@@ -46,7 +59,10 @@ class Tag(AzureBaseAction):
         **{
             'value': Lookup.lookup_type({'type': 'string'}),
             'tag': Lookup.lookup_type({'type': 'string'}),
-            'tags': {'type': 'object'}
+            'tags': {
+                'type': 'object',
+                'additionalProperties': Lookup.lookup_type({'type': 'string'})
+            }
         }
     )
     schema_alias = True
@@ -71,7 +87,10 @@ class Tag(AzureBaseAction):
         return TagHelper.add_tags(self, resource, new_tags)
 
     def _get_tags(self, resource):
-        return self.data.get('tags') or {Lookup.extract(
+        tags = self.data.get('tags')
+        if tags:
+            return {k: Lookup.extract(v, resource) for k, v in tags.items()}
+        return {Lookup.extract(
             self.data.get('tag'), resource): Lookup.extract(self.data.get('value'), resource)}
 
 

--- a/tools/c7n_azure/tests_azure/test_actions_tag.py
+++ b/tools/c7n_azure/tests_azure/test_actions_tag.py
@@ -49,6 +49,21 @@ class ActionsTagTest(BaseTest):
             ]
         }, validate=True))
 
+        self.assertTrue(self.load_policy({
+            'name': 'test-tag-schema-validate',
+            'resource': 'azure.vm',
+            'actions': [
+                {'type': 'tag',
+                 'tags': {
+                     'tag1': 'value1',
+                     'tag2': {
+                         'type': 'resource',
+                         'key': 'name'
+                     }
+                 }},
+            ]
+        }, validate=True))
+
         with self.assertRaises(FilterValidationError):
             # Can't have both tags and tag/value
             self.load_policy(tools.get_policy([
@@ -177,5 +192,61 @@ class ActionsTagTest(BaseTest):
 
         expected_tags = self.existing_tags.copy()
         expected_tags.update({'tag1': 'value1', 'pre-existing-1': 'modified'})
+
+        self.assertEqual(tags, expected_tags)
+
+    @patch('c7n_azure.tags.TagHelper.update_resource_tags')
+    def test_add_or_update_tags_from_resource(self, update_resource_tags):
+        """Verifies values in the tags dictionary are resolved from the resource
+        rather than passed through as the raw lookup directive
+        """
+
+        action = self._get_action(
+            {
+                'tags': {
+                    'tag1': 'value1',
+                    'tag2': {
+                        'type': 'resource',
+                        'key': 'name'
+                    }
+                }
+            })
+
+        resource = tools.get_resource(self.existing_tags)
+
+        action.process([resource])
+
+        tags = tools.get_tags_parameter(update_resource_tags)
+
+        expected_tags = self.existing_tags.copy()
+        expected_tags.update({'tag1': 'value1', 'tag2': resource['name']})
+
+        self.assertEqual(tags, expected_tags)
+
+    @patch('c7n_azure.tags.TagHelper.update_resource_tags')
+    def test_add_or_update_tags_from_resource_default(self, update_resource_tags):
+        """Verifies values in the tags dictionary fall back to default-value
+        when the looked up key does not exist on the resource
+        """
+
+        action = self._get_action(
+            {
+                'tags': {
+                    'tag1': {
+                        'type': 'resource',
+                        'key': 'doesnotexist',
+                        'default-value': 'default_value'
+                    }
+                }
+            })
+
+        resource = tools.get_resource(self.existing_tags)
+
+        action.process([resource])
+
+        tags = tools.get_tags_parameter(update_resource_tags)
+
+        expected_tags = self.existing_tags.copy()
+        expected_tags.update({'tag1': 'default_value'})
 
         self.assertEqual(tags, expected_tags)


### PR DESCRIPTION
Closes #10953

### Problem

The Azure `tag` action declares `tags` as `{'type': 'object'}` with no constraint on the values, so a `Lookup` directive passed as a tag value **validates but is never resolved**. `_get_tags` returned `self.data.get('tags')` verbatim, so the raw dict was handed to the Azure SDK and stringified onto the resource.

The single `tag`/`value` form already calls `Lookup.extract`, so the two forms of the same action behaved inconsistently. Reproduced on `main`:

```
policy: {'tags': {'Owner': {'type': 'resource', 'key': 'name'}, 'Plain': 'literal'}}

before: {'Owner': {'type': 'resource', 'key': 'name'}, 'Plain': 'literal'}
after:  {'Owner': 'my-vm', 'Plain': 'literal'}
```

This fails silently rather than raising -- every resource the policy touches gets a tag whose value is the repr of the directive.

### Fix

Mirrors the equivalent GCP action (`c7n_gcp/actions/labels.py:130,138`), which already handles this correctly:

- schema: `'tags'` values constrained to `Lookup.lookup_type({'type': 'string'})`
- `_get_tags`: `{k: Lookup.extract(v, resource) for k, v in tags.items()}`

`Lookup.extract` passes non-dict values through unchanged, so plain string values and the existing `tag`/`value` form are unaffected.

### Tests

Two tests added to `tests_azure/test_actions_tag.py` (resource lookup, and `default-value` fallback when the key is absent), plus a schema-validation case. Both new tests **fail on unmodified `main`** with exactly the symptom above and pass with the change.

`test_actions_tag.py`: 7 passed. I also ran the wider `-k "tag or Tag"` selection across `tests_azure/` and diffed the FAILED/ERROR list against a clean tree -- identical, no regressions. (The pre-existing failures there are the live-credential functional tests and modules needing `pytest_terraform`.) `ruff check` clean on both files.

### One note for reviewers

Constraining the `tags` values is a deliberate tightening: previously *any* JSON value validated, so a policy using a non-string tag value (e.g. `tags: {foo: 123}`) would now fail validation instead of being stringified by the SDK. That matches GCP's `set-labels` and Azure's own tag-value semantics, but happy to relax it to `{'oneOf': [Lookup..., {}]}` if you would rather not change validation behaviour.