### PR TITLE
gcp - cloud-run - drop non-schema fields from label mutations

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/cloudrun.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/cloudrun.py
@@ -1,12 +1,63 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-import copy
-
 from c7n_gcp.provider import resources
 from c7n_gcp.query import QueryResourceManager, TypeInfo
 from c7n_gcp.filters import IamPolicyFilter
 from c7n_gcp.filters.iampolicy import IamPolicyValueFilter
+from c7n.exceptions import PolicyExecutionError
 from c7n.utils import local_session, jmespath_search
+
+# The only fields the Knative schema defines at the root of a Service or a Job.
+KNATIVE_FIELDS = ('apiVersion', 'kind', 'metadata', 'spec', 'status')
+
+# Prefixes of the annotations c7n keeps on a resource. Only the colon form is
+# written to a nested object; the dotted `c7n.metrics` is set at the root alone.
+# Nesting matches on the colon form only, because kubernetes annotation keys -
+# user controlled, and carried in `metadata.annotations` - may contain a dot but
+# never a colon, and this is a whole object replace: a key dropped from the body
+# is a key deleted from the service.
+C7N_ANNOTATION = 'c7n:'
+C7N_ROOT_ANNOTATIONS = (C7N_ANNOTATION, 'c7n.')
+
+
+def _without_annotations(value):
+    "Copy a value, dropping any c7n annotation held anywhere beneath it."
+    if isinstance(value, dict):
+        return {k: _without_annotations(v) for k, v in value.items()
+                if not k.startswith(C7N_ANNOTATION)}
+    if isinstance(value, list):
+        return [_without_annotations(v) for v in value]
+    # everything else in a decoded api response is an immutable scalar
+    return value
+
+
+def knative_body(resource):
+    """Copy a resource into a replace request body, dropping non schema fields.
+
+    Cloud Run replaces the whole object, so the body is the resource itself
+    rather than a fragment, and the api rejects the request with a 400 on any
+    field it can't place. A resource carries two kinds it can't: the top level
+    `labels` key that augment() flattens out of the metadata, and the
+    annotations the policy's filters leave behind - at the root, and nested
+    within `spec` when a list-item filter matched on something there.
+
+    A root field that is neither raises rather than being dropped. Under a
+    whole object replace a field left out of the body is deleted from the
+    service, so a field this doesn't recognize is one it cannot safely send
+    or safely omit.
+    """
+    unrecognized = {
+        k for k in resource
+        if k not in KNATIVE_FIELDS and k != 'labels'
+        and not k.startswith(C7N_ROOT_ANNOTATIONS)
+    }
+    if unrecognized:
+        raise PolicyExecutionError(
+            '%s %s has fields absent from the cloud run schema: %s' % (
+                resource.get('kind', 'resource'),
+                resource.get('metadata', {}).get('name'),
+                ', '.join(sorted(unrecognized))))
+    return {k: _without_annotations(v) for k, v in resource.items() if k in KNATIVE_FIELDS}
 
 
 @resources.register("cloud-run-service")
@@ -35,7 +86,7 @@ class CloudRunService(QueryResourceManager):
             location = metadata['labels']['cloud.googleapis.com/location']
             namespace = metadata['namespace']
             svc_name = metadata['name']
