### PR TITLE
aws - tagging - tolerate resources deleted mid-run

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -22,7 +22,7 @@ from c7n.manager import resources
 from c7n.resources.kms import ResourceKmsKeyAlias
 from c7n.resources.securityhub import PostFinding
 from c7n.query import QueryResourceManager, TypeInfo
-from c7n.tags import Tag, coalesce_copy_user_tags
+from c7n.tags import coalesce_copy_user_tags
 from c7n.utils import (
     camelResource,
     chunks,
@@ -95,16 +95,6 @@ class Snapshot(QueryResourceManager):
 class ErrorHandler:
 
     @staticmethod
-    def remove_snapshot(rid, resource_set):
-        found = None
-        for r in resource_set:
-            if r['SnapshotId'] == rid:
-                found = r
-                break
-        if found:
-            resource_set.remove(found)
-
-    @staticmethod
     def extract_bad_snapshot(e):
         """Handle various client side errors when describing snapshots"""
         msg = e.response['Error']['Message']
@@ -131,16 +121,6 @@ class ErrorHandler:
             e_vol_id = msg[msg.find('"') + 1:msg.rfind('"')]
             log.warning("Volume id malformed %s" % e_vol_id)
         return e_vol_id
-
-    @staticmethod
-    def remove_volume(rid, resource_set):
-        found = None
-        for r in resource_set:
-            if r['VolumeId'] == rid:
-                found = r
-                break
-        if found:
-            resource_set.remove(found)
 
 
 class SnapshotQueryParser(QueryParser):
@@ -198,24 +178,6 @@ class VolumeQueryParser(QueryParser):
     single_value_fields = ('MaxResults',)
 
     type_name = 'EBS Volume'
-
-
-@Snapshot.action_registry.register('tag')
-class SnapshotTag(Tag):
-
-    permissions = ('ec2:CreateTags',)
-
-    def process_resource_set(self, client, resource_set, tags):
-        while resource_set:
-            try:
-                return super(SnapshotTag, self).process_resource_set(
-                    client, resource_set, tags)
-            except ClientError as e:
-                bad_snap = ErrorHandler.extract_bad_snapshot(e)
-                if bad_snap:
-                    ErrorHandler.remove_snapshot(bad_snap, resource_set)
-                    continue
-                raise
 
 
 @Snapshot.filter_registry.register('age')
@@ -737,24 +699,6 @@ class EBS(QueryResourceManager):
                     continue
                 raise
         return []
-
-
-@EBS.action_registry.register('tag')
-class VolumeTag(Tag):
-
-    permissions = ('ec2:CreateTags',)
-
-    def process_resource_set(self, client, resource_set, tags):
-        while resource_set:
-            try:
-                return super(VolumeTag, self).process_resource_set(
-                    client, resource_set, tags)
-            except ClientError as e:
-                bad_vol = ErrorHandler.extract_bad_volume(e)
-                if bad_vol:
-                    ErrorHandler.remove_volume(bad_vol, resource_set)
-                    continue
-                raise
 
 
 @EBS.filter_registry.register('snapshots')

--- a/c7n/resources/eks.py
+++ b/c7n/resources/eks.py
@@ -10,9 +10,11 @@ from c7n.filters.vpc import SecurityGroupFilter, SubnetFilter, VpcFilter
 from c7n.manager import resources
 from c7n.resources.aws import shape_schema
 from c7n import tags, query
+from c7n.tags import is_resource_gone
 from c7n.query import QueryResourceManager, TypeInfo, DescribeSource, \
     ChildResourceManager, ChildDescribeSource
 from c7n.utils import local_session, type_schema, get_retry
+from botocore.exceptions import ClientError
 from botocore.waiter import WaiterModel, create_waiter_with_client
 from .aws import shape_validate
 from .ecs import ContainerConfigSource
@@ -339,7 +341,9 @@ class EKSTag(tags.Tag):
                     client.tag_resource,
                     resourceArn=r['arn'],
                     tags={t['Key']: t['Value'] for t in tags})
-            except client.exceptions.ResourceNotFoundException:
+            except ClientError as e:
+                if not is_resource_gone(e.response['Error']['Code']):
+                    raise
                 continue
 
 
@@ -358,7 +362,9 @@ class EKSRemoveTag(tags.RemoveTag):
                 self.manager.retry(
                     client.untag_resource,
                     resourceArn=r['arn'], tagKeys=tags)
