### PR TITLE
feat(aws): add ssm service setting resource

### DIFF
--- a/c7n/resources/resource_map.py
+++ b/c7n/resources/resource_map.py
@@ -361,6 +361,7 @@ ResourceMap = {
   "aws.ssm-parameter": "c7n.resources.ssm.SSMParameter",
   "aws.ssm-patch-group": "c7n.resources.ssm.SsmPatchGroup",
   "aws.ssm-session-manager": "c7n.resources.ssm.SSMSessionManager",
+  "aws.ssm-service-setting": "c7n.resources.ssm.SSMServiceSetting",
   "aws.step-machine": "c7n.resources.sfn.StepFunction",
   "aws.storage-gateway": "c7n.resources.storagegw.StorageGateway",
   "aws.streaming-distribution": "c7n.resources.cloudfront.StreamingDistribution",

--- a/c7n/resources/ssm.py
+++ b/c7n/resources/ssm.py
@@ -9,7 +9,7 @@ from c7n.actions import Action
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import Filter, CrossAccountAccessFilter, ValueFilter
 from c7n.filters.kms import KmsRelatedFilter
-from c7n.query import QueryResourceManager, TypeInfo
+from c7n.query import QueryResourceManager, DescribeSource, TypeInfo
 from c7n.manager import resources
 from c7n.tags import universal_augment
 from c7n.utils import chunks, get_retry, local_session, type_schema, filter_empty
@@ -17,6 +17,64 @@ from c7n.version import version
 
 from .aws import shape_validate
 from .ec2 import EC2
+
+
+SSM_SERVICE_SETTING_ID = '/ssm/documents/console/public-sharing-permission'
+
+
+class DescribeSSMServiceSetting(DescribeSource):
+    """Source for the regional SSM console public-sharing setting."""
+
+    def get_permissions(self):
+        return ('ssm:GetServiceSetting',)
+
+    def get_setting(self):
+        client = local_session(self.manager.session_factory).client('ssm')
+        return client.get_service_setting(
+            SettingId=SSM_SERVICE_SETTING_ID)['ServiceSetting']
+
+    def resources(self, query=None):
+        return [self.get_setting()]
+
+    def get_resources(self, ids, cache=True, augment=True):
+        setting = self.get_setting()
+        if not ids or setting['SettingId'] in ids:
+            return [setting]
+        return []
+
+
+@resources.register('ssm-service-setting')
+class SSMServiceSetting(QueryResourceManager):
+    """Regional account-level SSM console public-sharing service setting."""
+
+    class resource_type(TypeInfo):
+        service = 'ssm'
+        id = name = 'SettingId'
+        arn_type = 'servicesetting'
+
+    source_mapping = {'describe': DescribeSSMServiceSetting}
+
+
+@SSMServiceSetting.action_registry.register('enforce')
+class EnforceSSMServiceSetting(Action):
+    """Enforce the SSM console public-sharing setting.
+
+    Set the value to ``Disable`` to block public sharing from the SSM
+    Documents console. The setting is account-level and regional.
+    """
+
+    schema = type_schema(
+        'enforce',
+        value={'type': 'string', 'enum': ['Enable', 'Disable']})
+    permissions = ('ssm:UpdateServiceSetting',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('ssm')
+        value = self.data.get('value', 'Disable')
+        for resource in resources:
+            client.update_service_setting(
+                SettingId=resource.get('SettingId', SSM_SERVICE_SETTING_ID),
+                SettingValue=value)
 
 
 @resources.register('ssm-parameter')

--- a/docs/source/aws/topics/ssm.rst
+++ b/docs/source/aws/topics/ssm.rst
@@ -36,6 +36,28 @@ custodian you can.
   - Manage ops items as a resource, to resolve or update ops items.
     See :ref:`ops-item resource <aws.ops-item>`
 
+Document public sharing
++++++++++++++++++++++++
+
+The ``ssm-service-setting`` resource manages the account-level, regional SSM
+Documents console setting ``/ssm/documents/console/public-sharing-permission``.
+Set the value to ``Disable`` to block public document sharing from the console.
+This setting does not remove public permissions from documents that are already
+shared, and it does not replace controls on programmatic document sharing.
+
+For example:
+
+.. code-block:: yaml
+
+    policies:
+      - name: disable-ssm-public-sharing
+        resource: ssm-service-setting
+        filters:
+          - SettingValue: Enable
+        actions:
+          - type: enforce
+            value: Disable
+
 .. image:: opscenter.png
 
 OmniSSM

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 import time
+from unittest.mock import MagicMock, patch
 
 from c7n.exceptions import PolicyValidationError
 from pytest_terraform import terraform
@@ -128,6 +129,71 @@ class TestOpsCenter(BaseTest):
 
 
 class TestSSM(BaseTest):
+
+    def test_ssm_service_setting_query(self):
+        client = MagicMock()
+        client.get_service_setting.return_value = {
+            'ServiceSetting': {
+                'SettingId': '/ssm/documents/console/public-sharing-permission',
+                'SettingValue': 'Enable',
+                'Status': 'Default'}}
+        session = MagicMock()
+        session.client.return_value = client
+        manager = MagicMock(session_factory=MagicMock())
+
+        with patch('c7n.resources.ssm.local_session', return_value=session):
+            from c7n.resources.ssm import DescribeSSMServiceSetting
+            source = DescribeSSMServiceSetting(manager)
+            resources = source.resources()
+            matching = source.get_resources([
+                '/ssm/documents/console/public-sharing-permission'])
+            missing = source.get_resources(['/ssm/unknown'])
+
+        self.assertEqual(source.get_permissions(), ('ssm:GetServiceSetting',))
+        self.assertEqual(resources[0]['SettingValue'], 'Enable')
+        self.assertEqual(matching[0]['SettingValue'], 'Enable')
+        self.assertEqual(missing, [])
+        client.get_service_setting.assert_called_with(
+            SettingId='/ssm/documents/console/public-sharing-permission')
+
+    def test_ssm_service_setting_enforce_defaults_to_disable(self):
+        client = MagicMock()
+        session = MagicMock()
+        session.client.return_value = client
+        manager = MagicMock(session_factory=MagicMock())
+
+        with patch('c7n.resources.ssm.local_session', return_value=session):
+            from c7n.resources.ssm import EnforceSSMServiceSetting
+            EnforceSSMServiceSetting({'type': 'enforce'}, manager).process([{
+                'SettingId': '/ssm/documents/console/public-sharing-permission'}])
+
+        client.update_service_setting.assert_called_once_with(
+            SettingId='/ssm/documents/console/public-sharing-permission',
+            SettingValue='Disable')
+
+    def test_ssm_service_setting_policy(self):
+        client = MagicMock()
+        client.get_service_setting.return_value = {
+            'ServiceSetting': {
+                'SettingId': '/ssm/documents/console/public-sharing-permission',
+                'SettingValue': 'Enable',
+                'Status': 'Default'}}
+        session = MagicMock()
+        session.client.return_value = client
+
+        with patch('c7n.resources.ssm.local_session', return_value=session):
+            p = self.load_policy({
+                'name': 'disable-ssm-document-public-sharing',
+                'resource': 'aws.ssm-service-setting',
+                'filters': [{'SettingValue': 'Enable'}],
+                'actions': [{'type': 'enforce'}]})
+            resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['SettingValue'], 'Enable')
+        client.update_service_setting.assert_called_once_with(
+            SettingId='/ssm/documents/console/public-sharing-permission',
+            SettingValue='Disable')
 
     def test_ec2_ssm_send_command_validate(self):
         self.assertRaises(


### PR DESCRIPTION
## Summary

Adds Cloud Custodian support for the account-level regional SSM document console public-sharing service setting:

`/ssm/documents/console/public-sharing-permission`

This introduces a new `aws.ssm-service-setting` resource and an `enforce` action so users can detect and set the service setting to `Disable`, blocking public sharing of SSM documents through the console.

Fixes #11019

## Example

```yaml
policies:
  - name: disable-ssm-document-public-sharing
    resource: aws.ssm-service-setting
    filters:
      - SettingValue: Enable
    actions:
      - type: enforce
        value: Disable