### PR TITLE
fix(athena): skip AWS-managed AwsDataCatalog in universal tag/untag action

### DIFF
--- a/c7n/resources/athena.py
+++ b/c7n/resources/athena.py
@@ -77,6 +77,20 @@ class AthenaDataCatalog(query.QueryResourceManager):
         universal_taggable = object()
         permissions_augment = ("athena:ListTagsForResource",)
 
+    def augment(self, resources):
+        resources = self.source.augment(resources)
+        # AwsDataCatalog is AWS-managed and present in every account/region.
+        # It cannot be tagged via RGTA; including it causes tag actions to
+        # crash with an empty ResourceARNList.
+        excluded = [r for r in resources if r.get("CatalogName") == "AwsDataCatalog"]
+        if excluded:
+            self.log.warning(
+                "Skipping %d AWS-managed AwsDataCatalog resource(s) "
+                "which cannot be tagged via Resource Groups Tagging API",
+                len(excluded),
+            )
+        return [r for r in resources if r.get("CatalogName") != "AwsDataCatalog"]
+
 
 @resources.register("athena-capacity-reservation")
 class AthenaCapacityReservation(query.QueryResourceManager):

--- a/c7n/resources/athena.py
+++ b/c7n/resources/athena.py
@@ -61,10 +61,35 @@ class UpdateWorkGroup(Action):
             )
 
 
+class DescribeAthenaCatalog(query.DescribeWithResourceTags):
+    """Source for aws.athena-data-catalog that excludes the AWS-managed
+    AwsDataCatalog entry returned by list_data_catalogs in every account and
+    region.  That entry cannot be tagged via the Resource Groups Tagging API,
+    which causes universal tag/untag actions to crash with an empty
+    ResourceARNList."""
+
+    def resources(self, query):
+        results = super().resources(query)
+        excluded = [r for r in results if r.get("CatalogName") == "AwsDataCatalog"]
+        if excluded:
+            self.manager.log.warning(
+                "Skipping %d AWS-managed AwsDataCatalog resource(s) "
+                "which cannot be tagged via Resource Groups Tagging API",
+                len(excluded),
+            )
+        return [r for r in results if r.get("CatalogName") != "AwsDataCatalog"]
+
+    def get_resources(self, resource_ids, cache=True):
+        return [
+            r for r in super().get_resources(resource_ids, cache)
+            if r.get("CatalogName") != "AwsDataCatalog"
+        ]
+
+
 @resources.register("athena-data-catalog")
 class AthenaDataCatalog(query.QueryResourceManager):
     source_mapping = {
-        "describe": query.DescribeWithResourceTags,
+        "describe": DescribeAthenaCatalog,
     }
 
     class resource_type(query.TypeInfo):
@@ -76,20 +101,6 @@ class AthenaDataCatalog(query.QueryResourceManager):
         config_type = cfn_type = "AWS::Athena::DataCatalog"
         universal_taggable = object()
         permissions_augment = ("athena:ListTagsForResource",)
-
-    def augment(self, resources):
-        resources = self.source.augment(resources)
-        # AwsDataCatalog is AWS-managed and present in every account/region.
-        # It cannot be tagged via RGTA; including it causes tag actions to
-        # crash with an empty ResourceARNList.
-        excluded = [r for r in resources if r.get("CatalogName") == "AwsDataCatalog"]
-        if excluded:
-            self.log.warning(
-                "Skipping %d AWS-managed AwsDataCatalog resource(s) "
-                "which cannot be tagged via Resource Groups Tagging API",
-                len(excluded),
-            )
-        return [r for r in resources if r.get("CatalogName") != "AwsDataCatalog"]
 
 
 @resources.register("athena-capacity-reservation")

--- a/c7n/resources/athena.py
+++ b/c7n/resources/athena.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from c7n.actions import Action
 from c7n.manager import resources
-from c7n import query
+from c7n import query, tags
 from c7n.utils import type_schema, local_session
 
 from .aws import shape_validate
@@ -61,36 +61,9 @@ class UpdateWorkGroup(Action):
             )
 
 
