### PR TITLE
gcp - add vertex-ai-model resource

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -131,6 +131,7 @@ ResourceMap = {
     "gcp.vertex-ai-hyperparameter-tuning-job": (
         "c7n_gcp.resources.vertexai.VertexAIHyperparameterTuningJob"),
     "gcp.vertex-ai-location": "c7n_gcp.resources.vertexai.VertexAILocation",
+    "gcp.vertex-ai-model": "c7n_gcp.resources.vertexai.VertexAIModel",
     "gcp.vpc": "c7n_gcp.resources.network.Network",
     "gcp.zone": "c7n_gcp.resources.compute.Zone",
 }

--- a/tools/c7n_gcp/c7n_gcp/resources/vertexai.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/vertexai.py
@@ -744,6 +744,49 @@ class VertexAIDataset(VertexAIQueryManager):
         urn_component = 'dataset'
 
 
+@resources.register('vertex-ai-model')
+class VertexAIModel(VertexAIQueryManager):
+    """GCP Vertex AI Model Registry Resource
+
+    Vertex AI Model Registry models are ML models uploaded to Vertex AI
+    for deployment, versioning, and lifecycle management.
+
+    :example:
+
+    List all Vertex AI Models across all locations:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: vertexai-models-inventory
+            resource: gcp.vertex-ai-model
+
+    :example:
+
+    Find models missing an owner label:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: vertex-ai-models-missing-owner-label
+            resource: gcp.vertex-ai-model
+            filters:
+              - type: value
+                key: labels.owner
+                value: absent
+    """
+
+    class resource_type(VertexAITypeInfo):
+        component = 'projects.locations.models'
+        enum_spec = ('list', 'models[]', None)
+        default_report_fields = [
+            'name', 'displayName', 'trainingPipeline', 'createTime', 'updateTime'
+        ]
+        asset_type = 'aiplatform.googleapis.com/Model'
+        permissions = ('aiplatform.models.list',)
+        urn_component = 'model'
+
+
 @resources.register('vertex-ai-batch-prediction-job')
 class VertexAIBatchPredictionJob(VertexAIQueryManager):
     """GCP Vertex AI Batch Prediction Job Resource

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-4799834997928230912_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-4799834997928230912_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:47 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "452",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/4799834997928230912/operations/3958105902803845120",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:49:47.964409Z",
+        "updateTime": "2026-08-11T17:49:47.964409Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-7954043586947842048_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-7954043586947842048_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:47 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "452",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/7954043586947842048/operations/6869964536875581440",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:49:47.669155Z",
+        "updateTime": "2026-08-11T17:49:47.669155Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-4799834997928230912-operations-3283832596093468672_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-4799834997928230912-operations-3283832596093468672_1.json
@@ -1,0 +1,33 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:43 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "596",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/models/4799834997928230912/operations/3283832596093468672?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/4799834997928230912/operations/3283832596093468672",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:49:38.144453Z",
+        "updateTime": "2026-08-11T17:49:38.434714Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelResponse",
+      "model": "projects/cloud-custodian/locations/us-central1/models/4799834997928230912",
+      "modelVersionId": "1"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-4799834997928230912_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-4799834997928230912_1.json
@@ -1,0 +1,53 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:44 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "884",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/models/4799834997928230912?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/4799834997928230912",
+    "displayName": "c7n-test-model-unowned",
+    "supportedDeploymentResourcesTypes": [
+      "DEDICATED_RESOURCES"
+    ],
+    "supportedInputStorageFormats": [
+      "jsonl",
+      "bigquery",
+      "csv",
+      "tf-record",
+      "tf-record-gzip",
+      "file-list"
+    ],
+    "supportedOutputStorageFormats": [
+      "jsonl",
+      "bigquery"
+    ],
+    "createTime": "2026-08-11T17:49:38.144453Z",
+    "updateTime": "2026-08-11T17:49:38.380221Z",
+    "etag": "AMEw9yNF5rL-U1-UG9oe5ZZq7xDJpRELcq1ScpSkuAYqAltffjOpZEz_mVKIt6S9AQj5",
+    "supportedExportFormats": [
+      {
+        "id": "custom-trained"
+      }
+    ],
+    "versionId": "1",
+    "versionAliases": [
+      "default"
+    ],
+    "versionCreateTime": "2026-08-11T17:49:38.144453Z",
+    "versionUpdateTime": "2026-08-11T17:49:38.380221Z",
+    "modelSourceInfo": {
+      "sourceType": "CUSTOM"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-7954043586947842048-operations-8260450921826222080_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-7954043586947842048-operations-8260450921826222080_1.json
@@ -1,0 +1,33 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:36 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "596",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/models/7954043586947842048/operations/8260450921826222080?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/7954043586947842048/operations/8260450921826222080",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:49:31.077998Z",
+        "updateTime": "2026-08-11T17:49:31.445723Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelResponse",
+      "model": "projects/cloud-custodian/locations/us-central1/models/7954043586947842048",
+      "modelVersionId": "1"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-7954043586947842048_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-7954043586947842048_1.json
@@ -1,0 +1,56 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:37 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "920",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/models/7954043586947842048?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/7954043586947842048",
+    "displayName": "c7n-test-model-owned",
+    "supportedDeploymentResourcesTypes": [
+      "DEDICATED_RESOURCES"
+    ],
+    "supportedInputStorageFormats": [
+      "jsonl",
+      "bigquery",
+      "csv",
+      "tf-record",
+      "tf-record-gzip",
+      "file-list"
+    ],
+    "supportedOutputStorageFormats": [
+      "jsonl",
+      "bigquery"
+    ],
+    "createTime": "2026-08-11T17:49:31.077998Z",
+    "updateTime": "2026-08-11T17:49:31.345692Z",
+    "etag": "AMEw9yPktYMCmPmfuy9PZBSuD9sgO0lmbQZ18qinJf6dLoZUw7Te8ZXpuj0IbGTJkRnA",
+    "labels": {
+      "owner": "c7n"
+    },
+    "supportedExportFormats": [
+      {
+        "id": "custom-trained"
+      }
+    ],
+    "versionId": "1",
+    "versionAliases": [
+      "default"
+    ],
+    "versionCreateTime": "2026-08-11T17:49:31.077998Z",
+    "versionUpdateTime": "2026-08-11T17:49:31.345692Z",
+    "modelSourceInfo": {
+      "sourceType": "CUSTOM"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models_1.json
@@ -1,0 +1,171 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:47 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "4232",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/models?alt=json"
+  },
+  "body": {
+    "models": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/models/4799834997928230912",
+        "displayName": "c7n-test-model-unowned",
+        "supportedDeploymentResourcesTypes": [
+          "DEDICATED_RESOURCES"
+        ],
+        "supportedInputStorageFormats": [
+          "jsonl",
+          "bigquery",
+          "csv",
+          "tf-record",
+          "tf-record-gzip",
+          "file-list"
+        ],
+        "supportedOutputStorageFormats": [
+          "jsonl",
+          "bigquery"
+        ],
+        "createTime": "2026-08-11T17:49:38.144453Z",
+        "updateTime": "2026-08-11T17:49:38.380221Z",
+        "etag": "AMEw9yMfzjJKrlvYW9CtslQrGETnzVMsf7xMO10p-foTH2lAAmkrTSLg20f9XRsc2jah",
+        "supportedExportFormats": [
+          {
+            "id": "custom-trained"
+          }
+        ],
+        "versionId": "1",
+        "versionAliases": [
+          "default"
+        ],
+        "versionCreateTime": "2026-08-11T17:49:38.144453Z",
+        "versionUpdateTime": "2026-08-11T17:49:38.380221Z",
+        "modelSourceInfo": {
+          "sourceType": "CUSTOM"
+        }
+      },
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/models/7954043586947842048",
+        "displayName": "c7n-test-model-owned",
+        "supportedDeploymentResourcesTypes": [
+          "DEDICATED_RESOURCES"
+        ],
+        "supportedInputStorageFormats": [
+          "jsonl",
+          "bigquery",
+          "csv",
+          "tf-record",
+          "tf-record-gzip",
+          "file-list"
+        ],
+        "supportedOutputStorageFormats": [
+          "jsonl",
+          "bigquery"
+        ],
+        "createTime": "2026-08-11T17:49:31.077998Z",
+        "updateTime": "2026-08-11T17:49:31.345692Z",
+        "etag": "AMEw9yObN2xc-0yJyje_Llu0l6COxvKnOyA9x8MfOULd3QuOBhM6EhIAliXO8LPB-ED3",
+        "labels": {
+          "owner": "c7n"
+        },
+        "supportedExportFormats": [
+          {
+            "id": "custom-trained"
+          }
+        ],
+        "versionId": "1",
+        "versionAliases": [
+          "default"
+        ],
+        "versionCreateTime": "2026-08-11T17:49:31.077998Z",
+        "versionUpdateTime": "2026-08-11T17:49:31.345692Z",
+        "modelSourceInfo": {
+          "sourceType": "CUSTOM"
+        }
+      },
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/models/4002697863883653120",
+        "displayName": "c7n-test-model-owned",
+        "supportedDeploymentResourcesTypes": [
+          "DEDICATED_RESOURCES"
+        ],
+        "supportedInputStorageFormats": [
+          "jsonl",
+          "bigquery",
+          "csv",
+          "tf-record",
+          "tf-record-gzip",
+          "file-list"
+        ],
+        "supportedOutputStorageFormats": [
+          "jsonl",
+          "bigquery"
+        ],
+        "createTime": "2026-08-11T17:46:23.958112Z",
+        "updateTime": "2026-08-11T17:46:24.224102Z",
+        "etag": "AMEw9yP-dleP_tNF5UTKdOk8e-8kPgmCajuyllryj9XQvSVp737tE4offjAQgH7krXc=",
+        "labels": {
+          "owner": "c7n"
+        },
+        "supportedExportFormats": [
+          {
+            "id": "custom-trained"
+          }
+        ],
+        "versionId": "1",
+        "versionAliases": [
+          "default"
+        ],
+        "versionCreateTime": "2026-08-11T17:46:23.958112Z",
+        "versionUpdateTime": "2026-08-11T17:46:24.224102Z",
+        "modelSourceInfo": {
+          "sourceType": "CUSTOM"
+        }
+      },
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/models/188148979500843008",
+        "displayName": "c7n-test-model-central",
+        "supportedDeploymentResourcesTypes": [
+          "DEDICATED_RESOURCES"
+        ],
+        "supportedInputStorageFormats": [
+          "jsonl",
+          "bigquery",
+          "csv",
+          "tf-record",
+          "tf-record-gzip",
+          "file-list"
+        ],
+        "supportedOutputStorageFormats": [
+          "jsonl",
+          "bigquery"
+        ],
+        "createTime": "2026-08-11T17:46:17.858613Z",
+        "updateTime": "2026-08-11T17:46:18.155292Z",
+        "etag": "AMEw9yNwFOo3xYCoDvX_p1p_oo8nSqQs3OWIBnsOrUPttJhGCgYSWfpAa46YqF7ElbM=",
+        "supportedExportFormats": [
+          {
+            "id": "custom-trained"
+          }
+        ],
+        "versionId": "1",
+        "versionAliases": [
+          "default"
+        ],
+        "versionCreateTime": "2026-08-11T17:46:17.858613Z",
+        "versionUpdateTime": "2026-08-11T17:46:18.155292Z",
+        "modelSourceInfo": {
+          "sourceType": "CUSTOM"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-upload_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-upload_1.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:31 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "363",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/7954043586947842048/operations/8260450921826222080",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:49:31.077998Z",
+        "updateTime": "2026-08-11T17:49:31.077998Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-upload_2.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-upload_2.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:38 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "363",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/4799834997928230912/operations/3283832596093468672",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:49:38.144453Z",
+        "updateTime": "2026-08-11T17:49:38.144453Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-3241026576904617984_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-3241026576904617984_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:29 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "452",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/3241026576904617984/operations/6901489734267174912",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:49:29.685414Z",
+        "updateTime": "2026-08-11T17:49:29.685414Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:29 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "449",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/6075877959187562496",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:49:29.876645Z",
+        "updateTime": "2026-08-11T17:49:29.876645Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-3241026576904617984-operations-7074596844944228352_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-3241026576904617984-operations-7074596844944228352_1.json
@@ -1,0 +1,33 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:08 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "596",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/models/3241026576904617984/operations/7074596844944228352?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/3241026576904617984/operations/7074596844944228352",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:03.420954Z",
+        "updateTime": "2026-08-11T17:47:03.750733Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelResponse",
+      "model": "projects/cloud-custodian/locations/us-central1/models/3241026576904617984",
+      "modelVersionId": "1"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-3241026576904617984_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-3241026576904617984_1.json
@@ -1,0 +1,53 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:11 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "884",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/models/3241026576904617984?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/3241026576904617984",
+    "displayName": "c7n-test-model-central",
+    "supportedDeploymentResourcesTypes": [
+      "DEDICATED_RESOURCES"
+    ],
+    "supportedInputStorageFormats": [
+      "jsonl",
+      "bigquery",
+      "csv",
+      "tf-record",
+      "tf-record-gzip",
+      "file-list"
+    ],
+    "supportedOutputStorageFormats": [
+      "jsonl",
+      "bigquery"
+    ],
+    "createTime": "2026-08-11T17:47:03.420954Z",
+    "updateTime": "2026-08-11T17:47:03.676892Z",
+    "etag": "AMEw9yN7o-1ZpsyVzfv4DSWzCn7vNQDy_nEwzuoiR1fGD7AvDYo3CaAdzNpqGZF6vz6l",
+    "supportedExportFormats": [
+      {
+        "id": "custom-trained"
+      }
+    ],
+    "versionId": "1",
+    "versionAliases": [
+      "default"
+    ],
+    "versionCreateTime": "2026-08-11T17:47:03.420954Z",
+    "versionUpdateTime": "2026-08-11T17:47:03.676892Z",
+    "modelSourceInfo": {
+      "sourceType": "CUSTOM"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models_1.json
@@ -1,0 +1,132 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:29 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "3155",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/models?alt=json"
+  },
+  "body": {
+    "models": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/models/3241026576904617984",
+        "displayName": "c7n-test-model-central",
+        "supportedDeploymentResourcesTypes": [
+          "DEDICATED_RESOURCES"
+        ],
+        "supportedInputStorageFormats": [
+          "jsonl",
+          "bigquery",
+          "csv",
+          "tf-record",
+          "tf-record-gzip",
+          "file-list"
+        ],
+        "supportedOutputStorageFormats": [
+          "jsonl",
+          "bigquery"
+        ],
+        "createTime": "2026-08-11T17:47:03.420954Z",
+        "updateTime": "2026-08-11T17:47:03.676892Z",
+        "etag": "AMEw9yObwnonHcWQvT9iUtW_JNrZeZMPVoH5vleoxz0mtA7UYoBlja9OjHAhCGAAUyME",
+        "supportedExportFormats": [
+          {
+            "id": "custom-trained"
+          }
+        ],
+        "versionId": "1",
+        "versionAliases": [
+          "default"
+        ],
+        "versionCreateTime": "2026-08-11T17:47:03.420954Z",
+        "versionUpdateTime": "2026-08-11T17:47:03.676892Z",
+        "modelSourceInfo": {
+          "sourceType": "CUSTOM"
+        }
+      },
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/models/4002697863883653120",
+        "displayName": "c7n-test-model-owned",
+        "supportedDeploymentResourcesTypes": [
+          "DEDICATED_RESOURCES"
+        ],
+        "supportedInputStorageFormats": [
+          "jsonl",
+          "bigquery",
+          "csv",
+          "tf-record",
+          "tf-record-gzip",
+          "file-list"
+        ],
+        "supportedOutputStorageFormats": [
+          "jsonl",
+          "bigquery"
+        ],
+        "createTime": "2026-08-11T17:46:23.958112Z",
+        "updateTime": "2026-08-11T17:46:24.224102Z",
+        "etag": "AMEw9yMLlJsCfLjEGuzHal7hF5HOwyKvwQacR5-flfNeG3Ruf5V0PyPP21FKUlk-abE=",
+        "labels": {
+          "owner": "c7n"
+        },
+        "supportedExportFormats": [
+          {
+            "id": "custom-trained"
+          }
+        ],
+        "versionId": "1",
+        "versionAliases": [
+          "default"
+        ],
+        "versionCreateTime": "2026-08-11T17:46:23.958112Z",
+        "versionUpdateTime": "2026-08-11T17:46:24.224102Z",
+        "modelSourceInfo": {
+          "sourceType": "CUSTOM"
+        }
+      },
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/models/188148979500843008",
+        "displayName": "c7n-test-model-central",
+        "supportedDeploymentResourcesTypes": [
+          "DEDICATED_RESOURCES"
+        ],
+        "supportedInputStorageFormats": [
+          "jsonl",
+          "bigquery",
+          "csv",
+          "tf-record",
+          "tf-record-gzip",
+          "file-list"
+        ],
+        "supportedOutputStorageFormats": [
+          "jsonl",
+          "bigquery"
+        ],
+        "createTime": "2026-08-11T17:46:17.858613Z",
+        "updateTime": "2026-08-11T17:46:18.155292Z",
+        "etag": "AMEw9yMJOuliknYX6t25fE1DJChtsomsl3Cac-sL6tTHk_QdXf_omxS-9HAnGf8UH8M=",
+        "supportedExportFormats": [
+          {
+            "id": "custom-trained"
+          }
+        ],
+        "versionId": "1",
+        "versionAliases": [
+          "default"
+        ],
+        "versionCreateTime": "2026-08-11T17:46:17.858613Z",
+        "versionUpdateTime": "2026-08-11T17:46:18.155292Z",
+        "modelSourceInfo": {
+          "sourceType": "CUSTOM"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_1.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:17 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_10.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_10.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:04 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_11.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_11.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:09 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_12.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_12.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:14 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_13.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_13.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:19 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_14.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_14.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:25 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_15.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_15.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:30 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_16.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_16.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:35 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_17.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_17.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:40 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_18.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_18.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:45 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_19.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_19.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:51 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_2.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_2.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:22 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_20.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_20.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:48:56 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_21.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_21.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:01 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_22.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_22.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:06 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_23.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_23.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:11 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_24.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_24.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:16 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_25.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_25.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:21 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_26.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_26.json
@@ -1,0 +1,33 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:27 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "590",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:49:24.454825Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelResponse",
+      "model": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320",
+      "modelVersionId": "1"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_3.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_3.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:28 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_4.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_4.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:33 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_5.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_5.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:38 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_6.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_6.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:43 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_7.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_7.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:48 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_8.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_8.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:53 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_9.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320-operations-1343157700774592512_9.json
@@ -1,0 +1,27 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:59 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-7412434604465848320_1.json
@@ -1,0 +1,53 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:27 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "878",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models/7412434604465848320?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320",
+    "displayName": "c7n-test-model-east",
+    "supportedDeploymentResourcesTypes": [
+      "DEDICATED_RESOURCES"
+    ],
+    "supportedInputStorageFormats": [
+      "jsonl",
+      "bigquery",
+      "csv",
+      "tf-record",
+      "tf-record-gzip",
+      "file-list"
+    ],
+    "supportedOutputStorageFormats": [
+      "jsonl",
+      "bigquery"
+    ],
+    "createTime": "2026-08-11T17:47:12.528040Z",
+    "updateTime": "2026-08-11T17:49:24.384736Z",
+    "etag": "AMEw9yN0zKWFD6OlHa5AjUOUxh27N6IHvUuIMdEXObTLlLsKBUwXH_AbrFjw7JF_eK6b",
+    "supportedExportFormats": [
+      {
+        "id": "custom-trained"
+      }
+    ],
+    "versionId": "1",
+    "versionAliases": [
+      "default"
+    ],
+    "versionCreateTime": "2026-08-11T17:47:12.528040Z",
+    "versionUpdateTime": "2026-08-11T17:49:24.384736Z",
+    "modelSourceInfo": {
+      "sourceType": "CUSTOM"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models_1.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:49:29 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1044",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/models?alt=json"
+  },
+  "body": {
+    "models": [
+      {
+        "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320",
+        "displayName": "c7n-test-model-east",
+        "supportedDeploymentResourcesTypes": [
+          "DEDICATED_RESOURCES"
+        ],
+        "supportedInputStorageFormats": [
+          "jsonl",
+          "bigquery",
+          "csv",
+          "tf-record",
+          "tf-record-gzip",
+          "file-list"
+        ],
+        "supportedOutputStorageFormats": [
+          "jsonl",
+          "bigquery"
+        ],
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:49:24.384736Z",
+        "etag": "AMEw9yPvPWeiIXmCwNFWxNZOJdqhS1ZWHTStOgyor7V_t5Id_Ko-5eFirDkxDg9EKMrm",
+        "supportedExportFormats": [
+          {
+            "id": "custom-trained"
+          }
+        ],
+        "versionId": "1",
+        "versionAliases": [
+          "default"
+        ],
+        "versionCreateTime": "2026-08-11T17:47:12.528040Z",
+        "versionUpdateTime": "2026-08-11T17:49:24.384736Z",
+        "modelSourceInfo": {
+          "sourceType": "CUSTOM"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-upload_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-models-upload_1.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:03 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "363",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/models/3241026576904617984/operations/7074596844944228352",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:03.420954Z",
+        "updateTime": "2026-08-11T17:47:03.420954Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/post-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-upload_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-model-multi-location/post-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-models-upload_1.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 11 Aug 2026 17:47:12 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "360",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/models/7412434604465848320/operations/1343157700774592512",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.UploadModelOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-11T17:47:12.528040Z",
+        "updateTime": "2026-08-11T17:47:12.528040Z"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/test_vertexai.py
+++ b/tools/c7n_gcp/tests/test_vertexai.py
@@ -98,6 +98,54 @@ class VertexAIJobs:
                 print(f'Warning: failed to delete {name} during cleanup: {e}')
 
 
+class VertexAIModels:
+    """Helper for creating/cleaning up ephemeral Vertex AI models in tests.
+
+    Vertex AI Models, unlike datasets/endpoints, have no Terraform resource,
+    so tests upload a minimal Model directly through the API (mirroring
+    VertexAIJobs above). Upload is a long-running operation; create() polls
+    it to completion and returns the resulting Model.
+    """
+
+    def __init__(self, test):
+        self.test = test
+        self.created = []
+
+    def _client(self, session, location, component='projects.locations.models'):
+        return session.client(
+            'aiplatform', 'v1', component,
+            client_options=ClientOptions(
+                api_endpoint=f'https://{location}-aiplatform.googleapis.com'))
+
+    def create(self, location, display_name, labels=None):
+        session = self.test.session_factory()
+        project = session.get_default_project()
+        client = self._client(session, location)
+        operation = client.execute_command(
+            'upload',
+            {'parent': f'projects/{project}/locations/{location}',
+             'body': {'model': {'displayName': display_name, 'labels': labels or {}}}})
+
+        ops_client = self._client(session, location, 'projects.locations.models.operations')
+        for _ in range(30):
+            if operation.get('done'):
+                break
+            if self.test.recording:
+                time.sleep(5)
+            operation = ops_client.execute_query('get', {'name': operation['name']})
+        model_name = operation['response']['model']
+
+        self.created.append((client, model_name))
+        return client.execute_query('get', {'name': model_name})
+
+    def cleanup(self):
+        for client, name in self.created:
+            try:
+                client.execute_command('delete', {'name': name})
+            except HttpError:
+                pass
+
+
 def get_test_model_id(project_id, location):
     """Get full model resource name for testing.
 
