### PR TITLE
fix(gcp): normalize None source results before augment (#10955)

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -228,7 +228,7 @@ class QueryResourceManager(ResourceManager, metaclass=QueryMeta):
 
     def _fetch_resources(self, query):
         try:
-            return self.augment(self.source.get_resources(query)) or []
+            return self.augment(self.source.get_resources(query) or [])
         except HttpError as e:
             error_reason, error_code, error_message = extract_errors(e)
 

--- a/tools/c7n_gcp/tests/data/flights/gcp-cloud-run-service-empty/get-v1-projects-cloud-custodian-locations---services_1.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-cloud-run-service-empty/get-v1-projects-cloud-custodian-locations---services_1.json
@@ -1,0 +1,14 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "server": "ESF",
+    "cache-control": "private",
+    "status": "200",
+    "content-location": "https://run.googleapis.com/v1/projects/cloud-custodian/locations/-/services?alt=json"
+  },
+  "body": {
+    "apiVersion": "serving.knative.dev/v1",
+    "kind": "ServiceList"
+  }
+}

--- a/tools/c7n_gcp/tests/test_cloudrun.py
+++ b/tools/c7n_gcp/tests/test_cloudrun.py
@@ -16,6 +16,18 @@ class RunServiceTest(BaseTest):
         assert len(resources) == 1
         assert resources[0]["metadata"]["name"] == "hello"
 
+    def test_query_empty(self):
+        # regression for #10955: accounts with zero Cloud Run resources must
+        # return [] rather than crash. The source layer returns None (not [])
+        # for an empty result set, which augment() previously iterated over.
+        factory = self.replay_flight_data("gcp-cloud-run-service-empty")
+        p = self.load_policy(
+            {"name": "cloud-run-svc-empty", "resource": "gcp.cloud-run-service"},
+            session_factory=factory,
+        )
+        resources = p.run()
+        assert resources == []
+
     def test_set_labels(self):
         project_id = 'cloud-custodian'
         factory = self.replay_flight_data(


### PR DESCRIPTION
## What / why

Policies targeting `gcp.cloud-run-service` or `gcp.cloud-run-job` crash with
`TypeError: 'NoneType' object is not iterable` on any account that has **zero**
Cloud Run resources.

The non-paginated GCP source path (`ResourceQuery._invoke_client_enum`) returns
`None` (not `[]`) for an empty result set:

```python
return jmespath_search(path, client.execute_query(enum_op, verb_arguments=params))
```

The `augment()` methods added for Cloud Run in #10658 iterate `resources`
directly:

```python
def augment(self, resources):
    for r in resources:      # TypeError when resources is None
        ...
```

so the crash fires inside `augment()` **before** the existing `or []` in
`_fetch_resources` can coerce the result.

## Fix

Per @ajkerrigan's suggestion in #10955, move the guard up one level so the
source result is normalized to `[]` before `augment()` runs:

```diff
-            return self.augment(self.source.get_resources(query)) or []
+            return self.augment(self.source.get_resources(query) or [])
```

This single choke point in `QueryResourceManager._fetch_resources` protects
every GCP resource type's `augment()` — several others share the same
unguarded iterate-over-`resources` pattern — rather than adding a brittle
per-`augment()` guard.

## Test

Adds `RunServiceTest.test_query_empty` with a flight fixture whose response
omits `items` (the empty / `None` path). It reproduces the original
`TypeError` before the fix and passes after.

```
uv run pytest -n auto tools/c7n_gcp/tests   ->  449 passed, 1 skipped
```

Regression introduced by #10658. Reported and root-caused by Thatcher Smith
(@tjs-rubrik).

Closes #10955

🤖 Generated with [Claude Code](https://claude.com/claude-code)