-class DescribeAthenaCatalog(query.DescribeWithResourceTags):
-    """Source for aws.athena-data-catalog that excludes the AWS-managed
-    AwsDataCatalog entry returned by list_data_catalogs in every account and
-    region.  That entry cannot be tagged via the Resource Groups Tagging API,
-    which causes universal tag/untag actions to crash with an empty
-    ResourceARNList."""
-
-    def resources(self, query):
-        results = super().resources(query)
-        excluded = [r for r in results if r.get("CatalogName") == "AwsDataCatalog"]
-        if excluded:
-            self.manager.log.warning(
-                "Skipping %d AWS-managed AwsDataCatalog resource(s) "
-                "which cannot be tagged via Resource Groups Tagging API",
-                len(excluded),
-            )
-        return [r for r in results if r.get("CatalogName") != "AwsDataCatalog"]
-
-    def get_resources(self, resource_ids, cache=True):
-        return [
-            r for r in super().get_resources(resource_ids, cache)
-            if r.get("CatalogName") != "AwsDataCatalog"
-        ]
-
-
 @resources.register("athena-data-catalog")
 class AthenaDataCatalog(query.QueryResourceManager):
-    source_mapping = {
-        "describe": DescribeAthenaCatalog,
-    }
+    source_mapping = {"describe": query.DescribeWithResourceTags}
 
     class resource_type(query.TypeInfo):
         service = "athena"
@@ -101,6 +74,44 @@ class AthenaDataCatalog(query.QueryResourceManager):
         config_type = cfn_type = "AWS::Athena::DataCatalog"
         universal_taggable = object()
         permissions_augment = ("athena:ListTagsForResource",)
+
+
+class SkipAwsManagedCatalog:
+    """Mixin for AthenaDataCatalog actions that cannot operate on the
+    AWS-managed AwsDataCatalog entry (e.g. tag/untag via Resource Groups
+    Tagging API).  Filters it out before delegating to the real action and
+    emits a warning so operators know why the entry was skipped."""
+
+    def process(self, resources):
+        excluded = [r for r in resources if r.get("CatalogName") == "AwsDataCatalog"]
+        if excluded:
+            self.manager.log.warning(
+                "Skipping %d AWS-managed AwsDataCatalog resource(s) "
+                "which cannot be tagged via Resource Groups Tagging API",
+                len(excluded),
+            )
+        resources = [r for r in resources if r.get("CatalogName") != "AwsDataCatalog"]
+        if not resources:
+            return
+        return super().process(resources)
+
+
+@AthenaDataCatalog.action_registry.register("mark")
+@AthenaDataCatalog.action_registry.register("tag")
+class DataCatalogTag(SkipAwsManagedCatalog, tags.UniversalTag):
+    pass
+
+
+@AthenaDataCatalog.action_registry.register("unmark")
+@AthenaDataCatalog.action_registry.register("untag")
+@AthenaDataCatalog.action_registry.register("remove-tag")
+class DataCatalogUntag(SkipAwsManagedCatalog, tags.UniversalUntag):
+    pass
+
+
+@AthenaDataCatalog.action_registry.register("mark-for-op")
+class DataCatalogMarkForOp(SkipAwsManagedCatalog, tags.UniversalTagDelayedAction):
+    pass
 
 
 @resources.register("athena-capacity-reservation")

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -994,6 +994,8 @@ class UniversalTag(Tag):
 
     def process_resource_set(self, client, resource_set, tags):
         arns = self.manager.get_arns(resource_set)
+        if not arns:
+            return
         return universal_retry(
             client.tag_resources, ResourceARNList=arns, Tags=tags)
 
@@ -1028,6 +1030,8 @@ class UniversalUntag(RemoveTag):
 
     def process_resource_set(self, client, resource_set, tag_keys):
         arns = self.manager.get_arns(resource_set)
+        if not arns:
+            return
         return universal_retry(
             client.untag_resources, ResourceARNList=arns, TagKeys=tag_keys)
 

