### PR TITLE
aws - cloudwatch-dashboard - use native cloudwatch apis for tagging

### DIFF
--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -6,6 +6,8 @@ from collections import defaultdict
 from concurrent.futures import as_completed
 from datetime import datetime, timedelta
 
+from botocore.exceptions import ClientError
+
 from c7n.actions import AutoTagUser, BaseAction
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import Filter, MetricsFilter
@@ -696,10 +698,23 @@ class DescribeDashboard(DescribeSource):
         # fetch their tags from cloudwatch directly.
         resources = super().augment(resources)
         client = local_session(self.manager.session_factory).client('cloudwatch')
+        results = []
         for r, arn in zip(resources, self.manager.get_arns(resources)):
-            r['Tags'] = self.manager.retry(
-                client.list_tags_for_resource, ResourceARN=arn).get('Tags', [])
-        return resources
+            try:
+                tags = self.manager.retry(
+                    client.list_tags_for_resource, ResourceARN=arn).get('Tags', [])
+            except ClientError as e:
+                if e.response['Error']['Code'] not in (
+                        'ResourceNotFound', 'ResourceNotFoundException'):
+                    raise
+                # the dashboard was deleted between enumeration and augment
+                self.manager.log.warning(
+                    "Resource not found: list_tags_for_resource using %s" % {
+                        'ResourceARN': arn})
+                continue
+            r['Tags'] = tags
+            results.append(r)
+        return results
 
 
 @resources.register("cloudwatch-dashboard")

--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from concurrent.futures import as_completed
 from datetime import datetime, timedelta
 
-from c7n.actions import BaseAction
+from c7n.actions import AutoTagUser, BaseAction
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import Filter, MetricsFilter
 from c7n.filters.core import parse_date, ValueFilter
@@ -17,7 +17,8 @@ from c7n.query import (
     QueryResourceManager,
     TypeInfo, DescribeSource, ConfigSource, DescribeWithResourceTags)
 from c7n.resolver import ValuesFrom
-from c7n.tags import universal_augment
+from c7n.tags import (
+    RemoveTag, Tag, TagActionFilter, TagDelayedAction, universal_augment)
 from c7n.utils import type_schema, local_session, chunks, get_retry, jmespath_search
 
 
@@ -688,6 +689,19 @@ class SubscriptionFilter(BaseAction):
                 logGroupName=r['logGroupName'], **params)
 
 
+class DescribeDashboard(DescribeSource):
+
+    def augment(self, resources):
+        # Dashboards aren't supported by the resource groups tagging api,
+        # fetch their tags from cloudwatch directly.
+        resources = super().augment(resources)
+        client = local_session(self.manager.session_factory).client('cloudwatch')
+        for r, arn in zip(resources, self.manager.get_arns(resources)):
+            r['Tags'] = self.manager.retry(
+                client.list_tags_for_resource, ResourceARN=arn).get('Tags', [])
+        return resources
+
+
 @resources.register("cloudwatch-dashboard")
 class CloudWatchDashboard(QueryResourceManager):
     class resource_type(TypeInfo):
@@ -698,12 +712,69 @@ class CloudWatchDashboard(QueryResourceManager):
         id = "DashboardName"
         name = "DashboardName"
         cfn_type = "AWS::CloudWatch::Dashboard"
-        universal_taggable = object()
         global_resource = True
+        permissions_augment = ("cloudwatch:ListTagsForResource",)
 
     source_mapping = {
-       "describe": DescribeWithResourceTags,
+       "describe": DescribeDashboard,
     }
+
+
+@CloudWatchDashboard.action_registry.register('tag')
+class DashboardTag(Tag):
+    """Add tags to a cloudwatch dashboard
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: cloudwatch-dashboard-tag-owner
+                resource: aws.cloudwatch-dashboard
+                filters:
+                  - "tag:Owner": absent
+                actions:
+                  - type: tag
+                    key: Owner
+                    value: platform-team
+    """
+
+    permissions = ("cloudwatch:TagResource",)
+
+    def process_resource_set(self, client, resource_set, tags):
+        for arn in self.manager.get_arns(resource_set):
+            self.manager.retry(client.tag_resource, ResourceARN=arn, Tags=tags)
+
+
+@CloudWatchDashboard.action_registry.register('remove-tag')
+class DashboardRemoveTag(RemoveTag):
+    """Remove tags from a cloudwatch dashboard
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: cloudwatch-dashboard-remove-owner
+                resource: aws.cloudwatch-dashboard
+                filters:
+                  - "tag:Owner": present
+                actions:
+                  - type: remove-tag
+                    tags: [Owner]
+    """
+
+    permissions = ("cloudwatch:UntagResource",)
+
+    def process_resource_set(self, client, resource_set, tag_keys):
+        for arn in self.manager.get_arns(resource_set):
+            self.manager.retry(
+                client.untag_resource, ResourceARN=arn, TagKeys=tag_keys)
+
+
+CloudWatchDashboard.filter_registry.register('marked-for-op', TagActionFilter)
+CloudWatchDashboard.action_registry.register('mark-for-op', TagDelayedAction)
+CloudWatchDashboard.action_registry.register('auto-tag-user', AutoTagUser)
 
 
 @resources.register("destination")

