### PR TITLE
aws - cleanrooms - Add members filter to collaboration resource

### DIFF
--- a/c7n/resources/cleanrooms.py
+++ b/c7n/resources/cleanrooms.py
@@ -1,10 +1,12 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+from c7n.filters import ListItemFilter
 from c7n.manager import resources
 from c7n.query import (
     ChildResourceManager, QueryResourceManager, TypeInfo,
     DescribeWithResourceTags)
+from c7n.utils import local_session, type_schema
 
 
 @resources.register('cleanrooms-collaboration')
@@ -25,6 +27,53 @@ class CleanRoomsCollaboration(QueryResourceManager):
         universal_taggable = object()
 
     source_mapping = {'describe': DescribeWithResourceTags}
+
+
+@CleanRoomsCollaboration.filter_registry.register('members')
+class CleanRoomsCollaborationMemberFilter(ListItemFilter):
+    """Filter Clean Rooms collaborations on their members details.
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: cleanrooms-collaboration-with-members
+            resource: cleanrooms-collaboration
+            filters:
+              - type: members
+                attrs:
+                  - type: value
+                    key: status
+                    value: ACTIVE
+                  - type: value
+                    key: abilities
+                    op: intersect
+                    value: [CAN_QUERY, CAN_RECEIVE]
+    """
+
+    schema = type_schema('members',
+        attrs={"$ref": "#/definitions/filters_common/list_item_attrs"},
+        count={"type": "number"},
+        count_op={"$ref": "#/definitions/filters_common/comparison_operators"})
+
+    annotation_key = 'c7n:Members'
+    permissions = ('cleanrooms:ListMembers',)
+
+    def __init__(self, data, manager=None):
+        super().__init__(data, manager)
+        data['key'] = f'"{self.annotation_key}"'
+
+    def get_item_values(self, collaboration):
+        if self.annotation_key in collaboration:
+            return collaboration[self.annotation_key]
+        client = local_session(self.manager.session_factory).client('cleanrooms')
+        members = self.manager.retry(
+            client.get_paginator('list_members').paginate,
+            collaborationIdentifier=collaboration['id']
+        ).build_full_result().get('memberSummaries', [])
+        collaboration[self.annotation_key] = members
+        return members
 
 
 @resources.register('cleanrooms-membership')

--- a/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.GetCollaboration_1.json
+++ b/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.GetCollaboration_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "collaboration": {
+            "id": "62647862-bee9-42e8-8c07-99b0fc492f3a",
+            "arn": "arn:aws:cleanrooms:us-east-1:644160558196:collaboration/62647862-bee9-42e8-8c07-99b0fc492f3a",
+            "name": "Compliant Collaboration",
+            "description": "Compliant Collaboration",
+            "creatorAccountId": "644160558196",
+            "creatorDisplayName": "Compliant Member",
+            "createTime": {
+                "__class__": "datetime",
+                "year": 2026,
+                "month": 6,
+                "day": 9,
+                "hour": 2,
+                "minute": 2,
+                "second": 3,
+                "microsecond": 366000
+            },
+            "updateTime": {
+                "__class__": "datetime",
+                "year": 2026,
+                "month": 6,
+                "day": 9,
+                "hour": 2,
+                "minute": 2,
+                "second": 3,
+                "microsecond": 366000
+            },
+            "memberStatus": "ACTIVE",
+            "membershipId": "c5773151-1c6c-40ff-86f2-543d68654295",
+            "membershipArn": "arn:aws:cleanrooms:us-east-1:644160558196:membership/c5773151-1c6c-40ff-86f2-543d68654295",
+            "dataEncryptionMetadata": {
+                "allowCleartext": false,
+                "allowDuplicates": false,
+                "allowJoinsOnColumnsWithDifferentNames": false,
+                "preserveNulls": false
+            },
+            "queryLogStatus": "ENABLED",
+            "analyticsEngine": "SPARK",
+            "allowedResultRegions": [
+                "us-east-1"
+            ],
+            "isMetricsEnabled": false
+        }
+    }
+}

