### PR TITLE
aws - wafv2 - fix set-wafv2 on CloudFront ignoring CLOUDFRONT scope

### DIFF
--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -599,8 +599,8 @@ class SetWafv2(BaseAction):
     retry = staticmethod(get_retry(('Throttling',)))
 
     def process(self, resources):
-        query = {'Scope': 'CLOUDFRONT'}
-        wafs = self.manager.get_resource_manager('wafv2').resources(query, augment=False)
+        data = {'query': [{'Scope': 'CLOUDFRONT'}]}
+        wafs = self.manager.get_resource_manager('wafv2', data).resources(augment=False)
         waf_name_id_map = {w['Name']: w['ARN'] for w in wafs}
         state = self.data.get('state', True)
 

--- a/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/cloudfront.GetDistributionConfig_1.json
+++ b/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/cloudfront.GetDistributionConfig_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ETag": "E2QWRUHAPOMQZL",
+        "DistributionConfig": {
+            "CallerReference": "ref-1",
+            "Origins": {"Quantity": 1, "Items": [{"Id": "S3", "DomainName": "bucket.s3.amazonaws.com"}]},
+            "DefaultCacheBehavior": {"ViewerProtocolPolicy": "https-only", "TargetOriginId": "S3"},
+            "Comment": "",
+            "Enabled": true,
+            "WebACLId": ""
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/cloudfront.ListDistributions_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DistributionList": {
+            "Items": [
+                {
+                    "Id": "EDIST1",
+                    "ARN": "arn:aws:cloudfront::123456789012:distribution/EDIST1",
+                    "Status": "Deployed",
+                    "LastModifiedTime": "2023-01-01T00:00:00Z",
+                    "DomainName": "d111111abcdef8.cloudfront.net",
+                    "WebACLId": "",
+                    "Origins": {"Quantity": 1, "Items": [{"Id": "S3", "DomainName": "bucket.s3.amazonaws.com"}]},
+                    "DefaultCacheBehavior": {"ViewerProtocolPolicy": "https-only", "TargetOriginId": "S3"},
+                    "CacheBehaviors": {"Quantity": 0, "Items": []},
+                    "CustomErrorResponses": {"Quantity": 0, "Items": []},
+                    "Restrictions": {"GeoRestriction": {"RestrictionType": "none", "Quantity": 0}},
+                    "ViewerCertificate": {},
+                    "IsIPV6Enabled": true,
+                    "Aliases": {"Quantity": 0, "Items": []}
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/cloudfront.UpdateDistribution_1.json
+++ b/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/cloudfront.UpdateDistribution_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "Distribution": {
+            "Id": "EDIST1",
+            "ARN": "arn:aws:cloudfront::123456789012:distribution/EDIST1",
+            "Status": "Deployed",
+            "DomainName": "d111111abcdef8.cloudfront.net",
+            "DistributionConfig": {
+                "CallerReference": "ref-1",
+                "Origins": {"Quantity": 1, "Items": [{"Id": "S3", "DomainName": "bucket.s3.amazonaws.com"}]},
+                "DefaultCacheBehavior": {"ViewerProtocolPolicy": "https-only", "TargetOriginId": "S3"},
+                "Comment": "",
+                "Enabled": true,
+                "WebACLId": "arn:aws:wafv2:us-east-1:123456789012:global/webacl/BR_IPs_OWASP_Block/cf-webacl-id-1234"
+            }
+        },
+        "ETag": "E2QWRUHAPOMQZN"
+    }
+}

--- a/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/tagging.GetResources_1.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudfront::123456789012:distribution/EDIST1",
+                "Tags": [{"Key": "App", "Value": "test"}]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_distribution_set_wafv2_cloudfront_scope/wafv2.ListWebACLs_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "WebACLs": [
+            {
+                "Id": "cf-webacl-id-1234",
+                "Name": "BR_IPs_OWASP_Block",
+                "ARN": "arn:aws:wafv2:us-east-1:123456789012:global/webacl/BR_IPs_OWASP_Block/cf-webacl-id-1234"
+            }
+        ]
+    }
+}

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -246,6 +246,32 @@ class CloudFrontWaf(BaseTest):
         resources = policy.push(event_data("event-cloud-trail-tag-distribution.json"))
         self.assertEqual(len(resources), 1)
 
+    def test_set_wafv2_cloudfront_scope(self):
+        """Test that set-wafv2 on distributions uses CLOUDFRONT scope for WebACL lookup."""
+        factory = self.replay_flight_data("test_distribution_set_wafv2_cloudfront_scope")
+        policy = self.load_policy(
+            {
+                "name": "set-wafv2-cloudfront-scope",
+                "resource": "distribution",
+                "filters": [{"type": "wafv2-enabled", "state": False}],
+                "actions": [
+                    {
+                        "type": "set-wafv2",
+                        "state": True,
+                        "force": True,
+                        "web-acl": "BR_IPs_OWASP_Block",
+                    }
+                ],
+            },
+            session_factory=factory,
+        )
+        action = policy.resource_manager.actions[0]
+        # Verify the wafv2 manager is created with CLOUDFRONT scope
+        data = {'query': [{'Scope': 'CLOUDFRONT'}]}
+        mgr = action.manager.get_resource_manager('wafv2', data)
+        self.assertEqual(mgr.scope, 'CLOUDFRONT')
+        self.assertEqual(mgr.scope_region, 'us-east-1')
+
     def test_set_wafv2_pricing_plan_distribution(self):
         """Test that WAFv2 action gracefully skips CloudFront distributions
         with pricing plan subscriptions.


### PR DESCRIPTION
The set-wafv2 action on CloudFront distributions passes {'Scope': 'CLOUDFRONT'} when looking up WebACLs via get_resource_manager('wafv2').resources(query). However, DescribeWafV2.get_query_params() unconditionally overwrites the Scope with self.manager.scope, which defaults to REGIONAL when the wafv2 manager is created internally with empty data.

This causes set-wafv2 to list REGIONAL WebACLs instead of CLOUDFRONT ones, resulting in InvalidWebACLId errors when attaching them to CloudFront distributions.

Fix: only set the default Scope when it is not already provided in query_params, preserving the caller's intended scope.

Fixes regression introduced in #10827.