### PR TITLE
gcp - add audit event fixture recorder for gcp-audit mode tests

### DIFF
--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -69,10 +69,7 @@ Filtering options
 - ``resource_name`` (optional) -- a substring match against
   ``protoPayload.resourceName``.
 - ``labels`` (optional) -- an exact-match mapping against
-  ``resource.labels``, e.g. ``{"database_id": database_id}``. The query
-  is already scoped to one project via ``resourceNames``, so a
-  ``project_id`` label wouldn't narrow anything further -- use ``labels``
-  for fields that distinguish resources *within* the project.
+  ``resource.labels``, e.g. ``{"database_id": database_id}``.
 - ``start_time_skew`` (default 60s) -- how far before construction time to
   set the query's lower time bound, to guard against clock skew between
   the test host and Cloud Logging.

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -104,13 +104,16 @@ operation swept up by the same filter (rare, but possible with a loose or no
 ``resource_name`` substring) would produce ``foo-1-first.json`` /
 ``foo-1-last.json``.
 
-If a computed filename already exists on disk (e.g. a stale fixture from
-an earlier recording run, or two truly ambiguous matches), a numeric
-suffix is appended *after* the extension instead --
-``foo.json``, then ``foo.json-1``, ``foo.json-2``, and so on -- and a
-warning is logged. These extra files are left in place rather than
-cleaned up automatically, so they show up in the diff for the developer
-to sort out (rename, merge, or delete as appropriate).
+If a computed filename already exists on disk with different content
+(e.g. a stale fixture from an earlier recording run, or two truly
+ambiguous matches), a numeric suffix is appended *after* the extension
+instead -- ``foo.json``, then ``foo.json-1``, ``foo.json-2``, and so on
+-- and a warning is logged. These extra files are left in place rather
+than cleaned up automatically, so they show up in the diff for the
+developer to sort out (rename, merge, or delete as appropriate). If the
+existing file's content is identical, it's left as-is and nothing new is
+written -- polling re-returns already-recorded entries as long as an
+operation is still in progress, and that isn't a collision.
 
 Events and operations may have multiple log entries
 -------------------------------------------------------

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -76,16 +76,18 @@ Filtering options
 - ``timeout`` / ``poll_interval`` (default 120s/5s) -- how long, and how often, to poll
   before giving up.
 
