### PR TITLE
gcp: add AlloyDB cluster and instance resources

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/alloydb.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/alloydb.py
@@ -1,0 +1,92 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from c7n_gcp.provider import resources
+from c7n_gcp.query import (
+    QueryResourceManager, TypeInfo, ChildTypeInfo, ChildResourceManager)
+
+
+@resources.register('alloydb-cluster')
+class AlloyDBCluster(QueryResourceManager):
+    """GCP resource:
+    https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.clusters
+    """
+    class resource_type(TypeInfo):
+        service = 'alloydb'
+        version = 'v1'
+        component = 'projects.locations.clusters'
+        enum_spec = ('list', 'clusters[]', None)
+        scope = 'project'
+        scope_key = 'parent'
+        scope_template = 'projects/{}/locations/-'
+        name = id = 'name'
+        default_report_fields = [
+            'name', 'state', 'clusterType', 'databaseVersion', 'createTime']
+        asset_type = 'alloydb.googleapis.com/Cluster'
+        urn_component = 'cluster'
+        urn_id_segments = (-1,)
+        labels = True
+        labels_op = 'patch'
+        labels_perm = 'update'
+
+        @classmethod
+        def _get_location(cls, resource):
+            return resource['name'].split('/')[3]
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command(
+                'get', {'name': resource_info['resourceName']})
+
+        @staticmethod
+        def get_label_params(resource, all_labels):
+            return {
+                'name': resource['name'],
+                'updateMask': 'labels',
+                'body': {'labels': all_labels}}
+
+
+@resources.register('alloydb-instance')
+class AlloyDBInstance(ChildResourceManager):
+    """GCP resource:
+    https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.clusters.instances
+    """
+    def _get_parent_resource_info(self, child_instance):
+        # instance name: projects/{p}/locations/{l}/clusters/{c}/instances/{i}
+        # the parent cluster name is everything up to /instances
+        return {'resourceName': child_instance['name'].split('/instances/')[0]}
+
+    def _get_child_enum_args(self, parent_instance):
+        return {'parent': parent_instance['name']}
+
+    class resource_type(ChildTypeInfo):
+        service = 'alloydb'
+        version = 'v1'
+        component = 'projects.locations.clusters.instances'
+        enum_spec = ('list', 'instances[]', None)
+        scope = 'global'
+        name = id = 'name'
+        parent_spec = {'resource': 'alloydb-cluster'}
+        default_report_fields = [
+            'name', 'state', 'instanceType', 'availabilityType', 'createTime']
+        asset_type = 'alloydb.googleapis.com/Instance'
+        urn_component = 'instance'
+        urn_id_segments = (-1,)
+        labels = True
+        labels_op = 'patch'
+        labels_perm = 'update'
+
+        @classmethod
+        def _get_location(cls, resource):
+            return resource['name'].split('/')[3]
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command(
+                'get', {'name': resource_info['resourceName']})
+
+        @staticmethod
+        def get_label_params(resource, all_labels):
+            return {
+                'name': resource['name'],
+                'updateMask': 'labels',
+                'body': {'labels': all_labels}}

