### PR TITLE
fix(c7n_org): continue policies after AccessDenied

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -1265,7 +1265,7 @@ def run_account(account, region, policies_config, output_path,
                 if e.response['Error']['Code'] == 'AccessDenied':
                     log.warning('Access denied api:%s policy:%s account:%s region:%s',
                                 e.operation_name, p.name, account['name'], region)
-                    return policy_counts, success
+                    continue
                 log.error(
                     "Exception running policy:%s account:%s region:%s error:%s",
                     p.name, account['name'], region, e)

--- a/tools/c7n_org/tests/test_org.py
+++ b/tools/c7n_org/tests/test_org.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 import yaml
+from botocore.exceptions import ClientError
 
 from c7n.testing import TestUtils
 from click.testing import CliRunner
@@ -183,6 +184,51 @@ class OrgTest(TestUtils):
         self.assertEqual(
             log_output.getvalue().strip(),
             "Policy resource counts Counter({'compute': 96, 'serverless': 48})")
+
+    def test_run_account_continues_after_access_denied(self):
+        denied_policy = mock.MagicMock(
+            execution_mode='pull', conditions=mock.Mock(env_vars={}))
+        denied_policy.name = 'denied'
+        denied_policy.get_variables.return_value = {}
+        denied_policy.run.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'AccessDenied',
+                    'Message': 'Access denied',
+                }
+            },
+            'GetBucketAcl',
+        )
+
+        succeeding_policy = mock.MagicMock(
+            execution_mode='pull', conditions=mock.Mock(env_vars={}))
+        succeeding_policy.name = 'succeeding'
+        succeeding_policy.get_variables.return_value = {}
+        succeeding_policy.run.return_value = [{}]
+
+        with mock.patch.object(
+                org.PolicyCollection, 'from_data',
+                return_value=[denied_policy, succeeding_policy]), \
+                mock.patch.object(org, 'load_available'):
+            counts, success = org.run_account(
+                {
+                    'name': 'dev',
+                    'account_id': '112233445566',
+                },
+                'us-east-1',
+                {'policies': []},
+                self.get_temp_dir(),
+                0,
+                self.get_temp_dir(),
+                False,
+                False,
+                False,
+            )
+
+        self.assertEqual(counts, {'succeeding': 1})
+        self.assertFalse(success)
+        denied_policy.run.assert_called_once_with()
+        succeeding_policy.run.assert_called_once_with()
 
     def test_filter_policies(self):
         d = {'policies': [


### PR DESCRIPTION
## Summary

- Continue running later policies in the same account and region after a policy returns `AccessDenied`.
- Preserve the unsuccessful run status so the overall command still exits non-zero.
- Add a regression test covering a denied policy followed by a successful policy.

Fixes #11004.

## Root cause

`c7n_org.cli.run_account()` returned immediately from the `AccessDenied` handler. That stopped every subsequent policy for the account and region without attempting them, leaving security policies unevaluated.

## Validation

- `PYTHONPATH=tools/c7n_org uv run pytest tools/c7n_org/tests/test_org.py -k run_account_continues_after_access_denied -q` passed.
- Available `c7n_org` tests: 51 passed; 6 optional-provider tests could not run because `c7n_azure`, `c7n_gcp`, and `c7n_oci` are not installed in the local environment.
- Ruff lint passed for the changed files.
- `git diff --check` passed.

The formatter reports existing whole-file formatting differences, so no unrelated reformatting is included.