-``record()`` polls until at least one matching entry appears (or the
+``record()`` polls until every matching operation is complete (or the
 timeout elapses), rather than issuing a single query -- Cloud Logging
 entries can take a few seconds to become queryable after the underlying
-API call completes.
+API call completes. On timeout it raises, naming any operation still
+missing its ``last`` entry; that usually means the filter is too loose and
+swept up an unrelated operation, so narrow ``resource_name`` or ``labels``.
 
 Files created
 --------------
 
 For a call with no `operation` field (see below), the matching entry is
-written under the requested name, e.g. ``foo.json``, and polling stops.
+written under the requested name, e.g. ``foo.json``.
 
 If an entry belongs to a Cloud Logging *operation* (see below), the
 filename reflects that:
@@ -96,7 +98,9 @@ filename reflects that:
   case doesn't get a numeric suffix at all
 - ``-first`` is appended when ``operation.first`` is set,
   ``-last`` when ``operation.last`` is set
-- polling stops once an entry with ``operation.last`` is seen
+- polling stops once *every* operation seen so far has produced its
+  ``last`` entry -- one operation completing doesn't cut short another
+  operation the same filter matched
 
 So the common case for an operation-tracked method produces exactly two
 files: ``foo-first.json`` and ``foo-last.json``. A second, distinct

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -104,14 +104,9 @@ operation swept up by the same filter (rare, but possible with a loose or no
 ``resource_name`` substring) would produce ``foo-1-first.json`` /
 ``foo-1-last.json``.
 
-Recording tracks entries it has already written by content hash, so a
-later poll re-returning an entry an earlier poll already wrote (Cloud
-Logging queries are cumulative from a fixed start time) is a no-op, not
-a collision.
-
-If a computed filename already exists on disk from something other than
-this recording run (e.g. a stale fixture left over from an earlier run),
-a numeric suffix is appended *after* the extension instead --
+If a computed filename already exists on disk (e.g. a stale fixture from
+an earlier recording run, or two truly ambiguous matches), a numeric
+suffix is appended *after* the extension instead --
 ``foo.json``, then ``foo.json-1``, ``foo.json-2``, and so on -- and a
 warning is logged. These extra files are left in place rather than
 cleaned up automatically, so they show up in the diff for the developer

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -61,8 +61,7 @@ Once recorded, commit the generated fixture(s) under
 Filtering options
 -------------------
 
-``audit_event_recorder`` takes only structured inputs -- it composes the
-Cloud Logging filter itself, rather than accepting a raw filter string:
+``audit_event_recorder`` takes arguments to filter desired log events:
 
 - ``method`` (required) -- a substring match against
   ``protoPayload.methodName``, e.g. ``"UpdateBackupSchedule"`` rather than
@@ -74,7 +73,7 @@ Cloud Logging filter itself, rather than accepting a raw filter string:
 - ``start_time_skew`` (default 60s) -- how far before construction time to
   set the query's lower time bound, to guard against clock skew between
   the test host and Cloud Logging.
-- ``timeout`` / ``poll_interval`` -- how long, and how often, to poll
+- ``timeout`` / ``poll_interval`` (default 120s/5s) -- how long, and how often, to poll
   before giving up.
 
 ``record()`` polls until at least one matching entry appears (or the

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -100,7 +100,7 @@ filename reflects that:
 
 So the common case for an operation-tracked method produces exactly two
 files: ``foo-first.json`` and ``foo-last.json``. A second, distinct
-operation swept up by the same filter (rare, but possible with a loose
+operation swept up by the same filter (rare, but possible with a loose or no
 ``resource_name`` substring) would produce ``foo-1-first.json`` /
 ``foo-1-last.json``.
 
@@ -140,11 +140,11 @@ is less consistent -- see below.
 Creation events don't always identify what was created
 -----------------------------------------------------------
 
-For "update" (PUT-like) audit events, ``protoPayload.resourceName``
+For "update" audit events, ``protoPayload.resourceName``
 reliably names the specific resource being changed, since it already
 exists and already has an assigned id.
 
-For "create" (POST-like) audit events, that isn't reliable. Whether the
+For "create" audit events, that isn't reliable. Whether the
 event identifies the *created* resource depends on whether the resource's
 id is client-specified (e.g. a Dataproc cluster name, chosen by the
 caller) or server-generated (e.g. a Firestore backup schedule id, a UUID

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -41,7 +41,7 @@ regardless of mode:
             "firestore-backup-schedule-update.json",
             method="UpdateBackupSchedule",
             resource_name=resource_name,
-            labels={"project_id": project_id},
+            labels={"database_id": database_id},
         )
 
         # trigger the real update here, e.g. a client.execute_command('patch', ...)
@@ -69,7 +69,10 @@ Filtering options
 - ``resource_name`` (optional) -- a substring match against
   ``protoPayload.resourceName``.
 - ``labels`` (optional) -- an exact-match mapping against
-  ``resource.labels``, e.g. ``{"project_id": project_id}``.
+  ``resource.labels``, e.g. ``{"database_id": database_id}``. The query
+  is already scoped to one project via ``resourceNames``, so a
+  ``project_id`` label wouldn't narrow anything further -- use ``labels``
+  for fields that distinguish resources *within* the project.
 - ``start_time_skew`` (default 60s) -- how far before construction time to
   set the query's lower time bound, to guard against clock skew between
   the test host and Cloud Logging.

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -104,16 +104,18 @@ operation swept up by the same filter (rare, but possible with a loose or no
 ``resource_name`` substring) would produce ``foo-1-first.json`` /
 ``foo-1-last.json``.
 
-If a computed filename already exists on disk with different content
-(e.g. a stale fixture from an earlier recording run, or two truly
-ambiguous matches), a numeric suffix is appended *after* the extension
-instead -- ``foo.json``, then ``foo.json-1``, ``foo.json-2``, and so on
--- and a warning is logged. These extra files are left in place rather
-than cleaned up automatically, so they show up in the diff for the
-developer to sort out (rename, merge, or delete as appropriate). If the
-existing file's content is identical, it's left as-is and nothing new is
-written -- polling re-returns already-recorded entries as long as an
-operation is still in progress, and that isn't a collision.
+Recording tracks entries it has already written by content hash, so a
+later poll re-returning an entry an earlier poll already wrote (Cloud
+Logging queries are cumulative from a fixed start time) is a no-op, not
+a collision.
+
+If a computed filename already exists on disk from something other than
+this recording run (e.g. a stale fixture left over from an earlier run),
+a numeric suffix is appended *after* the extension instead --
+``foo.json``, then ``foo.json-1``, ``foo.json-2``, and so on -- and a
+warning is logged. These extra files are left in place rather than
+cleaned up automatically, so they show up in the diff for the developer
+to sort out (rename, merge, or delete as appropriate).
 
 Events and operations may have multiple log entries
 -------------------------------------------------------

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -19,9 +19,11 @@ Basic usage
 ------------
 
 Construct the recorder *before* triggering the API call, so its polling
-window starts early enough to catch the resulting log entry. Call
-``record()`` only while actually recording; loading the fixture for
-assertions always goes through the existing ``event_data(...)``:
+window starts early enough to catch the resulting log entry. Gate
+``record()`` on ``test.recording`` -- it queries a live Cloud Logging
+client, so it can't run against replayed flight data. Loading the fixture
+for assertions always goes through the existing ``event_data(...)``,
+regardless of mode:
 
 .. code-block:: python
 
@@ -45,7 +47,8 @@ assertions always goes through the existing ``event_data(...)``:
         # trigger the real update here, e.g. a client.execute_command('patch', ...)
         # call, or a Terraform resource change
 
-        recorder.record()
+        if test.recording:
+            recorder.record()
 
         event = event_data("firestore-backup-schedule-update.json")
         exec_mode = policy.get_execution_mode()

--- a/docs/source/gcp/examples/audit-event-recording.rst
+++ b/docs/source/gcp/examples/audit-event-recording.rst
@@ -1,0 +1,161 @@
+.. _gcp_audit_event_recording:
+
+Recording gcp-audit Event Fixtures
+====================================
+
+Tests for ``gcp-audit`` mode policies run
+``exec_mode.run(event_data("some-event.json"), None)`` against a fixture
+event -- a Cloud Audit Log ``LogEntry``. ``audit_event_recorder``, in
+``tools/c7n_gcp/tests/gcp_common.py``, records those fixtures from real GCP
+Cloud Audit Log entries instead of hand-writing synthetic event JSON, which
+easily drifts from what GCP actually sends.
+
+It only queries Cloud Logging -- no logging sink, Pub/Sub topic, or Cloud
+Function is provisioned. That machinery is what a deployed ``gcp-audit``
+policy uses to receive events at runtime; a test only needs the event data
+itself.
+
+Basic usage
+------------
+
+Construct the recorder *before* triggering the API call, so its polling
+window starts early enough to catch the resulting log entry. Call
+``record()`` only while actually recording; loading the fixture for
+assertions always goes through the existing ``event_data(...)``:
+
+.. code-block:: python
+
+    from gcp_common import audit_event_recorder, event_data
+
+    def test_firestore_backup_schedule_update(test, firestore_database):
+        resource_name = firestore_database.resources[
+            "google_firestore_backup_schedule"]["c7n"]["id"]
+
+        session_factory = test.record_flight_data(
+            "firestore-backup-schedule-update", project_id=project_id)
+
+        recorder = audit_event_recorder(
+            session_factory,
+            "firestore-backup-schedule-update.json",
+            method="UpdateBackupSchedule",
+            resource_name=resource_name,
+            labels={"project_id": project_id},
+        )
+
+        # trigger the real update here, e.g. a client.execute_command('patch', ...)
+        # call, or a Terraform resource change
+
+        recorder.record()
+
+        event = event_data("firestore-backup-schedule-update.json")
+        exec_mode = policy.get_execution_mode()
+        resources = exec_mode.run(event, None)
+
+Once recorded, commit the generated fixture(s) under
+``tools/c7n_gcp/tests/data/events/`` and switch the test to
+``replay_flight_data(...)``, same as any other flight-data test.
+
+Filtering options
+-------------------
+
+``audit_event_recorder`` takes only structured inputs -- it composes the
+Cloud Logging filter itself, rather than accepting a raw filter string:
+
+- ``method`` (required) -- a substring match against
+  ``protoPayload.methodName``, e.g. ``"UpdateBackupSchedule"`` rather than
+  the full ``google.firestore.admin.v1.FirestoreAdmin.UpdateBackupSchedule``.
+- ``resource_name`` (optional) -- a substring match against
+  ``protoPayload.resourceName``.
+- ``labels`` (optional) -- an exact-match mapping against
+  ``resource.labels``, e.g. ``{"project_id": project_id}``.
+- ``start_time_skew`` (default 60s) -- how far before construction time to
+  set the query's lower time bound, to guard against clock skew between
+  the test host and Cloud Logging.
+- ``timeout`` / ``poll_interval`` -- how long, and how often, to poll
+  before giving up.
+
+``record()`` polls until at least one matching entry appears (or the
+timeout elapses), rather than issuing a single query -- Cloud Logging
+entries can take a few seconds to become queryable after the underlying
+API call completes.
+
+Files created
+--------------
+
+For a call with no `operation` field (see below), the matching entry is
+written under the requested name, e.g. ``foo.json``, and polling stops.
+
+If an entry belongs to a Cloud Logging *operation* (see below), the
+filename reflects that:
+
+- entries are grouped by ``operation.id``, and each distinct operation
+  seen is assigned an index in the order first encountered (0, 1, 2, ...);
+  index 0 is omitted from the filename, so the common single-operation
+  case doesn't get a numeric suffix at all
+- ``-first`` is appended when ``operation.first`` is set,
+  ``-last`` when ``operation.last`` is set
+- polling stops once an entry with ``operation.last`` is seen
+
+So the common case for an operation-tracked method produces exactly two
+files: ``foo-first.json`` and ``foo-last.json``. A second, distinct
+operation swept up by the same filter (rare, but possible with a loose
+``resource_name`` substring) would produce ``foo-1-first.json`` /
+``foo-1-last.json``.
+
+If a computed filename already exists on disk (e.g. a stale fixture from
+an earlier recording run, or two truly ambiguous matches), a numeric
+suffix is appended *after* the extension instead --
+``foo.json``, then ``foo.json-1``, ``foo.json-2``, and so on -- and a
+warning is logged. These extra files are left in place rather than
+cleaned up automatically, so they show up in the diff for the developer
+to sort out (rename, merge, or delete as appropriate).
+
+Events and operations may have multiple log entries
+-------------------------------------------------------
+
+A single logical API call frequently produces more than one Cloud Audit
+Log entry, correlated via a Cloud Logging ``LogEntryOperation``
+(the top-level ``operation`` field: ``id``, ``first``, ``last``) rather
+than anything under ``protoPayload``. Not every method uses this: many
+produce exactly one, standalone log entry per call, with no ``operation``
+field at all.
+
+This matters for ``gcp-audit`` mode specifically because the deployed
+Cloud Function's Logging sink filters only on ``protoPayload.methodName``.
+Both the ``first`` and ``last`` rows of an operation-tracked call share
+the same method name, so *both* independently match the sink filter and
+get delivered as separate Pub/Sub messages -- meaning a real deployed
+policy can be invoked twice for one real-world API call. Recording both
+rows lets a test exercise the policy against either explicitly, rather
+than assuming the deployed function only ever sees one event per call.
+
+The two rows commonly carry different data: for update-type events the
+``first`` row typically has everything (``request``, permission info) that
+the ``last`` row lacks, with ``last`` mainly signalling completion (or
+failure, via ``protoPayload.status``). For create-type events, the split
+is less consistent -- see below.
+
+Creation events don't always identify what was created
+-----------------------------------------------------------
+
+For "update" (PUT-like) audit events, ``protoPayload.resourceName``
+reliably names the specific resource being changed, since it already
+exists and already has an assigned id.
+
+For "create" (POST-like) audit events, that isn't reliable. Whether the
+event identifies the *created* resource depends on whether the resource's
+id is client-specified (e.g. a Dataproc cluster name, chosen by the
+caller) or server-generated (e.g. a Firestore backup schedule id, a UUID
+assigned by the API). When the id is server-generated,
+``protoPayload.resourceName`` on the create event often names only the
+*parent* resource, not the child being created -- and depending on the
+service, the child's id may or may not show up elsewhere (``response``,
+or the ``operation.id`` from the previous section). Some create events
+provide no identity for the created resource anywhere in the log entry at
+all.
+
+Recorded event fixtures reflect this reality; a create-mode policy for a
+resource type with server-generated ids may need resource-specific
+handling (e.g. building a value directly from ``protoPayload.request``,
+rather than resolving an id and calling ``get()``) instead of the generic
+``resourceName``-based resolution that works for updates.

--- a/tools/c7n_gcp/tests/gcp_common.py
+++ b/tools/c7n_gcp/tests/gcp_common.py
@@ -55,6 +55,10 @@ def audit_event_recorder(
 
     Construct it before triggering the API call, then call ``record()`` in
     recording mode. Matching log entries are written under ``data/events``.
+
+    See ``docs/source/gcp/examples/audit-event-recording.rst`` for usage,
+    filtering options, file naming, and caveats around multi-entry
+    operations and creation events.
     """
     return AuditEventRecorder(
         session_factory,

--- a/tools/c7n_gcp/tests/gcp_common.py
+++ b/tools/c7n_gcp/tests/gcp_common.py
@@ -3,6 +3,7 @@
 
 import datetime
 import functools
+import hashlib
 import json
 import logging
 import os
@@ -100,31 +101,43 @@ class AuditEventRecorder:
     def record(self) -> None:
         deadline = time.time() + self.timeout
         operation_index: dict = {}
+        seen_hashes: set = set()
         while True:
             entries = self._get_entries()
             if entries:
-                if self._write_batch(entries, operation_index):
+                if self._write_batch(entries, operation_index, seen_hashes):
                     return
             if time.time() >= deadline:
                 raise AssertionError(
                     'No GCP audit log entries matched {}'.format(self.event_file))
             time.sleep(self.poll_interval)
 
-    def _write_batch(self, entries: list[dict], operation_index: dict) -> bool:
+    def _write_batch(
+            self, entries: list[dict], operation_index: dict, seen_hashes: set,
+    ) -> bool:
         """Write one poll batch. Returns True when polling should stop."""
         stop = False
         for entry in entries:
+            payload = json.dumps(entry, indent=2, sort_keys=True) + '\n'
+            digest = hashlib.sha256(payload.encode()).hexdigest()
+            if digest in seen_hashes:
+                # Cloud Logging queries are cumulative from a fixed start
+                # time, so a later poll re-returns entries an earlier poll
+                # already wrote. Not a collision.
+                continue
+            seen_hashes.add(digest)
+
             operation = entry.get('operation') or {}
             operation_id = operation.get('id')
             if not operation_id:
-                self._write_entry(self.event_file, entry)
+                self._write_entry(self.event_file, payload)
                 stop = True
                 continue
             if operation_id not in operation_index:
                 operation_index[operation_id] = len(operation_index)
             index = operation_index[operation_id]
             self._write_entry(
-                self._operation_file_name(index, operation), entry)
+                self._operation_file_name(index, operation), payload)
             if operation.get('last'):
                 stop = True
         return stop
@@ -169,16 +182,11 @@ class AuditEventRecorder:
             'orderBy': 'timestamp asc',
         }
 
-    def _write_entry(self, event_file: str, entry: dict) -> None:
+    def _write_entry(self, event_file: str, payload: str) -> None:
         os.makedirs(EVENT_DIR, exist_ok=True)
-        payload = json.dumps(entry, indent=2, sort_keys=True) + '\n'
         path = os.path.join(EVENT_DIR, event_file)
         index = 0
         while os.path.exists(path):
-            if open(path).read() == payload:
-                # A later poll re-returned an entry an earlier poll
-                # already wrote; not a collision.
-                return
             index += 1
             path = '{}-{}'.format(os.path.join(EVENT_DIR, event_file), index)
         if index:

--- a/tools/c7n_gcp/tests/gcp_common.py
+++ b/tools/c7n_gcp/tests/gcp_common.py
@@ -171,16 +171,20 @@ class AuditEventRecorder:
 
     def _write_entry(self, event_file: str, entry: dict) -> None:
         os.makedirs(EVENT_DIR, exist_ok=True)
+        payload = json.dumps(entry, indent=2, sort_keys=True) + '\n'
         path = os.path.join(EVENT_DIR, event_file)
-        if os.path.exists(path):
-            index = 1
-            while os.path.exists('{}-{}'.format(path, index)):
-                index += 1
-            path = '{}-{}'.format(path, index)
+        index = 0
+        while os.path.exists(path):
+            if open(path).read() == payload:
+                # A later poll re-returned an entry an earlier poll
+                # already wrote; not a collision.
+                return
+            index += 1
+            path = '{}-{}'.format(os.path.join(EVENT_DIR, event_file), index)
+        if index:
             log.warning('GCP audit event fixture collision, wrote %s', path)
         with open(path, 'w') as fh:
-            json.dump(entry, fh, indent=2, sort_keys=True)
-            fh.write('\n')
+            fh.write(payload)
 
     @staticmethod
     def _format_time(value: datetime.datetime) -> str:

--- a/tools/c7n_gcp/tests/gcp_common.py
+++ b/tools/c7n_gcp/tests/gcp_common.py
@@ -50,7 +50,7 @@ def audit_event_recorder(
         start_time_skew: int = 60,
         timeout: int = 120,
         poll_interval: int = 5,
-):
+) -> 'AuditEventRecorder':
     """Create a recorder for GCP audit LogEntry event fixtures.
 
     Construct it before triggering the API call, then call ``record()`` in
@@ -84,7 +84,7 @@ class AuditEventRecorder:
             start_time_skew: int = 60,
             timeout: int = 120,
             poll_interval: int = 5,
-    ):
+    ) -> None:
         self.session_factory = session_factory
         self.event_file = event_file
         self.method = method

--- a/tools/c7n_gcp/tests/gcp_common.py
+++ b/tools/c7n_gcp/tests/gcp_common.py
@@ -95,15 +95,46 @@ class AuditEventRecorder:
 
     def record(self) -> None:
         deadline = time.time() + self.timeout
+        operation_index: dict = {}
         while True:
             entries = self._get_entries()
             if entries:
-                self._write_entries(entries)
-                return
+                if self._write_batch(entries, operation_index):
+                    return
             if time.time() >= deadline:
                 raise AssertionError(
                     'No GCP audit log entries matched {}'.format(self.event_file))
             time.sleep(self.poll_interval)
+
+    def _write_batch(self, entries: list[dict], operation_index: dict) -> bool:
+        """Write one poll batch. Returns True when polling should stop."""
+        stop = False
+        for entry in entries:
+            operation = entry.get('operation') or {}
+            operation_id = operation.get('id')
+            if not operation_id:
+                self._write_entry(self.event_file, entry)
+                stop = True
+                continue
+            if operation_id not in operation_index:
+                operation_index[operation_id] = len(operation_index)
+            index = operation_index[operation_id]
+            self._write_entry(
+                self._operation_file_name(index, operation), entry)
+            if operation.get('last'):
+                stop = True
+        return stop
+
+    def _operation_file_name(self, index: int, operation: dict) -> str:
+        base, ext = os.path.splitext(self.event_file)
+        parts = [base]
+        if index > 0:
+            parts.append(str(index))
+        if operation.get('first'):
+            parts.append('first')
+        if operation.get('last'):
+            parts.append('last')
+        return '-'.join(parts) + ext
 
     def _get_entries(self) -> list[dict]:
         session = self.session_factory()
@@ -134,20 +165,18 @@ class AuditEventRecorder:
             'orderBy': 'timestamp asc',
         }
 
