### PR TITLE
secretsmanager - skip service-managed secrets in tag mutations

### DIFF
--- a/c7n/resources/secretsmanager.py
+++ b/c7n/resources/secretsmanager.py
@@ -239,8 +239,31 @@ class SecretVersionFilter(ValueFilter):
         return None
 
 
+class SkipServiceManagedSecret:
+    """Mixin for aws.secrets-manager tag mutation actions which cannot
+    operate on secrets owned by another AWS service (OwningService is
+    set, e.g. rds!db-*, aws-datasync!loc-*, events!connection/*).
+    Such secrets reject TagResource/UntagResource from any other caller
+    with an InvalidRequestException.  Filters them out before delegating
+    to the real action and emits a warning so operators know why the
+    entries were skipped."""
+
+    def process(self, resources):
+        excluded = [r for r in resources if r.get('OwningService')]
+        if excluded:
+            self.manager.log.warning(
+                'Skipping %d service-managed secret(s) which cannot be '
+                'tagged by callers other than the owning service',
+                len(excluded),
+            )
+        resources = [r for r in resources if not r.get('OwningService')]
+        if not resources:
+            return None
+        return super().process(resources)
+
+
 @SecretsManager.action_registry.register('tag')
-class TagSecretsManagerResource(Tag):
+class TagSecretsManagerResource(SkipServiceManagedSecret, Tag):
     """Action to create tag(s) on a Secret resource
 
     :example:
@@ -269,7 +292,7 @@ class TagSecretsManagerResource(Tag):
 
 
 @SecretsManager.action_registry.register('remove-tag')
-class RemoveTagSecretsManagerResource(RemoveTag):
+class RemoveTagSecretsManagerResource(SkipServiceManagedSecret, RemoveTag):
     """Action to remove tag(s) on a Secret resource
 
     :example:
@@ -292,7 +315,7 @@ class RemoveTagSecretsManagerResource(RemoveTag):
 
 
 @SecretsManager.action_registry.register('mark-for-op')