@@ -201,6 +249,15 @@ def test_vertexai_dataset_resource_registered(test):
         'projects.locations.datasets')
 
 
+def test_vertexai_model_resource_registered(test):
+    """Test that gcp.vertex-ai-model resolves as a resource type."""
+    policy = test.load_policy(
+        {'name': 'vertexai-model-check',
+         'resource': 'gcp.vertex-ai-model'})
+    assert policy.resource_manager.resource_type.component == (
+        'projects.locations.models')
+
+
 @terraform('vertexai_dataset', scope='module')
 def test_vertexai_dataset_multi_location(test, vertexai_dataset):
     """Test querying Vertex AI Datasets across multiple locations."""
@@ -249,6 +306,64 @@ def test_vertexai_dataset_filtering(test, vertexai_dataset):
     assert len(resources) >= 1
     assert all('image' in r['metadataSchemaUri'] for r in resources)
     assert not any('tabular' in r['metadataSchemaUri'] for r in resources)
+
+
+def test_vertexai_model_multi_location(test):
+    """Test querying Vertex AI Models across multiple locations."""
+    test.session_factory = test.replay_flight_data('vertexai-model-multi-location')
+
+    models = VertexAIModels(test)
+    if test.recording:
+        models.create('us-central1', 'c7n-test-model-central')
+        models.create('us-east1', 'c7n-test-model-east')
+    test.addCleanup(models.cleanup)
+
+    policy = test.load_policy(
+        {'name': 'vertexai-models-multi-location',
+         'resource': 'gcp.vertex-ai-model',
+         'query': [
+             {'location': 'us-central1'},
+             {'location': 'us-east1'}
+         ]},
+        session_factory=test.session_factory)
+
+    resources = policy.run()
+
+    assert len(resources) >= 2
+    locations = {r['name'].split('/')[3] for r in resources}
+    assert 'us-central1' in locations
+    assert 'us-east1' in locations
+
+
+def test_vertexai_model_filtering(test):
+    """Test filtering Vertex AI Models on labels.
+
+    Uses two fixture models (one with an owner label, one without) to prove
+    the filter actually discriminates, not just returns everything.
+    """
+    test.session_factory = test.replay_flight_data('vertexai-model-filtering')
+
+    models = VertexAIModels(test)
+    if test.recording:
+        models.create('us-central1', 'c7n-test-model-owned', labels={'owner': 'c7n'})
+        models.create('us-central1', 'c7n-test-model-unowned')
+    test.addCleanup(models.cleanup)
+
+    policy = test.load_policy(
+        {'name': 'vertexai-models-missing-owner-label',
+         'resource': 'gcp.vertex-ai-model',
+         'query': [{'location': 'us-central1'}],
+         'filters': [
+             {'type': 'value',
+              'key': 'labels.owner',
+              'value': 'absent'}
+         ]},
+        session_factory=test.session_factory)
+
+    resources = policy.run()
+
+    assert len(resources) >= 1
+    assert all('owner' not in r.get('labels', {}) for r in resources)
 
 
 def test_vertexai_endpoint_multi_location(test):