-    def _write_entries(self, entries: list[dict]) -> None:
+    def _write_entry(self, event_file: str, entry: dict) -> None:
         os.makedirs(EVENT_DIR, exist_ok=True)
-        for idx, entry in enumerate(entries):
-            event_file = self.event_file if idx == 0 else '{}-{}'.format(
-                self.event_file, idx)
-            with open(os.path.join(EVENT_DIR, event_file), 'w') as fh:
-                json.dump(entry, fh, indent=2, sort_keys=True)
-                fh.write('\n')
-        if len(entries) > 1:
-            log.warning(
-                'Wrote %d matching GCP audit event fixtures for %s',
-                len(entries),
-                self.event_file,
-            )
+        path = os.path.join(EVENT_DIR, event_file)
+        if os.path.exists(path):
+            index = 1
+            while os.path.exists('{}-{}'.format(path, index)):
+                index += 1
+            path = '{}-{}'.format(path, index)
+            log.warning('GCP audit event fixture collision, wrote %s', path)
+        with open(path, 'w') as fh:
+            json.dump(entry, fh, indent=2, sort_keys=True)
+            fh.write('\n')
 
     @staticmethod
     def _format_time(value: datetime.datetime) -> str:

--- a/tools/c7n_gcp/tests/gcp_common.py
+++ b/tools/c7n_gcp/tests/gcp_common.py
@@ -103,30 +103,36 @@ class AuditEventRecorder:
         operation_index: dict = {}
         seen_hashes: set = set()
         while True:
