### PR TITLE
aws - wafv2 - fix wafv2-enabled filter ignoring CLOUDFRONT scope

### DIFF
--- a/c7n/filters/waf.py
+++ b/c7n/filters/waf.py
@@ -223,8 +223,14 @@ class WafV2FilterBase(ValueFilter, metaclass=ABCMeta):
     # based on the scope
     def _get_web_acls(self, scope):
         if self._cached_web_acls is None:
-            self._cached_web_acls = self.manager.get_resource_manager('wafv2').resources(
-                query=dict(Scope=scope),
+            # Scope must be supplied as resource manager data rather than a query
+            # kwarg. The wafv2 manager derives both the API Scope and the region
+            # used for the call from its own data (CLOUDFRONT web acls are global
+            # and must be addressed via us-east-1), and a Scope passed via
+            # resources(query=...) is overwritten by the manager's own value.
+            wafv2 = self.manager.get_resource_manager(
+                'wafv2', {'query': [{'Scope': scope}]})
+            self._cached_web_acls = wafv2.resources(
                 # required to get the additional detail needed for this filter (e.g. Rules), but
                 # the legacy mode does not require additional detail
                 augment=(not self._is_legacy)

--- a/c7n/resources/waf.py
+++ b/c7n/resources/waf.py
@@ -249,6 +249,15 @@ class DescribeWafV2(DescribeSource):
     # set REGIONAL for Scope as default
     def get_query_params(self, query_params):
         query_params = query_params or {}
+        # Scope is owned by the resource manager, since it also determines which
+        # region the wafv2 API is called in. Fail loudly rather than silently
+        # discarding a conflicting Scope supplied by the caller.
+        requested_scope = query_params.get('Scope')
+        if requested_scope is not None and requested_scope != self.manager.scope:
+            raise PolicyValidationError(
+                "wafv2 Scope conflict: %s was requested but the resource manager "
+                "scope is %s. Pass Scope via the resource manager's 'query' data."
+                % (requested_scope, self.manager.scope))
         # Parse query from policy data
         queries = self.manager.data.get('query', [])
         for q in queries:

--- a/tests/data/placebo/test_distribution_wafv2_filter_scope/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_filter_scope/cloudfront.ListDistributions_1.json
@@ -1,0 +1,72 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "DistributionList": {
+            "Marker": "",
+            "MaxItems": 100,
+            "IsTruncated": false,
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "E1EXAMPLE1234",
+                    "ARN": "arn:aws:cloudfront::123456789012:distribution/E1EXAMPLE1234",
+                    "Status": "Deployed",
+                    "LastModifiedTime": {
+                        "hour": 0,
+                        "microsecond": 0,
+                        "second": 0,
+                        "year": 2024,
+                        "month": 1,
+                        "day": 1,
+                        "minute": 0
+                    },
+                    "DomainName": "d111111abcdef8.cloudfront.net",
+                    "Aliases": {
+                        "Quantity": 0,
+                        "Items": []
+                    },
+                    "Origins": {
+                        "Quantity": 1,
+                        "Items": [
+                            {
+                                "Id": "S3-example",
+                                "DomainName": "example-bucket.s3.amazonaws.com",
+                                "OriginPath": ""
+                            }
+                        ]
+                    },
+                    "DefaultCacheBehavior": {
+                        "TargetOriginId": "S3-example",
+                        "ViewerProtocolPolicy": "redirect-to-https"
+                    },
+                    "CacheBehaviors": {
+                        "Quantity": 0,
+                        "Items": []
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0,
+                        "Items": []
+                    },
+                    "Comment": "",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": true,
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "WebACLId": "arn:aws:wafv2:us-east-1:123456789012:global/webacl/example-cloudfront-acl/11111111-2222-3333-4444-555555555555",
+                    "HttpVersion": "http2",
+                    "IsIPV6Enabled": true
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_filter_scope/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_filter_scope/tagging.GetResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudfront::123456789012:distribution/E1EXAMPLE1234",
+                "Tags": []
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_distribution_wafv2_filter_scope/wafv2.ListWebACLs_1.json
+++ b/tests/data/placebo/test_distribution_wafv2_filter_scope/wafv2.ListWebACLs_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {},
+        "NextMarker": "",
+        "WebACLs": [
+            {
+                "Name": "example-cloudfront-acl",
+                "Id": "11111111-2222-3333-4444-555555555555",
+                "Description": "",
+                "LockToken": "22222222-3333-4444-5555-666666666666",
+                "ARN": "arn:aws:wafv2:us-east-1:123456789012:global/webacl/example-cloudfront-acl/11111111-2222-3333-4444-555555555555"
+            }
+        ]
+    }
+}

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -1,7 +1,9 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 from .common import BaseTest, event_data
+from c7n.exceptions import PolicyValidationError
 from c7n.resources.aws import shape_validate
+from c7n.resources.waf import WAFV2, DescribeWafV2
 from c7n.utils import local_session, jmespath_compile
 from unittest.mock import MagicMock, patch
 from botocore.exceptions import ClientError
@@ -1157,3 +1159,43 @@ class CloudFrontWafV2(BaseTest):
             manager = WAFV2(ctx, {})
             manager.get_client()
             mock_session.client.assert_called_once_with('wafv2', region_name='us-west-2')
+
+    def test_wafv2_filter_uses_cloudfront_scope(self):
+        """The wafv2-enabled filter must list CLOUDFRONT-scoped web acls.
+
+        A distribution with a CLOUDFRONT WebACL attached must not be reported by
+        `state: false`. If the filter's requested scope is dropped in favor of the
+        REGIONAL default, the distribution's CLOUDFRONT WebACL ARN is never found
+        and the distribution is incorrectly reported as unprotected.
+        """
+        factory = self.replay_flight_data("test_distribution_wafv2_filter_scope")
+        p = self.load_policy(
+            {
+                "name": "wafv2-cloudfront-scope",
+                "resource": "distribution",
+                "filters": [{"type": "wafv2-enabled", "state": False}],
+            },
+            session_factory=factory,
+        )
+
+        scopes = []
+        original = DescribeWafV2.get_query_params
+
+        def record(self, query):
+            params = original(self, query)
+            scopes.append(params.get('Scope'))
+            return params
+
+        with patch.object(DescribeWafV2, 'get_query_params', record):
+            resources = p.run()
+
+        self.assertEqual(scopes, ['CLOUDFRONT'])
+        self.assertEqual(len(resources), 0)
+
+    def test_wafv2_filter_scope_conflict_raises(self):
+        """A Scope passed via resources(query=) that conflicts with the resource
+        manager's own scope is an error rather than being silently ignored."""
+        p = self.load_policy({"name": "wafv2", "resource": "distribution"})
+        mgr = WAFV2(p.ctx, {'query': [{'Scope': 'REGIONAL'}]})
+        with self.assertRaises(PolicyValidationError):
+            mgr.source.get_query_params({'Scope': 'CLOUDFRONT'})


### PR DESCRIPTION
## Summary

**This is a serious regression and can/will cause outages for folks using a similar filter.**

`wafv2-enabled` reports **every WAF-protected CloudFront distribution as unprotected** when used with `state: false`.

This is the same regression fixed by #10975, which covered only the `set-wafv2` **action**. The **filter** in `c7n/filters/waf.py` was never migrated.

## Reproducer

```yaml
policies:
  - name: cloudfront-without-wafv2
    resource: distribution
    filters:
      - type: wafv2-enabled
        state: false
```

On 0.9.51 this returns 0. On mainline, it returns every distribution in the account, including ones with a CLOUDFRONT web ACL attached.

## Root cause

Before #10827, `WAFV2` scope came from a `resources(query=...)` kwarg:

```python
scope = (query or {}).get('Scope', 'REGIONAL')
```

#10827 moved scope ownership onto the manager's `data['query']` and made `DescribeWafV2.get_query_params` overwrite it unconditionally:

```python
query_params['Scope'] = self.manager.scope
```

`WafV2FilterBase._get_web_acls` still uses the old calling convention:

```python
self.manager.get_resource_manager('wafv2').resources(
    query=dict(Scope=scope),
    ...
)
```

The requested `CLOUDFRONT` is discarded and `REGIONAL` is substituted. Two things then go wrong:

1. `ListWebACLs` is called with `Scope=REGIONAL`, so no CLOUDFRONT web ACL is ever returned.
2. `scope_region` stays at the policy region instead of `us-east-1`, where global web ACLs live.

The distribution's `WebACLId` holds a CLOUDFRONT ARN, so every lookup misses and returns `{}`. With `state: false` the miss is inverted into a match — a silent false positive, not an error.

## Changes

- **`c7n/filters/waf.py`** — pass scope as resource manager data, matching the convention #10975 adopted for the action:
  ```python
  self.manager.get_resource_manager('wafv2', {'query': [{'Scope': scope}]})
  ```
- **`c7n/resources/waf.py`** — raise `PolicyValidationError` on a conflicting `Scope` in `query_params` instead of silently discarding it, so any remaining caller on the old convention fails loudly rather than returning wrong results.
- **`tests/test_cloudfront.py`** — two regression tests, plus synthetic placebo fixtures.

## Notes on the tests

`test_wafv2_filter_uses_cloudfront_scope` asserts the `Scope` that actually reaches `get_query_params`, since placebo replays fixtures regardless of request parameters — a fixture-only test passes even with the bug present. Verified fail-then-pass:

```
# without the fix
FAILED tests/test_cloudfront.py::CloudFrontWafV2::test_wafv2_filter_scope_conflict_raises
FAILED tests/test_cloudfront.py::CloudFrontWafV2::test_wafv2_filter_uses_cloudfront_scope
2 failed, 1 passed

# with the fix
3 passed
```

No regressions in the suites covering `wafv2-enabled` consumers:

```
tests/test_cloudfront.py tests/test_waf.py                          60 passed
tests/test_apigw.py tests/test_appelb.py tests/test_appsync.py     127 passed
```

`ruff check` clean on all changed files.

## Related

- #10827 — introduced the regression (`1f20e9fa0`)
- #10975 — fixed it for the `set-wafv2` action only (`611bb0f75`)

Happy to adjust the `PolicyValidationError` in `resources/waf.py` if you'd prefer the filter fix alone, or a silent precedence rule instead of a hard error.