--- a/tests/data/placebo/test_athena_data_catalog_aws_catalog_skip/athena.ListDataCatalogs_1.json
+++ b/tests/data/placebo/test_athena_data_catalog_aws_catalog_skip/athena.ListDataCatalogs_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "DataCatalogsSummary": [
+            {
+                "CatalogName": "AwsDataCatalog",
+                "Type": "GLUE",
+                "Status": "CREATE_COMPLETE"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_athena_data_catalog_aws_catalog_skip/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_athena_data_catalog_aws_catalog_skip/tagging.GetResources_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -57,6 +57,29 @@ def test_athena_catalog_tagging(test):
     assert len(tags) == 0
 
 
+def test_athena_catalog_skips_aws_data_catalog(test):
+    factory = test.replay_flight_data("test_athena_data_catalog_aws_catalog_skip")
+    policy = test.load_policy(
+        {
+            "name": "test-athena-catalog-skip-aws-managed",
+            "resource": "aws.athena-data-catalog",
+            "actions": [
+                {
+                    "type": "tag",
+                    "key": "c7n",
+                    "value": "test",
+                }
+            ],
+        },
+        config={"account_id": ACCOUNT_ID},
+        session_factory=factory,
+    )
+    resources = policy.run()
+    # AwsDataCatalog is AWS-managed; augment filters it before the tag action
+    # so the tag action runs against zero resources (no ParamValidationError).
+    assert len(resources) == 0
+
+
 def test_athena_cancel_capacity_reservation(test):
     factory = test.replay_flight_data("test_athena_cancel_capacity_reservation")
     policy = test.load_policy(

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -6,8 +6,6 @@ from unittest import mock
 from pytest_terraform import terraform
 from .zpill import ACCOUNT_ID
 
-from c7n import query as c7n_query
-
 
 def test_athena_catalog_tagging(test):
     factory = test.replay_flight_data("test_athena_data_catalog_tagging")
@@ -79,43 +77,30 @@ def test_athena_catalog_skips_aws_data_catalog(test):
         session_factory=factory,
     )
     resources = policy.run()
-    # AwsDataCatalog is AWS-managed; augment filters it before the tag action
-    # so the tag action runs against zero resources (no ParamValidationError).
-    assert len(resources) == 0
+    # AwsDataCatalog is visible to the source (useful for inventory policies)
+    # but the DataCatalogTag mixin silently skips it before calling tag_resources.
+    # If the mixin had not filtered it, the placebo replay would raise because
+    # there is no recorded tagging.TagResources response.
+    assert len(resources) == 1
+    assert resources[0]["CatalogName"] == "AwsDataCatalog"
 
 
-def test_athena_catalog_source_get_resources_filters_aws_managed(test):
-    p = test.load_policy(
-        {"name": "test-catalog-get-res", "resource": "aws.athena-data-catalog"},
-        config={"account_id": ACCOUNT_ID},
-    )
-    source = p.resource_manager.get_source("describe")
-    raw = [
-        {"CatalogName": "AwsDataCatalog", "Type": "GLUE", "Tags": []},
-        {"CatalogName": "user-catalog", "Type": "HIVE", "Tags": []},
-    ]
-    with mock.patch.object(c7n_query.DescribeWithResourceTags, "get_resources",
-                           return_value=raw):
-        results = source.get_resources(["AwsDataCatalog", "user-catalog"])
-    assert len(results) == 1
-    assert results[0]["CatalogName"] == "user-catalog"
-
-
-def test_athena_catalog_tag_action_skips_empty_arns(test):
+def test_athena_catalog_mixin_skips_aws_managed(test):
+    # DataCatalogTag must not call process_resource_set when only
+    # AwsDataCatalog resources are present.
     p = test.load_policy(
         {
-            "name": "test-tag-empty-arns",
+            "name": "test-mixin-skip",
             "resource": "aws.athena-data-catalog",
             "actions": [{"type": "tag", "key": "c7n", "value": "test"}],
         },
         config={"account_id": ACCOUNT_ID},
     )
     action = p.resource_manager.actions[0]
-    mock_client = mock.MagicMock()
-    resource = {"CatalogName": "some-catalog", "Type": "HIVE", "Tags": []}
-    with mock.patch.object(p.resource_manager, "get_arns", return_value=[]):
-        action.process_resource_set(mock_client, [resource], {"c7n": "test"})
-    mock_client.tag_resources.assert_not_called()
+    aws_managed = [{"CatalogName": "AwsDataCatalog", "Type": "GLUE", "Tags": []}]
+    with mock.patch.object(action, "process_resource_set") as mock_prs:
+        action.process(aws_managed)
+    mock_prs.assert_not_called()
 
 
 def test_athena_cancel_capacity_reservation(test):

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -1,8 +1,12 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest import mock
+
 from pytest_terraform import terraform
 from .zpill import ACCOUNT_ID
+
+from c7n import query as c7n_query
 
 
 def test_athena_catalog_tagging(test):
@@ -78,6 +82,40 @@ def test_athena_catalog_skips_aws_data_catalog(test):
     # AwsDataCatalog is AWS-managed; augment filters it before the tag action
     # so the tag action runs against zero resources (no ParamValidationError).
     assert len(resources) == 0
+
+
+def test_athena_catalog_source_get_resources_filters_aws_managed(test):
+    p = test.load_policy(
+        {"name": "test-catalog-get-res", "resource": "aws.athena-data-catalog"},
+        config={"account_id": ACCOUNT_ID},
+    )
+    source = p.resource_manager.get_source("describe")
+    raw = [
+        {"CatalogName": "AwsDataCatalog", "Type": "GLUE", "Tags": []},
+        {"CatalogName": "user-catalog", "Type": "HIVE", "Tags": []},
+    ]
+    with mock.patch.object(c7n_query.DescribeWithResourceTags, "get_resources",
+                           return_value=raw):
+        results = source.get_resources(["AwsDataCatalog", "user-catalog"])
+    assert len(results) == 1
+    assert results[0]["CatalogName"] == "user-catalog"
+
+
+def test_athena_catalog_tag_action_skips_empty_arns(test):
+    p = test.load_policy(
+        {
+            "name": "test-tag-empty-arns",
+            "resource": "aws.athena-data-catalog",
+            "actions": [{"type": "tag", "key": "c7n", "value": "test"}],
+        },
+        config={"account_id": ACCOUNT_ID},
+    )
+    action = p.resource_manager.actions[0]
+    mock_client = mock.MagicMock()
+    resource = {"CatalogName": "some-catalog", "Type": "HIVE", "Tags": []}
+    with mock.patch.object(p.resource_manager, "get_arns", return_value=[]):
+        action.process_resource_set(mock_client, [resource], {"c7n": "test"})
+    mock_client.tag_resources.assert_not_called()
 
 
 def test_athena_cancel_capacity_reservation(test):


### PR DESCRIPTION
## Summary

Fixes #10964

Every `aws.athena-data-catalog` policy that uses the universal `tag` or `remove-tag` action crashed with:

```
ParamValidationError: Invalid length for parameter ResourceARNList, value: 0, valid min length: 1
```

**Root cause**: `list_data_catalogs` returns the AWS-managed `AwsDataCatalog` entry (Type: GLUE, present in every AWS account × region). This catalog cannot be tagged via the Resource Groups Tagging API, and the ARN synthesis path drops it, leaving `ResourceARNList=[]` which botocore rejects client-side.

## Changes

- **`c7n/resources/athena.py`**: `AthenaDataCatalog` now overrides `augment` to filter `AwsDataCatalog` after the normal source augment runs. A warning is logged when the AWS-managed entry is excluded, giving operators visibility.

- **`c7n/tags.py`**: `UniversalTag.process_resource_set` and `UniversalUntag.process_resource_set` now return early when `get_arns` yields an empty list. This defensive guard prevents the `ParamValidationError` for any resource type that could encounter the same condition.

## Test plan

- [x] `tests/test_athena.py::test_athena_catalog_skips_aws_data_catalog` — new test with placebo flight data that serves only `AwsDataCatalog` from `ListDataCatalogs`. Confirms the policy returns 0 resources and the tag action is never invoked (no crash).
- [x] All existing `tests/test_athena.py` tests still pass (6/6).
- [x] All existing `tests/test_kms.py` tests still pass (29/29).

