### PR TITLE
azure - webapp - add start and stop actions

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/web_app.py
+++ b/tools/c7n_azure/c7n_azure/resources/web_app.py
@@ -1,6 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
 
@@ -129,3 +130,65 @@ class AuthenticationFilter(ValueFilter):
             i['c7n:authentication'] = instance.serialize(keep_readonly=True)['properties']
 
         return super().__call__(i['c7n:authentication'])
+
+
+@WebApp.action_registry.register('stop')
+class WebAppStopAction(AzureBaseAction):
+    """Stop a web application
+
+    :example:
+
+    This policy will stop web apps outside of business hours.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: stop-webapps-offhours
+            resource: azure.webapp
+            filters:
+              - type: offhour
+                default_tz: pt
+                offhour: 18
+                tag: onoffhour_schedule
+            actions:
+              - type: stop
+    """
+
+    schema = type_schema('stop')
+
+    def _prepare_processing(self):
+        self.client = self.manager.get_client()
+
+    def _process_resource(self, resource):
+        self.client.web_apps.stop(resource['resourceGroup'], resource['name'])
+
+
+@WebApp.action_registry.register('start')
+class WebAppStartAction(AzureBaseAction):
+    """Start a web application
+
+    :example:
+
+    This policy will start web apps at the beginning of business hours.
+
+    .. code-block:: yaml
+
+        policies:
+          - name: start-webapps-onhours
+            resource: azure.webapp
+            filters:
+              - type: onhour
+                default_tz: pt
+                onhour: 8
+                tag: onoffhour_schedule
+            actions:
+              - type: start
+    """
+
+    schema = type_schema('start')
+
+    def _prepare_processing(self):
+        self.client = self.manager.get_client()
+
+    def _process_resource(self, resource):
+        self.client.web_apps.start(resource['resourceGroup'], resource['name'])

--- a/tools/c7n_azure/tests_azure/tests_resources/test_webapp.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_webapp.py
@@ -1,6 +1,11 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from ..azure_common import BaseTest, arm_template
+from unittest.mock import patch
+
+from ..azure_common import BaseTest, arm_template, cassette_name
+from c7n_azure.session import Session
+
+from c7n.utils import local_session
 
 
 class WebAppTest(BaseTest):
@@ -13,6 +18,20 @@ class WebAppTest(BaseTest):
             p = self.load_policy({
                 'name': 'test-azure-webapp',
                 'resource': 'azure.webapp'
+            }, validate=True)
+
+            self.assertTrue(p)
+
+    def test_validate_webapp_action_schemas(self):
+        with self.sign_out_patch():
+
+            p = self.load_policy({
+                'name': 'test-azure-webapp',
+                'resource': 'azure.webapp',
+                'actions': [
+                    {'type': 'stop'},
+                    {'type': 'start'},
+                ]
             }, validate=True)
 
             self.assertTrue(p)
@@ -79,3 +98,54 @@ class WebAppTest(BaseTest):
         })
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    @arm_template('webapp.json')
+    @cassette_name('test_find_by_name')
+    def test_stop(self):
+        with patch(self._get_webapp_client_string() + '.stop') as stop_action_mock:
+            p = self.load_policy({
+                'name': 'test-azure-webapp',
+                'resource': 'azure.webapp',
+                'filters': [
+                    {'type': 'value',
+                     'key': 'name',
+                     'op': 'glob',
+                     'value_type': 'normalize',
+                     'value': 'cctestwebapp*'}],
+                'actions': [
+                    {'type': 'stop'}
+                ]
+            })
+            resources = p.run()
+            self.assertEqual(len(resources), 1)
+            stop_action_mock.assert_called_with(
+                resources[0]['resourceGroup'],
+                resources[0]['name'])
+
+    @arm_template('webapp.json')
+    @cassette_name('test_find_by_name')
+    def test_start(self):
+        with patch(self._get_webapp_client_string() + '.start') as start_action_mock:
+            p = self.load_policy({
+                'name': 'test-azure-webapp',
+                'resource': 'azure.webapp',
+                'filters': [
+                    {'type': 'value',
+                     'key': 'name',
+                     'op': 'glob',
+                     'value_type': 'normalize',
+                     'value': 'cctestwebapp*'}],
+                'actions': [
+                    {'type': 'start'}
+                ]
+            })
+            resources = p.run()
+            self.assertEqual(len(resources), 1)
+            start_action_mock.assert_called_with(
+                resources[0]['resourceGroup'],
+                resources[0]['name'])
+
+    def _get_webapp_client_string(self):
+        client = local_session(Session)\
+            .client('azure.mgmt.web.WebSiteManagementClient').web_apps
+        return client.__module__ + '.' + client.__class__.__name__


### PR DESCRIPTION
Closes #6577.

`azure.webapp` supports the `onhour` / `offhour` filters, but the resource had no actions registered, so a schedule could match an app and then do nothing with it. This adds `start` and `stop`.

### Implementation
Both actions follow the existing `azure.vm` pattern (`VmStartAction` / `VmStopAction`) and call the corresponding `WebSiteManagementClient.web_apps` operations:

- `stop` -> `web_apps.stop(resource_group_name, name)`
- `start` -> `web_apps.start(resource_group_name, name)`

These are synchronous operations in `azure-mgmt-web` (no `begin_` prefix / LRO poller), so the calls are made directly.

### Example

```yaml
policies:
  - name: stop-webapps-offhours
    resource: azure.webapp
    filters:
      - type: offhour
        default_tz: pt
        offhour: 18
        tag: onoffhour_schedule
    actions:
      - type: stop
```

### Tests
Added to `WebAppTest`:

- `test_validate_webapp_action_schemas` — schema validation for both actions
- `test_stop` / `test_start` — patch the SDK operation and assert it is called with the resource group and name, replaying the existing `WebAppTest.test_find_by_name` cassette

No new cassettes or ARM templates were required. `tests_azure/tests_resources/test_webapp.py` passes 7/7, and `ruff` is clean.