### PR TITLE
aws.s3: don't abort augment() on a single bucket's connection error

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -628,7 +628,7 @@ class BucketAssembly:
                 # this field, same as the ssl error case above, rather
                 # than aborting assembly of the rest of the account.
                 log.warning(
-                    "Bucket:%s unable to invoke method:%s error:%s ",
+                    "Bucket: %s unable to invoke method: %s error: %s ",
                     bucket['Name'], method_name, e)
                 continue
             except ClientError as e:

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -619,22 +619,18 @@ class BucketAssembly:
                     "Bucket ssl error %s: %s %s",
                     bucket['Name'], bucket.get('Location', 'unknown'), e)
                 continue
-            except (ConnectTimeoutError, ReadTimeoutError) as e:
-                # Regional endpoint is reachable but hung/degraded - don't let
-                # one bad bucket abort assembly of the rest of the account.
+            except (ConnectTimeoutError, ReadTimeoutError, EndpointConnectionError) as e:
+                # Endpoint is unreachable or hung - could be a degraded/
+                # unreachable region, or a bucket deleted between
+                # list_buckets and here. We can't tell those apart, so
+                # don't assume not-found (that would fabricate a default
+                # for a field we simply couldn't check) - warn and skip
+                # this field, same as the ssl error case above, rather
+                # than aborting assembly of the rest of the account.
                 log.warning(
                     "Bucket:%s unable to invoke method:%s error:%s ",
                     bucket['Name'], method_name, e)
                 continue
-            except EndpointConnectionError as e:
-                # Endpoint didn't resolve/connect at all - most likely the
-                # bucket was deleted between list_buckets and here (its DNS
-                # entry is gone). Treat like a not-found bucket.
-                log.warning(
-                    "Bucket:%s unable to invoke method:%s error:%s ",
-                    bucket['Name'], method_name, e)
-                self.handle_not_found(bucket, method_name)
-                value = default
             except ClientError as e:
                 code = e.response['Error']['Code']
                 if code.startswith("NoSuch") or "NotFound" in code:

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -37,7 +37,8 @@ import threading
 import ssl
 
 from botocore.client import Config
-from botocore.exceptions import ClientError
+from botocore.exceptions import (
+    ClientError, ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError)
 
 from collections import defaultdict
 from concurrent.futures import as_completed
@@ -618,6 +619,22 @@ class BucketAssembly:
                     "Bucket ssl error %s: %s %s",
                     bucket['Name'], bucket.get('Location', 'unknown'), e)
                 continue
+            except (ConnectTimeoutError, ReadTimeoutError) as e:
+                # Regional endpoint is reachable but hung/degraded - don't let
+                # one bad bucket abort assembly of the rest of the account.
+                log.warning(
+                    "Bucket:%s unable to invoke method:%s error:%s ",
+                    bucket['Name'], method_name, e)
+                continue
+            except EndpointConnectionError as e:
+                # Endpoint didn't resolve/connect at all - most likely the
+                # bucket was deleted between list_buckets and here (its DNS
+                # entry is gone). Treat like a not-found bucket.
+                log.warning(
+                    "Bucket:%s unable to invoke method:%s error:%s ",
+                    bucket['Name'], method_name, e)
+                self.handle_not_found(bucket, method_name)
+                value = default
             except ClientError as e:
                 code = e.response['Error']['Code']
                 if code.startswith("NoSuch") or "NotFound" in code:

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -622,11 +622,7 @@ class BucketAssembly:
             except (ConnectTimeoutError, ReadTimeoutError, EndpointConnectionError) as e:
                 # Endpoint is unreachable or hung - could be a degraded/
                 # unreachable region, or a bucket deleted between
-                # list_buckets and here. We can't tell those apart, so
-                # don't assume not-found (that would fabricate a default
-                # for a field we simply couldn't check) - warn and skip
-                # this field, same as the ssl error case above, rather
-                # than aborting assembly of the rest of the account.
+                # list_buckets and here.
                 log.warning(
                     "Bucket: %s unable to invoke method: %s error: %s ",
                     bucket['Name'], method_name, e)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -142,7 +142,9 @@ def test_s3_assembly_connect_timeout(test):
     bucket = assembly.assemble({'Name': 'zombie-bucket'})
     assert bucket['Name'] == 'zombie-bucket'
     assert 'Location' not in bucket
-    log_mock.warning.assert_called_once()
+    log_mock.warning.assert_called_once_with(
+        "Bucket:%s unable to invoke method:%s error:%s ",
+        'zombie-bucket', 'get_bucket_location', mock.ANY)
 
 
 def test_s3_assembly_endpoint_connection_error(test):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -143,7 +143,7 @@ def test_s3_assembly_connect_timeout(test):
     assert bucket['Name'] == 'zombie-bucket'
     assert 'Location' not in bucket
     log_mock.warning.assert_called_once_with(
-        "Bucket:%s unable to invoke method:%s error:%s ",
+        "Bucket: %s unable to invoke method: %s error: %s ",
         'zombie-bucket', 'get_bucket_location', mock.ANY)
 
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -148,8 +148,10 @@ def test_s3_assembly_connect_timeout(test):
 
 
 def test_s3_assembly_endpoint_connection_error(test):
