### PR TITLE
gcp - add Vertex AI evaluation run resource support

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -128,6 +128,7 @@ ResourceMap = {
     "gcp.vertex-ai-custom-job": "c7n_gcp.resources.vertexai.VertexAICustomJob",
     "gcp.vertex-ai-dataset": "c7n_gcp.resources.vertexai.VertexAIDataset",
     "gcp.vertex-ai-endpoint": "c7n_gcp.resources.vertexai.VertexAIEndpoint",
+    "gcp.vertex-ai-evaluation-run": "c7n_gcp.resources.vertexai.VertexAIEvaluationRun",
     "gcp.vertex-ai-hyperparameter-tuning-job": (
         "c7n_gcp.resources.vertexai.VertexAIHyperparameterTuningJob"),
     "gcp.vertex-ai-location": "c7n_gcp.resources.vertexai.VertexAILocation",

--- a/tools/c7n_gcp/c7n_gcp/resources/vertexai.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/vertexai.py
@@ -787,6 +787,61 @@ class VertexAIModel(VertexAIQueryManager):
         urn_component = 'model'
 
 
+@resources.register('vertex-ai-evaluation-run')
+class VertexAIEvaluationRun(VertexAIQueryManager):
+    """GCP Vertex AI Evaluation Run Resource
+
+    Vertex AI Evaluation Runs assess model or dataset quality against an
+    evaluation set, producing a terminal state and completion time that
+    can drive a retention-review policy on completed runs.
+
+    :example:
+
+    List all Vertex AI Evaluation Runs across all locations:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: vertexai-evaluation-runs-inventory
+            resource: gcp.vertex-ai-evaluation-run
+
+    :example:
+
+    Find terminal evaluation runs older than 30 days:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: vertex-ai-completed-evaluation-runs-past-retention
+            resource: gcp.vertex-ai-evaluation-run
+            filters:
+              - or:
+                  - type: value
+                    key: state
+                    value: SUCCEEDED
+                  - type: value
+                    key: state
+                    value: FAILED
+                  - type: value
+                    key: state
+                    value: CANCELLED
+              - type: value
+                key: completionTime
+                value_type: age
+                op: greater-than
+                value: 30
+    """
+
+    class resource_type(VertexAITypeInfo):
+        component = 'projects.locations.evaluationRuns'
+        enum_spec = ('list', 'evaluationRuns[]', None)
+        default_report_fields = [
+            'name', 'displayName', 'state', 'createTime', 'completionTime'
+        ]
+        permissions = ('aiplatform.evaluationRuns.list',)
+        urn_component = 'evaluation-run'
+
+
 @resources.register('vertex-ai-batch-prediction-job')
 class VertexAIBatchPredictionJob(VertexAIQueryManager):
     """GCP Vertex AI Batch Prediction Job Resource

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems-5527392287388073984_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems-5527392287388073984_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:06 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/4639314379106418688",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:31:06.894022Z",
+        "updateTime": "2026-08-14T17:31:06.894022Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems-6642033195162271744_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems-6642033195162271744_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:06 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/3252205693876305920",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:31:06.231315Z",
+        "updateTime": "2026-08-14T17:31:06.231315Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-1375049241696665600_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-1375049241696665600_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:05 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "424",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/457159175139491840",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:31:05.907250Z",
+        "updateTime": "2026-08-14T17:31:05.907250Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-7512329633895809024_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-7512329633895809024_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:06 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/2209059430186614784",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:31:06.575250Z",
+        "updateTime": "2026-08-14T17:31:06.575250Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-1733588988398141440_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-1733588988398141440_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:05 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/7876276611278962688",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:31:05.764489Z",
+        "updateTime": "2026-08-14T17:31:05.764489Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-2203089249551515648_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-2203089249551515648_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:06 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/6928831839670894592",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:31:06.084311Z",
+        "updateTime": "2026-08-14T17:31:06.084311Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-7844410732786483200_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-7844410732786483200_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:06 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/6958105237248802816",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:31:06.377339Z",
+        "updateTime": "2026-08-14T17:31:06.377339Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-849194611573260288_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-849194611573260288_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:06 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "423",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/99017451647270912",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:31:06.746906Z",
+        "updateTime": "2026-08-14T17:31:06.746906Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-1375049241696665600_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-1375049241696665600_1.json
@@ -1,0 +1,48 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:04 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1004",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/evaluationRuns/1375049241696665600?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/1375049241696665600",
+    "displayName": "c7n-test-eval-run-failed",
+    "metadata": {
+      "pipeline_id": "1606706559881052160"
+    },
+    "dataSource": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/2203089249551515648"
+    },
+    "evaluationConfig": {
+      "metrics": [
+        {
+          "metric": "exact_match",
+          "computationBasedMetricSpec": {
+            "type": "EXACT_MATCH"
+          }
+        }
+      ]
+    },
+    "state": "FAILED",
+    "error": {
+      "code": 9,
+      "message": "No metric scores to aggregate. Please check the result evaluation items for errors."
+    },
+    "evaluationResults": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/1733588988398141440"
+    },
+    "createTime": "2026-08-14T17:30:59.615666Z",
+    "completionTime": "2026-08-14T17:31:00.781015Z",
+    "evaluationSetSnapshot": "projects/cloud-custodian/locations/us-central1/evaluationSets/1733588988398141440"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-7512329633895809024_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-7512329633895809024_1.json
@@ -1,0 +1,58 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:58 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1446",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/evaluationRuns/7512329633895809024?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/7512329633895809024",
+    "displayName": "c7n-test-eval-run-succeeded",
+    "metadata": {
+      "pipeline_id": "8253914056763637760"
+    },
+    "dataSource": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/849194611573260288"
+    },
+    "evaluationConfig": {
+      "metrics": [
+        {
+          "metric": "exact_match",
+          "computationBasedMetricSpec": {
+            "type": "EXACT_MATCH"
+          }
+        }
+      ]
+    },
+    "state": "SUCCEEDED",
+    "evaluationResults": {
+      "summaryMetrics": {
+        "metrics": {
+          "model-under-test/exact_match/VARIANCE": 0,
+          "model-under-test/exact_match/PERCENTILE_P99": 1,
+          "model-under-test/exact_match/AVERAGE": 1,
+          "model-under-test/exact_match/STANDARD_DEVIATION": 0,
+          "model-under-test/exact_match/PERCENTILE_P95": 1,
+          "model-under-test/exact_match/MINIMUM": 1,
+          "model-under-test/exact_match/MAXIMUM": 1,
+          "model-under-test/exact_match/MEDIAN": 1,
+          "model-under-test/exact_match/PERCENTILE_P90": 1
+        },
+        "totalItems": 1
+      },
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/7844410732786483200"
+    },
+    "createTime": "2026-08-14T17:30:53.076299Z",
+    "completionTime": "2026-08-14T17:30:54.154065Z",
+    "evaluationSetSnapshot": "projects/cloud-custodian/locations/us-central1/evaluationSets/7844410732786483200"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_1.json
@@ -1,0 +1,89 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:31:05 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "2433",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/evaluationRuns?alt=json"
+  },
+  "body": {
+    "evaluationRuns": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/1375049241696665600",
+        "displayName": "c7n-test-eval-run-failed",
+        "metadata": {
+          "pipeline_id": "1606706559881052160"
+        },
+        "dataSource": {
+          "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/2203089249551515648"
+        },
+        "evaluationConfig": {
+          "metrics": [
+            {
+              "metric": "exact_match",
+              "computationBasedMetricSpec": {
+                "type": "EXACT_MATCH"
+              }
+            }
+          ]
+        },
+        "state": "FAILED",
+        "error": {
+          "code": 9,
+          "message": "No metric scores to aggregate. Please check the result evaluation items for errors."
+        },
+        "evaluationResults": {
+          "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/1733588988398141440"
+        },
+        "createTime": "2026-08-14T17:30:59.615666Z"
+      },
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/7512329633895809024",
+        "displayName": "c7n-test-eval-run-succeeded",
+        "metadata": {
+          "pipeline_id": "8253914056763637760"
+        },
+        "dataSource": {
+          "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/849194611573260288"
+        },
+        "evaluationConfig": {
+          "metrics": [
+            {
+              "metric": "exact_match",
+              "computationBasedMetricSpec": {
+                "type": "EXACT_MATCH"
+              }
+            }
+          ]
+        },
+        "state": "SUCCEEDED",
+        "evaluationResults": {
+          "summaryMetrics": {
+            "metrics": {
+              "model-under-test/exact_match/VARIANCE": 0,
+              "model-under-test/exact_match/PERCENTILE_P99": 1,
+              "model-under-test/exact_match/AVERAGE": 1,
+              "model-under-test/exact_match/STANDARD_DEVIATION": 0,
+              "model-under-test/exact_match/PERCENTILE_P95": 1,
+              "model-under-test/exact_match/MINIMUM": 1,
+              "model-under-test/exact_match/MAXIMUM": 1,
+              "model-under-test/exact_match/MEDIAN": 1,
+              "model-under-test/exact_match/PERCENTILE_P90": 1
+            },
+            "totalItems": 1
+          },
+          "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/7844410732786483200"
+        },
+        "createTime": "2026-08-14T17:30:53.076299Z"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems_1.json
@@ -1,0 +1,35 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:52 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "426",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationItems/5527392287388073984",
+    "displayName": "c7n-test-eval-run-succeeded-item",
+    "evaluationItemType": "REQUEST",
+    "evaluationRequest": {
+      "prompt": {
+        "text": "What is 2+2?"
+      },
+      "goldenResponse": {
+        "text": "4"
+      },
+      "candidateResponses": [
+        {
+          "candidate": "model-under-test",
+          "text": "4"
+        }
+      ]
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems_2.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems_2.json
@@ -1,0 +1,29 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:58 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "311",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationItems/6642033195162271744",
+    "displayName": "c7n-test-eval-run-failed-item",
+    "evaluationItemType": "REQUEST",
+    "evaluationRequest": {
+      "prompt": {
+        "text": "What is 2+2?"
+      },
+      "goldenResponse": {
+        "text": "4"
+      }
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_1.json
@@ -1,0 +1,38 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:53 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "578",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/7512329633895809024",
+    "displayName": "c7n-test-eval-run-succeeded",
+    "metadata": {
+      "pipeline_id": "8253914056763637760"
+    },
+    "dataSource": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/849194611573260288"
+    },
+    "evaluationConfig": {
+      "metrics": [
+        {
+          "metric": "exact_match",
+          "computationBasedMetricSpec": {
+            "type": "EXACT_MATCH"
+          }
+        }
+      ]
+    },
+    "state": "PENDING",
+    "completionTime": "1970-01-01T00:00:00Z"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_2.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_2.json
@@ -1,0 +1,38 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:59 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "576",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/1375049241696665600",
+    "displayName": "c7n-test-eval-run-failed",
+    "metadata": {
+      "pipeline_id": "1606706559881052160"
+    },
+    "dataSource": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/2203089249551515648"
+    },
+    "evaluationConfig": {
+      "metrics": [
+        {
+          "metric": "exact_match",
+          "computationBasedMetricSpec": {
+            "type": "EXACT_MATCH"
+          }
+        }
+      ]
+    },
+    "state": "PENDING",
+    "completionTime": "1970-01-01T00:00:00Z"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets_1.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:52 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "260",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationSets/849194611573260288",
+    "displayName": "c7n-test-eval-run-succeeded-set",
+    "evaluationItems": [
+      "projects/cloud-custodian/locations/us-central1/evaluationItems/5527392287388073984"
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets_2.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-filtering/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets_2.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:59 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "258",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationSets/2203089249551515648",
+    "displayName": "c7n-test-eval-run-failed-set",
+    "evaluationItems": [
+      "projects/cloud-custodian/locations/us-central1/evaluationItems/6642033195162271744"
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems-4635679561168715776_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems-4635679561168715776_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:45 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/3938441687096885248",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:30:45.220982Z",
+        "updateTime": "2026-08-14T17:30:45.220982Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-7139656764730900480_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-7139656764730900480_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:44 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/6306666588024078336",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:30:44.860467Z",
+        "updateTime": "2026-08-14T17:30:44.860467Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-6420851038072340480_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-6420851038072340480_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:45 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/5546226754068152320",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:30:45.050113Z",
+        "updateTime": "2026-08-14T17:30:45.050113Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-978954575836872704_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets-978954575836872704_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:44 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "425",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/operations/2489408506990428160",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:30:44.690090Z",
+        "updateTime": "2026-08-14T17:30:44.690090Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationItems-2870129968774381568_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationItems-2870129968774381568_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:44 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "422",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/operations/6754289827664887808",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:30:44.503378Z",
+        "updateTime": "2026-08-14T17:30:44.503378Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationRuns-3188830011155021824_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationRuns-3188830011155021824_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:44 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "422",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/operations/7108385348366893056",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:30:44.025614Z",
+        "updateTime": "2026-08-14T17:30:44.025614Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationSets-1357976025140559872_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationSets-1357976025140559872_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:43 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "422",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/operations/7220386000818667520",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:30:43.816777Z",
+        "updateTime": "2026-08-14T17:30:43.816777Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationSets-9104167384217812992_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/delete-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationSets-9104167384217812992_1.json
@@ -1,0 +1,30 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:44 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "422",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/operations/4892587943421542400",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.aiplatform.v1.DeleteOperationMetadata",
+      "genericMetadata": {
+        "createTime": "2026-08-14T17:30:44.270723Z",
+        "updateTime": "2026-08-14T17:30:44.270723Z"
+      }
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-7139656764730900480_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns-7139656764730900480_1.json
@@ -1,0 +1,58 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:34 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1443",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/evaluationRuns/7139656764730900480?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/7139656764730900480",
+    "displayName": "c7n-test-eval-run-central",
+    "metadata": {
+      "pipeline_id": "3047858440639610880"
+    },
+    "dataSource": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/6420851038072340480"
+    },
+    "evaluationConfig": {
+      "metrics": [
+        {
+          "metric": "exact_match",
+          "computationBasedMetricSpec": {
+            "type": "EXACT_MATCH"
+          }
+        }
+      ]
+    },
+    "state": "SUCCEEDED",
+    "evaluationResults": {
+      "summaryMetrics": {
+        "metrics": {
+          "model-under-test/exact_match/VARIANCE": 0,
+          "model-under-test/exact_match/PERCENTILE_P99": 1,
+          "model-under-test/exact_match/AVERAGE": 1,
+          "model-under-test/exact_match/STANDARD_DEVIATION": 0,
+          "model-under-test/exact_match/PERCENTILE_P95": 1,
+          "model-under-test/exact_match/MINIMUM": 1,
+          "model-under-test/exact_match/MAXIMUM": 1,
+          "model-under-test/exact_match/MEDIAN": 1,
+          "model-under-test/exact_match/PERCENTILE_P90": 1
+        },
+        "totalItems": 1
+      },
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/978954575836872704"
+    },
+    "createTime": "2026-08-14T17:30:28.967873Z",
+    "completionTime": "2026-08-14T17:30:30.024033Z",
+    "evaluationSetSnapshot": "projects/cloud-custodian/locations/us-central1/evaluationSets/978954575836872704"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/get-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_1.json
@@ -1,0 +1,60 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:43 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1470",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-central1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/evaluationRuns?alt=json"
+  },
+  "body": {
+    "evaluationRuns": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/7139656764730900480",
+        "displayName": "c7n-test-eval-run-central",
+        "metadata": {
+          "pipeline_id": "3047858440639610880"
+        },
+        "dataSource": {
+          "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/6420851038072340480"
+        },
+        "evaluationConfig": {
+          "metrics": [
+            {
+              "metric": "exact_match",
+              "computationBasedMetricSpec": {
+                "type": "EXACT_MATCH"
+              }
+            }
+          ]
+        },
+        "state": "SUCCEEDED",
+        "evaluationResults": {
+          "summaryMetrics": {
+            "metrics": {
+              "model-under-test/exact_match/VARIANCE": 0,
+              "model-under-test/exact_match/PERCENTILE_P99": 1,
+              "model-under-test/exact_match/AVERAGE": 1,
+              "model-under-test/exact_match/STANDARD_DEVIATION": 0,
+              "model-under-test/exact_match/PERCENTILE_P95": 1,
+              "model-under-test/exact_match/MINIMUM": 1,
+              "model-under-test/exact_match/MAXIMUM": 1,
+              "model-under-test/exact_match/MEDIAN": 1,
+              "model-under-test/exact_match/PERCENTILE_P90": 1
+            },
+            "totalItems": 1
+          },
+          "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/978954575836872704"
+        },
+        "createTime": "2026-08-14T17:30:28.967873Z"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationRuns-3188830011155021824_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationRuns-3188830011155021824_1.json
@@ -1,0 +1,58 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:41 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1428",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/evaluationRuns/3188830011155021824?alt=json"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/evaluationRuns/3188830011155021824",
+    "displayName": "c7n-test-eval-run-east",
+    "metadata": {
+      "pipeline_id": "38034271868289024"
+    },
+    "dataSource": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-east1/evaluationSets/9104167384217812992"
+    },
+    "evaluationConfig": {
+      "metrics": [
+        {
+          "metric": "exact_match",
+          "computationBasedMetricSpec": {
+            "type": "EXACT_MATCH"
+          }
+        }
+      ]
+    },
+    "state": "SUCCEEDED",
+    "evaluationResults": {
+      "summaryMetrics": {
+        "metrics": {
+          "model-under-test/exact_match/VARIANCE": 0,
+          "model-under-test/exact_match/PERCENTILE_P99": 1,
+          "model-under-test/exact_match/AVERAGE": 1,
+          "model-under-test/exact_match/STANDARD_DEVIATION": 0,
+          "model-under-test/exact_match/PERCENTILE_P95": 1,
+          "model-under-test/exact_match/MINIMUM": 1,
+          "model-under-test/exact_match/MAXIMUM": 1,
+          "model-under-test/exact_match/MEDIAN": 1,
+          "model-under-test/exact_match/PERCENTILE_P90": 1
+        },
+        "totalItems": 1
+      },
+      "evaluationSet": "projects/cloud-custodian/locations/us-east1/evaluationSets/1357976025140559872"
+    },
+    "createTime": "2026-08-14T17:30:36.452268Z",
+    "completionTime": "2026-08-14T17:30:38.580804Z",
+    "evaluationSetSnapshot": "projects/cloud-custodian/locations/us-east1/evaluationSets/1357976025140559872"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationRuns_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/get-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationRuns_1.json
@@ -1,0 +1,60 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:43 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "1457",
+    "-content-encoding": "gzip",
+    "content-location": "https://us-east1-aiplatform.googleapis.com/v1/projects/cloud-custodian/locations/us-east1/evaluationRuns?alt=json"
+  },
+  "body": {
+    "evaluationRuns": [
+      {
+        "name": "projects/cloud-custodian/locations/us-east1/evaluationRuns/3188830011155021824",
+        "displayName": "c7n-test-eval-run-east",
+        "metadata": {
+          "pipeline_id": "38034271868289024"
+        },
+        "dataSource": {
+          "evaluationSet": "projects/cloud-custodian/locations/us-east1/evaluationSets/9104167384217812992"
+        },
+        "evaluationConfig": {
+          "metrics": [
+            {
+              "metric": "exact_match",
+              "computationBasedMetricSpec": {
+                "type": "EXACT_MATCH"
+              }
+            }
+          ]
+        },
+        "state": "SUCCEEDED",
+        "evaluationResults": {
+          "summaryMetrics": {
+            "metrics": {
+              "model-under-test/exact_match/VARIANCE": 0,
+              "model-under-test/exact_match/PERCENTILE_P99": 1,
+              "model-under-test/exact_match/AVERAGE": 1,
+              "model-under-test/exact_match/STANDARD_DEVIATION": 0,
+              "model-under-test/exact_match/PERCENTILE_P95": 1,
+              "model-under-test/exact_match/MINIMUM": 1,
+              "model-under-test/exact_match/MAXIMUM": 1,
+              "model-under-test/exact_match/MEDIAN": 1,
+              "model-under-test/exact_match/PERCENTILE_P90": 1
+            },
+            "totalItems": 1
+          },
+          "evaluationSet": "projects/cloud-custodian/locations/us-east1/evaluationSets/1357976025140559872"
+        },
+        "createTime": "2026-08-14T17:30:36.452268Z"
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationItems_1.json
@@ -1,0 +1,35 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:28 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "424",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationItems/4635679561168715776",
+    "displayName": "c7n-test-eval-run-central-item",
+    "evaluationItemType": "REQUEST",
+    "evaluationRequest": {
+      "prompt": {
+        "text": "What is 2+2?"
+      },
+      "goldenResponse": {
+        "text": "4"
+      },
+      "candidateResponses": [
+        {
+          "candidate": "model-under-test",
+          "text": "4"
+        }
+      ]
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationRuns_1.json
@@ -1,0 +1,38 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:28 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "577",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationRuns/7139656764730900480",
+    "displayName": "c7n-test-eval-run-central",
+    "metadata": {
+      "pipeline_id": "3047858440639610880"
+    },
+    "dataSource": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-central1/evaluationSets/6420851038072340480"
+    },
+    "evaluationConfig": {
+      "metrics": [
+        {
+          "metric": "exact_match",
+          "computationBasedMetricSpec": {
+            "type": "EXACT_MATCH"
+          }
+        }
+      ]
+    },
+    "state": "PENDING",
+    "completionTime": "1970-01-01T00:00:00Z"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-central1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-central1-evaluationSets_1.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:28 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "259",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-central1/evaluationSets/6420851038072340480",
+    "displayName": "c7n-test-eval-run-central-set",
+    "evaluationItems": [
+      "projects/cloud-custodian/locations/us-central1/evaluationItems/4635679561168715776"
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationItems_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationItems_1.json
@@ -1,0 +1,35 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:35 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "418",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/evaluationItems/2870129968774381568",
+    "displayName": "c7n-test-eval-run-east-item",
+    "evaluationItemType": "REQUEST",
+    "evaluationRequest": {
+      "prompt": {
+        "text": "What is 2+2?"
+      },
+      "goldenResponse": {
+        "text": "4"
+      },
+      "candidateResponses": [
+        {
+          "candidate": "model-under-test",
+          "text": "4"
+        }
+      ]
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationRuns_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationRuns_1.json
@@ -1,0 +1,38 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:36 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "566",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/evaluationRuns/3188830011155021824",
+    "displayName": "c7n-test-eval-run-east",
+    "metadata": {
+      "pipeline_id": "38034271868289024"
+    },
+    "dataSource": {
+      "evaluationSet": "projects/cloud-custodian/locations/us-east1/evaluationSets/9104167384217812992"
+    },
+    "evaluationConfig": {
+      "metrics": [
+        {
+          "metric": "exact_match",
+          "computationBasedMetricSpec": {
+            "type": "EXACT_MATCH"
+          }
+        }
+      ]
+    },
+    "state": "PENDING",
+    "completionTime": "1970-01-01T00:00:00Z"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationSets_1.json
+++ b/tools/c7n_gcp/tests/data/flights/vertexai-evaluation-run-multi-location/post-us-east1-aiplatform.googleapis.com-v1-projects-cloud-custodian-locations-us-east1-evaluationSets_1.json
@@ -1,0 +1,23 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Fri, 14 Aug 2026 17:30:35 GMT",
+    "server": "ESF",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "250",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/cloud-custodian/locations/us-east1/evaluationSets/9104167384217812992",
+    "displayName": "c7n-test-eval-run-east-set",
+    "evaluationItems": [
+      "projects/cloud-custodian/locations/us-east1/evaluationItems/2870129968774381568"
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/test_query.py
+++ b/tools/c7n_gcp/tests/test_query.py
@@ -47,7 +47,8 @@ def test_gcp_resource_metadata_asset_type():
         'region',
         'vertex-ai-publisher',  # Synthetic resource (no asset inventory type)
         'vertex-ai-publisher-model',  # Catalog resource (no asset inventory type)
-        'vertex-ai-location'
+        'vertex-ai-location',
+        'vertex-ai-evaluation-run',  # No asset inventory type yet
     ))
     missing = set()
     for k, v in GoogleCloud.resources.items():

--- a/tools/c7n_gcp/tests/test_vertexai.py
+++ b/tools/c7n_gcp/tests/test_vertexai.py
@@ -190,6 +190,7 @@ class VertexAIEvaluationRuns:
             evaluation_request['candidateResponses'] = [
                 {'candidate': 'model-under-test', 'text': prediction}]
 
+        # Create an evaluation item:
         items_client = self._client(session, location, 'projects.locations.evaluationItems')
         item = items_client.execute_command(
             'create',
@@ -201,6 +202,7 @@ class VertexAIEvaluationRuns:
                  }})
         self.created.append((items_client, item['name']))
 
+        # Create its evaluation set:
         sets_client = self._client(session, location, 'projects.locations.evaluationSets')
         eval_set = sets_client.execute_command(
             'create',
@@ -208,6 +210,7 @@ class VertexAIEvaluationRuns:
              'body': {'displayName': f'{display_name}-set', 'evaluationItems': [item['name']]}})
         self.created.append((sets_client, eval_set['name']))
 
+        # Create a run over it
         runs_client = self._client(session, location, 'projects.locations.evaluationRuns')
         run = runs_client.execute_command(
             'create',

--- a/tools/c7n_gcp/tests/test_vertexai.py
+++ b/tools/c7n_gcp/tests/test_vertexai.py
@@ -151,6 +151,98 @@ class VertexAIModels:
                 pass
 
 
+class VertexAIEvaluationRuns:
+    """Helper for creating/cleaning up ephemeral Vertex AI evaluation runs.
+
+    Uses the computation-based EXACT_MATCH metric with a pre-supplied
+    prediction/reference pair, so the run completes by pure computation --
+    no model inference -- making it fast, free, and deterministic.
+    """
+
+    TERMINAL_STATES = {'SUCCEEDED', 'FAILED', 'CANCELLED'}
+
+    def __init__(self, test):
+        self.test = test
+        self.created = []
+
+    def _client(self, session, location, component):
+        return session.client(
+            'aiplatform', 'v1', component,
+            client_options=ClientOptions(
+                api_endpoint=f'https://{location}-aiplatform.googleapis.com'))
+
+    def create(self, location, display_name, prediction='4', reference='4', fail=False):
+        """Create an evaluation item, its evaluation set, and a run over it.
+
+        By default the item has a matching prediction/reference, and the run
+        succeeds. Pass `fail=True` to omit the candidate response, which
+        produces a deterministic FAILED run (no metric score to aggregate).
+        """
+        session = self.test.session_factory()
+        project = session.get_default_project()
+        parent = f'projects/{project}/locations/{location}'
+
+        evaluation_request = {
+            'prompt': {'text': 'What is 2+2?'},
+            'goldenResponse': {'text': reference},
+            }
+        if not fail:
+            evaluation_request['candidateResponses'] = [
+                {'candidate': 'model-under-test', 'text': prediction}]
+
+        items_client = self._client(session, location, 'projects.locations.evaluationItems')
+        item = items_client.execute_command(
+            'create',
+            {'parent': parent,
+             'body': {
+                 'displayName': f'{display_name}-item',
+                 'evaluationItemType': 'REQUEST',
+                 'evaluationRequest': evaluation_request,
+                 }})
+        self.created.append((items_client, item['name']))
+
+        sets_client = self._client(session, location, 'projects.locations.evaluationSets')
+        eval_set = sets_client.execute_command(
+            'create',
+            {'parent': parent,
+             'body': {'displayName': f'{display_name}-set', 'evaluationItems': [item['name']]}})
+        self.created.append((sets_client, eval_set['name']))
+
+        runs_client = self._client(session, location, 'projects.locations.evaluationRuns')
+        run = runs_client.execute_command(
+            'create',
+            {'parent': parent,
+             'body': {
+                 'displayName': display_name,
+                 'dataSource': {'evaluationSet': eval_set['name']},
+                 'evaluationConfig': {
+                     'metrics': [{'metric': 'exact_match',
+                                  'computationBasedMetricSpec': {'type': 'EXACT_MATCH'}}]},
+                 }})
+        self.created.append((runs_client, run['name']))
+
+        for _ in range(6):
+            if run['state'] in self.TERMINAL_STATES:
+                break
+            if self.test.recording:
+                time.sleep(5)
+            run = runs_client.execute_query('get', {'name': run['name']})
+
+        # Track the run's auto-created results set for cleanup, if any.
+        results_set = run.get('evaluationResults', {}).get('evaluationSet')
+        if results_set:
+            self.created.append((sets_client, results_set))
+
+        return run
+
+    def cleanup(self):
+        for client, name in reversed(self.created):
+            try:
+                client.execute_command('delete', {'name': name})
+            except HttpError as e:
+                print(f'Warning: failed to delete {name} during cleanup: {e}')
+
+
 def get_test_model_id(project_id, location):
     """Get full model resource name for testing.
 
@@ -261,6 +353,75 @@ def test_vertexai_model_resource_registered(test):
          'resource': 'gcp.vertex-ai-model'})
     assert policy.resource_manager.resource_type.component == (
         'projects.locations.models')