-            body = copy.deepcopy(resource)
+            body = knative_body(resource)
             body['metadata']['labels'] = all_labels
             return {
                 'name': 'projects/{}/locations/{}/services/{}'.format(
@@ -98,7 +149,7 @@ class CloudRunJob(QueryResourceManager):
             metadata = resource['metadata']
             namespace = metadata['namespace']
             job_name = metadata['name']
-            body = copy.deepcopy(resource)
+            body = knative_body(resource)
             body['metadata']['labels'] = all_labels
             return {
                 'name': 'namespaces/{}/jobs/{}'.format(namespace, job_name),

--- a/tools/c7n_gcp/tests/data/flights/gcp-cloud-run-service-mark-for-op/get-v1-projects-cloud-custodian-locations---services_1.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-cloud-run-service-mark-for-op/get-v1-projects-cloud-custodian-locations---services_1.json
@@ -1,0 +1,57 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "status": "200"
+  },
+  "body": {
+    "apiVersion": "serving.knative.dev/v1",
+    "kind": "ServiceList",
+    "items": [
+      {
+        "apiVersion": "serving.knative.dev/v1",
+        "kind": "Service",
+        "metadata": {
+          "name": "hello",
+          "namespace": "cloud-custodian",
+          "selfLink": "/apis/serving.knative.dev/v1/namespaces/cloud-custodian/services/hello",
+          "uid": "46b28549-6c5c-4245-bc8d-9cec06d262b6",
+          "resourceVersion": "AAX4MAndusc",
+          "generation": 1,
+          "labels": {
+            "cloud.googleapis.com/location": "us-central1"
+          },
+          "annotations": {
+            "run.googleapis.com/ingress": "all"
+          },
+          "creationTimestamp": "2023-03-31T10:53:45.882066Z"
+        },
+        "spec": {
+          "template": {
+            "metadata": {
+              "name": "hello-00001-tiv",
+              "annotations": {}
+            },
+            "spec": {
+              "containerConcurrency": 80,
+              "timeoutSeconds": 300,
+              "containers": [
+                {
+                  "image": "us-docker.pkg.dev/cloudrun/container/hello",
+                  "ports": [{"name": "http1", "containerPort": 8080}]
+                }
+              ]
+            }
+          },
+          "traffic": [{"percent": 100, "latestRevision": true}]
+        },
+        "status": {
+          "observedGeneration": 1,
+          "conditions": [
+            {"type": "Ready", "status": "True"}
+          ],
+          "url": "https://hello-g3kdvpt64a-uc.a.run.app"
+        }
+      }
+    ]
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/gcp-cloud-run-service-mark-for-op/put-v1-projects-cloud-custodian-locations-us-central1-services-hello_1.json
+++ b/tools/c7n_gcp/tests/data/flights/gcp-cloud-run-service-mark-for-op/put-v1-projects-cloud-custodian-locations-us-central1-services-hello_1.json
@@ -1,0 +1,52 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "status": "200"
+  },
+  "body": {
+    "apiVersion": "serving.knative.dev/v1",
+    "kind": "Service",
+    "metadata": {
+      "name": "hello",
+      "namespace": "cloud-custodian",
+      "selfLink": "/apis/serving.knative.dev/v1/namespaces/cloud-custodian/services/hello",
+      "uid": "46b28549-6c5c-4245-bc8d-9cec06d262b6",
+      "resourceVersion": "AAX4MBndusc",
+      "generation": 2,
+      "labels": {
+        "cloud.googleapis.com/location": "us-central1",
+        "custodian_status": "resource_policy-notify-2026_08_21__0_0"
+      },
+      "annotations": {
+        "run.googleapis.com/ingress": "all"
+      },
+      "creationTimestamp": "2023-03-31T10:53:45.882066Z"
+    },
+    "spec": {
+      "template": {
+        "metadata": {
+          "name": "hello-00001-tiv",
+          "annotations": {}
+        },
+        "spec": {
+          "containerConcurrency": 80,
+          "timeoutSeconds": 300,
+          "containers": [
+            {
+              "image": "us-docker.pkg.dev/cloudrun/container/hello",
+              "ports": [{"name": "http1", "containerPort": 8080}]
+            }
+          ]
+        }
+      },
+      "traffic": [{"percent": 100, "latestRevision": true}]
+    },
+    "status": {
+      "observedGeneration": 2,
+      "conditions": [
+        {"type": "Ready", "status": "True"}
+      ],
+      "url": "https://hello-g3kdvpt64a-uc.a.run.app"
+    }
+  }
+}

--- a/tools/c7n_gcp/tests/test_cloudrun.py
+++ b/tools/c7n_gcp/tests/test_cloudrun.py
@@ -1,8 +1,152 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
+from freezegun import freeze_time
+
 from gcp_common import BaseTest
+from c7n.exceptions import PolicyExecutionError
 from c7n.utils import yaml_load
+
+from c7n_gcp.actions.core import MethodAction
+from c7n_gcp.resources.cloudrun import CloudRunJob, CloudRunService, knative_body
+
+# The root fields the api accepts, independent of the module under test.
+SCHEMA_FIELDS = {'apiVersion', 'kind', 'metadata', 'spec', 'status'}
+LOCATION = {'cloud.googleapis.com/location': 'us-central1'}
+
+
+def listed_resource(api_version, kind, name):
+    "A resource as augment() and a value filter leave it once listed."
+    return {
+        'apiVersion': api_version,
+        'kind': kind,
+        'metadata': {
+            'name': name,
+            'namespace': 'cloud-custodian',
+            'labels': dict(LOCATION),
+        },
+        'spec': {'template': {}},
+        'status': {'observedGeneration': 1},
+        'labels': dict(LOCATION),
+        'c7n:MatchedFilters': ['metadata.name'],
+    }
+
+
+def capture_api_params(test):
+    """Record the params of every api call the policy's actions make."""
+    captured = []
+    invoke_api = MethodAction.invoke_api
+
+    def record(action, client, op_name, params):
+        captured.append((op_name, params))
+        return invoke_api(action, client, op_name, params)
+
+    test.patch(MethodAction, 'invoke_api', record)
+    return captured
+
+
+def assert_replace_body(body, labels):
+    "A replace body holds the schema fields and the merged labels, nothing else."
+    assert set(body) == SCHEMA_FIELDS
+    assert 'labels' not in body
+    assert 'c7n:MatchedFilters' not in body
+    assert body['metadata']['labels'] == labels
+
+
+def assert_label_params(model, resource, expected_name):
+    "get_label_params addresses the resource and leaves it fit to read again."
+    all_labels = dict(LOCATION, environment='test')
+    params = model.get_label_params(resource, all_labels)
+
+    assert params['name'] == expected_name
+    assert_replace_body(params['body'], all_labels)
+    # the action reads its current label state from the resource, so both the
+    # synthetic key and the metadata it came from have to survive the call
+    assert resource['labels'] == LOCATION
+    assert resource['metadata']['labels'] == LOCATION
+
+
+class KnativeBodyTest(BaseTest):
+
+    def test_keeps_only_the_schema_fields(self):
+        body = knative_body({
+            'apiVersion': 'serving.knative.dev/v1',
+            'kind': 'Service',
+            'metadata': {'name': 'hello'},
+            'spec': {},
+            'status': {},
+            'labels': {'env': 'test'},
+            'c7n:MatchedFilters': ['metadata.name'],
+        })
+        assert set(body) == SCHEMA_FIELDS
+
+    def test_drops_annotations_nested_in_spec(self):
+        # a list-item filter annotates the objects it matched in place
+        body = knative_body({
+            'metadata': {'name': 'hello'},
+            'spec': {
+                'template': {
+                    'spec': {
+                        'containers': [{
+                            'image': 'us-docker.pkg.dev/cloudrun/container/hello',
+                            'c7n:MatchedFilters': ['image'],
+                        }],
+                    },
+                },
+            },
+            'c7n.metrics': {'run.googleapis.com/request_count': []},
+        })
+        assert body['spec'] == {
+            'template': {
+                'spec': {
+                    'containers': [{
+                        'image': 'us-docker.pkg.dev/cloudrun/container/hello'}],
+                },
+            },
+        }
+
+    def test_keeps_user_annotations(self):
+        # a kubernetes annotation key may contain a dot, so only the colon form
+        # is recognized below the root - a replace deletes what the body omits
+        annotations = {
+            'run.googleapis.com/ingress': 'all',
+            'c7n.example.com/owner': 'platform-team',
+        }
+        body = knative_body({
+            'metadata': {'name': 'hello', 'annotations': dict(annotations)},
+            'spec': {'template': {'metadata': {'annotations': dict(annotations)}}},
+        })
+        assert body['metadata']['annotations'] == annotations
+        assert body['spec']['template']['metadata']['annotations'] == annotations
+
+    def test_copies_rather_than_mutates(self):
+        resource = {
+            'metadata': {'name': 'hello'},
+            'spec': {'containers': [{'c7n:MatchedFilters': ['image']}]},
+        }
+        knative_body(resource)['metadata']['name'] = 'changed'
+        assert resource['metadata']['name'] == 'hello'
+        assert resource['spec']['containers'][0] == {'c7n:MatchedFilters': ['image']}
+
+    def test_raises_on_fields_outside_the_schema(self):
+        with pytest.raises(PolicyExecutionError) as raised:
+            knative_body({
+                'kind': 'Service',
+                'metadata': {'name': 'hello'},
+                'somethingNew': 'unrecognized',
+            })
+        assert 'somethingNew' in str(raised.value)
+        assert 'hello' in str(raised.value)
+
+    def test_accepts_the_synthetic_fields(self):
+        knative_body({
+            'metadata': {'name': 'hello'},
+            'labels': {'env': 'test'},
+            'c7n:MatchedFilters': ['metadata.name'],
+            'c7n.metrics': {'run.googleapis.com/request_count': []},
+        })
 
 
 class RunServiceTest(BaseTest):
@@ -28,11 +172,18 @@ class RunServiceTest(BaseTest):
         resources = p.run()
         assert resources == []
 
+    def test_label_params(self):
+        assert_label_params(
+            CloudRunService.resource_type,
+            listed_resource('serving.knative.dev/v1', 'Service', 'hello'),
+            'projects/cloud-custodian/locations/us-central1/services/hello')
+
     def test_set_labels(self):
         project_id = 'cloud-custodian'
         factory = self.replay_flight_data(
             "gcp-cloud-run-service-set-labels", project_id=project_id
         )
+        captured = capture_api_params(self)
         p = self.load_policy(
             {
                 'name': 'cloud-run-svc-set-labels',
@@ -52,6 +203,49 @@ class RunServiceTest(BaseTest):
         resources = p.run()
         assert len(resources) == 1
         assert resources[0]['metadata']['name'] == 'hello'
+
+        assert len(captured) == 1
+        op_name, params = captured.pop()
+        assert op_name == 'replaceService'
+        assert_replace_body(params['body'], {
+            'cloud.googleapis.com/location': 'us-central1',
+            'environment': 'test',
+        })
+
+    @freeze_time("2026-08-19")
+    def test_mark_for_op(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data(
+            "gcp-cloud-run-service-mark-for-op", project_id=project_id
+        )
+        captured = capture_api_params(self)
+        p = self.load_policy(
+            {
+                'name': 'cloud-run-svc-mark-for-op',
+                'resource': 'gcp.cloud-run-service',
+                'filters': [
+                    {'type': 'value',
+                     'key': 'metadata.name',
+                     'value': 'hello'}
+                ],
+                'actions': [
+                    {'type': 'mark-for-op',
+                     'op': 'notify',
+                     'days': 2}
+                ]
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        assert len(resources) == 1
+
+        assert len(captured) == 1
+        op_name, params = captured.pop()
+        assert op_name == 'replaceService'
+        assert_replace_body(params['body'], {
+            'cloud.googleapis.com/location': 'us-central1',
+            'custodian_status': 'resource_policy-notify-2026_08_21__0_0',
+        })
 
     def test_filter(self):
 
@@ -103,11 +297,18 @@ class JobServiceTest(BaseTest):
         assert len(resources) == 1
         assert resources[0]["metadata"]["name"] == "job"
 
+    def test_label_params(self):
+        assert_label_params(
+            CloudRunJob.resource_type,
+            listed_resource('run.googleapis.com/v1', 'Job', 'job'),
+            'namespaces/cloud-custodian/jobs/job')
+
     def test_set_labels(self):
         project_id = 'cloud-custodian'
         factory = self.replay_flight_data(
             "gcp-cloud-run-job-set-labels", project_id=project_id
         )
+        captured = capture_api_params(self)
         p = self.load_policy(
             {
                 'name': 'cloud-run-job-set-labels',
@@ -127,6 +328,14 @@ class JobServiceTest(BaseTest):
         resources = p.run()
         assert len(resources) == 1
         assert resources[0]['metadata']['name'] == 'job'
+
+        assert len(captured) == 1
+        op_name, params = captured.pop()
+        assert op_name == 'replaceJob'
+        assert_replace_body(params['body'], {
+            'cloud.googleapis.com/location': 'us-central1',
+            'environment': 'test',
+        })
 
 
 class RevisionServiceTest(BaseTest):


### PR DESCRIPTION
### what

`CloudRunService.get_label_params` and `CloudRunJob.get_label_params`
build their request body by deepcopying the whole resource, because
`replaceService` and `replaceJob` replace the entire object rather
than patching it. A shared `knative_body()` helper now does that
copy, keeping only the fields the Knative schema defines at the root
of a Service or a Job — `apiVersion`, `kind`, `metadata`, `spec` and
`status` — and dropping both the synthetic `labels` key that
`augment()` adds and c7n's own annotations wherever they sit,
including nested inside `spec`.

Any other root field raises rather than being dropped. An allow-list
under a whole object replace means a field it does not recognise
would be deleted from the live service on a 200, so the one case it
cannot handle safely is the one case it refuses to guess at: the
action fails, and nothing is written.

`status` is still sent, and `metadata.resourceVersion` is still
echoed back, both unchanged from before. The latter deserves its
own look: the list endpoint can hand back a resourceVersion that
lags a recent write by another actor, and replaying a stale one
draws a 409 that aborts the run for every resource after it.

This fixes the body, not every failure on this path. `set-labels`
and `mark-for-op` on `gcp.cloud-run-job` still fail, with a 404:
`replaceJob` is served only by the regional Cloud Run endpoint,
while the client is built against the global one. That is an
unrelated defect in the transport rather than the payload.

### why

Every label mutation on `gcp.cloud-run-service` and
`gcp.cloud-run-job` failed:

    Invalid JSON payload received. Unknown name "labels" at
    'service': Cannot find field.

Two kinds of key reached the body. `augment()` flattens
`metadata.labels` to a synthetic top level `labels` key, which the
label action needs in order to read the resource's current labels
but which the api has no field for. Separately, the annotations c7n
keeps on a resource rode along on the deepcopy — `c7n:MatchedFilters`
from a plain value filter is enough to trigger the rejection. Both
`set-labels` and `mark-for-op` were affected, since both reach the
same `get_label_params`.

Annotations are not confined to the root. A `list-item` filter
annotates the objects it matched in place, so a policy filtering on
`spec.template.spec.containers` leaves `c7n:MatchedFilters` on a
container, several levels inside a field the body has to carry
verbatim. Removing only the root keys would leave that policy shape
failing with the same error at a different path, so the copy drops
annotations at every depth.

Only the colon form is recognised below the root. `c7n.metrics` is
the sole dotted key c7n writes and it is only ever set on the
resource itself, whereas kubernetes annotation keys — user
controlled, and carried in `metadata.annotations` — may contain a
dot but never a colon. Matching the dotted form while descending
would strip an annotation such as `c7n.example.com/owner`, and
under a whole object replace a key omitted from the body is a key
deleted from the service.

Keeping an allow-list of schema fields rather than removing the two
known offenders means neither a new annotation key nor another
synthetic key added by `augment()` can reintroduce the failure.

### testing

New coverage asserts the outgoing request body directly, for both
resources and for both `set-labels` and `mark-for-op`: the body
carries exactly the five schema fields and neither contaminant key,
`metadata.labels` holds the merged label set, and the resource
itself keeps the synthetic `labels` key that the action reads its
current state from. The policy-level tests spy on the api call and
invoke it, so parameter names are still validated against the
discovery document and the body is still serialized. Helper-level
tests cover an annotation nested in a container inside `spec`, a
dotted user annotation surviving at both annotation sites, the
resource being copied rather than mutated, and an unrecognised root
field raising while the expected synthetic keys pass through.

The expected field set is spelled out in the tests rather than
imported from the module under test, so that widening the module's
own tuple fails them instead of travelling through them.

The existing replay tests could not catch this — the replay
harness discards request bodies and returns the recorded response
regardless of what was sent, which is why the broken behaviour
shipped with passing tests.

`mark-for-op` is exercised with `op: notify`, because neither
resource registers a `stop` or `delete` action for it to mark for.

Verified against a live project, since no replay test can observe
this. With the original body the api returns the reported 400,
naming both `labels` and `c7n:MatchedFilters` in one response;
with the allow-list the same policy succeeds and the label lands on
the service. A `list-item` policy reproduces the nested case —
`Unknown name "c7n:MatchedFilters" at
'service.spec.template.spec.containers[0]'` — and succeeds once
annotations are dropped at depth. The equivalent job policy still
fails with the 404 above, unchanged by this work.

The replace semantics were measured rather than assumed. Omitting a
single user annotation from an otherwise unchanged body returns 200
and removes that annotation from the service, so a field left out of
the body really is a field deleted. Matching the dotted prefix while
descending was confirmed to delete `c7n.example.com/owner` from a
live service on an ordinary `set-labels` run, which is what the
colon-only match below the root prevents; with the colon-only match
a service carrying both `c7n.example.com/owner` and an unrelated
`team.example.com/oncall` keeps both across a run that lands its
label.

### docs

No docs needed. Bug fix with no schema or user-facing surface.

---------------------------

Fixes: #11034
Assisted-by: LLM coding agent; patch and summary reviewed by the author