-    # A bucket removed between list_buckets and augment (dns entry gone)
-    # is treated like a not-found bucket rather than aborting (c7n#10859).
+    # An unreachable bucket endpoint (degraded region, or a bucket deleted
+    # between list_buckets and augment) shouldn't abort assembly of the
+    # rest of the account - warn and move on, same as a connect timeout,
+    # rather than assuming not-found and fabricating a default (c7n#10859).
     policy = test.load_policy({'name': 's3-attrs', 'resource': 's3'})
     assembly = s3.BucketAssembly(policy.resource_manager)
     assembly.initialize()
@@ -161,7 +163,7 @@ def test_s3_assembly_endpoint_connection_error(test):
 
     bucket = assembly.assemble({'Name': 'deleted-bucket'})
     assert bucket['Name'] == 'deleted-bucket'
-    assert bucket['Location'] == {}
+    assert 'Location' not in bucket
 
 
 def test_s3_express(test):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -14,7 +14,7 @@ from unittest import mock
 from unittest import TestCase
 
 from contextlib import suppress
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ConnectTimeoutError, EndpointConnectionError
 from dateutil.tz import tzutc
 import pytest
 from pytest_terraform import terraform
@@ -122,6 +122,44 @@ def test_s3_assembly_detect_denied(test):
     assert assembly.detect_augment_fields() == [
         'Location', 'Tags', 'Policy', 'Acl', 'Replication', 'Versioning', 'Website',
         'Logging', 'Notification', 'Lifecycle']
+
+
+def test_s3_assembly_connect_timeout(test):
+    # A bucket whose regional endpoint hangs shouldn't abort assembly of
+    # the other fields/buckets - warn and move on (c7n#10859).
+    policy = test.load_policy({'name': 's3-attrs', 'resource': 's3'})
+    assembly = s3.BucketAssembly(policy.resource_manager)
+    assembly.initialize()
+
+    client = mock.MagicMock()
+    client.meta.region_name = assembly.default_region
+    client.get_bucket_location.side_effect = ConnectTimeoutError(endpoint_url='x')
+    assembly.region_clients[assembly.default_region] = client
+
+    log_mock = mock.MagicMock()
+    test.patch(s3, 'log', log_mock)
+
+    bucket = assembly.assemble({'Name': 'zombie-bucket'})
+    assert bucket['Name'] == 'zombie-bucket'
+    assert 'Location' not in bucket
+    log_mock.warning.assert_called_once()
+
+
+def test_s3_assembly_endpoint_connection_error(test):
+    # A bucket removed between list_buckets and augment (dns entry gone)
+    # is treated like a not-found bucket rather than aborting (c7n#10859).
+    policy = test.load_policy({'name': 's3-attrs', 'resource': 's3'})
+    assembly = s3.BucketAssembly(policy.resource_manager)
+    assembly.initialize()
+
+    client = mock.MagicMock()
+    client.meta.region_name = assembly.default_region
+    client.get_bucket_location.side_effect = EndpointConnectionError(endpoint_url='x')
+    assembly.region_clients[assembly.default_region] = client
+
+    bucket = assembly.assemble({'Name': 'deleted-bucket'})
+    assert bucket['Name'] == 'deleted-bucket'
+    assert bucket['Location'] == {}
 
 
 def test_s3_express(test):


### PR DESCRIPTION
Fixes #10859

## Problem

`BucketAssembly.assemble()` (`s3.py`) fetches per-bucket metadata (tags,
location, encryption, etc.) for every bucket in the account. If a single
bucket's regional endpoint is unreachable (e.g. a degraded/opted-out
region), the resulting connection error propagates out of `assemble()`
and aborts `augment()` for the entire account via the `executor.map()`
call in `DescribeS3.augment()` - `status=error`, no buckets processed.

## Fix

Add exception handling for connection-level errors alongside the existing
`ssl.SSLError` handling in `assemble()`:

- `ConnectTimeoutError` / `ReadTimeoutError` / `EndpointConnectionError` -
  log a warning naming the bucket/method and skip that field, same as the
  existing `ssl.SSLError` branch, rather than letting the exception
  propagate.

These are grouped together rather than treating `EndpointConnectionError`
as a not-found bucket: while it can indicate a bucket deleted between
`list_buckets()` and augmentation (DNS entry gone), it can just as easily
indicate a persistently unreachable/degraded region (a bucket that very
much still exists) - the issue's own repro shows exactly this, with
`get-bucket-location` succeeding but the regional endpoint hanging on
every other call. We can't distinguish the two cases from the exception
alone, so we don't fabricate a default value for a field we simply
couldn't check - that could mask a real finding rather than just skip it.

Either way, no bucket-level exception escapes `assemble()`, so one bad
bucket in one region no longer blocks tagging/filtering/actions on every
other bucket in the account.

## Scope

This addresses Issue 1 from the report only. Issue 2 (S3's global
`list_buckets()` enumeration ignoring the policy's region scope) is a
separate, larger behavior question and is being discussed separately on
the issue before deciding on an approach.

## Testing

Two new unit tests in `tests/test_s3.py` mock a bucket's regional client
to raise each exception type and assert `assemble()` returns the bucket
instead of raising. Full `tests/test_s3.py` suite (118 tests) passes;
`ruff check` clean.