-            except client.exceptions.ResourceNotFoundException:
+            except ClientError as e:
+                if not is_resource_gone(e.response['Error']['Code']):
+                    raise
                 continue
 
 

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -8,6 +8,8 @@ to ec2 (subnets, vpc, security-groups, volumes, instances,
 snapshots) and resources that support Amazon's Resource Groups Tagging API
 
 """
+import re
+
 from collections import Counter
 from concurrent.futures import as_completed
 
@@ -16,6 +18,8 @@ from dateutil import tz as tzutil
 from dateutil.parser import parse
 
 import time
+
+from botocore.exceptions import ClientError
 
 from c7n.manager import resources as aws_resources
 from c7n.actions import BaseAction as Action, AutoTagUser
@@ -27,6 +31,54 @@ from c7n.lookup import Lookup
 from c7n import deprecated, utils
 
 DEFAULT_TAG = "maid_status"
+
+# Tag actions inherently race with resource deletion, we enumerate a
+# resource set and then mutate it. ec2 fails the whole batch when any
+# resource in it is unusable, but names the offending ids in the error
+# message, so we can drop those and tag the rest.
+EC2_BAD_RESOURCE_ID = re.compile(r'^Invalid.+\.(NotFound|Malformed)$')
+QUOTED_RESOURCE_IDS = re.compile(r"['\"]([^'\"]+)['\"]")
+
+# Other services report a resource as already gone with a service specific
+# error code - query protocol services use <ResourceType>NotFound(Fault),
+# json protocol services use (Resource)NotFoundException.
+RESOURCE_GONE_ERROR = re.compile(r'NotFound(Fault|Exception)?$')
+
+
+def is_resource_gone(error_code):
+    """Does an api error code mean the resource we wanted is already gone?"""
+    return bool(RESOURCE_GONE_ERROR.search(error_code))
+
+
+def extract_bad_resource_ids(e):
+    """Extract the resource ids an ec2 api call rejected from its error.
+
+    ec2 names the ids it couldn't use in the error message, ie
+    ``The instance IDs 'i-0e8f4b9a' do not exist``.
+    """
+    if not EC2_BAD_RESOURCE_ID.match(e.response['Error']['Code']):
+        return ()
+    return tuple(
+        rid.strip(" []")
+        for quoted in QUOTED_RESOURCE_IDS.findall(e.response['Error']['Message'])
+        for rid in quoted.split(','))
+
+
+def retry_skip_bad_ids(retry, method, resource_ids, log, **kw):
+    """Invoke a batched ec2 tag api call, skipping unusable resource ids.
+
+    A resource deleted between enumeration and tagging fails the entire
+    batch, so drop the ids ec2 rejected and tag the ones still around.
+    """
+    while resource_ids:
+        try:
+            return retry(method, Resources=resource_ids, **kw)
+        except ClientError as e:
+            bad_ids = set(extract_bad_resource_ids(e)).intersection(resource_ids)
+            if not bad_ids:
+                raise
+            log.info("skipping missing resources %s", ", ".join(sorted(bad_ids)))
+            resource_ids = [r for r in resource_ids if r not in bad_ids]
 
 
 # Sentinel: the resolver returns this to omit a tag from a resource's payload.
@@ -552,9 +604,9 @@ class Tag(TagValueResolver, Action):
 
     def process_resource_set(self, client, resource_set, tags):
         mid = self.manager.get_model().id
-        self.manager.retry(
-            client.create_tags,
-            Resources=[v[mid] for v in resource_set],
+        retry_skip_bad_ids(
+            self.manager.retry, client.create_tags,
+            [v[mid] for v in resource_set], self.log,
             Tags=tags,
             DryRun=self.manager.config.dryrun)
 
@@ -593,9 +645,9 @@ class RemoveTag(Action):
             self.process_resource_set, self.id_key, resources, tags, self.log)
 
     def process_resource_set(self, client, resource_set, tag_keys):
-        return self.manager.retry(
-            client.delete_tags,
-            Resources=[v[self.id_key] for v in resource_set],
+        return retry_skip_bad_ids(
+            self.manager.retry, client.delete_tags,
+            [v[self.id_key] for v in resource_set], self.log,
             Tags=[{'Key': k} for k in tag_keys],
             DryRun=self.manager.config.dryrun)
 
@@ -1420,13 +1472,17 @@ def universal_retry(method, ResourceARNList, **kw):
             error_code = failures[f_arn]['ErrorCode']
             if error_code == 'ThrottlingException':
                 throttles.add(f_arn)
-            elif error_code == 'ResourceNotFoundException':
+            elif is_resource_gone(error_code):
                 continue
             else:
                 errors[f_arn] = error_code
 
         if errors:
             raise Exception("Resource Tag Errors %s" % (errors))
+
+        if not throttles:
+            # everything else was skipped, the api rejects an empty arn list
+            return response
 
         if idx == max_attempts - 1:
             raise Exception("Resource Tag Throttled %s" % (", ".join(throttles)))

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,7 +10,7 @@ from c7n.config import Bag
 
 from c7n.testing import TestUtils, TextTestIO, functional # NOQA
 
-from .zpill import PillTest, ACCOUNT_ID
+from .zpill import PillTest, ACCOUNT_ID  # NOQA
 
 
 logging.getLogger("placebo.pill").setLevel(logging.DEBUG)
@@ -32,10 +32,6 @@ if "AWS_DEFAULT_REGION" not in os.environ:
 class BaseTest(TestUtils, PillTest):
 
     # custodian_schema = C7N_SCHEMA
-
-    @property
-    def account_id(self):
-        return ACCOUNT_ID
 
     def _get_policy_config(self, **kw):
         if 'account_id' not in kw:

--- a/tests/data/placebo/test_eks_tag_deleted_cluster/eks.TagResource_1.json
+++ b/tests/data/placebo/test_eks_tag_deleted_cluster/eks.TagResource_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Resource was not found",
+            "Code": "NotFoundException"
+        },
+        "ResponseMetadata": {},
+        "message": "Resource was not found"
+    }
+}

--- a/tests/data/placebo/test_eks_tag_deleted_cluster/eks.UntagResource_1.json
+++ b/tests/data/placebo/test_eks_tag_deleted_cluster/eks.UntagResource_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Resource was not found",
+            "Code": "NotFoundException"
+        },
+        "ResponseMetadata": {},
+        "message": "Resource was not found"
+    }
+}

--- a/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.CreateTags_1.json
+++ b/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.CreateTags_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 400,
+    "data": {
+        "Error": {
+            "Code": "InvalidInstanceID.NotFound",
+            "Message": "The instance ID 'i-0023456789abcdef0' does not exist"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.CreateTags_2.json
+++ b/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.CreateTags_2.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.DeleteTags_1.json
+++ b/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.DeleteTags_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.DescribeInstanceImageMetadata_1.json
+++ b/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.DescribeInstanceImageMetadata_1.json
@@ -1,0 +1,132 @@
+{
+    "status_code": 200,
+    "data": {
+        "InstanceImageMetadata": [
+            {
+                "InstanceId": "i-09347f9d6785dbe53",
+                "InstanceType": "t2.micro",
+                "LaunchTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 9,
+                    "day": 9,
+                    "hour": 14,
+                    "minute": 32,
+                    "second": 26,
+                    "microsecond": 0
+                },
+                "AvailabilityZone": "us-east-1f",
+                "ZoneId": "use1-az5",
+                "State": {
+                    "Code": 48,
+                    "Name": "terminated"
+                },
+                "OwnerId": "644160558196",
+                "ImageMetadata": {
+                    "ImageId": "ami-0757b090c88c85bab",
+                    "Name": "amzn2-ami-hvm-2.0.20260908.0-x86_64-gp2",
+                    "OwnerId": "644160558196",
+                    "State": "available",
+                    "ImageOwnerAlias": "amazon",
+                    "CreationDate": "2026-09-08T17:09:15Z",
+                    "DeprecationTime": "2026-12-07T17:11:00Z",
+                    "IsPublic": true
+                }
+            },
+            {
+                "InstanceId": "i-0fd2708167c1cdb5a",
+                "InstanceType": "t2.micro",
+                "LaunchTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 9,
+                    "day": 9,
+                    "hour": 14,
+                    "minute": 32,
+                    "second": 26,
+                    "microsecond": 0
+                },
+                "AvailabilityZone": "us-east-1f",
+                "ZoneId": "use1-az5",
+                "State": {
+                    "Code": 48,
+                    "Name": "terminated"
+                },
+                "OwnerId": "644160558196",
+                "ImageMetadata": {
+                    "ImageId": "ami-0757b090c88c85bab",
+                    "Name": "amzn2-ami-hvm-2.0.20260908.0-x86_64-gp2",
+                    "OwnerId": "644160558196",
+                    "State": "available",
+                    "ImageOwnerAlias": "amazon",
+                    "CreationDate": "2026-09-08T17:09:15Z",
+                    "DeprecationTime": "2026-12-07T17:11:00Z",
+                    "IsPublic": true
+                }
+            },
+            {
+                "InstanceId": "i-0e6f711d31e6675f4",
+                "InstanceType": "t2.micro",
+                "LaunchTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 9,
+                    "day": 9,
+                    "hour": 14,
+                    "minute": 39,
+                    "second": 53,
+                    "microsecond": 0
+                },
+                "AvailabilityZone": "us-east-1c",
+                "ZoneId": "use1-az2",
+                "State": {
+                    "Code": 16,
+                    "Name": "running"
+                },
+                "OwnerId": "644160558196",
+                "ImageMetadata": {
+                    "ImageId": "ami-0757b090c88c85bab",
+                    "Name": "amzn2-ami-hvm-2.0.20260908.0-x86_64-gp2",
+                    "OwnerId": "644160558196",
+                    "State": "available",
+                    "ImageOwnerAlias": "amazon",
+                    "CreationDate": "2026-09-08T17:09:15Z",
+                    "DeprecationTime": "2026-12-07T17:11:00Z",
+                    "IsPublic": true
+                }
+            },
+            {
+                "InstanceId": "i-042a559882c4907dc",
+                "InstanceType": "t2.micro",
+                "LaunchTime": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 9,
+                    "day": 9,
+                    "hour": 14,
+                    "minute": 39,
+                    "second": 53,
+                    "microsecond": 0
+                },
+                "AvailabilityZone": "us-east-1c",
+                "ZoneId": "use1-az2",
+                "State": {
+                    "Code": 16,
+                    "Name": "running"
+                },
+                "OwnerId": "644160558196",
+                "ImageMetadata": {
+                    "ImageId": "ami-0757b090c88c85bab",
+                    "Name": "amzn2-ami-hvm-2.0.20260908.0-x86_64-gp2",
+                    "OwnerId": "644160558196",
+                    "State": "available",
+                    "ImageOwnerAlias": "amazon",
+                    "CreationDate": "2026-09-08T17:09:15Z",
+                    "DeprecationTime": "2026-12-07T17:11:00Z",
+                    "IsPublic": true
+                }
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.DescribeInstances_1.json
@@ -1,0 +1,374 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "ReservationId": "r-00cf274ff3ee020d9",
+                "OwnerId": "644160558196",
+                "Groups": [],
+                "Instances": [
+                    {
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2026,
+                                        "month": 9,
+                                        "day": 9,
+                                        "hour": 14,
+                                        "minute": 39,
+                                        "second": 54,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0e9414ef1d2eb432c",
+                                    "EbsCardIndex": 0
+                                }
+                            }
+                        ],
+                        "ClientToken": "terraform-aHfqApEb7WCuXQ32mgMxEZBCP7",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2026,
+                                        "month": 9,
+                                        "day": 9,
+                                        "hour": 14,
+                                        "minute": 39,
+                                        "second": 53,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-026ad86d2c3a449f5",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupId": "sg-0034c1e69b8e6bcc5",
+                                        "GroupName": "default"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:cd:c8:af:f4:41",
+                                "NetworkInterfaceId": "eni-0816616bd448027b2",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.200",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.200"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-01fd2d48d6f162150",
+                                "VpcId": "vpc-0977a508b64394d7e",
+                                "InterfaceType": "interface",
+                                "Operator": {
+                                    "Managed": false
+                                }
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupId": "sg-0034c1e69b8e6bcc5",
+                                "GroupName": "default"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [
+                            {
+                                "Key": "App",
+                                "Value": "Custodian"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2026,
+                            "month": 9,
+                            "day": 9,
+                            "hour": 14,
+                            "minute": 39,
+                            "second": 53,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default",
+                            "RebootMigration": "default"
+                        },
+                        "CurrentInstanceBootMode": "legacy-bios",
+                        "NetworkPerformanceOptions": {
+                            "BandwidthWeighting": "default"
+                        },
+                        "Operator": {
+                            "Managed": false,
+                            "HiddenByDefault": false
+                        },
+                        "SecondaryInterfaces": [],
+                        "InstanceId": "i-042a559882c4907dc",
+                        "ImageId": "ami-0757b090c88c85bab",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-200.ec2.internal",
+                        "PublicDnsName": "",
+                        "StateTransitionReason": "",
+                        "AmiLaunchIndex": 0,
+                        "ProductCodes": [],
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2026,
+                            "month": 9,
+                            "day": 9,
+                            "hour": 14,
+                            "minute": 39,
+                            "second": 53,
+                            "microsecond": 0
+                        },
+                        "Placement": {
+                            "AvailabilityZoneId": "use1-az2",
+                            "GroupName": "",
+                            "Tenancy": "default",
+                            "AvailabilityZone": "us-east-1c"
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "SubnetId": "subnet-01fd2d48d6f162150",
+                        "VpcId": "vpc-0977a508b64394d7e",
+                        "PrivateIpAddress": "10.0.1.200"
+                    }
+                ]
+            },
+            {
+                "ReservationId": "r-0bc85187826350a15",
+                "OwnerId": "644160558196",
+                "Groups": [],
+                "Instances": [
+                    {
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2026,
+                                        "month": 9,
+                                        "day": 9,
+                                        "hour": 14,
+                                        "minute": 39,
+                                        "second": 54,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-039e696c5d3bd6f13",
+                                    "EbsCardIndex": 0
+                                }
+                            }
+                        ],
+                        "ClientToken": "terraform-f8i4majTXcSBEqpc3kEVYJlrjG",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2026,
+                                        "month": 9,
+                                        "day": 9,
+                                        "hour": 14,
+                                        "minute": 39,
+                                        "second": 53,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-074366427f4cb6808",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupId": "sg-0034c1e69b8e6bcc5",
+                                        "GroupName": "default"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:68:a3:b5:b6:99",
+                                "NetworkInterfaceId": "eni-086f9944f87e7b575",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.73",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.73"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-01fd2d48d6f162150",
+                                "VpcId": "vpc-0977a508b64394d7e",
+                                "InterfaceType": "interface",
+                                "Operator": {
+                                    "Managed": false
+                                }
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupId": "sg-0034c1e69b8e6bcc5",
+                                "GroupName": "default"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [
+                            {
+                                "Key": "App",
+                                "Value": "Custodian"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2026,
+                            "month": 9,
+                            "day": 9,
+                            "hour": 14,
+                            "minute": 39,
+                            "second": 53,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default",
+                            "RebootMigration": "default"
+                        },
+                        "CurrentInstanceBootMode": "legacy-bios",
+                        "NetworkPerformanceOptions": {
+                            "BandwidthWeighting": "default"
+                        },
+                        "Operator": {
+                            "Managed": false,
+                            "HiddenByDefault": false
+                        },
+                        "SecondaryInterfaces": [],
+                        "InstanceId": "i-0e6f711d31e6675f4",
+                        "ImageId": "ami-0757b090c88c85bab",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-73.ec2.internal",
+                        "PublicDnsName": "",
+                        "StateTransitionReason": "",
+                        "AmiLaunchIndex": 0,
+                        "ProductCodes": [],
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2026,
+                            "month": 9,
+                            "day": 9,
+                            "hour": 14,
+                            "minute": 39,
+                            "second": 53,
+                            "microsecond": 0
+                        },
+                        "Placement": {
+                            "AvailabilityZoneId": "use1-az2",
+                            "GroupName": "",
+                            "Tenancy": "default",
+                            "AvailabilityZone": "us-east-1c"
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "SubnetId": "subnet-01fd2d48d6f162150",
+                        "VpcId": "vpc-0977a508b64394d7e",
+                        "PrivateIpAddress": "10.0.1.73"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.DescribeInstances_2.json
+++ b/tests/data/placebo/test_native_tag_skips_gone_instance/ec2.DescribeInstances_2.json
@@ -1,0 +1,362 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "ReservationId": "r-00cf274ff3ee020d9",
+                "OwnerId": "644160558196",
+                "Groups": [],
+                "Instances": [
+                    {
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2026,
+                                        "month": 9,
+                                        "day": 9,
+                                        "hour": 14,
+                                        "minute": 39,
+                                        "second": 54,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-0e9414ef1d2eb432c",
+                                    "EbsCardIndex": 0
+                                }
+                            }
+                        ],
+                        "ClientToken": "terraform-aHfqApEb7WCuXQ32mgMxEZBCP7",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2026,
+                                        "month": 9,
+                                        "day": 9,
+                                        "hour": 14,
+                                        "minute": 39,
+                                        "second": 53,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-026ad86d2c3a449f5",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupId": "sg-0034c1e69b8e6bcc5",
+                                        "GroupName": "default"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:cd:c8:af:f4:41",
+                                "NetworkInterfaceId": "eni-0816616bd448027b2",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.200",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.200"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-01fd2d48d6f162150",
+                                "VpcId": "vpc-0977a508b64394d7e",
+                                "InterfaceType": "interface",
+                                "Operator": {
+                                    "Managed": false
+                                }
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupId": "sg-0034c1e69b8e6bcc5",
+                                "GroupName": "default"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2026,
+                            "month": 9,
+                            "day": 9,
+                            "hour": 14,
+                            "minute": 39,
+                            "second": 53,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default",
+                            "RebootMigration": "default"
+                        },
+                        "CurrentInstanceBootMode": "legacy-bios",
+                        "NetworkPerformanceOptions": {
+                            "BandwidthWeighting": "default"
+                        },
+                        "Operator": {
+                            "Managed": false,
+                            "HiddenByDefault": false
+                        },
+                        "SecondaryInterfaces": [],
+                        "InstanceId": "i-042a559882c4907dc",
+                        "ImageId": "ami-0757b090c88c85bab",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-200.ec2.internal",
+                        "PublicDnsName": "",
+                        "StateTransitionReason": "",
+                        "AmiLaunchIndex": 0,
+                        "ProductCodes": [],
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2026,
+                            "month": 9,
+                            "day": 9,
+                            "hour": 14,
+                            "minute": 39,
+                            "second": 53,
+                            "microsecond": 0
+                        },
+                        "Placement": {
+                            "AvailabilityZoneId": "use1-az2",
+                            "GroupName": "",
+                            "Tenancy": "default",
+                            "AvailabilityZone": "us-east-1c"
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "SubnetId": "subnet-01fd2d48d6f162150",
+                        "VpcId": "vpc-0977a508b64394d7e",
+                        "PrivateIpAddress": "10.0.1.200"
+                    }
+                ]
+            },
+            {
+                "ReservationId": "r-0bc85187826350a15",
+                "OwnerId": "644160558196",
+                "Groups": [],
+                "Instances": [
+                    {
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2026,
+                                        "month": 9,
+                                        "day": 9,
+                                        "hour": 14,
+                                        "minute": 39,
+                                        "second": 54,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-039e696c5d3bd6f13",
+                                    "EbsCardIndex": 0
+                                }
+                            }
+                        ],
+                        "ClientToken": "terraform-f8i4majTXcSBEqpc3kEVYJlrjG",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2026,
+                                        "month": 9,
+                                        "day": 9,
+                                        "hour": 14,
+                                        "minute": 39,
+                                        "second": 53,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-074366427f4cb6808",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached",
+                                    "NetworkCardIndex": 0
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupId": "sg-0034c1e69b8e6bcc5",
+                                        "GroupName": "default"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "12:68:a3:b5:b6:99",
+                                "NetworkInterfaceId": "eni-086f9944f87e7b575",
+                                "OwnerId": "644160558196",
+                                "PrivateIpAddress": "10.0.1.73",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateIpAddress": "10.0.1.73"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-01fd2d48d6f162150",
+                                "VpcId": "vpc-0977a508b64394d7e",
+                                "InterfaceType": "interface",
+                                "Operator": {
+                                    "Managed": false
+                                }
+                            }
+                        ],
+                        "RootDeviceName": "/dev/xvda",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupId": "sg-0034c1e69b8e6bcc5",
+                                "GroupName": "default"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 1
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled",
+                            "HttpProtocolIpv6": "disabled",
+                            "InstanceMetadataTags": "disabled"
+                        },
+                        "EnclaveOptions": {
+                            "Enabled": false
+                        },
+                        "PlatformDetails": "Linux/UNIX",
+                        "UsageOperation": "RunInstances",
+                        "UsageOperationUpdateTime": {
+                            "__class__": "datetime",
+                            "year": 2026,
+                            "month": 9,
+                            "day": 9,
+                            "hour": 14,
+                            "minute": 39,
+                            "second": 53,
+                            "microsecond": 0
+                        },
+                        "PrivateDnsNameOptions": {
+                            "HostnameType": "ip-name",
+                            "EnableResourceNameDnsARecord": false,
+                            "EnableResourceNameDnsAAAARecord": false
+                        },
+                        "MaintenanceOptions": {
+                            "AutoRecovery": "default",
+                            "RebootMigration": "default"
+                        },
+                        "CurrentInstanceBootMode": "legacy-bios",
+                        "NetworkPerformanceOptions": {
+                            "BandwidthWeighting": "default"
+                        },
+                        "Operator": {
+                            "Managed": false,
+                            "HiddenByDefault": false
+                        },
+                        "SecondaryInterfaces": [],
+                        "InstanceId": "i-0e6f711d31e6675f4",
+                        "ImageId": "ami-0757b090c88c85bab",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "PrivateDnsName": "ip-10-0-1-73.ec2.internal",
+                        "PublicDnsName": "",
+                        "StateTransitionReason": "",
+                        "AmiLaunchIndex": 0,
+                        "ProductCodes": [],
+                        "InstanceType": "t2.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2026,
+                            "month": 9,
+                            "day": 9,
+                            "hour": 14,
+                            "minute": 39,
+                            "second": 53,
+                            "microsecond": 0
+                        },
+                        "Placement": {
+                            "AvailabilityZoneId": "use1-az2",
+                            "GroupName": "",
+                            "Tenancy": "default",
+                            "AvailabilityZone": "us-east-1c"
+                        },
+                        "Monitoring": {
+                            "State": "disabled"
+                        },
+                        "SubnetId": "subnet-01fd2d48d6f162150",
+                        "VpcId": "vpc-0977a508b64394d7e",
+                        "PrivateIpAddress": "10.0.1.73"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_universal_tag_skips_gone_snapshot/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_universal_tag_skips_gone_snapshot/tagging.TagResources_1.json
@@ -1,0 +1,13 @@
+{
+    "status_code": 200,
+    "data": {
+        "FailedResourcesMap": {
+            "arn:aws:elasticache:us-east-1:644160558196:snapshot:c7n-deleted": {
+                "StatusCode": 404,
+                "ErrorCode": "SnapshotNotFoundFault",
+                "ErrorMessage": "c7n-deleted is either not present or not available"
+            }
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/ec2_instance_tag/main.tf
+++ b/tests/terraform/ec2_instance_tag/main.tf
@@ -1,0 +1,36 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+provider "aws" {}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "example" {
+  vpc_id     = aws_vpc.example.id
+  cidr_block = "10.0.1.0/24"
+}
+
+# two instances, so a batch that loses one id still has more than one
+# survivor to prove the retry keeps all of them
+resource "aws_instance" "first" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.example.id
+}
+
+resource "aws_instance" "second" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.example.id
+}

--- a/tests/terraform/ec2_instance_tag/tf_resources.json
+++ b/tests/terraform/ec2_instance_tag/tf_resources.json
@@ -1,0 +1,392 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_ami": {
+            "amazon_linux": {
+                "allow_unsafe_filter": null,
+                "architecture": "x86_64",
+                "arn": "arn:aws:ec2:us-east-1::image/ami-0757b090c88c85bab",
+                "block_device_mappings": [
+                    {
+                        "device_name": "/dev/xvda",
+                        "ebs": {
+                            "delete_on_termination": "true",
+                            "encrypted": "false",
+                            "iops": "0",
+                            "snapshot_id": "snap-0b2af24c3d555bc22",
+                            "throughput": "0",
+                            "volume_initialization_rate": "0",
+                            "volume_size": "8",
+                            "volume_type": "gp2"
+                        },
+                        "no_device": "",
+                        "virtual_name": ""
+                    }
+                ],
+                "boot_mode": "",
+                "creation_date": "2026-09-08T17:09:15.000Z",
+                "deprecation_time": "2026-12-07T17:11:00.000Z",
+                "description": "Amazon Linux 2 AMI 2.0.20260908.0 x86_64 HVM gp2",
+                "ena_support": true,
+                "executable_users": null,
+                "filter": [
+                    {
+                        "name": "name",
+                        "values": [
+                            "amzn2-ami-hvm-*-x86_64-gp2"
+                        ]
+                    }
+                ],
+                "hypervisor": "xen",
+                "id": "ami-0757b090c88c85bab",
+                "image_id": "ami-0757b090c88c85bab",
+                "image_location": "amazon/amzn2-ami-hvm-2.0.20260908.0-x86_64-gp2",
+                "image_owner_alias": "amazon",
+                "image_type": "machine",
+                "imds_support": "",
+                "include_deprecated": false,
+                "kernel_id": "",
+                "last_launched_time": "",
+                "most_recent": true,
+                "name": "amzn2-ami-hvm-2.0.20260908.0-x86_64-gp2",
+                "name_regex": null,
+                "owner_id": "644160558196",
+                "owners": [
+                    "amazon"
+                ],
+                "platform": "",
+                "platform_details": "Linux/UNIX",
+                "product_codes": [],
+                "public": true,
+                "ramdisk_id": "",
+                "region": "us-east-1",
+                "root_device_name": "/dev/xvda",
+                "root_device_type": "ebs",
+                "root_snapshot_id": "snap-0b2af24c3d555bc22",
+                "sriov_net_support": "simple",
+                "state": "available",
+                "state_reason": {
+                    "code": "UNSET",
+                    "message": "UNSET"
+                },
+                "tags": {},
+                "timeouts": null,
+                "tpm_support": "",
+                "uefi_data": null,
+                "usage_operation": "RunInstances",
+                "virtualization_type": "hvm"
+            }
+        },
+        "aws_instance": {
+            "first": {
+                "ami": "ami-0757b090c88c85bab",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-0e6f711d31e6675f4",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1c",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_options": [
+                    {
+                        "amd_sev_snp": "",
+                        "core_count": 1,
+                        "nested_virtualization": "",
+                        "threads_per_core": 1
+                    }
+                ],
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enable_primary_ipv6": null,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "force_destroy": false,
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": "",
+                "host_resource_group_arn": null,
+                "iam_instance_profile": "",
+                "id": "i-0e6f711d31e6675f4",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_lifecycle": "",
+                "instance_market_options": [],
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_protocol_ipv6": "disabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_group_id": "",
+                "placement_partition_number": 0,
+                "primary_network_interface": [
+                    {
+                        "delete_on_termination": true,
+                        "network_interface_id": "eni-086f9944f87e7b575"
+                    }
+                ],
+                "primary_network_interface_id": "eni-086f9944f87e7b575",
+                "private_dns": "ip-10-0-1-73.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.73",
+                "public_dns": "",
+                "public_ip": "",
+                "region": "us-east-1",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": true,
+                        "iops": 100,
+                        "kms_key_id": "arn:aws:kms:us-east-1:644160558196:key/04fa09fb-afe3-46c8-ad3c-410b8047f7b9",
+                        "tags": {},
+                        "tags_all": {},
+                        "throughput": 0,
+                        "volume_id": "vol-039e696c5d3bd6f13",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_network_interface": [],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "spot_instance_request_id": "",
+                "subnet_id": "subnet-01fd2d48d6f162150",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0034c1e69b8e6bcc5"
+                ]
+            },
+            "second": {
+                "ami": "ami-0757b090c88c85bab",
+                "arn": "arn:aws:ec2:us-east-1:644160558196:instance/i-042a559882c4907dc",
+                "associate_public_ip_address": false,
+                "availability_zone": "us-east-1c",
+                "capacity_reservation_specification": [
+                    {
+                        "capacity_reservation_preference": "open",
+                        "capacity_reservation_target": []
+                    }
+                ],
+                "cpu_options": [
+                    {
+                        "amd_sev_snp": "",
+                        "core_count": 1,
+                        "nested_virtualization": "",
+                        "threads_per_core": 1
+                    }
+                ],
+                "credit_specification": [
+                    {
+                        "cpu_credits": "standard"
+                    }
+                ],
+                "disable_api_stop": false,
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enable_primary_ipv6": null,
+                "enclave_options": [
+                    {
+                        "enabled": false
+                    }
+                ],
+                "ephemeral_block_device": [],
+                "force_destroy": false,
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": "",
+                "host_resource_group_arn": null,
+                "iam_instance_profile": "",
+                "id": "i-042a559882c4907dc",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_lifecycle": "",
+                "instance_market_options": [],
+                "instance_state": "running",
+                "instance_type": "t2.micro",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "",
+                "launch_template": [],
+                "maintenance_options": [
+                    {
+                        "auto_recovery": "default"
+                    }
+                ],
+                "metadata_options": [
+                    {
+                        "http_endpoint": "enabled",
+                        "http_protocol_ipv6": "disabled",
+                        "http_put_response_hop_limit": 1,
+                        "http_tokens": "optional",
+                        "instance_metadata_tags": "disabled"
+                    }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_group_id": "",
+                "placement_partition_number": 0,
+                "primary_network_interface": [
+                    {
+                        "delete_on_termination": true,
+                        "network_interface_id": "eni-0816616bd448027b2"
+                    }
+                ],
+                "primary_network_interface_id": "eni-0816616bd448027b2",
+                "private_dns": "ip-10-0-1-200.ec2.internal",
+                "private_dns_name_options": [
+                    {
+                        "enable_resource_name_dns_a_record": false,
+                        "enable_resource_name_dns_aaaa_record": false,
+                        "hostname_type": "ip-name"
+                    }
+                ],
+                "private_ip": "10.0.1.200",
+                "public_dns": "",
+                "public_ip": "",
+                "region": "us-east-1",
+                "root_block_device": [
+                    {
+                        "delete_on_termination": true,
+                        "device_name": "/dev/xvda",
+                        "encrypted": true,
+                        "iops": 100,
+                        "kms_key_id": "arn:aws:kms:us-east-1:644160558196:key/04fa09fb-afe3-46c8-ad3c-410b8047f7b9",
+                        "tags": {},
+                        "tags_all": {},
+                        "throughput": 0,
+                        "volume_id": "vol-0e9414ef1d2eb432c",
+                        "volume_size": 8,
+                        "volume_type": "gp2"
+                    }
+                ],
+                "secondary_network_interface": [],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "spot_instance_request_id": "",
+                "subnet_id": "subnet-01fd2d48d6f162150",
+                "tags": null,
+                "tags_all": {},
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "user_data_replace_on_change": false,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                    "sg-0034c1e69b8e6bcc5"
+                ]
+            }
+        },
+        "aws_subnet": {
+            "example": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:subnet/subnet-01fd2d48d6f162150",
+                "assign_ipv6_address_on_creation": false,
+                "availability_zone": "us-east-1c",
+                "availability_zone_id": "use1-az2",
+                "cidr_block": "10.0.1.0/24",
+                "customer_owned_ipv4_pool": "",
+                "enable_dns64": false,
+                "enable_lni_at_device_index": 0,
+                "enable_resource_name_dns_a_record_on_launch": false,
+                "enable_resource_name_dns_aaaa_record_on_launch": false,
+                "id": "subnet-01fd2d48d6f162150",
+                "ipv4_ipam_pool_id": null,
+                "ipv4_netmask_length": null,
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_association_id": "",
+                "ipv6_ipam_pool_id": null,
+                "ipv6_native": false,
+                "ipv6_netmask_length": null,
+                "map_customer_owned_ip_on_launch": false,
+                "map_public_ip_on_launch": false,
+                "outpost_arn": "",
+                "owner_id": "644160558196",
+                "private_dns_hostname_type_on_launch": "ip-name",
+                "region": "us-east-1",
+                "tags": null,
+                "tags_all": {},
+                "timeouts": null,
+                "vpc_id": "vpc-0977a508b64394d7e"
+            }
+        },
+        "aws_vpc": {
+            "example": {
+                "arn": "arn:aws:ec2:us-east-1:644160558196:vpc/vpc-0977a508b64394d7e",
+                "assign_generated_ipv6_cidr_block": false,
+                "cidr_block": "10.0.0.0/16",
+                "default_network_acl_id": "acl-05bc7b1ba43105f96",
+                "default_route_table_id": "rtb-02919e3e487a62814",
+                "default_security_group_id": "sg-0034c1e69b8e6bcc5",
+                "dhcp_options_id": "dopt-05763bf1939671093",
+                "enable_dns_hostnames": false,
+                "enable_dns_support": true,
+                "enable_network_address_usage_metrics": false,
+                "id": "vpc-0977a508b64394d7e",
+                "instance_tenancy": "default",
+                "ipv4_ipam_pool_id": null,
+                "ipv4_netmask_length": null,
+                "ipv6_association_id": "",
+                "ipv6_cidr_block": "",
+                "ipv6_cidr_block_network_border_group": "",
+                "ipv6_ipam_pool_id": "",
+                "ipv6_netmask_length": 0,
+                "main_route_table_id": "rtb-02919e3e487a62814",
+                "owner_id": "644160558196",
+                "region": "us-east-1",
+                "tags": null,
+                "tags_all": {}
+            }
+        }
+    }
+}

--- a/tests/test_ebs.py
+++ b/tests/test_ebs.py
@@ -177,16 +177,6 @@ class SnapshotErrorHandler(BaseTest):
         tagger.process_resource_set(client, snaps, [{'Key': 'bar', 'Value': 'foo'}])
         client.create_tags.assert_called_once()
 
-    def test_remove_snapshot(self):
-        snaps = [{'SnapshotId': 'a'}, {'SnapshotId': 'b'}, {'SnapshotId': 'c'}]
-
-        t1 = list(snaps)
-        ErrorHandler.remove_snapshot('c', t1)
-        self.assertEqual([t['SnapshotId'] for t in t1], ['a', 'b'])
-
-        ErrorHandler.remove_snapshot('d', snaps)
-        self.assertEqual(len(snaps), 3)
-
     def test_get_bad_snapshot_malformed(self):
         operation_name = "DescribeSnapshots"
         error_response = {
@@ -234,16 +224,6 @@ class SnapshotErrorHandler(BaseTest):
         e = ClientError(error_response, operation_name)
         vol = ErrorHandler.extract_bad_volume(e)
         self.assertEqual(vol, "vol-notfound")
-
-    def test_remove_volume(self):
-        vols = [{'VolumeId': 'a'}, {'VolumeId': 'b'}, {'VolumeId': 'c'}]
-
-        t1 = list(vols)
-        ErrorHandler.remove_volume('c', t1)
-        self.assertEqual([t['VolumeId'] for t in t1], ['a', 'b'])
-
-        ErrorHandler.remove_volume('d', vols)
-        self.assertEqual(len(vols), 3)
 
     def test_volume_tag_error(self):
         vols = [{'VolumeId': 'vol-aa'}]

--- a/tests/test_eks.py
+++ b/tests/test_eks.py
@@ -5,7 +5,7 @@ import pytest
 import os
 import json
 from botocore.exceptions import ClientError
-from .common import ACCOUNT_ID, BaseTest
+from .common import BaseTest
 from c7n.exceptions import PolicyValidationError
 
 from pytest_terraform import terraform

--- a/tests/test_eks.py
+++ b/tests/test_eks.py
@@ -5,7 +5,7 @@ import pytest
 import os
 import json
 from botocore.exceptions import ClientError
-from .common import BaseTest
+from .common import ACCOUNT_ID, BaseTest
 from c7n.exceptions import PolicyValidationError
 
 from pytest_terraform import terraform
@@ -182,6 +182,35 @@ class EKS(BaseTest):
             client.describe_cluster(
                 name='devx')['cluster']['tags'],
             {'App': 'Custodian'})
+
+    def test_tag_deleted_cluster(self):
+        # eks raises NotFoundException (not ResourceNotFoundException) when
+        # a cluster is gone by the time we tag it. No terraform fixture
+        # here - the cluster's absence is the whole point, so we tag an
+        # arn that isn't there rather than spend 20m creating a cluster
+        # to delete it.
+        aws_region = 'us-east-1'
+        factory = self.replay_flight_data(
+            'test_eks_tag_deleted_cluster', region=aws_region)
+
+        p = self.load_policy({
+            'name': 'eks-tag-deleted',
+            'resource': 'aws.eks',
+            'actions': [
+                {'type': 'tag', 'tags': {'App': 'Custodian'}},
+                {'type': 'remove-tag', 'tags': ['Env']}]},
+            session_factory=factory, config={'region': aws_region})
+
+        gone = {
+            'name': 'c7n-deleted',
+            'arn': 'arn:aws:eks:%s:%s:cluster/c7n-deleted' % (
+                aws_region, self.account_id),
+            'tags': {'Env': 'Dev'}}
+        tag, remove_tag = p.resource_manager.actions
+
+        # neither raises, the cluster is simply skipped
+        tag.process([gone])
+        remove_tag.process([gone])
 
     def test_kms_filter(self):
         factory = self.replay_flight_data('test_eks_kms_filter')

--- a/tests/test_networkmanager.py
+++ b/tests/test_networkmanager.py
@@ -203,7 +203,7 @@ class TestNetworkManager(BaseTest):
 
     def test_core_network_delete_error(self):
         invalid_network_id = 'core-network-7a6b617270696e736b69'
-        factory = self.record_flight_data("test_core_network_delete_error")
+        factory = self.replay_flight_data("test_core_network_delete_error")
         client = factory().client("networkmanager")
         mock_factory = MagicMock()
         mock_factory.region = 'us-east-1'

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from freezegun import freeze_time
 from unittest.mock import MagicMock, call, patch
 
+from botocore.exceptions import ClientError
+
 from c7n import tags as tagmod
 from c7n.tags import universal_retry, coalesce_copy_user_tags
 from c7n.exceptions import PolicyExecutionError, PolicyValidationError
@@ -795,3 +797,183 @@ class DynamicUniversalTagTest(BaseTest):
             {"K": "v"})
         tag_resources.assert_called_once_with(
             ResourceARNList=["arn:x"], Tags={"K": "v"})
+
+
+# a syntactically valid instance id that doesn't exist, so ec2 answers the
+# tag call with its real "resource gone" error rather than a malformed id one
+GONE_INSTANCE_ID = 'i-0023456789abcdef0'
+
+
+@terraform('ec2_instance_tag')
+def test_native_tag_skips_gone_instance(test, ec2_instance_tag):
+    """A terminated instance in the batch shouldn't cost the rest their tags.
+
+    ec2 fails the whole create_tags call when any resource in it is gone,
+    so we drop the ids it named and tag the rest. aws.ec2-instance-ami is
+    the resource from #10999 - it tags via instance id.
+    """
+    aws_region = 'us-east-1'
+    session_factory = test.replay_flight_data(
+        'test_native_tag_skips_gone_instance', region=aws_region)
+
+    instance_ids = [
+        ec2_instance_tag['aws_instance.first.id'],
+        ec2_instance_tag['aws_instance.second.id'],
+    ]
+
+    p = test.load_policy({
+        'name': 'ec2-instance-ami-tag',
+        'resource': 'aws.ec2-instance-ami',
+        'actions': [
+            {'type': 'tag', 'tags': {'App': 'Custodian'}},
+            {'type': 'remove-tag', 'tags': ['App']}]},
+        session_factory=session_factory, config={'region': aws_region})
+
+    resources = [r for r in p.resource_manager.resources()
+                 if r['InstanceId'] in instance_ids]
+    test.assertEqual(len(resources), 2)
+
+    # the batch ec2 rejects, plus the ones it should still tag
+    resource_set = resources + [{'InstanceId': GONE_INSTANCE_ID}]
+    tag, remove_tag = p.resource_manager.actions
+
+    tag.process(resource_set)
+    client = session_factory().client('ec2')
+    tags = {
+        i['InstanceId']: {t['Key']: t['Value'] for t in i.get('Tags', [])}
+        for r in client.describe_instances(
+            InstanceIds=instance_ids)['Reservations']
+        for i in r['Instances']}
+    for instance_id in instance_ids:
+        test.assertEqual(tags[instance_id].get('App'), 'Custodian')
+
+    # and the same salvage on the way back out
+    remove_tag.id_key = 'InstanceId'
+    remove_tag.process(resource_set)
+    tags = {
+        i['InstanceId']: {t['Key']: t['Value'] for t in i.get('Tags', [])}
+        for r in client.describe_instances(
+            InstanceIds=instance_ids)['Reservations']
+        for i in r['Instances']}
+    for instance_id in instance_ids:
+        test.assertNotIn('App', tags[instance_id])
+
+
+def test_universal_tag_skips_gone_snapshot(test):
+    """The rgta path passes through the service's own resource gone fault.
+
+    elasticache reports a deleted snapshot as SnapshotNotFoundFault, which
+    universal_retry used to raise on - it only skipped
+    ResourceNotFoundException. No fixture, a snapshot that isn't there is
+    the point.
+    """
+    aws_region = 'us-east-1'
+    session_factory = test.replay_flight_data(
+        'test_universal_tag_skips_gone_snapshot', region=aws_region)
+
+    p = test.load_policy({
+        'name': 'cache-snapshot-tag',
+        'resource': 'aws.cache-snapshot',
+        'actions': [{'type': 'tag', 'tags': {'App': 'Custodian'}}]},
+        session_factory=session_factory,
+        config={'region': aws_region, 'account_id': test.account_id})
+
+    # doesn't raise, the snapshot is skipped
+    p.resource_manager.actions[0].process([{'SnapshotName': 'c7n-deleted'}])
+
+
+class ResourceGoneTest(BaseTest):
+    """Tag actions race with resource deletion, a resource which is gone by
+    the time we tag it should be skipped, not abort the whole resource set.
+
+    The recorded tests above cover what aws actually answers with. These
+    cover our own control flow around it, which needs no api.
+    """
+
+    def client_error(self, code, message, op='CreateTags'):
+        return ClientError(
+            {'Error': {'Code': code, 'Message': message}}, op)
+
+    def get_tag_action(self, name):
+        p = self.load_policy({
+            'name': 'tag-instances',
+            'resource': 'aws.ec2',
+            'actions': [
+                {'type': 'tag', 'tags': {'Env': 'Dev'}},
+                {'type': 'remove-tag', 'tags': ['Env']}]})
+        action = {a.type: a for a in p.resource_manager.actions}[name]
+        action.id_key = 'InstanceId'
+        return action
+
+    def test_extract_bad_resource_ids(self):
+        # message shapes here are the ones in our recorded api data, see
+        # tests/data/placebo - ec2 words them per resource type
+        for code, message, expected in (
+                ('InvalidNetworkInterfaceID.NotFound',
+                 "The networkInterface ID 'eni-d834cdcf' does not exist",
+                 ('eni-d834cdcf',)),
+                ('InvalidVolume.NotFound',
+                 "The volume 'vol-notfound' does not exist.",
+                 ('vol-notfound',)),
+                ('InvalidSnapshotID.Malformed',
+                 'Invalid id: "snap-malformedsnap"',
+                 ('snap-malformedsnap',)),
+                # not an ec2 bad id error, nothing to skip
+                ('UnauthorizedOperation', "You are not authorized", ()),
+                ('SnapshotNotFoundFault', "'snap-1' not found", ())):
+            self.assertEqual(
+                tagmod.extract_bad_resource_ids(
+                    self.client_error(code, message)),
+                expected)
+
+    def test_native_tag_raises_other_errors(self):
+        action = self.get_tag_action('tag')
+        client = MagicMock()
+        client.create_tags.side_effect = self.client_error(
+            'UnauthorizedOperation', "You are not authorized")
+        self.assertRaises(
+            ClientError,
+            action.process_resource_set,
+            client, [{'InstanceId': 'i-1'}], [{'Key': 'Env', 'Value': 'Dev'}])
+
+    def test_native_tag_raises_on_unknown_bad_id(self):
+        # we only skip the resources ec2 actually named, an id we don't
+        # recognize means we don't understand the error - don't swallow it
+        action = self.get_tag_action('tag')
+        client = MagicMock()
+        client.create_tags.side_effect = self.client_error(
+            'InvalidInstanceID.NotFound',
+            "The instance IDs 'i-9' do not exist")
+        self.assertRaises(
+            ClientError,
+            action.process_resource_set,
+            client, [{'InstanceId': 'i-1'}], [{'Key': 'Env', 'Value': 'Dev'}])
+
+    def test_universal_retry_skips_gone_and_retries_throttle(self):
+        # a throttle alongside a skip still retries the throttled arn
+        self.patch(time, "sleep", MagicMock())
+        method = MagicMock()
+        method.side_effect = [
+            {"FailedResourcesMap": {
+                "arn:abc": {"ErrorCode": "ThrottlingException"},
+                "arn:def": {"ErrorCode": "NotFoundException"}}},
+            {"Result": 32},
+        ]
+        self.assertEqual(
+            universal_retry(method, ["arn:abc", "arn:def"]), {"Result": 32})
+        self.assertEqual(
+            method.call_args_list,
+            [call(ResourceARNList=["arn:abc", "arn:def"]),
+             call(ResourceARNList=["arn:abc"])])
+
+    def test_universal_retry_all_skipped_stops(self):
+        # nothing left to retry, and the api rejects an empty arn list
+        sleep = MagicMock()
+        self.patch(time, "sleep", sleep)
+        method = MagicMock()
+        method.side_effect = [{
+            "FailedResourcesMap": {
+                "arn:abc": {"ErrorCode": "SnapshotNotFoundFault"}}}]
+        universal_retry(method, ["arn:abc"])
+        method.assert_called_once()
+        sleep.assert_not_called()

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import base64
 import fnmatch
+import functools
 from io import BytesIO
 import json
 import os
@@ -17,6 +18,7 @@ from botocore.response import StreamingBody
 from placebo import pill
 
 from c7n.testing import CustodianTestCore
+from c7n.utils import get_account_id_from_sts
 
 # Custodian Test Account. This is used only for testing.
 
@@ -267,6 +269,11 @@ class RedPill(pill.Pill):
         super(RedPill, self).save_response(service, operation, response_data, http_response)
 
 
+@functools.lru_cache(maxsize=None)
+def get_recording_account_id():
+    return get_account_id_from_sts(boto3.Session())
+
+
 class PillTest(CustodianTestCore):
     archive_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "placebo_data.zip")
 
@@ -275,6 +282,19 @@ class PillTest(CustodianTestCore):
     output_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "output")
 
     recording = False
+
+    @property
+    def account_id(self):
+        """The account id to construct arns with.
+
+        Recorded api data is sanitized to ACCOUNT_ID, but while recording
+        (or running functionally) we're talking to a real account and need
+        its real id, which is what the aws provider's initialization would
+        have resolved for us.
+        """
+        if not self.recording:
+            return ACCOUNT_ID
+        return get_recording_account_id()
 
     def cleanUp(self):
         self.pill = None


### PR DESCRIPTION
Tagging functionality had a few fine-grained ways to gracefully handle resources deleted between the initial fetch and action phases. Centralize some of that so it can be shared across resource types, and expand it to include some reported failure cases.

Some details:

- The native ec2 path (aws.ec2-instance-ami, aws.eni) applied no tolerance at all, so InvalidInstanceID.NotFound and InvalidNetworkInterfaceID.NotFound propagated.
- universal_retry skipped only ResourceNotFoundException, so the service specific faults which the resource groups tagging api passes through (elasticache's SnapshotNotFoundFault) raised.
- EKSTag / EKSRemoveTag caught ResourceNotFoundException, but eks raises NotFoundException from TagResource, so that tolerance never fired.

ec2 fails an entire batch when any resource in it is gone, so tagging 25 resources would lose the other 24. It does name the offending ids in the error message though, so drop those and tag the rest. ebs carried this logic per-resource-type already (SnapshotTag / VolumeTag); the generic version replaces both.

Note that aws documents the ec2 code as InvalidInstanceID.NotFound while parts of the codebase spell it InvalidInstanceId.NotFound - the pattern here matches either.

Re-record tests for both the EC2 and Universal tagging patterns.

Closes #10999