### PR TITLE
azure - metric filter - support parent-scoped dimensions

### DIFF
--- a/docs/source/azure/examples/metrics-general.rst
+++ b/docs/source/azure/examples/metrics-general.rst
@@ -66,6 +66,40 @@ Find SQL servers with less than 10% average DTU consumption over last 24 hours
             timeframe: 24
             filter:  "DatabaseResourceId eq '*'"
 
+The ``dimensions`` key lets a policy filter a resource by a metric of that
+resource's parent, restricted back to the resource itself with an OData
+filter clause. When ``dimensions`` is set, the filter queries the parent
+resource's scope, taken from the ``c7n:parent-id`` annotation, instead of the
+resource's own id. Each dimension's ``value`` accepts a literal string, or
+one of two sentinels: ``resource-name`` (the resource's own ``name``) or
+``resource-id`` (the resource's own ``id``). Because those two strings are
+reserved as sentinels, a dimension value can't currently be the literal
+string ``resource-name`` or ``resource-id`` themselves.
+
+Find Azure OpenAI model deployments with no requests in the last week, by
+querying the parent Cognitive Services account's ``AzureOpenAIRequests``
+metric and filtering it back to the deployment via the
+``ModelDeploymentName`` dimension
+
+.. code-block:: yaml
+
+    policies:
+      - name: unused-openai-deployments
+        resource: azure.cognitiveservice-deployment
+        filters:
+          - type: metric
+            metric: AzureOpenAIRequests
+            metric_namespace: Microsoft.CognitiveServices/accounts
+            aggregation: total
+            op: lte
+            threshold: 0
+            timeframe: 168
+            interval: P1D
+            no_data_action: to_zero
+            dimensions:
+              - name: ModelDeploymentName
+                value: resource-name
+
 Find storage accounts with low blob count
 
 .. code-block:: yaml

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -218,7 +218,6 @@ class MetricFilter(Filter):
         self.metricnamespace = self.data.get("metric_namespace", None)
         # default to false if not passed in
         self.period_start = self.data.get('period_start', 'auto')
-        # Optional per-dimension OData clauses for parent-scoped metrics
         self.dimensions = self.data.get('dimensions', [])
 
     def process(self, resources, event=None):

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -21,6 +21,7 @@ from azure.core.exceptions import HttpResponseError
 from c7n_azure.provider import resources
 from c7n.filters import Filter, FilterValidationError, ValueFilter
 from c7n.filters.core import PolicyValidationError
+from c7n.exceptions import PolicyExecutionError
 from c7n.filters.metrics import METRIC_WINDOW_ALIGNMENT
 from c7n.filters.related import RelatedResourceFilter
 from c7n.filters.offhours import OffHour, OnHour, Time
@@ -146,6 +147,42 @@ class MetricFilter(Filter):
                 threshold: 20
                 timeframe: 24
                 period_start: start-of-day
+
+    The ``dimensions`` key lets a policy filter a resource by a metric of that
+    resource's parent, restricted back to the resource itself with an OData
+    filter clause. When ``dimensions`` is set, the filter queries the parent
+    resource's scope, taken from the ``c7n:parent-id`` annotation, instead of
+    the resource's own id. Each dimension's ``value`` accepts a literal
+    string, or one of two sentinels: ``resource-name`` (the resource's own
+    ``name``) or ``resource-id`` (the resource's own ``id``). Because those
+    two strings are reserved as sentinels, a dimension value can't currently
+    be the literal string ``resource-name`` or ``resource-id`` themselves.
+
+    :example:
+
+    Find Azure OpenAI model deployments with no requests in the last week,
+    by querying the parent Cognitive Services account's ``AzureOpenAIRequests``
+    metric and filtering it back to the deployment via the
+    ``ModelDeploymentName`` dimension
+
+    .. code-block:: yaml
+
+        policies:
+          - name: unused-openai-deployments
+            resource: azure.cognitiveservice-deployment
+            filters:
+              - type: metric
+                metric: AzureOpenAIRequests
+                metric_namespace: Microsoft.CognitiveServices/accounts
+                aggregation: total
+                op: lte
+                threshold: 0
+                timeframe: 168
+                interval: P1D
+                no_data_action: to_zero
+                dimensions:
+                  - name: ModelDeploymentName
+                    value: resource-name
 
     """
 
@@ -292,10 +329,14 @@ class MetricFilter(Filter):
     def get_filter(self, resource):
         if not self.dimensions:
             return self.filter
-        clauses = [
-            "%s eq '%s'" % (d['name'], self.resolve_dimension_value(resource, d['value']))
-            for d in self.dimensions
-        ]
+        clauses = []
+        for d in self.dimensions:
+            value = self.resolve_dimension_value(resource, d['value'])
+            if value is None:
+                raise PolicyExecutionError(
+                    "policy:%s Could not resolve dimension %s for resource %s" % (
+                        self.manager.ctx.policy.name, d['name'], resource.get('id')))
+            clauses.append("%s eq '%s'" % (d['name'], str(value).replace("'", "''")))
         dim_filter = " and ".join(clauses)
         return "%s and %s" % (self.filter, dim_filter) if self.filter else dim_filter
 
@@ -307,12 +348,13 @@ class MetricFilter(Filter):
         }
 
     def _get_metrics_cache_key(self):
-        return "{}, {}, {}, {}, {}".format(
+        return "{}, {}, {}, {}, {}, {}".format(
             self.metric,
             self.aggregation,
             self.timeframe,
             self.interval,
             self.filter,
+            self.dimensions,
         )
 
     def _get_cached_metric_data(self, resource):

--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -177,7 +177,19 @@ class MetricFilter(Filter):
                 'PT1M', 'PT5M', 'PT15M', 'PT30M', 'PT1H', 'PT6H', 'PT12H', 'P1D']},
             'aggregation': {'enum': ['total', 'average', 'count', 'minimum', 'maximum']},
             'no_data_action': {'enum': ['include', 'exclude', 'to_zero']},
-            'filter': {'type': 'string'}
+            'filter': {'type': 'string'},
+            'dimensions': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'additionalProperties': False,
+                    'required': ['name', 'value'],
+                    'properties': {
+                        'name': {'type': 'string'},
+                        'value': {'type': 'string'},
+                    },
+                },
+            },
         }
     }
     schema_alias = True
@@ -206,6 +218,8 @@ class MetricFilter(Filter):
         self.metricnamespace = self.data.get("metric_namespace", None)
         # default to false if not passed in
         self.period_start = self.data.get('period_start', 'auto')
+        # Optional per-dimension OData clauses for parent-scoped metrics
+        self.dimensions = self.data.get('dimensions', [])
 
     def process(self, resources, event=None):
         # Import utcnow function as it may have been overridden for testing purposes
@@ -262,11 +276,29 @@ class MetricFilter(Filter):
 
         return m
 
+    _DIMENSION_VALUE_SENTINELS = {
+        'resource-name': lambda r: r.get('name'),
+        'resource-id': lambda r: r.get('id'),
+    }
+
+    def resolve_dimension_value(self, resource, value):
+        resolver = self._DIMENSION_VALUE_SENTINELS.get(value)
+        return resolver(resource) if resolver else value
+
     def get_resource_id(self, resource):
+        if self.dimensions and 'c7n:parent-id' in resource:
+            return resource['c7n:parent-id']
         return resource['id']
 
     def get_filter(self, resource):
-        return self.filter
+        if not self.dimensions:
+            return self.filter
+        clauses = [
+            "%s eq '%s'" % (d['name'], self.resolve_dimension_value(resource, d['value']))
+            for d in self.dimensions
+        ]
+        dim_filter = " and ".join(clauses)
+        return "%s and %s" % (self.filter, dim_filter) if self.filter else dim_filter
 
     def _write_metric_to_resource(self, resource, metrics_data, m):
         resource_metrics = resource.setdefault(get_annotation_prefix('metrics'), {})

--- a/tools/c7n_azure/tests_azure/cassettes/AiFoundryCognitiveServiceDeploymentTest.ai-foundry-cognitiveservice-deployment-metric.json
+++ b/tools/c7n_azure/tests_azure/cassettes/AiFoundryCognitiveServiceDeploymentTest.ai-foundry-cognitiveservice-deployment-metric.json
@@ -1,0 +1,690 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.CognitiveServices/accounts?api-version=2025-06-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-msedge-ref": [
+                        "Ref A: 6838DD0B86B444919A5282C85806DC0F Ref B: BL2AA2011003031 Ref C: 2026-09-11T19:41:33Z"
+                    ],
+                    "x-envoy-upstream-service-time": [
+                        "14"
+                    ],
+                    "content-length": [
+                        "637"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "1932b8bb-e679-4921-a9dc-d3c9d9dfc4d3"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Fri, 11 Sep 2026 19:41:32 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [],
+                        "nextLink": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.CognitiveServices/accounts?api-version=2025-06-01&%24skiptoken=7VE9b8IwFPwvVtuJkA%2fAgkioimiRgshSKEFVFtt5BDfEjmwnkCL%2bew3q1oWhY4cb7t6X3t0ZCTiZJRelRuEZvUar9fsKhWhvTK1D162IIAVUIEyffDUK%2bkxWrm6oZorXhkuhXR%2fjHR6NsQOEUGeYM%2boQmIydgAKbjAKP0hy7tZItz0FpN%2bFMSS13pj%2bTheCGt7AC1XIG2iWMyUYY%2fUxq7rS22x6YBl4wcjzseP7Tgy55vZYliCl0i%2bZju%2ffW6bwjwaaLPyVPB4bF4q21vNnOYkzFRtPZyWqLPa3yw1UD%2f8hperjVLT8lL9HxLsyPfGlB0%2fnwuseiu2vuut%2fO7bZ%2bHgvvcZCjSw8RVUVFoaAgBvLbQ9bz6C1BvVseCVElKCuds59IMhRm%2f6H8MvzPQsnQBV2%2bAQ%3d%3d"
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.CognitiveServices/accounts?api-version=2025-06-01&$skiptoken=7VE9b8IwFPwvVtuJkA/AgkioimiRgshSKEFVFtt5BDfEjmwnkCL%2Bew3q1oWhY4cb7t6X3t0ZCTiZJRelRuEZvUar9fsKhWhvTK1D162IIAVUIEyffDUK%2BkxWrm6oZorXhkuhXR/jHR6NsQOEUGeYM%2BoQmIydgAKbjAKP0hy7tZItz0FpN%2BFMSS13pj%2BTheCGt7AC1XIG2iWMyUYY/Uxq7rS22x6YBl4wcjzseP7Tgy55vZYliCl0i%2BZju/fW6bwjwaaLPyVPB4bF4q21vNnOYkzFRtPZyWqLPa3yw1UD/8hperjVLT8lL9HxLsyPfGlB0/nwuseiu2vuut/O7bZ%2BHgvvcZCjSw8RVUVFoaAgBvLbQ9bz6C1BvVseCVElKCuds59IMhRm/6H8MvzPQsnQBV2%2BAQ%3D%3D",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-msedge-ref": [
+                        "Ref A: 0731C7393889434EBA101E6FBB7A2DC4 Ref B: YQ1AA2090602054 Ref C: 2026-09-11T19:41:33Z"
+                    ],
+                    "x-envoy-upstream-service-time": [
+                        "14"
+                    ],
+                    "content-length": [
+                        "643"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "63ff3dd3-5b22-4de5-b2cd-0717fe4f8abd"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Fri, 11 Sep 2026 19:41:33 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [],
+                        "nextLink": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.CognitiveServices/accounts?api-version=2025-06-01&%24skiptoken=7VHBTsJAFPyXjXqytBRogIQYUkVLaEwAaWO47G4fZW272%2bxuWyrh313QxIMH%2fQAPc5h5k%2fdeZo6Iw0EvGM8UGh%2fRw3S1flmhMdprXaqxbReY4xQK4LqD3ysJHSoKW1VEUclKzQRXdtfzdt5g6FmAMbH6CSUWhtHQcgnQ0cB1CEk8u5SiZglIZYeMSqHETnd8kXKmWQ0rkDWjoGxMqai4Vne4ZFZt3ObAxHXcgeV4ltO9uVIZK9ciAz6Bdl69xntnHc1a7G7a4E2wqKdpwJe14VXsBx7hG0X8g9Hme1Ik%2bVmDbsNIlF%2fmhrfh%2fbT5E2YNWxiQaNY%2f74n9%2beMyb9gu7iYBd657CTrdfof5zJ9EnphIjYhlMU1TCSnWkFy%2bNwFPlyH69IdYZiCNdNx%2b5b9F4%2b1%2fAz9a%2bbWBLTqh0wc%3d"
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.CognitiveServices/accounts?api-version=2025-06-01&$skiptoken=7VHBTsJAFPyXjXqytBRogIQYUkVLaEwAaWO47G4fZW272%2BxuWyrh313QxIMH/QAPc5h5k/deZo6Iw0EvGM8UGh/Rw3S1flmhMdprXaqxbReY4xQK4LqD3ysJHSoKW1VEUclKzQRXdtfzdt5g6FmAMbH6CSUWhtHQcgnQ0cB1CEk8u5SiZglIZYeMSqHETnd8kXKmWQ0rkDWjoGxMqai4Vne4ZFZt3ObAxHXcgeV4ltO9uVIZK9ciAz6Bdl69xntnHc1a7G7a4E2wqKdpwJe14VXsBx7hG0X8g9Hme1Ik%2BVmDbsNIlF/mhrfh/bT5E2YNWxiQaNY/74n9%2BeMyb9gu7iYBd657CTrdfof5zJ9EnphIjYhlMU1TCSnWkFy%2BNwFPlyH69IdYZiCNdNx%2B5b9F4%2B1/Az9a%2BbWBLTqh0wc%3D",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-msedge-ref": [
+                        "Ref A: C8519699D6544A71BFB6F2B91DDE610F Ref B: YQ1AA2090601034 Ref C: 2026-09-11T19:41:34Z"
+                    ],
+                    "x-envoy-upstream-service-time": [
+                        "31"
+                    ],
+                    "content-length": [
+                        "5777"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "9a46de96-7bb2-4f6b-9ec9-04ec608faa75"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Fri, 11 Sep 2026 19:41:34 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cognitive-service-deployment/providers/Microsoft.CognitiveServices/accounts/cctestcogdeploy",
+                                "name": "cctestcogdeploy",
+                                "type": "Microsoft.CognitiveServices/accounts",
+                                "etag": "\"7d002376-0000-0100-0000-6aa455fc0000\"",
+                                "location": "eastus",
+                                "sku": {
+                                    "name": "S0"
+                                },
+                                "kind": "OpenAI",
+                                "properties": {
+                                    "endpoint": "https://cctestcogdeploy.openai.azure.com/",
+                                    "provisioningState": "Succeeded",
+                                    "internalId": "0d074c9ec6c8418fb9cd65d19aed7ab9",
+                                    "dateCreated": "2026-09-11T19:00:47.704445Z",
+                                    "apiProperties": {},
+                                    "callRateLimit": {
+                                        "rules": [
+                                            {
+                                                "key": "openai.dalle.post",
+                                                "renewalPeriod": 1,
+                                                "count": 30,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "dalle/*",
+                                                        "method": "POST"
+                                                    },
+                                                    {
+                                                        "path": "openai/images/*",
+                                                        "method": "POST"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.dalle.other",
+                                                "renewalPeriod": 1,
+                                                "count": 30,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "dalle/*",
+                                                        "method": "*"
+                                                    },
+                                                    {
+                                                        "path": "openai/operations/images/*",
+                                                        "method": "*"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.assistants.list",
+                                                "renewalPeriod": 60,
+                                                "count": 120,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/assistants",
+                                                        "method": "GET"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.threads.list",
+                                                "renewalPeriod": 60,
+                                                "count": 120,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/threads",
+                                                        "method": "GET"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.vectorstores.list",
+                                                "renewalPeriod": 60,
+                                                "count": 120,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/vector_stores",
+                                                        "method": "GET"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.vectorstores.post",
+                                                "renewalPeriod": 1,
+                                                "count": 60,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/vector_stores",
+                                                        "method": "POST"
+                                                    },
+                                                    {
+                                                        "path": "openai/vector_stores/*",
+                                                        "method": "POST"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.assistants.default",
+                                                "renewalPeriod": 60,
+                                                "count": 6000,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/assistants",
+                                                        "method": "*"
+                                                    },
+                                                    {
+                                                        "path": "openai/assistants/*",
+                                                        "method": "*"
+                                                    },
+                                                    {
+                                                        "path": "openai/threads",
+                                                        "method": "*"
+                                                    },
+                                                    {
+                                                        "path": "openai/threads/*",
+                                                        "method": "*"
+                                                    },
+                                                    {
+                                                        "path": "openai/vector_stores",
+                                                        "method": "*"
+                                                    },
+                                                    {
+                                                        "path": "openai/vector_stores/*",
+                                                        "method": "*"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.responses.default",
+                                                "renewalPeriod": 1,
+                                                "count": 100000,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/responses",
+                                                        "method": "*"
+                                                    },
+                                                    {
+                                                        "path": "openai/responses/*",
+                                                        "method": "*"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.batches.post",
+                                                "renewalPeriod": 60,
+                                                "count": 30,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/v1/batches",
+                                                        "method": "POST"
+                                                    },
+                                                    {
+                                                        "path": "openai/batches",
+                                                        "method": "POST"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.batches.get",
+                                                "renewalPeriod": 60,
+                                                "count": 500,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/v1/batches/*",
+                                                        "method": "GET"
+                                                    },
+                                                    {
+                                                        "path": "openai/batches/*",
+                                                        "method": "GET"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.batches.list",
+                                                "renewalPeriod": 60,
+                                                "count": 100,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/v1/batches",
+                                                        "method": "GET"
+                                                    },
+                                                    {
+                                                        "path": "openai/batches",
+                                                        "method": "GET"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai.moderations.post",
+                                                "renewalPeriod": 60,
+                                                "count": 120,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/v1/moderations",
+                                                        "method": "POST"
+                                                    },
+                                                    {
+                                                        "path": "openai/v1/moderations/exp/m4",
+                                                        "method": "POST"
+                                                    },
+                                                    {
+                                                        "path": "openai/v1/moderations/exp/safeberry",
+                                                        "method": "POST"
+                                                    },
+                                                    {
+                                                        "path": "openai/v1/safeberry/moderations",
+                                                        "method": "POST"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "openai",
+                                                "renewalPeriod": 1,
+                                                "count": 30,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "openai/*",
+                                                        "method": "*"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "default",
+                                                "renewalPeriod": 1,
+                                                "count": 30,
+                                                "matchPatterns": [
+                                                    {
+                                                        "path": "*",
+                                                        "method": "*"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "isMigrated": false,
+                                    "customSubDomainName": "cctestcogdeploy",
+                                    "allowProjectManagement": false,
+                                    "privateEndpointConnections": [],
+                                    "publicNetworkAccess": "Enabled",
+                                    "capabilities": [
+                                        {
+                                            "name": "VirtualNetworks"
+                                        },
+                                        {
+                                            "name": "CustomerManagedKey"
+                                        },
+                                        {
+                                            "name": "EnabledApimVnet",
+                                            "value": "true"
+                                        },
+                                        {
+                                            "name": "useEndpointRateLimiter",
+                                            "value": "Enabled"
+                                        },
+                                        {
+                                            "name": "MaxFineTuneCount",
+                                            "value": "500"
+                                        },
+                                        {
+                                            "name": "MaxRunningFineTuneCount",
+                                            "value": "3"
+                                        },
+                                        {
+                                            "name": "MaxUserFileCount",
+                                            "value": "100"
+                                        },
+                                        {
+                                            "name": "MaxTrainingFileSize",
+                                            "value": "512000000"
+                                        },
+                                        {
+                                            "name": "MaxUserFileImportDurationInHours",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "name": "MaxFineTuneJobDurationInHours",
+                                            "value": "720"
+                                        },
+                                        {
+                                            "name": "MaxEvaluationRunDurationInHours",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "name": "MaxRunningEvaluationCount",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "name": "MaxRunningGlobalStandardFineTuneCount",
+                                            "value": "3"
+                                        },
+                                        {
+                                            "name": "TrustedServices",
+                                            "value": "Microsoft.CognitiveServices,Microsoft.MachineLearningServices,Microsoft.Search,Microsoft.VideoIndexer"
+                                        },
+                                        {
+                                            "name": "NetworkSecurityPerimeter"
+                                        },
+                                        {
+                                            "name": "RaiMonitor"
+                                        },
+                                        {
+                                            "name": "quotaRefundsEnabled",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "endpoints": {
+                                        "OpenAI Language Model Instance API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Dall-E API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Sora API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Moderations API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Whisper API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Model Scaleset API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Realtime API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "Token Service API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "Azure OpenAI Legacy API - Latest moniker": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Response API on Websocket": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Realtime Translation WebSocket API": "https://cctestcogdeploy.openai.azure.com/",
+                                        "OpenAI Realtime Live WebSocket API": "https://cctestcogdeploy.openai.azure.com/"
+                                    }
+                                },
+                                "systemData": {
+                                    "createdBy": "test@example.com",
+                                    "createdByType": "User",
+                                    "createdAt": "2026-09-11T19:00:47.0950693Z",
+                                    "lastModifiedBy": "test@example.com",
+                                    "lastModifiedByType": "User",
+                                    "lastModifiedAt": "2026-09-11T19:26:17.286859Z"
+                                }
+                            }
+                        ],
+                        "nextLink": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.CognitiveServices/accounts?api-version=2025-06-01&%24skiptoken=7VHLTsJAFP2Xibqy9AE00IQYgqIlNiaAQEw387iUse1MMzMtr%2fDvDmjiwoV%2bgIuzOOee3HtzzhEJ2JlnLnKNoiN6GM7mrzMUoY0xlY5ct8QCZ1CCMC18qBW0qCxdXRNNFa8Ml0K7fhiuw24vdABj4nQYJQ6Gfs8JCNB%2bN%2fAIYaFbKdlwBkq7CadKark2rZHMBDe8gRmohlPQLqZU1sLoO1xxp7Fue2AQeEHX8ULH82%2budM6rucxBDGA%2fqd9WG2%2b%2bHO9xsNjH75Iv24bGYtpYXq9GcUjEQpPRzmqTDSlZcdbA33KyLC5zyw%2fJ%2fXD7J4y3%2fNmCLMed857VaPI4LbZ8vfJZLLzrNkOn2%2b8wX8STLJiN1IpYlcMsU5BhA%2bzyvQ14OE3Qpz%2fBKgdlpWP6lX%2bKovS%2fgR%2bt%2fNpAik7o9AE%3d"
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.CognitiveServices/accounts?api-version=2025-06-01&$skiptoken=7VHLTsJAFP2Xibqy9AE00IQYgqIlNiaAQEw387iUse1MMzMtr/DvDmjiwoV%2BgIuzOOee3HtzzhEJ2JlnLnKNoiN6GM7mrzMUoY0xlY5ct8QCZ1CCMC18qBW0qCxdXRNNFa8Ml0K7fhiuw24vdABj4nQYJQ6Gfs8JCNB%2BN/AIYaFbKdlwBkq7CadKark2rZHMBDe8gRmohlPQLqZU1sLoO1xxp7Fue2AQeEHX8ULH82%2BudM6rucxBDGA/qd9WG2%2B%2BHO9xsNjH75Iv24bGYtpYXq9GcUjEQpPRzmqTDSlZcdbA33KyLC5zyw/J/XD7J4y3/NmCLMed857VaPI4LbZ8vfJZLLzrNkOn2%2B8wX8STLJiN1IpYlcMsU5BhA%2BzyvQ14OE3Qpz/BKgdlpWP6lX%2BKovS/gR%2Bt/NpAik7o9AE%3D",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-msedge-ref": [
+                        "Ref A: A206CE8DCF314CD68AD40276CBDB2DDE Ref B: MNZ221060610047 Ref C: 2026-09-11T19:41:35Z"
+                    ],
+                    "x-envoy-upstream-service-time": [
+                        "19"
+                    ],
+                    "content-length": [
+                        "12"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "788590c8-1484-43c0-add0-9ab5e4b91fba"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "date": [
+                        "Fri, 11 Sep 2026 19:41:35 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": []
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com//subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cognitive-service-deployment/providers/Microsoft.CognitiveServices/accounts/cctestcogdeploy/deployments?api-version=2024-10-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-msedge-ref": [
+                        "Ref A: 721138783B054B14BCA5B39B894D74F2 Ref B: YQ1AA2090601062 Ref C: 2026-09-11T19:41:36Z"
+                    ],
+                    "x-envoy-upstream-service-time": [
+                        "32"
+                    ],
+                    "content-length": [
+                        "1088"
+                    ],
+                    "date": [
+                        "Fri, 11 Sep 2026 19:41:35 GMT"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-global-reads": [
+                        "3749"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cognitive-service-deployment/providers/Microsoft.CognitiveServices/accounts/cctestcogdeploy/deployments/cctest-gpt4o-mini",
+                                "type": "Microsoft.CognitiveServices/accounts/deployments",
+                                "name": "cctest-gpt4o-mini",
+                                "sku": {
+                                    "name": "GlobalStandard",
+                                    "capacity": 1
+                                },
+                                "properties": {
+                                    "model": {
+                                        "format": "OpenAI",
+                                        "name": "gpt-5-nano",
+                                        "version": "2025-08-07"
+                                    },
+                                    "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
+                                    "currentCapacity": 1,
+                                    "capabilities": {
+                                        "area": "US",
+                                        "chatCompletion": "true",
+                                        "responses": "true",
+                                        "agentsV2": "true",
+                                        "assistants": "true"
+                                    },
+                                    "raiPolicyName": "Microsoft.DefaultV2",
+                                    "provisioningState": "Succeeded",
+                                    "rateLimits": [
+                                        {
+                                            "key": "request",
+                                            "renewalPeriod": 60,
+                                            "count": 1
+                                        },
+                                        {
+                                            "key": "token",
+                                            "renewalPeriod": 60,
+                                            "count": 1000
+                                        }
+                                    ]
+                                },
+                                "systemData": {
+                                    "createdBy": "test@example.com",
+                                    "createdByType": "User",
+                                    "createdAt": "2026-09-11T19:26:50.364454Z",
+                                    "lastModifiedBy": "test@example.com",
+                                    "lastModifiedByType": "User",
+                                    "lastModifiedAt": "2026-09-11T19:26:50.364454Z"
+                                },
+                                "etag": "\"f3938b46-af9b-44f8-b7a3-261f5e435935\""
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cognitive-service-deployment/providers/Microsoft.CognitiveServices/accounts/cctestcogdeploy/providers/microsoft.insights/metrics?timespan=2026-09-04%2023%3A59%3A59%2F2026-09-11%2023%3A59%3A59&interval=P1D&metricnames=AzureOpenAIRequests&aggregation=total&$filter=ModelDeploymentName%20eq%20%27cctest-gpt4o-mini%27&api-version=2018-01-01&metricnamespace=Microsoft.CognitiveServices%2Faccounts",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-msedge-ref": [
+                        "Ref A: 7BF3C6AE8DC243398E8C0D7FA787B50B Ref B: MNZ221060618045 Ref C: 2026-09-11T19:41:37Z"
+                    ],
+                    "x-envoy-upstream-service-time": [
+                        "51"
+                    ],
+                    "mise-correlation-id": [
+                        "d7936be2-923a-4f65-b41a-3c490be6bbd3"
+                    ],
+                    "content-length": [
+                        "1034"
+                    ],
+                    "date": [
+                        "Fri, 11 Sep 2026 19:41:37 GMT"
+                    ],
+                    "x-cache": [
+                        "CONFIG_NOCACHE"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "999"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "cost": 10079,
+                        "timespan": "2026-09-04T23:59:59Z/2026-09-11T23:59:59Z",
+                        "interval": "P1D",
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cognitive-service-deployment/providers/Microsoft.CognitiveServices/accounts/cctestcogdeploy/providers/Microsoft.Insights/metrics/AzureOpenAIRequests",
+                                "type": "Microsoft.Insights/metrics",
+                                "name": {
+                                    "value": "AzureOpenAIRequests",
+                                    "localizedValue": "Azure OpenAI Requests"
+                                },
+                                "displayDescription": "Number of calls made to the Azure OpenAI API over a period of time. Applies to PTU, PTU-Managed and Pay-as-you-go deployments. To breakdown API requests, you can add a filter or apply splitting by the following dimensions: ModelDeploymentName, ModelName, ModelVersion, StatusCode (successful, clienterrors, server errors), IsSpillover for spillover information, ServiceTier, StreamType (Streaming vs non-streaming requests) and operation.",
+                                "unit": "Count",
+                                "timeseries": [],
+                                "errorCode": "Success"
+                            }
+                        ],
+                        "namespace": "Microsoft.CognitiveServices/accounts",
+                        "resourceregion": "eastus"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/templates/provision.sh
+++ b/tools/c7n_azure/tests_azure/templates/provision.sh
@@ -189,10 +189,10 @@ deploy_resource() {
     elif [[ "$fileName" == "cognitive-service-deployment.json" ]]; then
 
         openai_location="${AZURE_OPENAI_LOCATION:-eastus}"
-        model_name="${AZURE_OPENAI_MODEL_NAME:-gpt-4o-mini}"
-        model_version="${AZURE_OPENAI_MODEL_VERSION:-2024-07-18}"
+        model_name="${AZURE_OPENAI_MODEL_NAME:-gpt-5-nano}"
+        model_version="${AZURE_OPENAI_MODEL_VERSION:-2025-08-07}"
         deployment_name="${AZURE_OPENAI_DEPLOYMENT_NAME:-cctest-gpt4o-mini}"
-        account_name="${AZURE_OPENAI_ACCOUNT_NAME}"
+        account_name="${AZURE_OPENAI_ACCOUNT_NAME:-cctestcogdeploy}"
 
         if az cognitiveservices account show-deleted \
             --resource-group "$rgName" \
@@ -249,6 +249,8 @@ deploy_resource() {
             exit 1
         fi
 
+        sku_name="${AZURE_OPENAI_SKU_NAME:-GlobalStandard}"
+
         if ! az cognitiveservices account deployment create \
             --resource-group $rgName \
             --name $account_name \
@@ -256,7 +258,7 @@ deploy_resource() {
             --model-format OpenAI \
             --model-name $model_name \
             --model-version $model_version \
-            --sku-name Standard \
+            --sku-name $sku_name \
             --sku-capacity 1 \
             --output None; then
             echo "Failed to create Cognitive Services deployment ${deployment_name} in account ${account_name}"

--- a/tools/c7n_azure/tests_azure/templates/provision.sh
+++ b/tools/c7n_azure/tests_azure/templates/provision.sh
@@ -191,6 +191,8 @@ deploy_resource() {
         openai_location="${AZURE_OPENAI_LOCATION:-eastus}"
         model_name="${AZURE_OPENAI_MODEL_NAME:-gpt-5-nano}"
         model_version="${AZURE_OPENAI_MODEL_VERSION:-2025-08-07}"
+        # Pinned by committed test fixtures (recorded VCR cassettes reference this exact
+        # deployment name) -- do not rename to match the model default above.
         deployment_name="${AZURE_OPENAI_DEPLOYMENT_NAME:-cctest-gpt4o-mini}"
         account_name="${AZURE_OPENAI_ACCOUNT_NAME:-cctestcogdeploy}"
 

--- a/tools/c7n_azure/tests_azure/templates/readme.md
+++ b/tools/c7n_azure/tests_azure/templates/readme.md
@@ -30,8 +30,9 @@ If you deploy `cognitive-service-deployment`, provisioning creates an OpenAI acc
 
 - `AZURE_OPENAI_ACCOUNT_NAME` (default: `cctestcogdeploy`)
 - `AZURE_OPENAI_LOCATION` (default: `eastus`)
-- `AZURE_OPENAI_MODEL_NAME` (default: `gpt-4o-mini`)
-- `AZURE_OPENAI_MODEL_VERSION` (default: `2024-07-18`)
+- `AZURE_OPENAI_MODEL_NAME` (default: `gpt-5-nano`)
+- `AZURE_OPENAI_MODEL_VERSION` (default: `2025-08-07`)
 - `AZURE_OPENAI_DEPLOYMENT_NAME` (default: `cctest-gpt4o-mini`)
+- `AZURE_OPENAI_SKU_NAME` (default: `GlobalStandard`) — must be a SKU the chosen model/version actually supports; check with `az cognitiveservices account list-models --resource-group <rg> --name <account> -o json` (the `skus` field per model) if changing the model.
 
 If a soft-deleted Cognitive Services account with the target name already exists, provisioning will purge it automatically before redeploying.

--- a/tools/c7n_azure/tests_azure/test_filters_metric.py
+++ b/tools/c7n_azure/tests_azure/test_filters_metric.py
@@ -14,7 +14,7 @@ class MetricFilterDimensionsTest(BaseTest):
             'resource': 'azure.vm',
             'filters': [
                 {'type': 'metric',
-                 'metric': 'TotalCalls',
+                 'metric': 'AzureOpenAIRequests',
                  'metric_namespace': 'Microsoft.CognitiveServices/accounts',
                  'op': 'lte',
                  'threshold': 0,
@@ -24,7 +24,7 @@ class MetricFilterDimensionsTest(BaseTest):
         self.assertTrue(p)
 
     def _get_filter(self, dimensions=None):
-        data = {'type': 'metric', 'metric': 'TotalCalls', 'op': 'lte', 'threshold': 0}
+        data = {'type': 'metric', 'metric': 'AzureOpenAIRequests', 'op': 'lte', 'threshold': 0}
         if dimensions is not None:
             data['dimensions'] = dimensions
         return MetricFilter(data=data, manager=Mock())
@@ -81,3 +81,8 @@ class MetricFilterDimensionsTest(BaseTest):
         self.assertEqual(
             f.get_filter(resource),
             "Region eq 'eastus' and ModelDeploymentName eq 'my-deployment'")
+
+    def test_get_metrics_cache_key_differs_by_dimensions(self):
+        f1 = self._get_filter(dimensions=[{'name': 'ModelDeploymentName', 'value': 'dep-a'}])
+        f2 = self._get_filter(dimensions=[{'name': 'ModelDeploymentName', 'value': 'dep-b'}])
+        self.assertNotEqual(f1._get_metrics_cache_key(), f2._get_metrics_cache_key())

--- a/tools/c7n_azure/tests_azure/test_filters_metric.py
+++ b/tools/c7n_azure/tests_azure/test_filters_metric.py
@@ -1,0 +1,83 @@
+# Copyright The Cloud Custodian Authors.
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import Mock
+
+from .azure_common import BaseTest
+from c7n_azure.filters import MetricFilter
+
+
+class MetricFilterDimensionsTest(BaseTest):
+
+    def test_schema_accepts_dimensions(self):
+        p = self.load_policy({
+            'name': 'test-metric-dimensions',
+            'resource': 'azure.vm',
+            'filters': [
+                {'type': 'metric',
+                 'metric': 'TotalCalls',
+                 'metric_namespace': 'Microsoft.CognitiveServices/accounts',
+                 'op': 'lte',
+                 'threshold': 0,
+                 'dimensions': [
+                     {'name': 'ModelDeploymentName', 'value': 'resource-name'}]}]
+        }, validate=True)
+        self.assertTrue(p)
+
+    def _get_filter(self, dimensions=None):
+        data = {'type': 'metric', 'metric': 'TotalCalls', 'op': 'lte', 'threshold': 0}
+        if dimensions is not None:
+            data['dimensions'] = dimensions
+        return MetricFilter(data=data, manager=Mock())
+
+    def test_resolve_dimension_value_literal(self):
+        f = self._get_filter()
+        self.assertEqual(f.resolve_dimension_value({'name': 'anything'}, 'a-literal-value'),
+                          'a-literal-value')
+
+    def test_resolve_dimension_value_resource_name(self):
+        f = self._get_filter()
+        self.assertEqual(
+            f.resolve_dimension_value({'name': 'my-deployment', 'id': 'ignored'},
+                                       'resource-name'),
+            'my-deployment')
+
+    def test_resolve_dimension_value_resource_id(self):
+        f = self._get_filter()
+        self.assertEqual(
+            f.resolve_dimension_value({'name': 'ignored', 'id': '/subscriptions/x'},
+                                       'resource-id'),
+            '/subscriptions/x')
+
+    def test_get_resource_id_without_dimensions_uses_own_id(self):
+        f = self._get_filter()
+        resource = {'id': '/subscriptions/child', 'c7n:parent-id': '/subscriptions/parent'}
+        self.assertEqual(f.get_resource_id(resource), '/subscriptions/child')
+
+    def test_get_resource_id_with_dimensions_and_parent_id_uses_parent(self):
+        f = self._get_filter(dimensions=[{'name': 'ModelDeploymentName', 'value': 'resource-name'}])
+        resource = {'id': '/subscriptions/child', 'c7n:parent-id': '/subscriptions/parent',
+                    'name': 'my-deployment'}
+        self.assertEqual(f.get_resource_id(resource), '/subscriptions/parent')
+
+    def test_get_resource_id_with_dimensions_but_no_parent_id_falls_back(self):
+        f = self._get_filter(dimensions=[{'name': 'ModelDeploymentName', 'value': 'resource-name'}])
+        resource = {'id': '/subscriptions/child', 'name': 'my-deployment'}
+        self.assertEqual(f.get_resource_id(resource), '/subscriptions/child')
+
+    def test_get_filter_without_dimensions_returns_plain_filter(self):
+        f = self._get_filter()
+        f.filter = "DatabaseName eq 'x'"
+        self.assertEqual(f.get_filter({'id': 'x'}), "DatabaseName eq 'x'")
+
+    def test_get_filter_with_dimensions_builds_odata_clause(self):
+        f = self._get_filter(dimensions=[{'name': 'ModelDeploymentName', 'value': 'resource-name'}])
+        resource = {'id': '/subscriptions/child', 'name': 'my-deployment'}
+        self.assertEqual(f.get_filter(resource), "ModelDeploymentName eq 'my-deployment'")
+
+    def test_get_filter_with_dimensions_and_existing_filter_ands_together(self):
+        f = self._get_filter(dimensions=[{'name': 'ModelDeploymentName', 'value': 'resource-name'}])
+        f.filter = "Region eq 'eastus'"
+        resource = {'id': '/subscriptions/child', 'name': 'my-deployment'}
+        self.assertEqual(
+            f.get_filter(resource),
+            "Region eq 'eastus' and ModelDeploymentName eq 'my-deployment'")

--- a/tools/c7n_azure/tests_azure/tests_resources/test_ai_foundry.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_ai_foundry.py
@@ -135,6 +135,39 @@ class AiFoundryCognitiveServiceDeploymentTest(BaseTest):
         self.assertGreaterEqual(len(resources), 1)
         self.assertTrue(any(r['name'].endswith(deployment_name) for r in resources))
 
+    @requires_arm_polling
+    @arm_template('cognitive-service-deployment.json')
+    @cassette_name('ai-foundry-cognitiveservice-deployment-metric')
+    def test_cognitiveservice_deployment_metric_filter(self):
+        deployment_name = os.environ.get('AZURE_OPENAI_DEPLOYMENT_NAME', 'cctest-gpt4o-mini')
+        p = self.load_policy(
+            {
+                'name': 'test-azure-cognitiveservice-deployment-metric',
+                'resource': 'azure.cognitiveservice-deployment',
+                'filters': [
+                    {'type': 'value',
+                     'key': 'name',
+                     'op': 'glob',
+                     'value': '*' + deployment_name},
+                    {'type': 'metric',
+                     'metric': 'AzureOpenAIRequests',
+                     'metric_namespace': 'Microsoft.CognitiveServices/accounts',
+                     'aggregation': 'total',
+                     'op': 'lte',
+                     'threshold': 0,
+                     'timeframe': 168,
+                     'interval': 'P1D',
+                     'no_data_action': 'to_zero',
+                     'dimensions': [
+                         {'name': 'ModelDeploymentName', 'value': 'resource-name'}]}],
+            },
+            validate=True,
+        )
+
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+
     def test_cognitiveservice_deployment_tagging_not_implemented(self):
         with self.assertRaises(PolicyValidationError):
             self.load_policy(


### PR DESCRIPTION
Closes #11079

## Summary

`MetricFilter` always queried a metric against its own resource ID. Some Azure services emit a metric only at a parent resource's scope, dimensioned by the child's name, so a policy on the child resource couldn't reach it — `azure.cognitiveservice-deployment` (an AI model deployment) is one example.

Adds an optional `dimensions` field to `MetricFilter`. When set, the filter queries the parent resource, using the existing `c7n:parent-id` annotation, and builds an OData `$filter` clause from the dimensions, combined with any existing `filter:` string.

No behavior change for a policy that doesn't set `dimensions`. `CosmosDBDatabaseMetricFilter`, `CosmosDBCollectionMetricFilter`, and `StorageMetricsFilter` are unchanged — each overrides `get_resource_id` and `get_filter` directly and never reaches the new code path.

## Cloud API verification

The issue's proposed policy used the `TotalCalls` metric. Per Azure's metrics reference, `TotalCalls` has no `ModelDeploymentName` dimension, and its own description says not to use it for Azure OpenAI. `AzureOpenAIRequests` carries that dimension and matches the issue's actual goal — call count per model deployment — so this PR uses it instead.

- [Azure Monitor Metrics - List](https://learn.microsoft.com/en-us/rest/api/monitor/metrics/list)
- [Supported metrics - Microsoft.CognitiveServices/accounts](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-cognitiveservices-accounts-metrics)

## Tests

```
uv run pytest tools/c7n_azure/tests_azure/test_filters_metric.py -v
```
Result: 11 passed (10 for the new schema/behavior, 1 confirming the metrics cache key varies by `dimensions`).

```
uv run pytest tools/c7n_azure/tests_azure/tests_resources/test_ai_foundry.py -k test_cognitiveservice_deployment_metric_filter -v
```
Result: 1 passed — recorded against a real Azure OpenAI deployment.

```
uv run pytest tools/c7n_azure/tests_azure/tests_resources/test_cosmos_db.py -k metrics_filter -v
```
Result: 2 passed — confirms no regression.

```
uv run pytest tools/c7n_azure/tests_azure/tests_resources/test_storage.py -k metric -v
```
Result: 13 passed — confirms no regression.

Recording also surfaced 4 stale defaults in `tests_azure/templates/provision.sh` (an empty account-name fallback, a deprecated model version, and a SKU some current models no longer support) — fixed here since they blocked recording the test above.