--- a/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/resource_map.py
@@ -1,5 +1,7 @@
 # Copyright The Cloud Custodian Authors.
 ResourceMap = {
+    "gcp.alloydb-cluster": "c7n_gcp.resources.alloydb.AlloyDBCluster",
+    "gcp.alloydb-instance": "c7n_gcp.resources.alloydb.AlloyDBInstance",
     "gcp.api-key": "c7n_gcp.resources.iam.ApiKey",
     "gcp.armor-policy": "c7n_gcp.resources.armor.SecurityPolicy",
     "gcp.app-engine": "c7n_gcp.resources.appengine.AppEngineApp",

--- a/tools/c7n_gcp/tests/data/flights/gcp-alloydb-cluster-query/get-v1-projects-cloud-custodian-locations---clusters_1.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-alloydb-cluster-query/get-v1-projects-cloud-custodian-locations---clusters_1.json
@@ -1,0 +1,34 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-location": "https://alloydb.googleapis.com/v1/projects/cloud-custodian/locations/-/clusters?alt=json"
+  },
+  "body": {
+    "clusters": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/clusters/test-cluster",
+        "uid": "a1b2c3d4-0000-1111-2222-333344445555",
+        "state": "READY",
+        "clusterType": "PRIMARY",
+        "databaseVersion": "POSTGRES_15",
+        "createTime": "2026-06-15T12:00:00.000000Z",
+        "updateTime": "2026-06-15T12:05:00.000000Z",
+        "network": "projects/cloud-custodian/global/networks/default",
+        "networkConfig": {
+          "network": "projects/cloud-custodian/global/networks/default"
+        },
+        "labels": {
+          "env": "test"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/gcp-alloydb-instance-query/get-v1-projects-cloud-custodian-locations---clusters_1.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-alloydb-instance-query/get-v1-projects-cloud-custodian-locations---clusters_1.json
@@ -1,0 +1,34 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-location": "https://alloydb.googleapis.com/v1/projects/cloud-custodian/locations/-/clusters?alt=json"
+  },
+  "body": {
+    "clusters": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/clusters/test-cluster",
+        "uid": "a1b2c3d4-0000-1111-2222-333344445555",
+        "state": "READY",
+        "clusterType": "PRIMARY",
+        "databaseVersion": "POSTGRES_15",
+        "createTime": "2026-06-15T12:00:00.000000Z",
+        "updateTime": "2026-06-15T12:05:00.000000Z",
+        "network": "projects/cloud-custodian/global/networks/default",
+        "networkConfig": {
+          "network": "projects/cloud-custodian/global/networks/default"
+        },
+        "labels": {
+          "env": "test"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/gcp-alloydb-instance-query/get-v1-projects-cloud-custodian-locations-us-central1-clusters-test-cluster-instances_1.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-alloydb-instance-query/get-v1-projects-cloud-custodian-locations-us-central1-clusters-test-cluster-instances_1.json
@@ -1,0 +1,34 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-location": "https://alloydb.googleapis.com/v1/projects/cloud-custodian/locations/us-central1/clusters/test-cluster/instances?alt=json"
+  },
+  "body": {
+    "instances": [
+      {
+        "name": "projects/cloud-custodian/locations/us-central1/clusters/test-cluster/instances/test-instance",
+        "uid": "99998888-7777-6666-5555-444433332222",
+        "state": "READY",
+        "instanceType": "PRIMARY",
+        "availabilityType": "REGIONAL",
+        "createTime": "2026-06-15T12:10:00.000000Z",
+        "updateTime": "2026-06-15T12:12:00.000000Z",
+        "machineConfig": {
+          "cpuCount": 2
+        },
+        "ipAddress": "10.0.0.5",
+        "labels": {
+          "env": "test"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/test_alloydb.py
+++ b/tools/c7n_gcp/tests/test_alloydb.py
@@ -1,0 +1,49 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from gcp_common import BaseTest
+
+
+class AlloyDBClusterTest(BaseTest):
+
+    def test_query(self):
+        factory = self.replay_flight_data('gcp-alloydb-cluster-query')
+        p = self.load_policy({
+            'name': 'gcp-alloydb-cluster',
+            'resource': 'gcp.alloydb-cluster'},
+            session_factory=factory)
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['name'],
+            'projects/cloud-custodian/locations/us-central1/'
+            'clusters/test-cluster')
+        self.assertEqual(resources[0]['state'], 'READY')
+        self.assertEqual(resources[0]['labels'], {'env': 'test'})
+
+        self.assertEqual(
+            p.resource_manager.get_urns(resources),
+            ['gcp:alloydb:us-central1:cloud-custodian:cluster/test-cluster'])
+
+
+class AlloyDBInstanceTest(BaseTest):
+
+    def test_query(self):
+        factory = self.replay_flight_data('gcp-alloydb-instance-query')
+        p = self.load_policy({
+            'name': 'gcp-alloydb-instance',
+            'resource': 'gcp.alloydb-instance'},
+            session_factory=factory)
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['name'],
+            'projects/cloud-custodian/locations/us-central1/'
+            'clusters/test-cluster/instances/test-instance')
+        self.assertEqual(resources[0]['instanceType'], 'PRIMARY')
+
+        self.assertEqual(
+            p.resource_manager.get_urns(resources),
+            ['gcp:alloydb:us-central1:cloud-custodian:'
+             'instance/test-instance'])


### PR DESCRIPTION
Adds `gcp.alloydb-cluster` and `gcp.alloydb-instance` so policies can describe and label AlloyDB, which the provider had no support for. Refs #10874.

Clusters list against `projects/{project}/locations/-` so the aggregated wildcard picks them up across regions in one call. Instances hang off the AlloyDB Admin API as a child of the cluster, so `alloydb-instance` is a `ChildResourceManager` that walks each cluster and lists `.../clusters/{cluster}/instances`. Both wire up `set-labels` through the `patch` method with an `updateMask` of `labels`, matching how the other GCP label-capable resources do it.

I scoped this to the describe + label phase the issue calls out first. Backups, operations, and users (and the metrics/delete/update actions) are left for follow-ups per the checklist.

Tests use hand-authored flight-recorder cassettes for the cluster and instance list calls, mirroring `test_spanner`/`test_datafusion`. `python -m pytest tools/c7n_gcp/tests/test_alloydb.py` passes (2 tests), covering the query results and URN generation for both resources. Also confirmed the schema loads and a `set-labels` policy validates on each, resolving to `alloydb.clusters.list/update` and `alloydb.instances.list/update` permissions.