### PR TITLE
feat: Added anonymous model versions to Azure's ML model version querying.

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/machine_learning_model_version.py
+++ b/tools/c7n_azure/c7n_azure/resources/machine_learning_model_version.py
@@ -53,6 +53,7 @@ class MachineLearningModelVersion(ChildArmResourceManager):
             for version in client.model_versions.list(
                     resource_group_name=resource_group,
                     workspace_name=workspace_name,
-                    name=container.name):
+                    name=container.name,
+                    list_view_type="All"):
                 versions.append(version.serialize(True))
         return versions

--- a/tools/c7n_azure/tests_azure/cassettes/MachineLearningModelVersionTest.test_machine_learning_model_version_filter_anonymous.json
+++ b/tools/c7n_azure/tests_azure/cassettes/MachineLearningModelVersionTest.test_machine_learning_model_version_filter_anonymous.json
@@ -69,7 +69,7 @@
                                 "type": "Microsoft.MachineLearningServices/workspaces/models",
                                 "properties": {
                                     "description": "Cloud Custodian test model",
-                                    "latestVersion": "2"
+                                    "latestVersion": "3"
                                 }
                             }
                         ]
@@ -107,7 +107,8 @@
                                 "properties": {
                                     "modelType": "CustomModel",
                                     "modelUri": "azureml://locations/eastus/workspaces/mlvvtest/models/cctest-model/versions/1",
-                                    "isArchived": false
+                                    "isArchived": false,
+                                    "isAnonymous": false
                                 }
                             },
                             {
@@ -117,7 +118,19 @@
                                 "properties": {
                                     "modelType": "CustomModel",
                                     "modelUri": "azureml://locations/eastus/workspaces/mlvvtest/models/cctest-model/versions/2",
-                                    "isArchived": true
+                                    "isArchived": false,
+                                    "isAnonymous": true
+                                }
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.MachineLearningServices/workspaces/mlvvtest/models/cctest-model/versions/3",
+                                "name": "3",
+                                "type": "Microsoft.MachineLearningServices/workspaces/models/versions",
+                                "properties": {
+                                    "modelType": "CustomModel",
+                                    "modelUri": "azureml://locations/eastus/workspaces/mlvvtest/models/cctest-model/versions/3",
+                                    "isArchived": false,
+                                    "isAnonymous": true
                                 }
                             }
                         ]

--- a/tools/c7n_azure/tests_azure/cassettes/MachineLearningModelVersionTest.test_machine_learning_model_version_query.json
+++ b/tools/c7n_azure/tests_azure/cassettes/MachineLearningModelVersionTest.test_machine_learning_model_version_query.json
@@ -80,7 +80,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.MachineLearningServices/workspaces/mlvvtest/models/cctest-model/versions?api-version=2023-04-01",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.MachineLearningServices/workspaces/mlvvtest/models/cctest-model/versions?api-version=2023-04-01&listViewType=All",
                 "body": null,
                 "headers": {}
             },

--- a/tools/c7n_azure/tests_azure/tests_resources/test_machine_learning_model_version.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_machine_learning_model_version.py
@@ -39,3 +39,19 @@ class MachineLearningModelVersionTest(BaseTest):
         resources = p.run()
         self.assertEqual(1, len(resources))
         self.assertEqual('2', resources[0]['name'])
+
+    @arm_template('machine-learning-model-version.json')
+    def test_machine_learning_model_version_filter_anonymous(self):
+        p = self.load_policy({
+            'name': 'find-anonymous-model-versions',
+            'resource': 'azure.machine-learning-model-version',
+            'filters': [{
+                'type': 'value',
+                'key': 'properties.isAnonymous',
+                'value': True
+            }],
+        })
+        resources = p.run()
+        self.assertEqual(2, len(resources))
+        self.assertTrue(all(r['properties']['isAnonymous'] for r in resources))
+        self.assertEqual({'2', '3'}, {r['name'] for r in resources})


### PR DESCRIPTION
## what

Resolves #11067

## why

When listing model versions in Azure's Machine Learning service, anonymous model versions were previously omitted silently by default. This includes them in the listing (which can then be further filtered by `isAnonymous`).

## testing

* [x] Unittests added & passing

## docs

N/A