--- a/tools/c7n_gcp/tests/test_vertexai.py
+++ b/tools/c7n_gcp/tests/test_vertexai.py
@@ -126,6 +126,13 @@ class VertexAIModels:
             {'parent': f'projects/{project}/locations/{location}',
              'body': {'model': {'displayName': display_name, 'labels': labels or {}}}})
 
+        # The upload operation's name is already scoped under the model it
+        # will produce (.../models/{id}/operations/{opid}), so the model can
+        # be tracked for cleanup immediately -- before polling, which may
+        # fail or time out -- rather than waiting for operation['response'].
+        model_name = operation['name'].rsplit('/operations/', 1)[0]
+        self.created.append((client, model_name))
+
         ops_client = self._client(session, location, 'projects.locations.models.operations')
         for _ in range(30):
             if operation.get('done'):
@@ -133,9 +140,7 @@ class VertexAIModels:
             if self.test.recording:
                 time.sleep(5)
             operation = ops_client.execute_query('get', {'name': operation['name']})
-        model_name = operation['response']['model']
 
-        self.created.append((client, model_name))
         return client.execute_query('get', {'name': model_name})
 
     def cleanup(self):
@@ -313,10 +318,10 @@ def test_vertexai_model_multi_location(test):
     test.session_factory = test.replay_flight_data('vertexai-model-multi-location')
 
     models = VertexAIModels(test)