-            entries = self._get_entries()
+            entries = self._dedup_entries(seen_hashes, self._get_entries())
             if entries:
-                if self._write_batch(entries, operation_index, seen_hashes):
+                if self._write_batch(entries, operation_index):
                     return
             if time.time() >= deadline:
                 raise AssertionError(
                     'No GCP audit log entries matched {}'.format(self.event_file))
             time.sleep(self.poll_interval)
 
-    def _write_batch(
-            self, entries: list[dict], operation_index: dict, seen_hashes: set,
-    ) -> bool:
+    def _dedup_entries(self, seen: set, entries: list[dict]) -> list[dict]:
+        """Update seen with each entry's hash. Return the entries not in seen.
+
+        Cloud Logging queries are cumulative from a fixed start time, so a
+        later poll re-returns entries an earlier poll already saw.
+        """
+        new_entries = []
+        for entry in entries:
+            digest = hashlib.sha256(
+                json.dumps(entry, sort_keys=True).encode()).hexdigest()
+            if digest in seen:
+                continue
+            seen.add(digest)
+            new_entries.append(entry)
+        return new_entries
+
+    def _write_batch(self, entries: list[dict], operation_index: dict) -> bool:
         """Write one poll batch. Returns True when polling should stop."""
         stop = False
         for entry in entries:
             payload = json.dumps(entry, indent=2, sort_keys=True) + '\n'
-            digest = hashlib.sha256(payload.encode()).hexdigest()
-            if digest in seen_hashes:
-                # Cloud Logging queries are cumulative from a fixed start
-                # time, so a later poll re-returns entries an earlier poll
-                # already wrote. Not a collision.
-                continue
-            seen_hashes.add(digest)
-
             operation = entry.get('operation') or {}
             operation_id = operation.get('id')
             if not operation_id:

--- a/tools/c7n_gcp/tests/gcp_common.py
+++ b/tools/c7n_gcp/tests/gcp_common.py
@@ -100,14 +100,23 @@ class AuditEventRecorder:
 
     def record(self) -> None:
         deadline = time.time() + self.timeout
