### PR TITLE
fix(c7n_org): stop forcing custodian.s3 logger to ERROR

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -195,7 +195,6 @@ def init(config, use, debug, verbose, accounts, tags, policies,
     logging.getLogger().setLevel(level)
     logging.getLogger('botocore').setLevel(logging.ERROR)
     logging.getLogger('s3transfer').setLevel(logging.WARNING)
-    logging.getLogger('custodian.s3').setLevel(logging.ERROR)
     logging.getLogger('urllib3').setLevel(logging.WARNING)
 
     accounts = comma_expand(accounts)


### PR DESCRIPTION
## What

Removes the hardcoded `logging.getLogger('custodian.s3').setLevel(logging.ERROR)` override in `c7n_org.cli.init()`.

## Why

`c7n_org` silences the `custodian.s3` logger to `ERROR` regardless of the `-v/--verbose` flag. This suppresses a WARNING-level, per-bucket diagnostic emitted by `FilterPublicBlock.process_bucket()` (`c7n/resources/s3.py`) whenever `GetPublicAccessBlock` is denied by a bucket's own resource policy - the only place in the call chain that names the specific bucket:

```python
log.warning(
    "Bucket:%s unable to invoke method:%s error:%s ",
    bucket['Name'], method, e.response['Error']['Message']
)
```

Every other `custodian.<resource>` logger inherits the root logger's level (set from `verbose`); `custodian.s3` is the sole exception, and I couldn't find a comment, issue link, or commit message tying this override to a reason (git blame traces it to c7n_org's very first commit, years before the WARNING it now silences existed).

Reproduced: running `c7n-org run` against a bucket with a resource policy that denies `GetBucketPublicAccessBlock` to a `check-public-block` policy shows zero indication in console output of which bucket, or why, even with `--verbose`.

**Not fully certain this is simply an oversight** rather than deliberate noise control - some cloud-custodian users run this against accounts with tens of thousands of S3 buckets, and un-silencing a per-bucket WARNING could be a meaningful log-volume increase at that scale. Posting this as a proposal for discussion rather than asserting it's definitely a bug; happy to gate it behind `--verbose` instead if that's a better fit, or close this if the override was intentional.

## References

N/A (found while debugging a recurring `s3-set-block-public-access-acl` failure - the account-level AccessDenied gave no indication of which bucket or why, and it turned out the answer was already being logged, just silenced).

## Checklist

- [x] Confirmed no other logger relies on `custodian.s3` being silenced (grepped for `custodian.s3` across the codebase; only this one line sets its level)
- [x] Existing test suite passes locally (confirmed identical pre-existing failures on unmodified `main`, all due to optional `c7n_azure`/`c7n_gcp`/`c7n_oci` providers not installed in my local env, unrelated to this change)