### PR TITLE
c7n_mailer - bundle jwt so lambda deploys work with redis 5.3+

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/deploy.py
@@ -32,6 +32,8 @@ CORE_DEPS = [
     "pyasn1",
     "redis",
     "jmespath",
+    # redis (recursive dep) - redis.auth.token imports jwt at module scope
+    "jwt",
     # transport datadog - recursive deps
     "datadog",
     "decorator",

--- a/tools/c7n_mailer/tests/test_misc.py
+++ b/tools/c7n_mailer/tests/test_misc.py
@@ -83,6 +83,16 @@ class DeployTests(unittest.TestCase):
         assert archive.size > 10000  # this should really be about 1.5 MB
         assert len(archive.get_filenames()) > 50  # should be > 500
 
+    def test_get_archive_bundles_redis_jwt_dep(self):
+        # redis imports jwt at module scope in redis/auth/token.py and the
+        # mailer imports redis unconditionally via ldap_lookup so an archive
+        # carrying redis without jwt fails on import in the deployed function.
+        archive = deploy.get_archive({"templates_folders": []})
+        names = archive.get_filenames()
+        assert "redis/auth/token.py" in names
+        assert any(n == "jwt" or n.startswith("jwt/") for n in names)
+        archive.remove()
+
     def test_get_archive_with_templates(self):
         with (
             tempfile.TemporaryDirectory() as template_folder1,


### PR DESCRIPTION
Fixes #10282.

`c7n-mailer` builds the Lambda package from the hardcoded `CORE_DEPS` list in `deploy.py`. `redis` is included there but `PyJWT` isn't. Since redis 5.3.0, `redis/auth/token.py` imports `jwt` at module load time so the deployed Lambda fails during import with:

`Runtime.ImportModuleError: Unable to import module 'periodic': No module named 'jwt'`

This is hit on the normal mailer entry path because `redis` is imported unconditionally through `ldap_lookup.py`.

`c7n_mailer` currently allows `redis>=5.0,<6.0` which resolves to an affected version on a fresh install. `PyJWT` is already installed as a redis dependency so this just makes sure it gets copied into the Lambda archive as well.

For testing, I added an archive-content check for both `redis/auth/token.py` and `jwt`. The test fails with the current `CORE_DEPS` list and passes once `PyJWT` is included. The rest of `test_misc.py` still passes.
