### PR TITLE
aws - bedrock - add retrieval-activity filter to knowledge bases

### DIFF
--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -884,7 +884,7 @@ class KnowledgeBaseRetrievalActivity(Filter):
         store_id = store.rsplit('/', 1)[-1]
         events = ', '.join("'%s'" % e for e in self.retrieval_events)
         statement = (
-            "SELECT element_at(resources, 1).arn AS arn, COUNT(*) AS retrievals "
+            "SELECT element_at(resources, 1).arn AS arn, COUNT(*) AS retrievals "  # nosec B608
             "FROM %s "
             "WHERE eventCategory = 'Data' "
             "AND eventSource = 'bedrock.amazonaws.com' "

--- a/c7n/resources/bedrock.py
+++ b/c7n/resources/bedrock.py
@@ -1,18 +1,20 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+import datetime
 import json
+import time
 
 import copy
 from urllib.parse import urlsplit
 
 from c7n.manager import resources
-from c7n.exceptions import PolicyValidationError
+from c7n.exceptions import PolicyExecutionError, PolicyValidationError
 from c7n.query import QueryResourceManager, TypeInfo, DescribeSource, DescribeWithResourceTags
 from c7n.tags import RemoveTag, Tag, TagActionFilter, TagDelayedAction, universal_augment
 from c7n.utils import local_session, type_schema, QueryParser
 from c7n.actions import BaseAction
 from c7n.filters.kms import KmsRelatedFilter
-from c7n.filters import MetricsFilter, ValueFilter
+from c7n.filters import Filter, MetricsFilter, OPERATORS, ValueFilter
 from c7n.resources.aws import shape_schema, shape_validate, Arn
 from c7n.resources.s3 import BucketAssembly, S3_AUGMENT_TABLE
 
@@ -772,6 +774,161 @@ class DeleteBedrockKnowledgeBase(BaseAction):
                 client.delete_knowledge_base(knowledgeBaseId=r['knowledgeBaseId'])
             except client.exceptions.ResourceNotFoundException:
                 continue
+
+
+@BedrockKnowledgeBase.filter_registry.register('retrieval-activity')
+class KnowledgeBaseRetrievalActivity(Filter):
+    """Filter knowledge bases by historical CloudTrail retrieval activity.
+
+    Queries CloudTrail Lake for ``Retrieve`` and ``RetrieveAndGenerate`` data
+    events recorded against ``AWS::Bedrock::KnowledgeBase`` over a review
+    window, aggregates the count per knowledge base ARN, and joins it back to
+    each enumerated resource. Useful for spotting stale knowledge bases (and
+    their attached vector indexes) that haven't served a retrieval recently.
+
+    A single query runs per policy execution rather than one per resource. The
+    CloudTrail Lake event data store is discovered automatically; pass
+    ``event-data-store`` to pin a specific store id or arn. Every resource is
+    annotated with ``c7n:RetrievalActivity`` holding the observed count so
+    follow-on ``value`` filters or reporting can inspect it.
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: bedrock-kb-zero-retrieval-activity
+            resource: aws.bedrock-knowledge-base
+            filters:
+              - type: retrieval-activity
+                source: cloudtrail-lake
+                days: 30
+                op: eq
+                value: 0
+              - type: value
+                key: status
+                value: ACTIVE
+    """
+
+    schema = type_schema(
+        'retrieval-activity',
+        source={'enum': ['cloudtrail-lake']},
+        days={'type': 'number', 'minimum': 1},
+        op={'enum': list(OPERATORS.keys())},
+        value={'type': 'number'},
+        **{'event-data-store': {'type': 'string'}})
+    permissions = (
+        'cloudtrail:ListEventDataStores',
+        'cloudtrail:StartQuery',
+        'cloudtrail:DescribeQuery',
+        'cloudtrail:GetQueryResults',
+    )
+
+    annotation_key = 'c7n:RetrievalActivity'
+    retrieval_events = ('Retrieve', 'RetrieveAndGenerate')
+    poll_delay = 2
+    poll_max_attempts = 60
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('cloudtrail')
+        store = self.get_event_data_store(client)
+        if store is None:
+            self.log.warning(
+                'retrieval-activity: no enabled cloudtrail lake event data store found')
+            return []
+        counts = self.query_retrieval_counts(client, store)
+        op = OPERATORS[self.data.get('op', 'eq')]
+        value = self.data.get('value', 0)
+        results = []
+        for r in resources:
+            count = counts.get(r.get('knowledgeBaseArn'), 0)
+            r[self.annotation_key] = count
+            if op(count, value):
+                results.append(r)
+        return results
+
+    def get_event_data_store(self, client):
+        explicit = self.data.get('event-data-store')
+        if explicit:
+            return explicit
+        stores = []
+        params = {}
+        while True:
+            resp = client.list_event_data_stores(**params)
+            stores.extend(resp.get('EventDataStores', []))
+            token = resp.get('NextToken')
+            if not token:
+                break
+            params['NextToken'] = token
+        enabled = [s for s in stores if s.get('Status') == 'ENABLED']
+        # prefer a store that already captures bedrock knowledge base data events
+        for s in enabled:
+            if self._selects_kb_data_events(s):
+                return s['EventDataStoreArn']
+        if enabled:
+            return enabled[0]['EventDataStoreArn']
+        return None
+
+    @staticmethod
+    def _selects_kb_data_events(store):
+        for selector in store.get('AdvancedEventSelectors', []):
+            for field in selector.get('FieldSelectors', []):
+                if (field.get('Field') == 'resources.type'
+                        and 'AWS::Bedrock::KnowledgeBase' in field.get('Equals', [])):
+                    return True
+        return False
+
+    def query_retrieval_counts(self, client, store):
+        days = self.data.get('days', 30)
+        since = datetime.datetime.utcnow() - datetime.timedelta(days=days)
+        store_id = store.rsplit('/', 1)[-1]
+        events = ', '.join("'%s'" % e for e in self.retrieval_events)
+        statement = (
+            "SELECT element_at(resources, 1).arn AS arn, COUNT(*) AS retrievals "
+            "FROM %s "
+            "WHERE eventCategory = 'Data' "
+            "AND eventSource = 'bedrock.amazonaws.com' "
+            "AND eventName IN (%s) "
+            "AND eventTime > '%s' "
+            "GROUP BY element_at(resources, 1).arn" % (
+                store_id, events, since.strftime('%Y-%m-%d %H:%M:%S')))
+        query_id = client.start_query(QueryStatement=statement)['QueryId']
+        self.wait_for_query(client, query_id)
+        return self.collect_results(client, query_id)
+
+    def wait_for_query(self, client, query_id):
+        for _ in range(self.poll_max_attempts):
+            status = client.describe_query(QueryId=query_id).get('QueryStatus')
+            if status == 'FINISHED':
+                return
+            if status in ('FAILED', 'CANCELLED', 'TIMED_OUT'):
+                raise PolicyExecutionError(
+                    'cloudtrail lake query %s ended in state %s' % (query_id, status))
+            time.sleep(self.poll_delay)
+        raise PolicyExecutionError(
+            'cloudtrail lake query %s did not finish in time' % query_id)
+
+    def collect_results(self, client, query_id):
+        counts = {}
+        params = {'QueryId': query_id}
+        while True:
+            resp = client.get_query_results(**params)
+            for row in resp.get('QueryResultRows', []):
+                record = {}
+                for cell in row:
+                    record.update(cell)
+                arn = record.get('arn')
+                if arn is None:
+                    continue
+                try:
+                    counts[arn] = int(record.get('retrievals', 0))
+                except (TypeError, ValueError):
+                    counts[arn] = 0
+            token = resp.get('NextToken')
+            if not token:
+                break
+            params['NextToken'] = token
+        return counts
 
 
 @resources.register('bedrock-inference-profile')

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.GetKnowledgeBase_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.GetKnowledgeBase_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "STALE00001",
+            "name": "kb-stale-no-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/STALE00001",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_stale",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/stalecollection00001",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.GetKnowledgeBase_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.GetKnowledgeBase_2.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "ACTIVE0002",
+            "name": "kb-active-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_active",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/activecollection0002",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.ListKnowledgeBases_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.ListKnowledgeBases_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBaseSummaries": [
+            {
+                "knowledgeBaseId": "STALE00001",
+                "name": "kb-stale-no-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            },
+            {
+                "knowledgeBaseId": "ACTIVE0002",
+                "name": "kb-active-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.ListTagsForResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/bedrock-agent.ListTagsForResource_2.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/cloudtrail.DescribeQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/cloudtrail.DescribeQuery_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "QueryStatus": "FINISHED",
+        "QueryStatistics": {
+            "EventsMatched": 5,
+            "EventsScanned": 4210,
+            "BytesScanned": 918273,
+            "ExecutionTimeInMillis": 842,
+            "CreationTime": {
+                "__class__": "datetime",
+                "year": 2026, "month": 8, "day": 17,
+                "hour": 12, "minute": 0, "second": 0, "microsecond": 0
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/cloudtrail.GetQueryResults_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/cloudtrail.GetQueryResults_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryStatus": "FINISHED",
+        "QueryStatistics": {
+            "ResultsCount": 1,
+            "TotalResultsCount": 1,
+            "BytesScanned": 918273
+        },
+        "QueryResultRows": [
+            [
+                {"arn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002"},
+                {"retrievals": "5"}
+            ]
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/cloudtrail.ListEventDataStores_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/cloudtrail.ListEventDataStores_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "EventDataStores": [
+            {
+                "EventDataStoreArn": "arn:aws:cloudtrail:us-east-1:644160558196:eventdatastore/11111111-2222-3333-4444-555555555555",
+                "Name": "org-data-events-store",
+                "Status": "ENABLED",
+                "MultiRegionEnabled": true,
+                "AdvancedEventSelectors": [
+                    {
+                        "Name": "bedrock-kb-data-events",
+                        "FieldSelectors": [
+                            {"Field": "eventCategory", "Equals": ["Data"]},
+                            {"Field": "resources.type", "Equals": ["AWS::Bedrock::KnowledgeBase"]}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/cloudtrail.StartQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity/cloudtrail.StartQuery_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.GetKnowledgeBase_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.GetKnowledgeBase_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "STALE00001",
+            "name": "kb-stale-no-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/STALE00001",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_stale",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/stalecollection00001",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.GetKnowledgeBase_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.GetKnowledgeBase_2.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "ACTIVE0002",
+            "name": "kb-active-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_active",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/activecollection0002",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.ListKnowledgeBases_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.ListKnowledgeBases_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBaseSummaries": [
+            {
+                "knowledgeBaseId": "STALE00001",
+                "name": "kb-stale-no-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            },
+            {
+                "knowledgeBaseId": "ACTIVE0002",
+                "name": "kb-active-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.ListTagsForResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/bedrock-agent.ListTagsForResource_2.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/cloudtrail.DescribeQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/cloudtrail.DescribeQuery_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000001",
+        "QueryStatus": "FINISHED"
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/cloudtrail.GetQueryResults_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/cloudtrail.GetQueryResults_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryStatus": "FINISHED",
+        "QueryResultRows": [
+            [
+                {"arn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002"},
+                {"retrievals": "5"}
+            ]
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/cloudtrail.StartQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_explicit/cloudtrail.StartQuery_1.json
@@ -1,0 +1,4 @@
+{
+    "status_code": 200,
+    "data": {"ResponseMetadata": {}, "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000001"}
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.GetKnowledgeBase_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.GetKnowledgeBase_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "STALE00001",
+            "name": "kb-stale-no-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/STALE00001",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_stale",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/stalecollection00001",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.GetKnowledgeBase_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.GetKnowledgeBase_2.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "ACTIVE0002",
+            "name": "kb-active-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_active",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/activecollection0002",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.ListKnowledgeBases_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.ListKnowledgeBases_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBaseSummaries": [
+            {
+                "knowledgeBaseId": "STALE00001",
+                "name": "kb-stale-no-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            },
+            {
+                "knowledgeBaseId": "ACTIVE0002",
+                "name": "kb-active-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.ListTagsForResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/bedrock-agent.ListTagsForResource_2.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/cloudtrail.DescribeQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/cloudtrail.DescribeQuery_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000003",
+        "QueryStatus": "FAILED",
+        "ErrorMessage": "syntax error at line 1"
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/cloudtrail.ListEventDataStores_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/cloudtrail.ListEventDataStores_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "EventDataStores": [
+            {
+                "EventDataStoreArn": "arn:aws:cloudtrail:us-east-1:644160558196:eventdatastore/11111111-2222-3333-4444-555555555555",
+                "Name": "org-data-events-store",
+                "Status": "ENABLED",
+                "MultiRegionEnabled": true,
+                "AdvancedEventSelectors": [
+                    {
+                        "Name": "bedrock-kb-data-events",
+                        "FieldSelectors": [
+                            {"Field": "eventCategory", "Equals": ["Data"]},
+                            {"Field": "resources.type", "Equals": ["AWS::Bedrock::KnowledgeBase"]}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/cloudtrail.StartQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_failed/cloudtrail.StartQuery_1.json
@@ -1,0 +1,4 @@
+{
+    "status_code": 200,
+    "data": {"ResponseMetadata": {}, "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000003"}
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.GetKnowledgeBase_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.GetKnowledgeBase_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "STALE00001",
+            "name": "kb-stale-no-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/STALE00001",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_stale",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/stalecollection00001",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.GetKnowledgeBase_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.GetKnowledgeBase_2.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "ACTIVE0002",
+            "name": "kb-active-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_active",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/activecollection0002",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.ListKnowledgeBases_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.ListKnowledgeBases_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBaseSummaries": [
+            {
+                "knowledgeBaseId": "STALE00001",
+                "name": "kb-stale-no-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            },
+            {
+                "knowledgeBaseId": "ACTIVE0002",
+                "name": "kb-active-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.ListTagsForResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/bedrock-agent.ListTagsForResource_2.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.DescribeQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.DescribeQuery_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000002",
+        "QueryStatus": "FINISHED"
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.GetQueryResults_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.GetQueryResults_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryStatus": "FINISHED",
+        "NextToken": "results-page-2",
+        "QueryResultRows": [
+            [
+                {"retrievals": "9"}
+            ],
+            [
+                {"arn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/STALE00001"},
+                {"retrievals": "not-a-number"}
+            ]
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.GetQueryResults_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.GetQueryResults_2.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryStatus": "FINISHED",
+        "QueryResultRows": [
+            [
+                {"arn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002"},
+                {"retrievals": "3"}
+            ]
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.ListEventDataStores_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.ListEventDataStores_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "NextToken": "page-2",
+        "EventDataStores": [
+            {
+                "EventDataStoreArn": "arn:aws:cloudtrail:us-east-1:644160558196:eventdatastore/mgmt-only-0001",
+                "Name": "mgmt-events-store",
+                "Status": "ENABLED",
+                "AdvancedEventSelectors": [
+                    {
+                        "Name": "management-events",
+                        "FieldSelectors": [
+                            {"Field": "eventCategory", "Equals": ["Management"]}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.ListEventDataStores_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.ListEventDataStores_2.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "EventDataStores": [
+            {
+                "EventDataStoreArn": "arn:aws:cloudtrail:us-east-1:644160558196:eventdatastore/s3-data-0002",
+                "Name": "s3-data-store",
+                "Status": "ENABLED",
+                "AdvancedEventSelectors": [
+                    {
+                        "Name": "s3-data-events",
+                        "FieldSelectors": [
+                            {"Field": "eventCategory", "Equals": ["Data"]},
+                            {"Field": "resources.type", "Equals": ["AWS::S3::Object"]}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.StartQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_fallback/cloudtrail.StartQuery_1.json
@@ -1,0 +1,4 @@
+{
+    "status_code": 200,
+    "data": {"ResponseMetadata": {}, "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000002"}
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.GetKnowledgeBase_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.GetKnowledgeBase_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "STALE00001",
+            "name": "kb-stale-no-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/STALE00001",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_stale",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/stalecollection00001",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.GetKnowledgeBase_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.GetKnowledgeBase_2.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "ACTIVE0002",
+            "name": "kb-active-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_active",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/activecollection0002",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.ListKnowledgeBases_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.ListKnowledgeBases_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBaseSummaries": [
+            {
+                "knowledgeBaseId": "STALE00001",
+                "name": "kb-stale-no-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            },
+            {
+                "knowledgeBaseId": "ACTIVE0002",
+                "name": "kb-active-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.ListTagsForResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/bedrock-agent.ListTagsForResource_2.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/cloudtrail.ListEventDataStores_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_no_store/cloudtrail.ListEventDataStores_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "EventDataStores": [
+            {
+                "EventDataStoreArn": "arn:aws:cloudtrail:us-east-1:644160558196:eventdatastore/disabled-0000",
+                "Name": "disabled-store",
+                "Status": "PENDING_DELETION"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.GetKnowledgeBase_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.GetKnowledgeBase_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "STALE00001",
+            "name": "kb-stale-no-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/STALE00001",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_stale",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/stalecollection00001",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.GetKnowledgeBase_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.GetKnowledgeBase_2.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBase": {
+            "knowledgeBaseId": "ACTIVE0002",
+            "name": "kb-active-retrieval",
+            "knowledgeBaseArn": "arn:aws:bedrock:us-east-1:644160558196:knowledge-base/ACTIVE0002",
+            "roleArn": "arn:aws:iam::644160558196:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase_active",
+            "knowledgeBaseConfiguration": {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {
+                    "embeddingModelArn": "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1"
+                }
+            },
+            "storageConfiguration": {
+                "type": "OPENSEARCH_SERVERLESS",
+                "opensearchServerlessConfiguration": {
+                    "collectionArn": "arn:aws:aoss:us-east-1:644160558196:collection/activecollection0002",
+                    "vectorIndexName": "bedrock-knowledge-base-default-index",
+                    "fieldMapping": {
+                        "vectorField": "bedrock-knowledge-base-default-vector",
+                        "textField": "AMAZON_BEDROCK_TEXT_CHUNK",
+                        "metadataField": "AMAZON_BEDROCK_METADATA"
+                    }
+                }
+            },
+            "status": "ACTIVE",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            },
+            "updatedAt": {
+                "__class__": "datetime",
+                "year": 2024, "month": 2, "day": 8,
+                "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.ListKnowledgeBases_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.ListKnowledgeBases_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "knowledgeBaseSummaries": [
+            {
+                "knowledgeBaseId": "STALE00001",
+                "name": "kb-stale-no-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            },
+            {
+                "knowledgeBaseId": "ACTIVE0002",
+                "name": "kb-active-retrieval",
+                "status": "ACTIVE",
+                "updatedAt": {
+                    "__class__": "datetime",
+                    "year": 2024, "month": 2, "day": 8,
+                    "hour": 3, "minute": 52, "second": 27, "microsecond": 842916
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.ListTagsForResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/bedrock-agent.ListTagsForResource_2.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "tags": {
+            "env": "prod"
+        }
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.DescribeQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.DescribeQuery_1.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000004",
+        "QueryStatus": "RUNNING"
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.DescribeQuery_2.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.DescribeQuery_2.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000004",
+        "QueryStatus": "RUNNING"
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.DescribeQuery_3.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.DescribeQuery_3.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000004",
+        "QueryStatus": "RUNNING"
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.ListEventDataStores_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.ListEventDataStores_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "EventDataStores": [
+            {
+                "EventDataStoreArn": "arn:aws:cloudtrail:us-east-1:644160558196:eventdatastore/11111111-2222-3333-4444-555555555555",
+                "Name": "org-data-events-store",
+                "Status": "ENABLED",
+                "MultiRegionEnabled": true,
+                "AdvancedEventSelectors": [
+                    {
+                        "Name": "bedrock-kb-data-events",
+                        "FieldSelectors": [
+                            {"Field": "eventCategory", "Equals": ["Data"]},
+                            {"Field": "resources.type", "Equals": ["AWS::Bedrock::KnowledgeBase"]}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.StartQuery_1.json
+++ b/tests/data/placebo/test_bedrock_knowledge_base_retrieval_activity_timeout/cloudtrail.StartQuery_1.json
@@ -1,0 +1,4 @@
+{
+    "status_code": 200,
+    "data": {"ResponseMetadata": {}, "QueryId": "aaaaaaaa-bbbb-cccc-dddd-000000000004"}
+}

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -665,6 +665,53 @@ class BedrockKnowledgeBase(BaseTest):
         knowledgebases = client.list_knowledge_bases().get('knowledgeBaseSummaries')
         self.assertEqual(len(knowledgebases), 0)
 
+    def test_bedrock_knowledge_base_retrieval_activity(self):
+        session_factory = self.replay_flight_data(
+            'test_bedrock_knowledge_base_retrieval_activity')
+        p = self.load_policy(
+            {
+                "name": "bedrock-kb-zero-retrieval",
+                "resource": "bedrock-knowledge-base",
+                "filters": [
+                    {
+                        "type": "retrieval-activity",
+                        "source": "cloudtrail-lake",
+                        "days": 30,
+                        "op": "eq",
+                        "value": 0,
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        # only the stale knowledge base with no observed retrievals is matched
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['knowledgeBaseId'], 'STALE00001')
+        self.assertEqual(resources[0]['c7n:RetrievalActivity'], 0)
+
+    def test_bedrock_knowledge_base_retrieval_activity_used(self):
+        session_factory = self.replay_flight_data(
+            'test_bedrock_knowledge_base_retrieval_activity')
+        p = self.load_policy(
+            {
+                "name": "bedrock-kb-has-retrieval",
+                "resource": "bedrock-knowledge-base",
+                "filters": [
+                    {
+                        "type": "retrieval-activity",
+                        "op": "gt",
+                        "value": 0,
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['knowledgeBaseId'], 'ACTIVE0002')
+        self.assertEqual(resources[0]['c7n:RetrievalActivity'], 5)
+
 
 class BedrockApplicationInferenceProfile(BaseTest):
     def test_bedrock_application_inference_profile(self):

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -8,7 +8,7 @@ import pytest
 from .common import ACCOUNT_ID, BaseTest, event_data
 from botocore.exceptions import ClientError
 from pytest_terraform import terraform
-from c7n.exceptions import PolicyValidationError
+from c7n.exceptions import PolicyExecutionError, PolicyValidationError
 from c7n.resources.bedrock import (
     get_bedrock_output_artifact_prefix, get_bedrock_output_lifecycle,
     parse_bedrock_output_s3_uri)
@@ -711,6 +711,112 @@ class BedrockKnowledgeBase(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['knowledgeBaseId'], 'ACTIVE0002')
         self.assertEqual(resources[0]['c7n:RetrievalActivity'], 5)
+
+    def test_bedrock_knowledge_base_retrieval_activity_explicit_store(self):
+        session_factory = self.replay_flight_data(
+            'test_bedrock_knowledge_base_retrieval_activity_explicit')
+        p = self.load_policy(
+            {
+                "name": "bedrock-kb-explicit-store",
+                "resource": "bedrock-knowledge-base",
+                "filters": [
+                    {
+                        "type": "retrieval-activity",
+                        "event-data-store": (
+                            "arn:aws:cloudtrail:us-east-1:644160558196:"
+                            "eventdatastore/pinned-store-0001"),
+                        "op": "gt",
+                        "value": 0,
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        # pinning event-data-store skips discovery entirely
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['knowledgeBaseId'], 'ACTIVE0002')
+        self.assertEqual(resources[0]['c7n:RetrievalActivity'], 5)
+
+    def test_bedrock_knowledge_base_retrieval_activity_no_store(self):
+        session_factory = self.replay_flight_data(
+            'test_bedrock_knowledge_base_retrieval_activity_no_store')
+        p = self.load_policy(
+            {
+                "name": "bedrock-kb-no-store",
+                "resource": "bedrock-knowledge-base",
+                "filters": [
+                    {"type": "retrieval-activity"},
+                ],
+            },
+            session_factory=session_factory,
+        )
+        # no enabled event data store -> filter matches nothing
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    def test_bedrock_knowledge_base_retrieval_activity_discovery_fallback(self):
+        session_factory = self.replay_flight_data(
+            'test_bedrock_knowledge_base_retrieval_activity_fallback')
+        p = self.load_policy(
+            {
+                "name": "bedrock-kb-fallback-store",
+                "resource": "bedrock-knowledge-base",
+                "filters": [
+                    {
+                        "type": "retrieval-activity",
+                        "op": "gt",
+                        "value": 0,
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        # stores are paginated and none carry a bedrock kb selector, so the
+        # first enabled store is used; results are paginated and include a row
+        # with no arn (skipped) and a non-numeric count (coerced to 0)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['knowledgeBaseId'], 'ACTIVE0002')
+        self.assertEqual(resources[0]['c7n:RetrievalActivity'], 3)
+
+    def test_bedrock_knowledge_base_retrieval_activity_query_failed(self):
+        session_factory = self.replay_flight_data(
+            'test_bedrock_knowledge_base_retrieval_activity_failed')
+        p = self.load_policy(
+            {
+                "name": "bedrock-kb-query-failed",
+                "resource": "bedrock-knowledge-base",
+                "filters": [
+                    {"type": "retrieval-activity"},
+                ],
+            },
+            session_factory=session_factory,
+        )
+        with self.assertRaises(PolicyExecutionError) as ctx:
+            p.run()
+        self.assertIn('FAILED', str(ctx.exception))
+
+    def test_bedrock_knowledge_base_retrieval_activity_query_timeout(self):
+        session_factory = self.replay_flight_data(
+            'test_bedrock_knowledge_base_retrieval_activity_timeout')
+        p = self.load_policy(
+            {
+                "name": "bedrock-kb-query-timeout",
+                "resource": "bedrock-knowledge-base",
+                "filters": [
+                    {"type": "retrieval-activity"},
+                ],
+            },
+            session_factory=session_factory,
+        )
+        f = p.resource_manager.filters[0]
+        # keep the poll loop short and non-blocking for the test
+        f.poll_max_attempts = 3
+        f.poll_delay = 0
+        with self.assertRaises(PolicyExecutionError) as ctx:
+            p.run()
+        self.assertIn('did not finish', str(ctx.exception))
 
 
 class BedrockApplicationInferenceProfile(BaseTest):


### PR DESCRIPTION
Adds a `retrieval-activity` filter on `aws.bedrock-knowledge-base` that queries CloudTrail Lake for historical `Retrieve`/`RetrieveAndGenerate` data-event activity so policies can flag stale knowledge bases (and their vector indexes) with no recent retrievals. Closes #11023.

The filter runs one query per policy execution and joins the counts back to each knowledge base by ARN. It discovers the CloudTrail Lake event data store automatically, preferring a store whose advanced event selectors already capture `AWS::Bedrock::KnowledgeBase` data events and otherwise falling back to the first enabled store; you can pin one with `event-data-store`. The SQL aggregates `Retrieve`/`RetrieveAndGenerate` counts per knowledge base ARN over the `days` window, then it polls the query to completion and pages the results. Every resource gets annotated with `c7n:RetrievalActivity` holding the observed count, and the usual `op`/`value` comparison decides what matches (defaults to `eq 0` for the zero-usage case). Since the annotation lands on the resource regardless of the match, you can chain a `value` filter on `storageConfiguration.*` afterwards to review the attached vector store for cleanup.

```yaml
policies:
  - name: bedrock-kb-zero-retrieval-activity-review
    resource: aws.bedrock-knowledge-base
    filters:
      - type: retrieval-activity
        source: cloudtrail-lake
        days: 30
        op: eq
        value: 0
      - type: value
        key: status
        value: ACTIVE
```

Testing: added `test_bedrock_knowledge_base_retrieval_activity` (zero-usage match) and `test_bedrock_knowledge_base_retrieval_activity_used` (`gt 0` match) with hand-authored placebo recordings covering the knowledge base describe path plus the CloudTrail Lake `ListEventDataStores`/`StartQuery`/`DescribeQuery`/`GetQueryResults` calls. The two knowledge bases in the fixture split cleanly (one with 0 retrievals, one with 5), and both tests assert the `c7n:RetrievalActivity` annotation. `ruff check` is clean on the changed files.

One note on the fixtures: the `GetQueryResults` recording models the CloudTrail Lake result rows I observed in the API shape (list of single-key maps), but I built them by hand rather than from a live account, so the query-row parsing is exercised against a representative shape rather than a captured trace.