### PR TITLE
aws - iam - retry concurrent tag updates

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -36,12 +36,24 @@ from c7n.query import (
 from c7n.resolver import ValuesFrom
 from c7n.tags import TagActionFilter, TagDelayedAction, Tag, RemoveTag, universal_augment
 from c7n.utils import (
-    get_partition, local_session, type_schema, chunks, filter_empty, QueryParser,
+    get_partition, get_retry, local_session, type_schema, chunks, filter_empty, QueryParser,
     select_keys
 )
 
 from c7n.resources.aws import Arn
 from c7n.resources.securityhub import OtherResourcePostFinding
+
+
+_iam_tag_retry = get_retry((
+    'ConcurrentModification',
+    'TooManyRequestsException',
+    'ThrottlingException',
+    'RequestLimitExceeded',
+    'Throttled',
+    'ThrottledException',
+    'Throttling',
+    'Client.RequestLimitExceeded',
+))
 
 
 class DescribeGroup(DescribeSource):
@@ -149,8 +161,7 @@ class RoleTag(Tag):
     def process_resource_set(self, client, roles, tags):
         for role in roles:
             try:
-                self.manager.retry(
-                    client.tag_role, RoleName=role['RoleName'], Tags=tags)
+                _iam_tag_retry(client.tag_role, RoleName=role['RoleName'], Tags=tags)
             except client.exceptions.NoSuchEntityException:
                 continue
 
@@ -164,8 +175,7 @@ class RoleRemoveTag(RemoveTag):
     def process_resource_set(self, client, roles, tags):
         for role in roles:
             try:
-                self.manager.retry(
-                    client.untag_role, RoleName=role['RoleName'], TagKeys=tags)
+                _iam_tag_retry(client.untag_role, RoleName=role['RoleName'], TagKeys=tags)
             except client.exceptions.NoSuchEntityException:
                 continue
 
@@ -281,8 +291,7 @@ class UserTag(Tag):
     def process_resource_set(self, client, users, tags):
         for u in users:
             try:
-                self.manager.retry(
-                    client.tag_user, UserName=u['UserName'], Tags=tags)
+                _iam_tag_retry(client.tag_user, UserName=u['UserName'], Tags=tags)
             except client.exceptions.NoSuchEntityException:
                 continue
 
@@ -296,8 +305,7 @@ class UserRemoveTag(RemoveTag):
     def process_resource_set(self, client, users, tags):
         for u in users:
             try:
-                self.manager.retry(
-                    client.untag_user, UserName=u['UserName'], TagKeys=tags)
+                _iam_tag_retry(client.untag_user, UserName=u['UserName'], TagKeys=tags)
             except client.exceptions.NoSuchEntityException:
                 continue
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -14,6 +14,8 @@ import pytest
 from pytest_terraform import terraform
 from dateutil import parser
 
+import botocore.session
+from botocore.stub import Stubber
 from c7n.exceptions import PolicyValidationError
 from c7n.executor import MainThreadExecutor
 from c7n.filters.iamaccess import CrossAccountAccessFilter, PolicyChecker
@@ -38,9 +40,13 @@ from c7n.resources.iam import (
     IamUserInlinePolicy,
     IamRoleInlinePolicy,
     IamGroupInlinePolicy,
+    RoleRemoveTag,
+    RoleTag,
     SpecificIamRoleManagedPolicy,
     NoSpecificIamRoleManagedPolicy,
     PolicyQueryParser,
+    UserRemoveTag,
+    UserTag,
     UserServiceSpecificCredentials,
 )
 
@@ -367,6 +373,105 @@ class UserCredentialReportTest(BaseTest):
                 "user_creation_time": "2016-10-06T16:11:27+00:00",
             },
         )
