### PR TITLE
Fix offhours ScheduleParser.parse mishandling a space after ';'

### DIFF
--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -649,7 +649,10 @@ class ScheduleParser:
         # parse schedule components
         pieces = tag_value.split(';')
         for piece in pieces:
-            kv = piece.split('=')
+            # strip surrounding whitespace so values with a space after the
+            # ';' separator (e.g. "off=(m-f,19); on=(m-f,7)") parse correctly.
+            # keys_are_valid()/raw_data() already tolerate such spacing.
+            kv = piece.strip().split('=')
             # components must by key=value
             if not len(kv) == 2:
                 return None

--- a/tests/test_offhours.py
+++ b/tests/test_offhours.py
@@ -630,6 +630,16 @@ class ScheduleParserTest(BaseTest):
         # random extra again
         ("off=(m-f,5);zebrablue,on=(t-w,5)", None),
         ("bar;off=(m-f,5);zebrablue,on=(t-w,5)", None),
+        ################
+        # space after the ';' separator (keys_are_valid already accepts this)
+        (
+            "off=(m-f,19); on=(m-f,7)",
+            {
+                "off": [{"days": [0, 1, 2, 3, 4], "hour": 19}],
+                "on": [{"days": [0, 1, 2, 3, 4], "hour": 7}],
+                "tz": "et",
+            },
+        ),
     ]
 
     def test_schedule_parser(self):


### PR DESCRIPTION
### What / Why

`offhours` `ScheduleParser.parse()` splits the tag value on `;` but never strips the resulting pieces, so a value with a space after the separator — a very natural way to write it — is parsed into a schedule with a malformed key:

```python
ScheduleParser({"tz": "et"}).parse("off=(m-f,19); on=(m-f,7)")
# -> {'off': [...], ' on': [...], 'tz': 'et'}   # note the ' on' key (leading space)
```

Because `keys_are_valid()` / `raw_data()` split on **both** spaces and semicolons, the value passes validation and `has_resource_schedule('on')` returns `True` — but `Time.match()` looks up `schedule.get('on')`, which misses the ` on` key. The result is a **silent** failure: the `OnHour`/`OffHour` never fires for that resource, so instances are not started/stopped as intended, with no parse error logged.

### Fix

Strip each piece before splitting on `=`, so `parse()` tolerates the same spacing that validation already accepts. One-line change; the asymmetry with `raw_data()` (which is space-tolerant) is what caused the bug.

### Tests

Added a case to the `ScheduleParserTest` parser table for `"off=(m-f,19); on=(m-f,7)"`. It fails before this change (key ` on`) and passes after. Full `tests/test_offhours.py` passes (33 tests); `ruff check` is clean.