-        operation_index: dict = {}
+        operations: dict = {}
         seen_hashes: set = set()
         while True:
             entries = self._dedup_entries(seen_hashes, self._get_entries())
             if entries:
-                if self._write_batch(entries, operation_index):
+                self._write_batch(entries, operations)
+                if all(s['complete'] for s in operations.values()):
                     return
             if time.time() >= deadline:
+                incomplete = [
+                    op_id for op_id, state in operations.items()
+                    if not state['complete']
+                ]
+                if incomplete:
+                    raise AssertionError(
+                        'Timed out recording {}, waiting on operations: {}'
+                        .format(self.event_file, ', '.join(incomplete)))
                 raise AssertionError(
                     'No GCP audit log entries matched {}'.format(self.event_file))
             time.sleep(self.poll_interval)
@@ -128,25 +137,25 @@ class AuditEventRecorder:
             new_entries.append(entry)
         return new_entries
 
-    def _write_batch(self, entries: list[dict], operation_index: dict) -> bool:
-        """Write one poll batch. Returns True when polling should stop."""
-        stop = False
+    def _write_batch(self, entries: list[dict], operations: dict) -> None:
+        """Write one poll batch, updating per-operation state.
+
+        ``operations`` maps ``operation.id`` to its assigned file-name index
+        and whether its ``last`` entry has been seen.
+        """
         for entry in entries:
             payload = json.dumps(entry, indent=2, sort_keys=True) + '\n'
             operation = entry.get('operation') or {}
             operation_id = operation.get('id')
             if not operation_id:
                 self._write_entry(self.event_file, payload)
-                stop = True
                 continue
-            if operation_id not in operation_index:
-                operation_index[operation_id] = len(operation_index)
-            index = operation_index[operation_id]
+            state = operations.setdefault(
+                operation_id, {'index': len(operations), 'complete': False})
             self._write_entry(
-                self._operation_file_name(index, operation), payload)
+                self._operation_file_name(state['index'], operation), payload)
             if operation.get('last'):
-                stop = True
-        return stop
+                state['complete'] = True
 
     def _operation_file_name(self, index: int, operation: dict) -> str:
         base, ext = os.path.splitext(self.event_file)
@@ -162,9 +171,12 @@ class AuditEventRecorder:
     def _get_entries(self) -> list[dict]:
         session = self.session_factory()
         client = session.client('logging', 'v2', 'entries')
-        response = client.execute_query('list', {'body': self._query_body(session)})
+        entries = []
+        for page in client.execute_paged_query(
+                'list', {'body': self._query_body(session)}):
+            entries.extend(page.get('entries', []))
         return sorted(
-            response.get('entries', []),
+            entries,
             key=lambda e: (e.get('timestamp', ''), e.get('insertId', '')),
         )
 

--- a/tools/c7n_gcp/tests/gcp_common.py
+++ b/tools/c7n_gcp/tests/gcp_common.py
@@ -1,10 +1,14 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
 import functools
 import json
+import logging
 import os
 import shutil
+import time
+import typing
 
 from pathlib import Path
 
@@ -29,9 +33,129 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), 'data', 'flights')
 EVENT_DIR = os.path.join(os.path.dirname(__file__), 'data', 'events')
 
 
+log = logging.getLogger('custodian.tests.gcp')
+
+
 def event_data(fname):
     with open(os.path.join(EVENT_DIR, fname)) as fh:
         return json.load(fh)
+
+
+def audit_event_recorder(
+        session_factory,
+        event_file: str,
+        method: str,
+        resource_name: typing.Optional[str] = None,
+        labels: typing.Optional[typing.Mapping[str, str]] = None,
+        start_time_skew: int = 60,
+        timeout: int = 120,
+        poll_interval: int = 5,
+):
+    """Create a recorder for GCP audit LogEntry event fixtures.
+
+    Construct it before triggering the API call, then call ``record()`` in
+    recording mode. Matching log entries are written under ``data/events``.
+    """
+    return AuditEventRecorder(
+        session_factory,
+        event_file,
+        method,
+        resource_name=resource_name,
+        labels=labels,
+        start_time_skew=start_time_skew,
+        timeout=timeout,
+        poll_interval=poll_interval,
+    )
+
+
+class AuditEventRecorder:
+
+    def __init__(
+            self,
+            session_factory,
+            event_file: str,
+            method: str,
+            resource_name: typing.Optional[str] = None,
+            labels: typing.Optional[typing.Mapping[str, str]] = None,
+            start_time_skew: int = 60,
+            timeout: int = 120,
+            poll_interval: int = 5,
+    ):
+        self.session_factory = session_factory
+        self.event_file = event_file
+        self.method = method
+        self.resource_name = resource_name
+        self.labels = labels or {}
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self.start_time = (
+            datetime.datetime.now(datetime.timezone.utc) -
+            datetime.timedelta(seconds=start_time_skew)
+        )
+
+    def record(self) -> None:
+        deadline = time.time() + self.timeout
+        while True:
+            entries = self._get_entries()
+            if entries:
+                self._write_entries(entries)
+                return
+            if time.time() >= deadline:
+                raise AssertionError(
+                    'No GCP audit log entries matched {}'.format(self.event_file))
+            time.sleep(self.poll_interval)
+
+    def _get_entries(self) -> list[dict]:
+        session = self.session_factory()
+        client = session.client('logging', 'v2', 'entries')
+        response = client.execute_query('list', {'body': self._query_body(session)})
+        return sorted(
+            response.get('entries', []),
+            key=lambda e: (e.get('timestamp', ''), e.get('insertId', '')),
+        )
+
+    def _query_body(self, session) -> dict:
+        project_id = session.get_default_project()
+        log_name = 'projects/{}/logs/cloudaudit.googleapis.com%2Factivity'.format(
+            project_id)
+        filters = [
+            'logName = {}'.format(self._quote(log_name)),
+            'protoPayload.methodName : {}'.format(self._quote(self.method)),
+            'timestamp >= {}'.format(self._quote(self._format_time(self.start_time))),
+        ]
+        if self.resource_name:
+            filters.append(
+                'protoPayload.resourceName : {}'.format(self._quote(self.resource_name)))
+        for k, v in self.labels.items():
+            filters.append('resource.labels.{} = {}'.format(k, self._quote(v)))
+        return {
+            'resourceNames': ['projects/{}'.format(project_id)],
+            'filter': '\n'.join(filters),
+            'orderBy': 'timestamp asc',
+        }
+
+    def _write_entries(self, entries: list[dict]) -> None:
+        os.makedirs(EVENT_DIR, exist_ok=True)
+        for idx, entry in enumerate(entries):
+            event_file = self.event_file if idx == 0 else '{}-{}'.format(
+                self.event_file, idx)
+            with open(os.path.join(EVENT_DIR, event_file), 'w') as fh:
+                json.dump(entry, fh, indent=2, sort_keys=True)
+                fh.write('\n')
+        if len(entries) > 1:
+            log.warning(
+                'Wrote %d matching GCP audit event fixtures for %s',
+                len(entries),
+                self.event_file,
+            )
+
+    @staticmethod
+    def _format_time(value: datetime.datetime) -> str:
+        return value.isoformat().replace('+00:00', 'Z')
+
+    @staticmethod
+    def _quote(value: str) -> str:
+        return '"{}"'.format(value.replace('\\', '\\\\').replace('"', '\\"'))
 
 
 class GoogleFlightRecorder(CustodianTestCore):