--- a/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.GetCollaboration_2.json
+++ b/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.GetCollaboration_2.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "collaboration": {
+            "id": "8326c03e-8c92-4cc0-9d84-3be7208e1528",
+            "arn": "arn:aws:cleanrooms:us-east-1:644160558196:collaboration/8326c03e-8c92-4cc0-9d84-3be7208e1528",
+            "name": "Noncompliant Collaboration",
+            "description": "Noncompliant CollaborationFor",
+            "creatorAccountId": "644160558196",
+            "creatorDisplayName": "Noncompliant Test creator",
+            "createTime": {
+                "__class__": "datetime",
+                "year": 2026,
+                "month": 6,
+                "day": 9,
+                "hour": 2,
+                "minute": 19,
+                "second": 43,
+                "microsecond": 53000
+            },
+            "updateTime": {
+                "__class__": "datetime",
+                "year": 2026,
+                "month": 6,
+                "day": 9,
+                "hour": 2,
+                "minute": 19,
+                "second": 43,
+                "microsecond": 53000
+            },
+            "memberStatus": "ACTIVE",
+            "membershipId": "471d06d5-b382-4d18-9ad5-8e61ffe2bfac",
+            "membershipArn": "arn:aws:cleanrooms:us-east-1:644160558196:membership/471d06d5-b382-4d18-9ad5-8e61ffe2bfac",
+            "dataEncryptionMetadata": {
+                "allowCleartext": true,
+                "allowDuplicates": false,
+                "allowJoinsOnColumnsWithDifferentNames": false,
+                "preserveNulls": false
+            },
+            "queryLogStatus": "DISABLED",
+            "analyticsEngine": "SPARK",
+            "allowedResultRegions": [
+                "us-east-1"
+            ],
+            "isMetricsEnabled": false
+        }
+    }
+}

