### PR TITLE
azure - vmss - add scale action for time-based capacity management

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/vmss.py
+++ b/tools/c7n_azure/c7n_azure/resources/vmss.py
@@ -63,7 +63,6 @@ class VmssSetCapacityAction(AzureBaseAction):
               - type: offhour
                 default_tz: utc
                 offhour: 19
-                onhour: 7
             actions:
               - type: scale
                 capacity: 1
@@ -73,7 +72,6 @@ class VmssSetCapacityAction(AzureBaseAction):
             filters:
               - type: onhour
                 default_tz: utc
-                offhour: 19
                 onhour: 7
             actions:
               - type: scale

--- a/tools/c7n_azure/c7n_azure/resources/vmss.py
+++ b/tools/c7n_azure/c7n_azure/resources/vmss.py
@@ -1,6 +1,10 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+from azure.mgmt.compute.models import Sku, VirtualMachineScaleSetUpdate
+
+from c7n.utils import type_schema
+from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
 
@@ -40,3 +44,62 @@ class VMScaleSet(ArmResourceManager):
             'sku.capacity'
         )
         resource_type = 'Microsoft.Compute/virtualMachineScaleSets'
+
+
+@VMScaleSet.action_registry.register('scale')
+class VmssSetCapacityAction(AzureBaseAction):
+    """Set the instance capacity of a VM Scale Set.
+
+    :example:
+
+    Scale VMSS down to 1 instance during off-hours and back up during on-hours:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: vmss-scale-down-offhours
+            resource: azure.vmss
+            filters:
+              - type: offhour
+                default_tz: utc
+                offhour: 19
+                onhour: 7
+            actions:
+              - type: scale
+                capacity: 1
+
+          - name: vmss-scale-up-onhours
+            resource: azure.vmss
+            filters:
+              - type: onhour
+                default_tz: utc
+                offhour: 19
+                onhour: 7
+            actions:
+              - type: scale
+                capacity: 10
+
+    """
+
+    schema = type_schema(
+        'scale',
+        required=['capacity'],
+        **{'capacity': {'type': 'integer', 'minimum': 0}}
+    )
+
+    def _prepare_processing(self):
+        self.client = self.manager.get_client()
+
+    def _process_resource(self, resource):
+        sku = resource.get('sku', {})
+        self.client.virtual_machine_scale_sets.begin_update(
+            resource['resourceGroup'],
+            resource['name'],
+            VirtualMachineScaleSetUpdate(
+                sku=Sku(
+                    name=sku.get('name'),
+                    tier=sku.get('tier'),
+                    capacity=self.data['capacity']
+                )
+            )
+        )

--- a/tools/c7n_azure/tests_azure/tests_resources/test_vmss.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_vmss.py
@@ -1,6 +1,15 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from ..azure_common import BaseTest, arm_template
+from unittest.mock import patch
+
+from azure.mgmt.compute.models import Sku, VirtualMachineScaleSetUpdate
+
+from ..azure_common import BaseTest, arm_template, cassette_name
+
+_VMSS_BEGIN_UPDATE = (
+    'azure.mgmt.compute.v2024_11_01.operations'
+    '._operations.VirtualMachineScaleSetsOperations.begin_update'
+)
 
 
 class VMSSTest(BaseTest):
@@ -17,6 +26,15 @@ class VMSSTest(BaseTest):
 
             self.assertTrue(p)
 
+    def test_validate_scale_schema(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-vmss-scale',
+                'resource': 'azure.vmss',
+                'actions': [{'type': 'scale', 'capacity': 2}]
+            }, validate=True)
+            self.assertTrue(p)
+
     @arm_template('vmss.json')
     def test_find_by_name(self):
         p = self.load_policy({
@@ -30,3 +48,32 @@ class VMSSTest(BaseTest):
         })
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    @patch(_VMSS_BEGIN_UPDATE)
+    @arm_template('vmss.json')
+    @cassette_name('test_find_by_name')
+    def test_scale_action(self, scale_mock):
+        p = self.load_policy({
+            'name': 'test-vmss-scale',
+            'resource': 'azure.vmss',
+            'filters': [
+                {'type': 'value',
+                 'key': 'name',
+                 'op': 'eq',
+                 'value': 'cctestvmss'}],
+            'actions': [{'type': 'scale', 'capacity': 1}]
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual(1, scale_mock.call_count)
+        scale_mock.assert_called_with(
+            resources[0]['resourceGroup'],
+            resources[0]['name'],
+            VirtualMachineScaleSetUpdate(
+                sku=Sku(
+                    name=resources[0]['sku']['name'],
+                    tier=resources[0]['sku']['tier'],
+                    capacity=1
+                )
+            )
+        )

--- a/tools/c7n_azure/tests_azure/tests_resources/test_vmss.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_vmss.py
@@ -35,6 +35,26 @@ class VMSSTest(BaseTest):
             }, validate=True)
             self.assertTrue(p)
 
+    def test_validate_offhour_scale_schema(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-vmss-offhour-scale',
+                'resource': 'azure.vmss',
+                'filters': [{'type': 'offhour', 'default_tz': 'utc', 'offhour': 19}],
+                'actions': [{'type': 'scale', 'capacity': 1}]
+            }, validate=True)
+            self.assertTrue(p)
+
+    def test_validate_onhour_scale_schema(self):
+        with self.sign_out_patch():
+            p = self.load_policy({
+                'name': 'test-vmss-onhour-scale',
+                'resource': 'azure.vmss',
+                'filters': [{'type': 'onhour', 'default_tz': 'utc', 'onhour': 7}],
+                'actions': [{'type': 'scale', 'capacity': 10}]
+            }, validate=True)
+            self.assertTrue(p)
+
     @arm_template('vmss.json')
     def test_find_by_name(self):
         p = self.load_policy({


### PR DESCRIPTION
Adds a `scale` action to the `azure.vmss` resource, allowing VMSS instance capacity to be set to a specific value via policy.

This enables time-based cost savings by pairing the new action with the existing `offhour`/`onhour` filters — scaling VMSS down during off-hours and back up during business hours, bringing similar functionality to AWS ASG off-hours support.

```yaml
policies:
  - name: vmss-scale-down-offhours
    resource: azure.vmss
    filters:
      - type: offhour
        default_tz: utc
        offhour: 19
    actions:
      - type: scale
        capacity: 1

  - name: vmss-scale-up-onhours
    resource: azure.vmss
    filters:
      - type: onhour
        default_tz: utc
        onhour: 7
    actions:
      - type: scale
        capacity: 10
```