+
+
+def test_vertexai_evaluation_run_resource_registered(test):
+    """Test that gcp.vertex-ai-evaluation-run resolves as a resource type."""
+    policy = test.load_policy(
+        {'name': 'vertexai-evaluation-run-check',
+         'resource': 'gcp.vertex-ai-evaluation-run'})
+    assert policy.resource_manager.resource_type.component == (
+        'projects.locations.evaluationRuns')
+
+
+def test_vertexai_evaluation_run_multi_location(test):
+    """Test querying Vertex AI Evaluation Runs across multiple locations."""
+    test.session_factory = test.replay_flight_data('vertexai-evaluation-run-multi-location')
+
+    runs = VertexAIEvaluationRuns(test)
+    test.addCleanup(runs.cleanup)
+    if test.recording:
+        runs.create('us-central1', 'c7n-test-eval-run-central')
+        runs.create('us-east1', 'c7n-test-eval-run-east')
+
+    policy = test.load_policy(
+        {'name': 'vertexai-evaluation-runs-multi-location',
+         'resource': 'gcp.vertex-ai-evaluation-run',
+         'query': [
+             {'location': 'us-central1'},
+             {'location': 'us-east1'}
+         ]},
+        session_factory=test.session_factory)
+
+    resources = policy.run()
+
+    assert len(resources) >= 2
+    locations = {r['name'].split('/')[3] for r in resources}
+    assert 'us-central1' in locations
+    assert 'us-east1' in locations
+
+
+def test_vertexai_evaluation_run_filtering(test):
+    """Test filtering Vertex AI Evaluation Runs on state.
+
+    Uses a run that succeeds (matching prediction/reference) and one that
+    fails (no candidate response to score) to prove the filter actually
+    discriminates by state, not just returns everything.
+    """
+    test.session_factory = test.replay_flight_data('vertexai-evaluation-run-filtering')
+
+    runs = VertexAIEvaluationRuns(test)
+    test.addCleanup(runs.cleanup)
+    if test.recording:
+        runs.create('us-central1', 'c7n-test-eval-run-succeeded')
+        runs.create('us-central1', 'c7n-test-eval-run-failed', fail=True)
+
+    policy = test.load_policy(
+        {'name': 'vertexai-evaluation-runs-failed',
+         'resource': 'gcp.vertex-ai-evaluation-run',
+         'query': [{'location': 'us-central1'}],
+         'filters': [
+             {'type': 'value',
+              'key': 'state',
+              'value': 'FAILED'}
+         ]},
+        session_factory=test.session_factory)
+
+    resources = policy.run()
+
+    assert len(resources) >= 1
+    assert all(r['state'] == 'FAILED' for r in resources)
+    assert not any(r['state'] == 'SUCCEEDED' for r in resources)
 
 
 @terraform('vertexai_dataset', scope='module')


### PR DESCRIPTION
Closes #10977.

Adds `gcp.vertex-ai-evaluation-run` as a location-scoped, read-only Vertex AI
resource, following the existing `VertexAIQueryManager` pattern used by
`vertex-ai-dataset`/`vertex-ai-model`/`vertex-ai-endpoint`.

- `component`: `projects.locations.evaluationRuns`
- report fields: `name`, `displayName`, `state`, `createTime`, `completionTime`
- permissions: `aiplatform.evaluationRuns.list`
- No actions (delete/cancel) added -- the issue scopes this to read-only
  discovery; those are straightforward follow-ups if wanted.

API reference consulted:
https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.evaluationRuns

## Testing

There's no Terraform resource for Vertex AI evaluation runs, and completing
a real one normally requires an evaluation dataset/rubrics and model
inference. Tests instead provision runs entirely through in-test API calls
using a computation-based `EXACT_MATCH` metric over a pre-supplied
prediction/reference pair -- this completes by pure computation, with no
model inference, so it's fast, free, and deterministic. A `FAILED` run is
produced deterministically by omitting the candidate response (no score to
aggregate). Flight data was recorded live against a real GCP project and
replays in CI; no live credentials are needed to run the test suite.