--- a/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListDashboards_1.json
+++ b/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListDashboards_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "DashboardEntries": [
+            {
+                "DashboardName": "c7n-test-e3dd19005e27e4f1",
+                "DashboardArn": "arn:aws:cloudwatch::644160558196:dashboard/c7n-test-e3dd19005e27e4f1",
+                "LastModified": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 9,
+                    "day": 8,
+                    "hour": 22,
+                    "minute": 59,
+                    "second": 16,
+                    "microsecond": 0
+                },
+                "Size": 158
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListDashboards_2.json
+++ b/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListDashboards_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "DashboardEntries": [
+            {
+                "DashboardName": "c7n-test-e3dd19005e27e4f1",
+                "DashboardArn": "arn:aws:cloudwatch::644160558196:dashboard/c7n-test-e3dd19005e27e4f1",
+                "LastModified": {
+                    "__class__": "datetime",
+                    "year": 2026,
+                    "month": 9,
+                    "day": 8,
+                    "hour": 22,
+                    "minute": 59,
+                    "second": 17,
+                    "microsecond": 0
+                },
+                "Size": 346
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListTagsForResource_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListTagsForResource_2.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "App",
+                "Value": "Custodian"
+            },
+            {
+                "Key": "Env",
+                "Value": "Dev"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListTagsForResource_3.json
+++ b/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListTagsForResource_3.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "App",
+                "Value": "Custodian"
+            },
+            {
+                "Key": "Env",
+                "Value": "Dev"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListTagsForResource_4.json
+++ b/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.ListTagsForResource_4.json
@@ -1,0 +1,12 @@
+{
+    "status_code": 200,
+    "data": {
+        "Tags": [
+            {
+                "Key": "App",
+                "Value": "Custodian"
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.TagResource_1.json
+++ b/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.TagResource_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.UntagResource_1.json
+++ b/tests/data/placebo/test_cloudwatch_dashboard_tag/monitoring.UntagResource_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/terraform/cloudwatch_dashboard_tag/main.tf
+++ b/tests/terraform/cloudwatch_dashboard_tag/main.tf
@@ -1,0 +1,26 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+provider "aws" {}
+
+resource "random_id" "id" {
+  byte_length = 8
+}
+
+resource "aws_cloudwatch_dashboard" "test" {
+  dashboard_name = "c7n-test-${random_id.id.hex}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 6
+        height = 6
+        properties = {
+          markdown = "cloud custodian test dashboard"
+        }
+      }
+    ]
+  })
+}

--- a/tests/terraform/cloudwatch_dashboard_tag/tf_resources.json
+++ b/tests/terraform/cloudwatch_dashboard_tag/tf_resources.json
@@ -1,0 +1,27 @@
+{
+    "pytest-terraform": 1,
+    "outputs": {},
+    "resources": {
+        "aws_cloudwatch_dashboard": {
+            "test": {
+                "dashboard_arn": "arn:aws:cloudwatch::644160558196:dashboard/c7n-test-e3dd19005e27e4f1",
+                "dashboard_body": "{\"widgets\":[{\"height\":6,\"properties\":{\"markdown\":\"cloud custodian test dashboard\"},\"type\":\"text\",\"width\":6,\"x\":0,\"y\":0}]}",
+                "dashboard_name": "c7n-test-e3dd19005e27e4f1",
+                "id": "c7n-test-e3dd19005e27e4f1",
+                "region": "us-east-2"
+            }
+        },
+        "random_id": {
+            "id": {
+                "b64_std": "490ZAF4n5PE=",
+                "b64_url": "490ZAF4n5PE",
+                "byte_length": 8,
+                "dec": "16419307305833063665",
+                "hex": "e3dd19005e27e4f1",
+                "id": "490ZAF4n5PE",
+                "keepers": null,
+                "prefix": null
+            }
+        }
+    }
+}

--- a/tests/test_cw_dashboard.py
+++ b/tests/test_cw_dashboard.py
@@ -1,0 +1,49 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from pytest_terraform import terraform
+
+
+@terraform('cloudwatch_dashboard_tag')
+def test_cloudwatch_dashboard_tag(test, cloudwatch_dashboard_tag):
+    # Dashboards are tagged through the native cloudwatch apis, the
+    # resource groups tagging api rejects their region-less arns.
+    aws_region = 'us-east-1'
+    session_factory = test.replay_flight_data(
+        'test_cloudwatch_dashboard_tag', region=aws_region)
+
+    dashboard_name = cloudwatch_dashboard_tag[
+        'aws_cloudwatch_dashboard.test.dashboard_name']
+
+    p = test.load_policy({
+        'name': 'dashboard-tag',
+        'resource': 'aws.cloudwatch-dashboard',
+        'filters': [{'DashboardName': dashboard_name}],
+        'actions': [
+            {'type': 'tag', 'tags': {'App': 'Custodian', 'Env': 'Dev'}}]},
+        session_factory=session_factory, config={'region': aws_region})
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+
+    client = session_factory().client('cloudwatch')
+    arn = resources[0]['DashboardArn']
+    test.assertEqual(
+        {t['Key']: t['Value']
+         for t in client.list_tags_for_resource(ResourceARN=arn)['Tags']},
+        {'App': 'Custodian', 'Env': 'Dev'})
+
+    # filtering on the tag we just set exercises the read path - these
+    # tags aren't visible through the resource groups tagging api.
+    p = test.load_policy({
+        'name': 'dashboard-remove-tag',
+        'resource': 'aws.cloudwatch-dashboard',
+        'filters': [
+            {'DashboardName': dashboard_name},
+            {'tag:App': 'Custodian'}],
+        'actions': [{'type': 'remove-tag', 'tags': ['Env']}]},
+        session_factory=session_factory, config={'region': aws_region})
+    resources = p.run()
+    test.assertEqual(len(resources), 1)
+
+    test.assertEqual(
+        client.list_tags_for_resource(ResourceARN=arn)['Tags'],
+        [{'Key': 'App', 'Value': 'Custodian'}])

--- a/tests/test_cw_dashboard.py
+++ b/tests/test_cw_dashboard.py
@@ -1,6 +1,13 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
+from unittest import mock
+
+from botocore.exceptions import ClientError
 from pytest_terraform import terraform
+
+from c7n.resources import cw
+
+from .common import BaseTest
 
 
 @terraform('cloudwatch_dashboard_tag')
@@ -47,3 +54,48 @@ def test_cloudwatch_dashboard_tag(test, cloudwatch_dashboard_tag):
     test.assertEqual(
         client.list_tags_for_resource(ResourceARN=arn)['Tags'],
         [{'Key': 'App', 'Value': 'Custodian'}])
+
+
+def _client_error(code):
+    return ClientError({'Error': {'Code': code, 'Message': code}}, 'Operation')
+
+
+class CloudWatchDashboardTest(BaseTest):
+
+    def get_source(self):
+        p = self.load_policy({
+            'name': 'dashboard-augment',
+            'resource': 'aws.cloudwatch-dashboard'})
+        return p.resource_manager.source
+
+    def test_augment_skips_deleted_dashboard(self):
+        source = self.get_source()
+        client = mock.MagicMock()
+        client.list_tags_for_resource.side_effect = [
+            _client_error('ResourceNotFoundException'),
+            {'Tags': [{'Key': 'App', 'Value': 'Custodian'}]},
+        ]
+        dashboards = [
+            {'DashboardName': 'gone',
+             'DashboardArn': 'arn:aws:cloudwatch::644160558196:dashboard/gone'},
+            {'DashboardName': 'here',
+             'DashboardArn': 'arn:aws:cloudwatch::644160558196:dashboard/here'},
+        ]
+        with mock.patch.object(cw, 'local_session') as ls:
+            ls.return_value.client.return_value = client
+            resources = source.augment(dashboards)
+        self.assertEqual(
+            [r['DashboardName'] for r in resources], ['here'])
+        self.assertEqual(
+            resources[0]['Tags'], [{'Key': 'App', 'Value': 'Custodian'}])
+
+    def test_augment_error(self):
+        source = self.get_source()
+        client = mock.MagicMock()
+        client.list_tags_for_resource.side_effect = _client_error('AccessDeniedException')
+        with mock.patch.object(cw, 'local_session') as ls:
+            ls.return_value.client.return_value = client
+            with self.assertRaises(ClientError):
+                source.augment([
+                    {'DashboardName': 'here',
+                     'DashboardArn': 'arn:aws:cloudwatch::644160558196:dashboard/here'}])


### PR DESCRIPTION
Dashboard tag support was only recently added to the CloudWatch APIs, and isn't yet available through the Resource Groups Tagging API.

AWS only exposes dashboard tagging through cloudwatch's own TagResource / UntagResource / ListTagsForResource apis, so use those for both reading and writing dashboard tags.

Closes #11029