--- a/tools/c7n_gcp/tests/test_gcp_common.py
+++ b/tools/c7n_gcp/tests/test_gcp_common.py
@@ -1,0 +1,76 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import gcp_common
+from gcp_common import audit_event_recorder
+
+
+class FakeLoggingClient:
+
+    def __init__(self, entries):
+        self.entries = entries
+        self.calls = []
+
+    def execute_query(self, verb, arguments):
+        self.calls.append((verb, arguments))
+        return {'entries': self.entries}
+
+
+class FakeSession:
+
+    def __init__(self, client):
+        self.logging_client = client
+
+    def get_default_project(self):
+        return 'test-project'
+
+    def client(self, service, version, component):
+        assert (service, version, component) == ('logging', 'v2', 'entries')
+        return self.logging_client
+
+
+def test_audit_event_recorder_writes_entries_and_duplicate_artifacts(
+        tmp_path, monkeypatch):
+    entries = [
+        {'timestamp': '2025-01-01T00:00:01Z', 'insertId': 'b'},
+        {'timestamp': '2025-01-01T00:00:00Z', 'insertId': 'a'},
+    ]
+    client = FakeLoggingClient(entries)
+    session = FakeSession(client)
+
+    monkeypatch.setattr(gcp_common, 'EVENT_DIR', str(tmp_path))
+
+    recorder = audit_event_recorder(
+        lambda: session,
+        'foo.json',
+        method='CreateKey',
+        resource_name='projects/test-project/locations/global/keys/key-1',
+        labels={
+            'project_id': 'test-project',
+        },
+    )
+
+    recorder.record()
+
+    assert json.loads((tmp_path / 'foo.json').read_text()) == entries[1]
+    assert json.loads((tmp_path / 'foo.json-1').read_text()) == entries[0]
+
+    assert client.calls[0][0] == 'list'
+    body = client.calls[0][1]['body']
+    assert body['resourceNames'] == ['projects/test-project']
+    assert body['orderBy'] == 'timestamp asc'
+    assert (
+        'logName = '
+        '"projects/test-project/logs/cloudaudit.googleapis.com%2Factivity"'
+        in body['filter']
+    )
+    assert 'protoPayload.methodName : "CreateKey"' in body['filter']
+    assert (
+        'protoPayload.resourceName : '
+        '"projects/test-project/locations/global/keys/key-1"'
+        in body['filter']
+    )
+    assert 'resource.labels.project_id = "test-project"' in body['filter']
+    assert 'timestamp >= ' in body['filter']

--- a/tools/c7n_gcp/tests/test_gcp_common.py
+++ b/tools/c7n_gcp/tests/test_gcp_common.py
@@ -78,6 +78,28 @@ def test_first_then_last_pair_writes_both_and_stops(tmp_path, monkeypatch):
     assert len(client.calls) == 2
 
 
+def test_repolling_the_same_entry_is_not_a_collision(tmp_path, monkeypatch):
+    first = {
+        'insertId': 'a',
+        'timestamp': '2025-01-01T00:00:00Z',
+        'operation': {'id': 'op-1', 'first': True},
+    }
+    last = {
+        'insertId': 'b',
+        'timestamp': '2025-01-01T00:00:01Z',
+        'operation': {'id': 'op-1', 'last': True},
+    }
+    # Cloud Logging queries are cumulative from a fixed start time, so a
+    # later poll re-returns entries an earlier poll already wrote.
+    recorder, client = make_recorder(
+        tmp_path, monkeypatch, [[first], [first], [first, last]])
+
+    recorder.record()
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        'foo-first.json', 'foo-last.json']
+
+
 def test_second_distinct_operation_gets_index_suffix(tmp_path, monkeypatch):
     op0_first = {
         'insertId': 'a',

--- a/tools/c7n_gcp/tests/test_gcp_common.py
+++ b/tools/c7n_gcp/tests/test_gcp_common.py
@@ -100,6 +100,45 @@ def test_repolling_the_same_entry_is_not_a_collision(tmp_path, monkeypatch):
         'foo-first.json', 'foo-last.json']
 
 