+    test.addCleanup(models.cleanup)
     if test.recording:
         models.create('us-central1', 'c7n-test-model-central')
         models.create('us-east1', 'c7n-test-model-east')
-    test.addCleanup(models.cleanup)
 
     policy = test.load_policy(
         {'name': 'vertexai-models-multi-location',
@@ -344,10 +349,10 @@ def test_vertexai_model_filtering(test):
     test.session_factory = test.replay_flight_data('vertexai-model-filtering')
 
     models = VertexAIModels(test)
+    test.addCleanup(models.cleanup)
     if test.recording:
         models.create('us-central1', 'c7n-test-model-owned', labels={'owner': 'c7n'})
         models.create('us-central1', 'c7n-test-model-unowned')
-    test.addCleanup(models.cleanup)
 
     policy = test.load_policy(
         {'name': 'vertexai-models-missing-owner-label',


### PR DESCRIPTION
Closes #10852.

Adds a `gcp.vertex-ai-model` resource for Vertex AI Model Registry models
(`projects.locations.models`), following the existing multi-location
`VertexAIQueryManager` pattern used by `vertex-ai-dataset`,
`vertex-ai-endpoint`, etc. Read-only enumeration/filtering only, matching
the issue's scope (no actions).

## API references consulted

- `aiplatform` v1 discovery document
  (`https://aiplatform.googleapis.com/$discovery/rest?version=v1`) —
  `projects.locations.models.list` request/response shape and `Model`
  schema fields (`name`, `displayName`, `trainingPipeline`, `labels`,
  `createTime`, `updateTime`).
- Cloud Asset Inventory supported asset types
  (https://cloud.google.com/asset-inventory/docs/supported-asset-types) —
  confirms `aiplatform.googleapis.com/Model`.
- Vertex AI IAM permissions reference
  (https://cloud.google.com/vertex-ai/docs/general/iam-permissions) —
  confirms `aiplatform.models.list`.

## Testing

Vertex AI Models have no Terraform resource (unlike datasets/endpoints), so
test fixtures were recorded against the live API: a `VertexAIModels` test
helper uploads/deletes minimal models via `models.upload`/`models.delete`
(mirroring the existing `VertexAIJobs` helper used for jobs, which have the
same constraint), then flight data was captured with
`record_flight_data`/switched to `replay_flight_data`.

- `test_vertexai_model_resource_registered`
- `test_vertexai_model_multi_location`
- `test_vertexai_model_filtering`

Full `c7n_gcp` suite passes (459 passed, 1 skipped) and `ruff check` is clean.