--- a/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.ListCollaborations_1.json
+++ b/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.ListCollaborations_1.json
@@ -1,0 +1,70 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "collaborationList": [
+            {
+                "id": "62647862-bee9-42e8-8c07-99b0fc492f3a",
+                "arn": "arn:aws:cleanrooms:us-east-1:644160558196:collaboration/62647862-bee9-42e8-8c07-99b0fc492f3a",
+                "name": "Compliant Collaboration",
+                "creatorAccountId": "644160558196",
+                "creatorDisplayName": "Compliant Member",
+                "createTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 2,
+                    "second": 3,
+                    "microsecond": 366000
+                },
+                "updateTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 2,
+                    "second": 3,
+                    "microsecond": 366000
+                },
+                "memberStatus": "ACTIVE",
+                "membershipId": "c5773151-1c6c-40ff-86f2-543d68654295",
+                "membershipArn": "arn:aws:cleanrooms:us-east-1:644160558196:membership/c5773151-1c6c-40ff-86f2-543d68654295",
+                "analyticsEngine": "SPARK"
+            },
+            {
+                "id": "8326c03e-8c92-4cc0-9d84-3be7208e1528",
+                "arn": "arn:aws:cleanrooms:us-east-1:644160558196:collaboration/8326c03e-8c92-4cc0-9d84-3be7208e1528",
+                "name": "Noncompliant Collaboration",
+                "creatorAccountId": "644160558196",
+                "creatorDisplayName": "Noncompliant Test creator",
+                "createTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 19,
+                    "second": 43,
+                    "microsecond": 53000
+                },
+                "updateTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 19,
+                    "second": 43,
+                    "microsecond": 53000
+                },
+                "memberStatus": "ACTIVE",
+                "membershipId": "471d06d5-b382-4d18-9ad5-8e61ffe2bfac",
+                "membershipArn": "arn:aws:cleanrooms:us-east-1:644160558196:membership/471d06d5-b382-4d18-9ad5-8e61ffe2bfac",
+                "analyticsEngine": "SPARK"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.ListMembers_1.json
+++ b/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.ListMembers_1.json
@@ -1,0 +1,58 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "memberSummaries": [
+            {
+                "accountId": "644160558196",
+                "status": "ACTIVE",
+                "displayName": "Compliant Member",
+                "abilities": [
+                    "CAN_QUERY",
+                    "CAN_RECEIVE_RESULTS"
+                ],
+                "createTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 2,
+                    "second": 3,
+                    "microsecond": 366000
+                },
+                "updateTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 2,
+                    "second": 4,
+                    "microsecond": 210000
+                },
+                "membershipId": "c5773151-1c6c-40ff-86f2-543d68654295",
+                "membershipArn": "arn:aws:cleanrooms:us-east-1:644160558196:membership/c5773151-1c6c-40ff-86f2-543d68654295",
+                "paymentConfiguration": {
+                    "queryCompute": {
+                        "isResponsible": true
+                    },
+                    "machineLearning": {
+                        "modelTraining": {
+                            "isResponsible": false
+                        },
+                        "modelInference": {
+                            "isResponsible": false
+                        },
+                        "syntheticDataGeneration": {
+                            "isResponsible": false
+                        }
+                    },
+                    "jobCompute": {
+                        "isResponsible": false
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.ListMembers_2.json
+++ b/tests/data/placebo/test_cleanrooms_collaboration_members/cleanrooms.ListMembers_2.json
@@ -1,0 +1,106 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "memberSummaries": [
+            {
+                "accountId": "644160558196",
+                "status": "INVITED",
+                "displayName": "Noncompliant Test Member",
+                "abilities": [
+                    "CAN_QUERY"
+                ],
+                "createTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 19,
+                    "second": 43,
+                    "microsecond": 53000
+                },
+                "updateTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 19,
+                    "second": 43,
+                    "microsecond": 53000
+                },
+                "membershipId": "786a4a30-7dfb-4917-a08d-d06fd6b191a0",
+                "membershipArn": "arn:aws:cleanrooms:us-east-1:644160558196:membership/786a4a30-7dfb-4917-a08d-d06fd6b191a0",
+                "paymentConfiguration": {
+                    "queryCompute": {
+                        "isResponsible": false
+                    },
+                    "machineLearning": {
+                        "modelTraining": {
+                            "isResponsible": false
+                        },
+                        "modelInference": {
+                            "isResponsible": false
+                        },
+                        "syntheticDataGeneration": {
+                            "isResponsible": false
+                        }
+                    },
+                    "jobCompute": {
+                        "isResponsible": false
+                    }
+                }
+            },
+            {
+                "accountId": "644160558196",
+                "status": "ACTIVE",
+                "displayName": "Noncompliant Test creator",
+                "abilities": [
+                    "CAN_RECEIVE_RESULTS"
+                ],
+                "createTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 19,
+                    "second": 43,
+                    "microsecond": 53000
+                },
+                "updateTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 6,
+                    "day": 9,
+                    "hour": 2,
+                    "minute": 19,
+                    "second": 55,
+                    "microsecond": 367000
+                },
+                "membershipId": "471d06d5-b382-4d18-9ad5-8e61ffe2bfac",
+                "membershipArn": "arn:aws:cleanrooms:us-east-1:644160558196:membership/471d06d5-b382-4d18-9ad5-8e61ffe2bfac",
+                "paymentConfiguration": {
+                    "queryCompute": {
+                        "isResponsible": true
+                    },
+                    "machineLearning": {
+                        "modelTraining": {
+                            "isResponsible": false
+                        },
+                        "modelInference": {
+                            "isResponsible": false
+                        },
+                        "syntheticDataGeneration": {
+                            "isResponsible": false
+                        }
+                    },
+                    "jobCompute": {
+                        "isResponsible": false
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_cleanrooms_collaboration_members/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_cleanrooms_collaboration_members/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cleanrooms:us-east-1:644160558196:collaboration/62647862-bee9-42e8-8c07-99b0fc492f3a",
+                "Tags": [
+                    {
+                        "Key": "ASV",
+                        "Value": "PolicyTestASV"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_cleanrooms.py
+++ b/tests/test_cleanrooms.py
@@ -80,6 +80,27 @@ class TestCleanRoomsCollaboration(BaseTest):
         tags = client.list_tags_for_resource(resourceArn=arn)["tags"]
         self.assertNotIn("Env", tags)
 
+    def test_collaboration_members_filter(self):
+        factory = self.replay_flight_data("test_cleanrooms_collaboration_members")
+        p = self.load_policy(
+            {
+                "name": "cleanrooms-collaboration-members",
+                "resource": "aws.cleanrooms-collaboration",
+                "filters": [
+                    {"type": "members",
+                     "attrs": [
+                         {"type": "value", "key": "status",
+                          "op": "in", "value": ["ACTIVE", "INVITED"]},
+                         {"type": "value", "key": "abilities", "op": "intersect",
+                          "value": ["CAN_QUERY", "CAN_RECEIVE"]},
+                     ]},
+                ],
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
 
 class TestCleanRoomsMembership(BaseTest):
 

--- a/tests/test_cleanrooms.py
+++ b/tests/test_cleanrooms.py
@@ -91,8 +91,10 @@ class TestCleanRoomsCollaboration(BaseTest):
                      "attrs": [
                          {"type": "value", "key": "status",
                           "op": "in", "value": ["ACTIVE", "INVITED"]},
+                         {"type": "value", "key": "accountId",
+                          "op": "in", "value": [self.account_id]},
                          {"type": "value", "key": "abilities", "op": "intersect",
-                          "value": ["CAN_QUERY", "CAN_RECEIVE"]},
+                          "value": ["CAN_QUERY", "CAN_RECEIVE_RESULTS"]},
                      ]},
                 ],
             },


### PR DESCRIPTION
## Overview
- Add a filter to Cleanrooms Collaboration resource.
- This allows us to filter collaborations with members that match a certain criteria.
- Members of a collaboration can be from external accounts. The membership of an external account lives in the external accounts.


## References
- https://docs.aws.amazon.com/boto3/latest/reference/services/cleanrooms/client/list_members.html