+def test_query_body_reflects_structured_filters(tmp_path, monkeypatch):
+    entry = {'insertId': 'a', 'timestamp': '2025-01-01T00:00:00Z'}
+    recorder, client = make_recorder(
+        tmp_path, monkeypatch, [[entry]],
+        resource_name='projects/test-project/things/thing-1',
+        labels={'database_id': 'db-1'},
+    )
+
+    recorder.record()
+
+    verb, arguments = client.calls[0]
+    assert verb == 'list'
+    body = arguments['body']
+    assert body['resourceNames'] == ['projects/test-project']
+    assert body['orderBy'] == 'timestamp asc'
+    assert 'protoPayload.methodName : "CreateThing"' in body['filter']
+    assert (
+        'protoPayload.resourceName : '
+        '"projects/test-project/things/thing-1"'
+        in body['filter']
+    )
+    assert 'resource.labels.database_id = "db-1"' in body['filter']
+    assert 'timestamp >= "' in body['filter']
+
+
+def test_record_raises_after_timeout_with_no_matches(tmp_path, monkeypatch):
+    recorder, client = make_recorder(
+        tmp_path, monkeypatch, [], timeout=0)
+
+    try:
+        recorder.record()
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError('expected record() to raise')
+
+    assert not list(tmp_path.iterdir())
+
+
 def test_second_distinct_operation_gets_index_suffix(tmp_path, monkeypatch):
     op0_first = {
         'insertId': 'a',

--- a/tools/c7n_gcp/tests/test_gcp_common.py
+++ b/tools/c7n_gcp/tests/test_gcp_common.py
@@ -78,6 +78,19 @@ def test_first_then_last_pair_writes_both_and_stops(tmp_path, monkeypatch):
     assert len(client.calls) == 2
 
 
+def test_dedup_entries_filters_seen_and_updates_seen(tmp_path, monkeypatch):
+    recorder, client = make_recorder(tmp_path, monkeypatch, [])
+    seen = set()
+    entry_a = {'insertId': 'a'}
+    entry_b = {'insertId': 'b'}
+
+    first_pass = recorder._dedup_entries(seen, [entry_a, entry_b])
+    second_pass = recorder._dedup_entries(seen, [entry_a, entry_b])
+
+    assert first_pass == [entry_a, entry_b]
+    assert second_pass == []
+
+
 def test_repolling_the_same_entry_is_not_a_collision(tmp_path, monkeypatch):
     first = {
         'insertId': 'a',

--- a/tools/c7n_gcp/tests/test_gcp_common.py
+++ b/tools/c7n_gcp/tests/test_gcp_common.py
@@ -8,16 +8,19 @@ from gcp_common import audit_event_recorder
 
 
 class FakeLoggingClient:
-    """Returns one queued batch of entries per execute_query call."""
+    """Yields one queued batch of entries, in pages, per query call."""
 
-    def __init__(self, batches):
+    def __init__(self, batches, page_size=None):
         self.batches = list(batches)
+        self.page_size = page_size
         self.calls = []
 
-    def execute_query(self, verb, arguments):
+    def execute_paged_query(self, verb, arguments):
         self.calls.append((verb, arguments))
         entries = self.batches.pop(0) if self.batches else []
-        return {'entries': entries}
+        size = self.page_size or len(entries) or 1
+        for start in range(0, len(entries), size):
+            yield {'entries': entries[start:start + size]}
 
 
 class FakeSession:
@@ -33,9 +36,11 @@ class FakeSession:
         return self.logging_client
 
 
-def make_recorder(tmp_path, monkeypatch, batches, event_file='foo.json', **kw):
+def make_recorder(
+        tmp_path, monkeypatch, batches, event_file='foo.json',
+        page_size=None, **kw):
     monkeypatch.setattr(gcp_common, 'EVENT_DIR', str(tmp_path))
-    client = FakeLoggingClient(batches)
+    client = FakeLoggingClient(batches, page_size)
     session = FakeSession(client)
     kw.setdefault('poll_interval', 0)
     recorder = audit_event_recorder(
@@ -163,17 +168,23 @@ def test_second_distinct_operation_gets_index_suffix(tmp_path, monkeypatch):
         'timestamp': '2025-01-01T00:00:01Z',
         'operation': {'id': 'op-1', 'first': True},
     }
-    op1_last = {
+    op0_last = {
         'insertId': 'c',
         'timestamp': '2025-01-01T00:00:02Z',
+        'operation': {'id': 'op-0', 'last': True},
+    }
+    op1_last = {
+        'insertId': 'd',
+        'timestamp': '2025-01-01T00:00:03Z',
         'operation': {'id': 'op-1', 'last': True},
     }
     recorder, client = make_recorder(
-        tmp_path, monkeypatch, [[op0_first, op1_first, op1_last]])
+        tmp_path, monkeypatch, [[op0_first, op1_first, op0_last, op1_last]])
 
     recorder.record()
 
     assert read(tmp_path, 'foo-first.json') == op0_first
+    assert read(tmp_path, 'foo-last.json') == op0_last
     assert read(tmp_path, 'foo-1-first.json') == op1_first
     assert read(tmp_path, 'foo-1-last.json') == op1_last
 
@@ -187,3 +198,74 @@ def test_collision_appends_index_after_extension(tmp_path, monkeypatch):
 
     assert read(tmp_path, 'foo.json') == {'pre-existing': True}
     assert read(tmp_path, 'foo.json-1') == entry
+
+
+def test_other_operation_completing_first_does_not_stop_polling_early(
+        tmp_path, monkeypatch):
+    # A query filter without a narrow resource_name can match entries from
+    # more than one operation. Polling must not stop as soon as ANY tracked
+    # operation reaches its 'last' entry, or another operation matched by
+    # the same filter is silently left incomplete.
+    op0_first = {
+        'insertId': 'a',
+        'timestamp': '2025-01-01T00:00:00Z',
+        'operation': {'id': 'op-0', 'first': True},
+    }
+    op1_first = {
+        'insertId': 'b',
+        'timestamp': '2025-01-01T00:00:01Z',
+        'operation': {'id': 'op-1', 'first': True},
+    }
+    op1_last = {
+        'insertId': 'c',
+        'timestamp': '2025-01-01T00:00:02Z',
+        'operation': {'id': 'op-1', 'last': True},
+    }
+    op0_last = {
+        'insertId': 'd',
+        'timestamp': '2025-01-01T00:00:03Z',
+        'operation': {'id': 'op-0', 'last': True},
+    }
+    # op-1 completes entirely within the first poll; op-0's 'last' entry
+    # only shows up on the second poll.
+    recorder, client = make_recorder(
+        tmp_path, monkeypatch,
+        [[op0_first, op1_first, op1_last], [op0_last]])
+
+    recorder.record()
+
+    assert read(tmp_path, 'foo-first.json') == op0_first
+    assert read(tmp_path, 'foo-last.json') == op0_last
+    assert len(client.calls) == 2
+
+
+def test_entries_are_collected_across_pages(tmp_path, monkeypatch):
+    # entries.list defaults to 50 results per page, so a poll can span pages.
+    entries = [
+        {'insertId': str(i), 'timestamp': '2025-01-01T00:00:0{}Z'.format(i)}
+        for i in range(3)
+    ]
+    recorder, client = make_recorder(
+        tmp_path, monkeypatch, [entries], page_size=1)
+
+    recorder.record()
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        'foo.json', 'foo.json-1', 'foo.json-2']
+
+
+def test_record_raises_naming_the_incomplete_operation(tmp_path, monkeypatch):
+    first = {
+        'insertId': 'a',
+        'timestamp': '2025-01-01T00:00:00Z',
+        'operation': {'id': 'op-0', 'first': True},
+    }
+    recorder, client = make_recorder(
+        tmp_path, monkeypatch, [[first]], timeout=0)
+
+    try:
+        recorder.record()
+    except AssertionError as e:
+        assert 'op-0' in str(e)
+    else:
+        raise AssertionError('expected record() to raise')

--- a/tools/c7n_gcp/tests/test_gcp_common.py
+++ b/tools/c7n_gcp/tests/test_gcp_common.py
@@ -8,14 +8,16 @@ from gcp_common import audit_event_recorder
 
 
 class FakeLoggingClient:
+    """Returns one queued batch of entries per execute_query call."""
 
-    def __init__(self, entries):
-        self.entries = entries
+    def __init__(self, batches):
+        self.batches = list(batches)
         self.calls = []
 
     def execute_query(self, verb, arguments):
         self.calls.append((verb, arguments))
-        return {'entries': self.entries}
+        entries = self.batches.pop(0) if self.batches else []
+        return {'entries': entries}
 
 
 class FakeSession:
@@ -31,46 +33,83 @@ class FakeSession:
         return self.logging_client
 
 
-def test_audit_event_recorder_writes_entries_and_duplicate_artifacts(
-        tmp_path, monkeypatch):
-    entries = [
-        {'timestamp': '2025-01-01T00:00:01Z', 'insertId': 'b'},
-        {'timestamp': '2025-01-01T00:00:00Z', 'insertId': 'a'},
-    ]
-    client = FakeLoggingClient(entries)
-    session = FakeSession(client)
-
+def make_recorder(tmp_path, monkeypatch, batches, event_file='foo.json', **kw):
     monkeypatch.setattr(gcp_common, 'EVENT_DIR', str(tmp_path))
-
+    client = FakeLoggingClient(batches)
+    session = FakeSession(client)
+    kw.setdefault('poll_interval', 0)
     recorder = audit_event_recorder(
-        lambda: session,
-        'foo.json',
-        method='CreateKey',
-        resource_name='projects/test-project/locations/global/keys/key-1',
-        labels={
-            'project_id': 'test-project',
-        },
-    )
+        lambda: session, event_file, method='CreateThing', **kw)
+    return recorder, client
+
+
+def read(tmp_path, name):
+    return json.loads((tmp_path / name).read_text())
+
+
+def test_standalone_entry_written_and_stops_polling(tmp_path, monkeypatch):
+    entry = {'insertId': 'a', 'timestamp': '2025-01-01T00:00:00Z'}
+    recorder, client = make_recorder(tmp_path, monkeypatch, [[entry]])
 
     recorder.record()
 