-class MarkSecretForOp(TagDelayedAction):
+class MarkSecretForOp(SkipServiceManagedSecret, TagDelayedAction):
     """Action to mark a Secret resource for deferred action :example:
 
     .. code-block:: yaml

--- a/tests/test_secretsmanager.py
+++ b/tests/test_secretsmanager.py
@@ -126,6 +126,55 @@ class TestSecretsManager(BaseTest):
         new_tags = client.describe_secret(SecretId="c7n-test-key").get("Tags")
         self.assertTrue("tag@" in new_tags[0].get("Value"))
 
+    def test_tag_action_skips_service_managed_secrets(self):
+        self.patch(SecretsManager, 'executor_factory', MainThreadExecutor)
+        p = self.load_policy({
+            'name': 'tag-secrets',
+            'resource': 'secrets-manager',
+            'actions': [{'type': 'tag', 'key': 'team', 'value': 'platform'}]})
+        action = p.resource_manager.actions[0]
+        resources = [
+            {'Name': 'user-owned', 'ARN': 'secret-arn:user-owned'},
+            {'Name': 'rds!db-abc', 'ARN': 'secret-arn:rds!db-abc',
+             'OwningService': 'rds'}]
+        with patch.object(action, 'process_resource_set') as process_resource_set:
+            action.process(resources)
+        self.assertEqual(process_resource_set.call_count, 1)
+        tagged = process_resource_set.call_args[0][1]
+        self.assertEqual([r['Name'] for r in tagged], ['user-owned'])
+
+    def test_remove_tag_action_skips_service_managed_secrets(self):
+        self.patch(SecretsManager, 'executor_factory', MainThreadExecutor)
+        p = self.load_policy({
+            'name': 'untag-secrets',
+            'resource': 'secrets-manager',
+            'actions': [{'type': 'remove-tag', 'tags': ['stale']}]})
+        action = p.resource_manager.actions[0]
+        resources = [
+            {'Name': 'user-owned', 'ARN': 'secret-arn:user-owned'},
+            {'Name': 'aws-datasync!loc-1', 'ARN': 'secret-arn:aws-datasync!loc-1',
+             'OwningService': 'aws-datasync'}]
+        with patch.object(action, 'process_resource_set') as process_resource_set:
+            action.process(resources)
+        self.assertEqual(process_resource_set.call_count, 1)
+        untagged = process_resource_set.call_args[0][1]
+        self.assertEqual([r['Name'] for r in untagged], ['user-owned'])
+
+    def test_all_service_managed_secret_set_skips_mutation(self):
+        self.patch(SecretsManager, 'executor_factory', MainThreadExecutor)
+        p = self.load_policy({
+            'name': 'mark-secrets',
+            'resource': 'secrets-manager',
+            'actions': [{'type': 'mark-for-op', 'op': 'delete', 'days': 1}]})
+        action = p.resource_manager.actions[0]
+        resources = [{
+            'Name': 'events!conn-1',
+            'ARN': 'secret-arn:events!conn-1',
+            'OwningService': 'events'}]
+        with patch.object(action, 'process_resource_set') as process_resource_set:
+            self.assertEqual(action.process(resources), None)
+        process_resource_set.assert_not_called()
+
     def test_secrets_manager_delete(self):
         self.patch(SecretsManager, 'executor_factory', MainThreadExecutor)
         session_factory = self.replay_flight_data('test_secrets_manager_delete')


### PR DESCRIPTION
## Summary

- `aws.secrets-manager` tag mutation actions (`tag`, `remove-tag`, `mark-for-op`) now skip secrets owned by another AWS service (`OwningService` set — e.g. `rds!db-*`, `aws-datasync!loc-*`, `events!connection/*`) instead of calling `TagResource`/`UntagResource` on them and failing with `InvalidRequestException`.
- A warning is logged with the skipped count so operators know why entries were excluded. Read paths (inventory/filters) are unchanged.

## Problem

Fixes #11035. Secrets created by another AWS service cannot be tagged by any other principal ([`TagResource` API reference](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_TagResource.html) documents this restriction). Custodian's three tag-mutation actions iterated every resource unconditionally, so any policy whose scope includes service-managed secrets produced one `InvalidRequestException` per secret on every run.

The `OwningService` field is already present on the raw resource dict (returned by both `ListSecrets` and `DescribeSecret`), so the discriminator is available at action time.

## Solution

Adds a `SkipServiceManagedSecret` mixin that filters `OwningService`-bearing resources out of `process()` before delegating, and wires it into all three mutation classes (`TagSecretsManagerResource`, `RemoveTagSecretsManagerResource`, `MarkSecretForOp`). This mirrors the structural pattern of #10967 (`SkipAwsManagedCatalog` for `aws.athena-data-catalog`). For `mark-for-op`, filtering in `process()` covers its delegation into the registry `tag` action. When the filtered set is empty the action returns without touching the API.

## Testing

- Added 3 unit tests to `tests/test_secretsmanager.py` (mock-based, mirroring `test_athena_catalog_mixin_skips_aws_managed`):
  - mixed set → only the user-owned secret reaches `process_resource_set` for `tag`
  - mixed set → same guarantee for `remove-tag`
  - all-service-managed set → `mark-for-op` never invokes the tag machinery
- Confirmed all 3 fail on unmodified source and pass with the fix (`3 failed` → `17 passed`).
- Full file suite: `pytest tests/test_secretsmanager.py` → **17 passed**.
- Neighbors: `pytest tests/test_tags.py tests/test_athena.py` → **49 passed**.
- Lint: `ruff check c7n/resources/secretsmanager.py tests/test_secretsmanager.py` → clean.

Not covered: a placebo/replay integration test would need recorded flight data including an `OwningService`-bearing secret; the unit tests assert the observable action behavior directly instead.

## Related Issue

Fixes #11035
