### PR TITLE
aws - kms - skip keys where GetKeyPolicy returns AccessDeniedException

### DIFF
--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -231,8 +231,15 @@ class KMSCrossAccountAccessFilter(CrossAccountAccessFilter):
         def _augment(r):
             key_id = r.get('TargetKeyId', r.get('KeyId'))
             assert key_id, "Invalid key resources %s" % r
-            r['Policy'] = client.get_key_policy(
-                KeyId=key_id, PolicyName='default')['Policy']
+            try:
+                r['Policy'] = client.get_key_policy(
+                    KeyId=key_id, PolicyName='default')['Policy']
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AccessDeniedException':
+                    self.log.warning(
+                        "Access denied when getting policy on key:%s", key_id)
+                    return None
+                raise
             return r
 
         self.log.debug("fetching policy for %d kms keys" % len(resources))

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -973,6 +973,61 @@ class KMSCrossAccount(BaseTest):
             KeyId="denied-key-id", PolicyName="default"
         )
 
+    def test_kms_cross_account_access_denied_does_not_suppress_batch(self):
+        # One denied key must not silently drop the remaining keys in the same
+        # batch.  On main, list() consumed the generator and the second key was
+        # never reached when the first raised.
+        from unittest import mock
+        from botocore.exceptions import ClientError
+        from c7n.resources import kms as kms_module
+
+        self.patch(CrossAccountAccessFilter, "executor_factory", MainThreadExecutor)
+        p = self.load_policy(
+            {
+                "name": "kms-cross-access-denied-batch",
+                "resource": "kms-key",
+                "filters": ["cross-account"],
+            }
+        )
+        f = p.resource_manager.filters[0]
+
+        denied_key = {
+            "KeyId": "denied-key-id",
+            "KeyArn": "arn:aws:kms:us-east-1:123456789012:key/denied",
+        }
+        readable_key = {
+            "KeyId": "readable-key-id",
+            "KeyArn": "arn:aws:kms:us-east-1:123456789012:key/readable",
+        }
+        cross_account_policy = json.dumps({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "kms:*",
+                "Resource": "*",
+            }],
+        })
+        access_denied = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Access Denied"}},
+            "GetKeyPolicy",
+        )
+        mock_client = mock.MagicMock()
+        mock_client.get_key_policy.side_effect = [
+            access_denied,
+            {"Policy": cross_account_policy},
+        ]
+
+        with mock.patch.object(kms_module, "local_session") as ls:
+            ls.return_value.client.return_value = mock_client
+            results = f.process([denied_key, readable_key])
+
+        # Both keys were attempted — the denial did not short-circuit the batch.
+        self.assertEqual(mock_client.get_key_policy.call_count, 2)
+        # Denied key is dropped; readable key has cross-account access so it is returned.
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["KeyId"], "readable-key-id")
+
     def test_kms_cross_account_other_error_reraises(self):
         # Non-AccessDenied ClientErrors must still propagate (issue #10962).
         from unittest import mock

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -941,6 +941,65 @@ class KMSCrossAccount(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["KeyId"], key_info["KeyId"])
 
+    def test_kms_cross_account_access_denied_skipped(self):
+        # A single key that raises AccessDeniedException must be silently
+        # skipped; the rest of the scan must continue (issue #10962).
+        from unittest import mock
+        from botocore.exceptions import ClientError
+        from c7n.resources import kms as kms_module
+
+        self.patch(CrossAccountAccessFilter, "executor_factory", MainThreadExecutor)
+        p = self.load_policy(
+            {
+                "name": "kms-cross-access-denied",
+                "resource": "kms-key",
+                "filters": ["cross-account"],
+            }
+        )
+        f = p.resource_manager.filters[0]
+
+        denied_key = {"KeyId": "denied-key-id", "KeyArn": "arn:aws:kms:us-east-1:123:key/denied"}
+        mock_client = mock.MagicMock()
+        mock_client.get_key_policy.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Access Denied"}},
+            "GetKeyPolicy",
+        )
+        with mock.patch.object(kms_module, "local_session") as ls:
+            ls.return_value.client.return_value = mock_client
+            results = f.process([denied_key])
+
+        self.assertEqual(results, [])
+        mock_client.get_key_policy.assert_called_once_with(
+            KeyId="denied-key-id", PolicyName="default"
+        )
+
+    def test_kms_cross_account_other_error_reraises(self):
+        # Non-AccessDenied ClientErrors must still propagate (issue #10962).
+        from unittest import mock
+        from botocore.exceptions import ClientError
+        from c7n.resources import kms as kms_module
+
+        self.patch(CrossAccountAccessFilter, "executor_factory", MainThreadExecutor)
+        p = self.load_policy(
+            {
+                "name": "kms-cross-other-error",
+                "resource": "kms-key",
+                "filters": ["cross-account"],
+            }
+        )
+        f = p.resource_manager.filters[0]
+
+        bad_key = {"KeyId": "some-key-id", "KeyArn": "arn:aws:kms:us-east-1:123:key/some"}
+        mock_client = mock.MagicMock()
+        mock_client.get_key_policy.side_effect = ClientError(
+            {"Error": {"Code": "InternalFailure", "Message": "Something broke"}},
+            "GetKeyPolicy",
+        )
+        with mock.patch.object(kms_module, "local_session") as ls:
+            ls.return_value.client.return_value = mock_client
+            with self.assertRaises(ClientError):
+                f.process([bad_key])
+
 
 class KMSMotoTests(BaseTest):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

`KMSCrossAccountAccessFilter` fetches every key policy inside an executor with no exception handling:

```python
def _augment(r):
    key_id = r.get('TargetKeyId', r.get('KeyId'))
    r['Policy'] = client.get_key_policy(KeyId=key_id, PolicyName='default')['Policy']
    return r

with self.executor_factory(max_workers=1) as w:
    resources = list(filter(None, w.map(_augment, resources)))
```

A single key that returns `AccessDeniedException` (e.g. a key in an external account, a service-managed key, or a key with a restrictive resource policy) causes the exception to propagate out of `w.map`, terminating the entire scan for that account and region. No `resources.json` is written, so the account looks identical to one with no findings.

Fixes #10962.

## Fix

Wrap `get_key_policy` in a `try/except ClientError`, matching the identical pattern already used by the rotation-status and describe-key augmenters in `kms.py`:

- `AccessDeniedException` → log a warning and return `None` (dropped by the existing `filter(None, ...)`)
- Any other `ClientError` → re-raise unchanged

## Changes

**`c7n/resources/kms.py`** — `KMSCrossAccountAccessFilter._augment`

```python
try:
    r['Policy'] = client.get_key_policy(
        KeyId=key_id, PolicyName='default')['Policy']
except ClientError as e:
    if e.response['Error']['Code'] == 'AccessDeniedException':
        self.log.warning(
            "Access denied when getting policy on key:%s", key_id)
        return None
    raise
return r
```

**`tests/test_kms.py`** — two new tests in `KMSCrossAccount`:

- `test_kms_cross_account_access_denied_skipped` — mocks `get_key_policy` to raise `AccessDeniedException`; asserts no exception is raised and result list is empty
- `test_kms_cross_account_other_error_reraises` — mocks a non-`AccessDeniedException` `ClientError`; asserts it still propagates

All 29 existing KMS tests pass.