### PR TITLE
feat(kms): add policy-access-denied filter to surface inaccessible KMS keys

### DIFF
--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -243,6 +243,46 @@ class KMSCrossAccountAccessFilter(CrossAccountAccessFilter):
             resources, event)
 
 
+@Key.filter_registry.register('policy-access-denied')
+class KMSPolicyAccessDenied(Filter):
+    """Filter KMS keys whose key policy cannot be fetched due to access denial.
+
+    The ``cross-account`` filter silently drops these keys, so under ``c7n-org``
+    an account with inaccessible keys appears to have fewer keys than it does.
+    This filter surfaces them explicitly so they reach ``resources.json``.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: kms-key-policy-inaccessible
+                resource: kms-key
+                filters:
+                  - type: policy-access-denied
+    """
+    schema = type_schema('policy-access-denied')
+    permissions = ('kms:GetKeyPolicy',)
+    annotation_key = 'c7n:PolicyAccessDenied'
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('kms')
+        results = []
+        for r in resources:
+            key_id = r.get('KeyId')
+            try:
+                client.get_key_policy(KeyId=key_id, PolicyName='default')
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'AccessDeniedException':
+                    self.log.warning(
+                        "Access denied fetching policy for key:%s", key_id)
+                    r[self.annotation_key] = True
+                    results.append(r)
+                else:
+                    raise
+        return results
+
+
 @KeyAlias.filter_registry.register('grant-count')
 class GrantCount(Filter):
     """Filters KMS key grants

--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -269,7 +269,8 @@ class KMSPolicyAccessDenied(Filter):
         client = local_session(self.manager.session_factory).client('kms')
         results = []
         for r in resources:
-            key_id = r.get('KeyId')
+            key_id = r.get('TargetKeyId', r.get('KeyId'))
+            assert key_id, "Invalid key resources %s" % r
             try:
                 client.get_key_policy(KeyId=key_id, PolicyName='default')
             except ClientError as e:

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -942,6 +942,93 @@ class KMSCrossAccount(BaseTest):
         self.assertEqual(resources[0]["KeyId"], key_info["KeyId"])
 
 
+class KMSPolicyAccessDeniedTest(BaseTest):
+
+    def _make_filter(self, name="kms-policy-access-denied"):
+        from c7n.executor import MainThreadExecutor
+        p = self.load_policy(
+            {"name": name, "resource": "kms-key",
+             "filters": [{"type": "policy-access-denied"}]}
+        )
+        f = p.resource_manager.filters[0]
+        self.patch(f, "executor_factory", MainThreadExecutor)
+        return f
+
+    def test_policy_access_denied_matches_inaccessible_key(self):
+        from unittest import mock
+        from botocore.exceptions import ClientError
+        from c7n.resources import kms as kms_module
+
+        f = self._make_filter()
+        key = {"KeyId": "denied-key", "KeyArn": "arn:aws:kms:us-east-1:123:key/denied"}
+        mock_client = mock.MagicMock()
+        mock_client.get_key_policy.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}},
+            "GetKeyPolicy",
+        )
+        with mock.patch.object(kms_module, "local_session") as ls:
+            ls.return_value.client.return_value = mock_client
+            results = f.process([key])
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["KeyId"], "denied-key")
+        self.assertTrue(results[0]["c7n:PolicyAccessDenied"])
+
+    def test_policy_access_denied_excludes_accessible_key(self):
+        from unittest import mock
+        from c7n.resources import kms as kms_module
+
+        f = self._make_filter()
+        key = {"KeyId": "ok-key", "KeyArn": "arn:aws:kms:us-east-1:123:key/ok"}
+        mock_client = mock.MagicMock()
+        mock_client.get_key_policy.return_value = {"Policy": "{}"}
+        with mock.patch.object(kms_module, "local_session") as ls:
+            ls.return_value.client.return_value = mock_client
+            results = f.process([key])
+
+        self.assertEqual(results, [])
+
+    def test_policy_access_denied_other_error_reraises(self):
+        from unittest import mock
+        from botocore.exceptions import ClientError
+        from c7n.resources import kms as kms_module
+
+        f = self._make_filter()
+        key = {"KeyId": "bad-key", "KeyArn": "arn:aws:kms:us-east-1:123:key/bad"}
+        mock_client = mock.MagicMock()
+        mock_client.get_key_policy.side_effect = ClientError(
+            {"Error": {"Code": "InternalFailure", "Message": "Boom"}},
+            "GetKeyPolicy",
+        )
+        with mock.patch.object(kms_module, "local_session") as ls:
+            ls.return_value.client.return_value = mock_client
+            with self.assertRaises(ClientError):
+                f.process([key])
+
+    def test_policy_access_denied_mixed_batch(self):
+        # Denied keys are returned; accessible keys are excluded.
+        from unittest import mock
+        from botocore.exceptions import ClientError
+        from c7n.resources import kms as kms_module
+
+        f = self._make_filter()
+        denied = {"KeyId": "denied", "KeyArn": "arn:aws:kms:us-east-1:123:key/denied"}
+        accessible = {"KeyId": "ok", "KeyArn": "arn:aws:kms:us-east-1:123:key/ok"}
+        access_denied = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}},
+            "GetKeyPolicy",
+        )
+        mock_client = mock.MagicMock()
+        mock_client.get_key_policy.side_effect = [access_denied, {"Policy": "{}"}]
+        with mock.patch.object(kms_module, "local_session") as ls:
+            ls.return_value.client.return_value = mock_client
+            results = f.process([denied, accessible])
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["KeyId"], "denied")
+        self.assertEqual(mock_client.get_key_policy.call_count, 2)
+
+
 class KMSMotoTests(BaseTest):
     @pytest.fixture(autouse=True)
     def use_utc_timezone(self, monkeypatch):


### PR DESCRIPTION
## Summary

- Adds a new `policy-access-denied` filter for `kms-key` resources
- The existing `cross-account` filter silently drops keys where `GetKeyPolicy` raises `AccessDeniedException`, so under `c7n-org` an account with inaccessible keys appears to have fewer keys than it does
- This filter does the opposite: it **returns only the inaccessible keys**, annotating each with `c7n:PolicyAccessDenied: true`, so they reach `resources.json` and can be alerted on or acted on

## Usage

```yaml
policies:
  - name: kms-key-policy-inaccessible
    resource: kms-key
    filters:
      - type: policy-access-denied
```

## Test plan

- [x] `test_policy_access_denied_matches_inaccessible_key` — denied key is returned with annotation
- [x] `test_policy_access_denied_excludes_accessible_key` — accessible key is excluded
- [x] `test_policy_access_denied_other_error_reraises` — non-AccessDenied errors still propagate
- [x] `test_policy_access_denied_mixed_batch` — both denial and success in same batch; denied key returned, accessible key excluded, both attempted

Follows up on #10966 (raised by @gustavoortega).