+
+
+class IamTagRetry(BaseTest):
+
+    def test_iam_tag_actions_retry_concurrent_modification(self):
+        self.patch(time, "sleep", lambda _: None)
+        cases = (
+            (RoleTag, "tag_role", "RoleName"),
+            (RoleRemoveTag, "untag_role", "RoleName"),
+            (UserTag, "tag_user", "UserName"),
+            (UserRemoveTag, "untag_user", "UserName"),
+        )
+
+        for action_class, operation_name, id_key in cases:
+            with self.subTest(operation=operation_name):
+                resource = {id_key: "resource-one"}
+                missing = {id_key: "resource-missing"}
+                if operation_name.startswith("untag_"):
+                    tag_key, tags = "TagKeys", ["Env"]
+                else:
+                    tag_key, tags = "Tags", [{"Key": "Env", "Value": "Dev"}]
+                client = botocore.session.get_session().create_client(
+                    "iam",
+                    region_name="us-east-1",
+                    aws_access_key_id="access-key",
+                    aws_secret_access_key="secret-key",
+                )
+                expected = {**resource, tag_key: tags}
+                missing_expected = {**missing, tag_key: tags}
+                stubber = Stubber(client)
+                stubber.add_client_error(
+                    operation_name,
+                    service_error_code="ConcurrentModification",
+                    service_message="simultaneous change",
+                    http_status_code=409,
+                    expected_params=expected,
+                )
+                stubber.add_response(operation_name, {}, expected)
+                stubber.add_client_error(
+                    operation_name,
+                    service_error_code="NoSuchEntity",
+                    service_message="missing",
+                    http_status_code=404,
+                    expected_params=missing_expected,
+                )
+
+                action = action_class({}, mock.Mock())
+                with stubber, mock.patch.object(
+                    client, operation_name, wraps=getattr(client, operation_name)
+                ) as operation:
+                    action.process_resource_set(client, [resource, missing], tags)
+
+                self.assertEqual(operation.call_count, 3)
+                self.assertEqual(
+                    operation.call_args_list,
+                    [
+                        mock.call(**expected),
+                        mock.call(**expected),
+                        mock.call(**missing_expected),
+                    ],
+                )
+
+    def test_iam_tag_retry_uses_single_attempt_budget(self):
+        sleep = mock.Mock()
+        self.patch(time, "sleep", sleep)
+        client = botocore.session.get_session().create_client(
+            "iam",
+            region_name="us-east-1",
+            aws_access_key_id="access-key",
+            aws_secret_access_key="secret-key",
+        )
+        expected = {
+            "RoleName": "resource-one",
+            "Tags": [{"Key": "Env", "Value": "Dev"}],
+        }
+        stubber = Stubber(client)
+        for attempt in range(8):
+            throttled = attempt % 2 == 0
+            stubber.add_client_error(
+                "tag_role",
+                service_error_code="Throttling" if throttled else "ConcurrentModification",
+                service_message="retry",
+                http_status_code=429 if throttled else 409,
+                expected_params=expected,
+            )
+
+        action = RoleTag({}, mock.Mock())
+        with stubber, mock.patch.object(
+            client, "tag_role", wraps=client.tag_role
+        ) as operation:
+            with self.assertRaises(ClientError):
+                action.process_resource_set(
+                    client,
+                    [{"RoleName": "resource-one"}],
+                    [{"Key": "Env", "Value": "Dev"}],
+                )
+
+        self.assertEqual(operation.call_count, 8)
+        self.assertEqual(sleep.call_count, 7)
 
 
 class IamUserTag(BaseTest):


### PR DESCRIPTION
## Why

IAM role and user `tag` / `remove-tag` actions fail immediately when AWS returns
`An error occurred (ConcurrentModification)` (HTTP 409). The condition is transient, but neither
`QueryResourceManager.retry` nor botocore classifies it as retryable. After this change, the same
action retries and can complete once the concurrent update clears.

Closes https://github.com/cloud-custodian/cloud-custodian/issues/11000.

## What changed

The IAM tag actions use one IAM-local retry budget containing the existing manager throttling codes
plus `ConcurrentModification`. The total remains eight attempts, including mixed throttle and 409
responses. This applies to role and user tag/untag calls. IAM policies use the Resource Groups
Tagging API, and IAM does not expose `TagGroup` or `UntagGroup`, so those paths are unchanged.

## Testing

| Scenario | Command | Result |
| --- | --- | --- |
| Before | `uv run pytest -q tests/test_iam.py::IamUserTag::test_iam_tag_actions_retry_concurrent_modification` | Each IAM mutator failed on its first 409 |
| After | `uv run pytest -q tests/test_iam.py::IamTagRetry` | Retry succeeds; mixed errors stop after 8 calls |
| IAM suite | `uv run pytest -q tests/test_iam.py tests/test_utils.py::Backoff` | 159 passed, 4 subtests passed |

<details>
<summary>Red/green logs</summary>

```text
Before:
$ uv run pytest -q tests/test_iam.py::IamUserTag::test_iam_tag_actions_retry_concurrent_modification
SUBFAILED(operation='tag_role')
botocore.errorfactory.ConcurrentModificationException:
An error occurred (ConcurrentModification) when calling the TagRole operation:
simultaneous change
SUBFAILED(operation='untag_role')
SUBFAILED(operation='tag_user')
SUBFAILED(operation='untag_user')
4 failed, 1 passed

After:
$ uv run pytest -q tests/test_iam.py::IamTagRetry
..                                                                   [100%]
2 passed, 4 subtests passed in 0.83s
```

</details>

Hygiene: Ruff passed; Black left 150 files unchanged.

No live AWS race was run. The tests use botocore Stubber without credentials or account mutations.