-    assert json.loads((tmp_path / 'foo.json').read_text()) == entries[1]
-    assert json.loads((tmp_path / 'foo.json-1').read_text()) == entries[0]
+    assert read(tmp_path, 'foo.json') == entry
+    assert len(client.calls) == 1
 
-    assert client.calls[0][0] == 'list'
-    body = client.calls[0][1]['body']
-    assert body['resourceNames'] == ['projects/test-project']
-    assert body['orderBy'] == 'timestamp asc'
-    assert (
-        'logName = '
-        '"projects/test-project/logs/cloudaudit.googleapis.com%2Factivity"'
-        in body['filter']
-    )
-    assert 'protoPayload.methodName : "CreateKey"' in body['filter']
-    assert (
-        'protoPayload.resourceName : '
-        '"projects/test-project/locations/global/keys/key-1"'
-        in body['filter']
-    )
-    assert 'resource.labels.project_id = "test-project"' in body['filter']
-    assert 'timestamp >= ' in body['filter']
+
+def test_first_then_last_pair_writes_both_and_stops(tmp_path, monkeypatch):
+    first = {
+        'insertId': 'a',
+        'timestamp': '2025-01-01T00:00:00Z',
+        'operation': {'id': 'op-1', 'first': True},
+    }
+    last = {
+        'insertId': 'b',
+        'timestamp': '2025-01-01T00:00:01Z',
+        'operation': {'id': 'op-1', 'last': True},
+    }
+    recorder, client = make_recorder(
+        tmp_path, monkeypatch, [[first], [first, last]])
+
+    recorder.record()
+
+    assert read(tmp_path, 'foo-first.json') == first
+    assert read(tmp_path, 'foo-last.json') == last
+    assert len(client.calls) == 2
+
+
+def test_second_distinct_operation_gets_index_suffix(tmp_path, monkeypatch):
+    op0_first = {
+        'insertId': 'a',
+        'timestamp': '2025-01-01T00:00:00Z',
+        'operation': {'id': 'op-0', 'first': True},
+    }
+    op1_first = {
+        'insertId': 'b',
+        'timestamp': '2025-01-01T00:00:01Z',
+        'operation': {'id': 'op-1', 'first': True},
+    }
+    op1_last = {
+        'insertId': 'c',
+        'timestamp': '2025-01-01T00:00:02Z',
+        'operation': {'id': 'op-1', 'last': True},
+    }
+    recorder, client = make_recorder(
+        tmp_path, monkeypatch, [[op0_first, op1_first, op1_last]])
+
+    recorder.record()
+
+    assert read(tmp_path, 'foo-first.json') == op0_first
+    assert read(tmp_path, 'foo-1-first.json') == op1_first
+    assert read(tmp_path, 'foo-1-last.json') == op1_last
+
+
+def test_collision_appends_index_after_extension(tmp_path, monkeypatch):
+    (tmp_path / 'foo.json').write_text('{"pre-existing": true}')
+    entry = {'insertId': 'a', 'timestamp': '2025-01-01T00:00:00Z'}
+    recorder, client = make_recorder(tmp_path, monkeypatch, [[entry]])
+
+    recorder.record()
+
+    assert read(tmp_path, 'foo.json') == {'pre-existing': True}
+    assert read(tmp_path, 'foo.json-1') == entry


### PR DESCRIPTION
Fixes #11022

Adds `audit_event_recorder(...)`, an importable helper in
`tools/c7n_gcp/tests/gcp_common.py`, for recording real GCP Cloud Audit Log
entries as event fixtures for `gcp-audit` mode tests, instead of hand-writing
synthetic event JSON.

## Limitations

This recorder mainly works for operations performed in test bodies.  By default, it may not capture operations performed by terraform, however:

- You can provide a recording time skew, which defaults to 60s.  This is subtracted from the time a recorder is created to 
  determine a recording time window.

  Terraform operations could likely be captured by increasing the time skew.

- Terraform is mainly used to create resources.  Creation events are challenging.
  See the documentation file added and comment on #11022.

## Design

- Structured inputs only: `method` (substring), optional `resource_name`
  (substring against `protoPayload.resourceName`), optional `labels` mapping
  (against `resource.labels`). No raw filter strings.
- Test controls timing explicitly: construct the recorder before triggering
  the API call (captures `start_time - start_time_skew`), then call
  `recorder.record()` only when `test.recording`. Loading fixtures for
  assertions still goes through the existing `event_data(...)`.
- `record()` polls Cloud Logging until at least one match appears (or times
  out), rather than a single query.
- Handles Cloud Logging's `LogEntryOperation` grouping
  (`operation.id`/`first`/`last`), discovered by recording against real GCP
  audit log entries during development (see below): a single logical API
  call frequently produces two log entries sharing one `operation.id` -- a
  `first` row and a `last` row -- and either row independently matches a
  method-name sink filter, so a deployed `gcp-audit` policy can be invoked
  twice for one real API call. Fixture naming makes both rows available so
  policies/tests can target either explicitly:
  - No `operation` field -> written as `<event_file>` (canonical name), stop
    polling.
  - `operation` field present -> tracked by `operation.id`, assigned an
    index in first-seen order (index 0 omitted from the name, others
    appended as `-<index>`); `-first`/`-last` appended per the entry's
    flags; stops polling once a `-last` row is seen.
  - Filename collisions with an existing file get a numeric suffix *after*
    the extension (`foo.json-1`), independent of the operation index --
    left in place for developer discovery rather than silently resolved.

No sink/Pub/Sub/Cloud Function provisioning is involved -- just a
structured Cloud Logging query, since that's the only piece needed to
produce the event fixture `gcp-audit` mode tests consume.

## Follow-on work

The `gcp-audit`-mode code should probably
provide a way to select first or last records for operations.
Where for multi-record events uses `operation.first` or `operation.last`,
and for single-record events, just uses the single record.

We may want to provide a decorator/text-fixture form of this helper that's easier to use, including capturing 
Terraform events without using time skew. This PR provides a minimal implementation.