### PR TITLE
aws - asg - fix tag action crash on value-spec (lookup) tag values

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -20,7 +20,9 @@ import c7n.policy
 from c7n.manager import resources
 from c7n import query
 from c7n.resources.securityhub import PostFinding
-from c7n.tags import TagActionFilter, DEFAULT_TAG, TagCountFilter, TagTrim, TagDelayedAction
+from c7n.tags import (
+    TagActionFilter, DEFAULT_TAG, TagCountFilter, TagTrim, TagDelayedAction,
+    resolve_tag_value, resource_tag_keys, tag_value_schema, TAG_VALUE_SKIP)
 from c7n.utils import (
     FormatDate, local_session, type_schema, chunks, get_retry, select_keys)
 
@@ -1130,8 +1132,8 @@ class Tag(Action):
     schema = type_schema(
         'tag',
         key={'type': 'string'},
-        value={'type': 'string'},
-        tags={'type': 'object'},
+        value=tag_value_schema(),
+        tags={'type': 'object', 'additionalProperties': tag_value_schema()},
         # Backwards compatibility
         tag={'type': 'string'},
         msg={'type': 'string'},
@@ -1141,34 +1143,41 @@ class Tag(Action):
     permissions = ('autoscaling:CreateOrUpdateTags',)
     batch_size = 1
 
-    def get_tag_set(self):
+    def get_tag_set(self, asg):
         tags = []
+        current = resource_tag_keys(asg)
         key = self.data.get('key', self.data.get('tag', DEFAULT_TAG))
         value = self.data.get(
             'value', self.data.get(
                 'msg', 'AutoScaleGroup does not meet policy guidelines'))
         if key and value:
-            tags.append({'Key': key, 'Value': value})
+            resolved = resolve_tag_value(value, key, asg, current)
+            if resolved is not TAG_VALUE_SKIP:
+                tags.append({'Key': key, 'Value': resolved})
 
         for k, v in self.data.get('tags', {}).items():
-            tags.append({'Key': k, 'Value': v})
+            resolved = resolve_tag_value(v, k, asg, current)
+            if resolved is not TAG_VALUE_SKIP:
+                tags.append({'Key': k, 'Value': resolved})
 
         return tags
 
     def process(self, asgs):
-        tags = self.get_tag_set()
         error = None
-
-        self.interpolate_values(tags)
 
         client = self.get_client()
         with self.executor_factory(max_workers=2) as w:
             futures = {}
+            # batch_size is fixed at 1, so each set is resolved against
+            # its single member; get_tag_set()'s lookups are per-resource.
             for asg_set in chunks(asgs, self.batch_size):
+                tags = self.get_tag_set(asg_set[0])
+                self.interpolate_values(tags)
                 futures[w.submit(
-                    self.process_resource_set, client, asg_set, tags)] = asg_set
+                    self.process_resource_set, client, asg_set, tags
+                )] = (asg_set, tags)
             for f in as_completed(futures):
-                asg_set = futures[f]
+                asg_set, tags = futures[f]
                 if f.exception():
                     self.log.exception(
                         "Exception tagging tag:%s error:%s asg:%s" % (
@@ -1192,6 +1201,8 @@ class Tag(Action):
                 atags['ResourceId'] = a['AutoScalingGroupName']
                 tag_params.append(atags)
                 a.setdefault('Tags', []).append(atags)
+        if not tag_params:
+            return
         self.manager.retry(client.create_or_update_tags, Tags=tag_params)
 
     def interpolate_values(self, tags):
@@ -1200,7 +1211,7 @@ class Tag(Action):
             'now': FormatDate.utcnow(),
             'region': self.manager.config.region}
         for t in tags:
-            t['Value'] = t['Value'].format(**params)
+            t['Value'] = str(t['Value']).format(**params)
 
     def get_client(self):
         return local_session(self.manager.session_factory).client('autoscaling')

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -401,6 +401,54 @@ class AutoScalingTest(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["LaunchConfigurationName"], "foo-bar")
 
+    def _run_tag_action(self, resources, action_data):
+        mock_factory = mock.MagicMock()
+        mock_factory.region = 'us-east-1'
+        client = mock_factory().client('autoscaling')
+        client.create_or_update_tags.return_value = {}
+        policy = self.load_policy(
+            {'name': 'asg-tag-spec', 'resource': 'asg',
+             'actions': [dict(action_data, type='tag')]},
+            session_factory=mock_factory)
+        policy.resource_manager.actions[0].process(resources)
+        return client.create_or_update_tags
+
+    def test_asg_tag_value_spec_default(self):
+        # https://github.com/cloud-custodian/cloud-custodian/issues/10997
+        # a value-spec (lookup) tag value used to crash asg's tag action
+        # with AttributeError: 'dict' object has no attribute 'format'
+        create_or_update_tags = self._run_tag_action(
+            [{'AutoScalingGroupName': 'asg-1', 'Tags': []}],
+            {'value': '', 'tags': {'acme_cost_center': {
+                'type': 'resource', 'default-value': '1234'}}})
+        create_or_update_tags.assert_called_once_with(
+            Tags=[{
+                'Key': 'acme_cost_center', 'Value': '1234',
+                'PropagateAtLaunch': False,
+                'ResourceType': 'auto-scaling-group',
+                'ResourceId': 'asg-1'}])
+
+    def test_asg_tag_value_spec_conditional_skip(self):
+        # default-value with no 'key' only writes when the tag is absent
+        create_or_update_tags = self._run_tag_action(
+            [{'AutoScalingGroupName': 'asg-1',
+              'Tags': [{'Key': 'acme_cost_center', 'Value': 'existing'}]}],
+            {'value': '', 'tags': {'acme_cost_center': {
+                'type': 'resource', 'default-value': '1234'}}})
+        create_or_update_tags.assert_not_called()
+
+    def test_asg_tag_value_spec_resource_key(self):
+        create_or_update_tags = self._run_tag_action(
+            [{'AutoScalingGroupName': 'asg-1', 'Tags': [],
+              'Team': 'platform'}],
+            {'value': '', 'tags': {'Owner': {'type': 'resource', 'key': 'Team'}}})
+        create_or_update_tags.assert_called_once_with(
+            Tags=[{
+                'Key': 'Owner', 'Value': 'platform',
+                'PropagateAtLaunch': False,
+                'ResourceType': 'auto-scaling-group',
+                'ResourceId': 'asg-1'}])
+
     def test_asg_tag_and_propagate(self):
         factory = self.replay_flight_data("test_asg_tag")
         p = self.load_policy(


### PR DESCRIPTION
## Summary

Fixes #10997.

`aws.asg`'s `tag`/`mark` action reimplemented tag-value interpolation
with a bare `str.format()` call instead of routing through
`c7n.tags.resolve_tag_value`, so a value-spec (lookup) tag value crashed
with:

```
AttributeError: 'dict' object has no attribute 'format'
```

The generic `c7n.tags.Tag` action already supports value-spec dicts
(`type: resource`, `key`, `default-value`) for every other
universally-taggable resource; `aws.asg` overrode `get_tag_set` /
`interpolate_values` in a way that only handled scalar string values.

## Fix

- `get_tag_set` now resolves each tag value per-ASG through the shared
  `c7n.tags.resolve_tag_value` / `resource_tag_keys` helpers, so lookup
  specs (`type: resource`, optional `key`, `default-value`) behave the
  same way they do on every other taggable resource, including the
  "write only if the tag is currently absent" conditional-default case.
- `interpolate_values` now coerces to `str()` before `.format()`,
  matching the base `tags.Tag.interpolate_single_value` behavior, as a
  defensive backstop for any other non-string scalar.
- Schema for `value`/`tags` now uses the shared `tag_value_schema()` so
  lookup-spec tag values validate cleanly instead of only passing by
  accident.
- `process_resource_set`'s external signature
  (`client, resource_set, tags`) is unchanged — `TagDelayedAction`
  (`mark-for-op`) calls it directly with a pre-built, already-resolved
  tags list, so that call site is unaffected.

## Test plan

- Added `test_asg_tag_value_spec_default`,
  `test_asg_tag_value_spec_conditional_skip`, and
  `test_asg_tag_value_spec_resource_key` to `tests/test_asg.py`,
  reproducing the crash from #10997 and covering the lookup/`key` and
  conditional-default/`default-value` cases.
- `pytest tests/test_asg.py tests/test_tags.py` — 96 passed.
- Full suite: `make test` — 5376 passed, 12 skipped, 1 xfailed (no
  regressions; +3 from this PR).
- `ruff check c7n/resources/asg.py tests/test_asg.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)